### PR TITLE
TB2 — Converse: prompt → streamed reasoning + answer

### DIFF
--- a/src/main/acp/client.ts
+++ b/src/main/acp/client.ts
@@ -135,6 +135,20 @@ export class AcpClient extends EventEmitter {
     this.writeMessage(child, { jsonrpc: '2.0', method, params })
   }
 
+  /** Answer a server-initiated request (e.g. `fs/read_text_file`) by its id. */
+  respond(id: JsonRpcId, result: unknown): void {
+    const child = this.child
+    if (!child) return
+    this.writeMessage(child, { jsonrpc: '2.0', id, result })
+  }
+
+  /** Reply to a server-initiated request with a JSON-RPC error. */
+  respondError(id: JsonRpcId, error: { code: number; message: string; data?: unknown }): void {
+    const child = this.child
+    if (!child) return
+    this.writeMessage(child, { jsonrpc: '2.0', id, error })
+  }
+
   stop(): void {
     this.child?.kill()
     this.child = null

--- a/src/main/acp/fs-read.test.ts
+++ b/src/main/acp/fs-read.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, afterAll } from 'vitest'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { handleFsReadTextFile, type ReadTextFn } from './fs-read'
+
+/**
+ * Seam C: the `fs/read_text_file` handler that main uses to serve the agent's
+ * read requests so read-only prompts don't stall (docs/acp-capture.md §5).
+ * We exercise it over a real temp file and over an injected failing reader.
+ */
+
+const dir = mkdtempSync(join(tmpdir(), 'vibe-fs-read-'))
+afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+describe('handleFsReadTextFile (Seam C)', () => {
+  it('returns {content} for a readable path (real fs)', async () => {
+    const file = join(dir, 'note.txt')
+    writeFileSync(file, 'vibe-monitor works.\n')
+
+    const outcome = await handleFsReadTextFile({
+      path: file,
+      limit: 2001,
+      sessionId: 's1',
+    })
+
+    expect(outcome).toEqual({ result: { content: 'vibe-monitor works.\n' } })
+  })
+
+  it('returns an error result for an unreadable path', async () => {
+    const outcome = await handleFsReadTextFile({ path: join(dir, 'does-not-exist.txt') })
+
+    expect('error' in outcome).toBe(true)
+    if ('error' in outcome) {
+      expect(outcome.error.code).toBe(-32603)
+      expect(outcome.error.message).toMatch(/ENOENT|no such file/i)
+    }
+  })
+
+  it('errors (not throws) on a missing path param', async () => {
+    const outcome = await handleFsReadTextFile({ sessionId: 's1' })
+    expect('error' in outcome).toBe(true)
+    if ('error' in outcome) expect(outcome.error.code).toBe(-32602)
+  })
+
+  it('applies a line limit when provided (injected reader)', async () => {
+    const reader: ReadTextFn = async () => 'l1\nl2\nl3\nl4\nl5'
+    const outcome = await handleFsReadTextFile({ path: '/abs', limit: 2 }, reader)
+    expect(outcome).toEqual({ result: { content: 'l1\nl2' } })
+  })
+})

--- a/src/main/acp/fs-read.ts
+++ b/src/main/acp/fs-read.ts
@@ -1,0 +1,52 @@
+import { readFile } from 'node:fs/promises'
+
+/**
+ * Serve the agent's `fs/read_text_file` request (agent → client). Vibe delegates
+ * file I/O to us, so a read-only prompt stalls until we reply. We read the file
+ * and answer `{content}`; on failure we return a JSON-RPC error result so the
+ * agent's turn can fail cleanly rather than hang (docs/acp-capture.md §5).
+ *
+ * Pure over an injected reader (Seam C): the WorkspaceAgent wires the real
+ * `node:fs` reader; tests pass a fake or a temp file.
+ */
+
+/** Reads a file's text content. Injectable for testing. */
+export type ReadTextFn = (path: string) => Promise<string>
+
+const defaultRead: ReadTextFn = (path) => readFile(path, 'utf8')
+
+/** A JSON-RPC-shaped outcome: either a result or an error, never both. */
+export type FsReadOutcome =
+  | { result: { content: string } }
+  | { error: { code: number; message: string } }
+
+/**
+ * Read `params.path` and produce `{content}`. If `params.limit` is a positive
+ * number it caps the reply to that many lines (the agent passes a line budget,
+ * e.g. `2001` in the capture).
+ */
+export async function handleFsReadTextFile(
+  params: unknown,
+  read: ReadTextFn = defaultRead,
+): Promise<FsReadOutcome> {
+  const path = (params as { path?: unknown } | null)?.path
+  if (typeof path !== 'string' || path.length === 0) {
+    return { error: { code: -32602, message: 'fs/read_text_file: missing or invalid `path`' } }
+  }
+
+  try {
+    const content = await read(path)
+    const limit = (params as { limit?: unknown }).limit
+    return { result: { content: applyLineLimit(content, limit) } }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return { error: { code: -32603, message } }
+  }
+}
+
+function applyLineLimit(content: string, limit: unknown): string {
+  if (typeof limit !== 'number' || limit <= 0) return content
+  const lines = content.split('\n')
+  if (lines.length <= limit) return content
+  return lines.slice(0, limit).join('\n')
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,6 +2,8 @@ import { app, BrowserWindow, dialog, ipcMain, shell } from 'electron'
 import { join } from 'node:path'
 import {
   IPC,
+  type SendPromptArgs,
+  type SendPromptResult,
   type StartThreadArgs,
   type StartThreadResult,
 } from '../shared/ipc'
@@ -78,6 +80,20 @@ function registerIpc(): void {
       return { ok: false, error: err instanceof Error ? err.message : String(err), hint: null }
     }
   })
+
+  ipcMain.handle(
+    IPC.sendPrompt,
+    async (_event, args: SendPromptArgs): Promise<SendPromptResult> => {
+      const agent = agents.get(args.agentId)
+      if (!agent) return { ok: false, error: `No active agent for id ${args.agentId}.` }
+      try {
+        const result = await agent.prompt(args.sessionId, args.text)
+        return { ok: true, result }
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) }
+      }
+    },
+  )
 
   ipcMain.handle(IPC.stopAgent, (_event, agentId: string) => {
     const agent = agents.get(agentId)

--- a/src/main/workspace-agent.test.ts
+++ b/src/main/workspace-agent.test.ts
@@ -126,3 +126,118 @@ describe('WorkspaceAgent.start()', () => {
     expect((err as WorkspaceAgentError).hint).toBe(AUTH_HINT)
   })
 })
+
+// --- TB2: prompt + fs/read serving (a writes-capturing fake) ----------------
+
+interface CapturingFake extends FakeChild {
+  writes: string[]
+}
+
+function makeCapturingFake(): CapturingFake {
+  const stdoutListeners: Array<(chunk: string) => void> = []
+  const writes: string[] = []
+  const child: ChildProcessLike = {
+    stdout: {
+      setEncoding: () => {},
+      on: (_event, listener) => {
+        stdoutListeners.push(listener)
+      },
+    },
+    stderr: { setEncoding: () => {}, on: () => {} },
+    stdin: {
+      write: (data) => {
+        writes.push(data)
+      },
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    on: () => {},
+    kill: () => {},
+  }
+  return {
+    child,
+    writes,
+    feed: (chunk) => stdoutListeners.forEach((l) => l(chunk)),
+    emitExit: () => {},
+    emitError: () => {},
+  }
+}
+
+interface SentRpc {
+  id?: number
+  method?: string
+  params?: { sessionId?: string; prompt?: Array<{ type: string; text: string }> }
+  result?: { content?: string }
+}
+
+function sent(fake: CapturingFake): SentRpc[] {
+  return fake.writes.map((w) => JSON.parse(w) as SentRpc)
+}
+
+const SESSION_ID = '8b7044cf-19d1-7a23-8da1-929c81b23170'
+
+/** Drive start() + openThread() to a ready agent over the capturing fake. */
+async function connect(
+  fake: CapturingFake,
+  readTextFile?: (path: string) => Promise<string>,
+): Promise<WorkspaceAgent> {
+  const agent = new WorkspaceAgent({
+    workspaceDir: '/abs/workspace',
+    spawn: () => fake.child,
+    readTextFile,
+  })
+  const started = agent.start()
+  fake.feed(JSON.stringify({ jsonrpc: '2.0', id: 1, result: { protocolVersion: 1 } }) + '\n')
+  await started
+  const opened = agent.openThread()
+  fake.feed(JSON.stringify({ jsonrpc: '2.0', id: 2, result: { sessionId: SESSION_ID } }) + '\n')
+  await opened
+  return agent
+}
+
+describe('WorkspaceAgent.prompt()', () => {
+  it('sends session/prompt with the ACP prompt shape and resolves on the turn response', async () => {
+    const fake = makeCapturingFake()
+    const agent = await connect(fake)
+
+    const turn = agent.prompt(SESSION_ID, 'read the readme')
+    const promptReq = sent(fake).find((m) => m.method === 'session/prompt')
+    expect(promptReq).toBeDefined()
+    expect(promptReq?.params?.sessionId).toBe(SESSION_ID)
+    expect(promptReq?.params?.prompt).toEqual([{ type: 'text', text: 'read the readme' }])
+
+    // The session/prompt response (id 3) ends the turn.
+    fake.feed(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: promptReq?.id,
+        result: { stopReason: 'end_turn', usage: { totalTokens: 21047 }, userMessageId: 'u1' },
+      }) + '\n',
+    )
+    await expect(turn).resolves.toMatchObject({ stopReason: 'end_turn' })
+  })
+
+  it('rejects when prompting an unknown sessionId', async () => {
+    const fake = makeCapturingFake()
+    const agent = await connect(fake)
+    await expect(agent.prompt('nope', 'hi')).rejects.toBeInstanceOf(WorkspaceAgentError)
+  })
+
+  it('serves an fs/read_text_file server request by replying {content}', async () => {
+    const fake = makeCapturingFake()
+    await connect(fake, async () => 'file body')
+
+    fake.feed(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 0,
+        method: 'fs/read_text_file',
+        params: { path: '/abs/file.ts', limit: 2001, sessionId: SESSION_ID },
+      }) + '\n',
+    )
+    // Let the async read + respond settle.
+    await new Promise((r) => setTimeout(r, 0))
+
+    const reply = sent(fake).find((m) => m.id === 0 && m.result !== undefined)
+    expect(reply?.result).toEqual({ content: 'file body' })
+  })
+})

--- a/src/main/workspace-agent.ts
+++ b/src/main/workspace-agent.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'node:events'
 import { AcpClient, type SpawnFn } from './acp/client'
-import type { ThreadInfo, ThreadModes, ThreadModels } from '../shared/ipc'
+import { handleFsReadTextFile, type ReadTextFn } from './acp/fs-read'
+import type { PromptResult, ThreadInfo, ThreadModes, ThreadModels } from '../shared/ipc'
 
 /**
  * A Workspace agent: one `vibe-acp` child process plus its `AcpClient`,
@@ -54,11 +55,14 @@ export interface WorkspaceAgentOptions {
   command?: string
   /** Injected process factory (testing). Forwarded to the AcpClient. */
   spawn?: SpawnFn
+  /** Override the file reader used to serve `fs/read_text_file` (testing). */
+  readTextFile?: ReadTextFn
 }
 
 export class WorkspaceAgent extends EventEmitter {
   private readonly client: AcpClient
   private readonly workspaceDir: string
+  private readonly readTextFile?: ReadTextFn
   /** Threads hosted by this agent, keyed by their ACP `sessionId`. */
   private readonly threads = new Map<string, ThreadInfo>()
   private initialized = false
@@ -66,6 +70,7 @@ export class WorkspaceAgent extends EventEmitter {
   constructor(options: WorkspaceAgentOptions) {
     super()
     this.workspaceDir = options.workspaceDir
+    this.readTextFile = options.readTextFile
     this.client = new AcpClient({
       command: options.command,
       cwd: options.workspaceDir,
@@ -75,7 +80,7 @@ export class WorkspaceAgent extends EventEmitter {
 
     // Forward raw protocol + lifecycle events; we do not interpret them here.
     this.client.on('notification', (msg: unknown) => this.emit('event', msg))
-    this.client.on('serverRequest', (msg: unknown) => this.emit('event', msg))
+    this.client.on('serverRequest', (msg: unknown) => this.onServerRequest(msg))
     this.client.on('stderr', (text: string) => this.emit('event', { type: 'stderr', text }))
     this.client.on('exit', (info: unknown) => this.emit('event', { type: 'exit', info }))
     this.client.on('error', (err: Error) => this.emit('event', { type: 'error', message: err.message }))
@@ -158,6 +163,51 @@ export class WorkspaceAgent extends EventEmitter {
     }
     this.threads.set(thread.sessionId, thread)
     return thread
+  }
+
+  /**
+   * Send a prompt to a Thread (`session/prompt`) and resolve when the turn
+   * ends. The streamed `session/update` notifications flow out on the `event`
+   * channel; per ADR-0001 the renderer reduces them — we only own the turn's
+   * lifecycle here. Resolves with `{stopReason, usage, userMessageId}`.
+   */
+  async prompt(sessionId: string, text: string): Promise<PromptResult> {
+    if (!this.initialized) {
+      throw new WorkspaceAgentError('Agent is not initialized; call start() first.')
+    }
+    if (!this.threads.has(sessionId)) {
+      throw new WorkspaceAgentError(`No open Thread for sessionId ${sessionId}.`)
+    }
+
+    try {
+      return await this.client.request<PromptResult>('session/prompt', {
+        sessionId,
+        prompt: [{ type: 'text', text }],
+      })
+    } catch (err) {
+      throw this.toAgentError(err)
+    }
+  }
+
+  /**
+   * Forward every server-initiated request for transparency, and serve the
+   * read-only `fs/read_text_file` ourselves so read prompts don't stall
+   * (docs/acp-capture.md §5). Writes / `request_permission` are TB3 — they are
+   * forwarded but not answered here; we just don't crash on them.
+   */
+  private onServerRequest(msg: unknown): void {
+    this.emit('event', msg)
+
+    const request = msg as { id?: number | string; method?: string; params?: unknown }
+    if (request.method === 'fs/read_text_file' && request.id !== undefined) {
+      void this.serveFsRead(request.id, request.params)
+    }
+  }
+
+  private async serveFsRead(id: number | string, params: unknown): Promise<void> {
+    const outcome = await handleFsReadTextFile(params, this.readTextFile)
+    if ('result' in outcome) this.client.respond(id, outcome.result)
+    else this.client.respondError(id, outcome.error)
   }
 
   stop(): void {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2,6 +2,8 @@ import { contextBridge, ipcRenderer } from 'electron'
 import {
   IPC,
   type AcpEvent,
+  type SendPromptArgs,
+  type SendPromptResult,
   type StartThreadArgs,
   type StartThreadResult,
   type VibeDetectResult,
@@ -12,6 +14,8 @@ const api = {
   openWorkspaceDialog: (): Promise<string | null> => ipcRenderer.invoke(IPC.openWorkspaceDialog),
   startThread: (args: StartThreadArgs): Promise<StartThreadResult> =>
     ipcRenderer.invoke(IPC.startThread, args),
+  sendPrompt: (args: SendPromptArgs): Promise<SendPromptResult> =>
+    ipcRenderer.invoke(IPC.sendPrompt, args),
   stopAgent: (agentId: string): Promise<void> => ipcRenderer.invoke(IPC.stopAgent, agentId),
   onAcpEvent: (listener: (event: AcpEvent) => void): (() => void) => {
     const handler = (_e: unknown, payload: AcpEvent): void => listener(payload)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -95,7 +95,11 @@ export function App(): JSX.Element {
             </div>
           )}
 
-          {connect.status === 'connected' && <Conversation thread={connect.thread} />}
+          {connect.status === 'connected' && (
+            // Key by agentId so the Conversation's useReducer state can't bleed
+            // across Threads — a new Thread gets a fresh reducer, not the old one.
+            <Conversation key={connect.thread.agentId} thread={connect.thread} />
+          )}
         </section>
       </main>
     </div>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, type JSX } from 'react'
 import type { ThreadConnection, VibeDetectResult } from '../../shared/ipc'
+import { Conversation } from './conversation/Conversation'
 
 type ConnectState =
   | { status: 'idle' }
@@ -94,70 +95,9 @@ export function App(): JSX.Element {
             </div>
           )}
 
-          {connect.status === 'connected' && <ThreadPanel thread={connect.thread} />}
+          {connect.status === 'connected' && <Conversation thread={connect.thread} />}
         </section>
       </main>
-    </div>
-  )
-}
-
-function ThreadPanel({ thread }: { thread: ThreadConnection }): JSX.Element {
-  return (
-    <div className="thread">
-      <div className="thread__head">
-        <span className="dot dot--ok" aria-hidden />
-        <span className="thread__title">{thread.title ?? 'Untitled Thread'}</span>
-        <span className="badge">connected</span>
-      </div>
-
-      <ul className="status">
-        <li className="status__row">
-          <span className="status__label">workspace</span>
-          <span className="status__value mono">{thread.workspaceDir}</span>
-        </li>
-        <li className="status__row">
-          <span className="status__label">sessionId</span>
-          <span className="status__value mono">{thread.sessionId}</span>
-        </li>
-      </ul>
-
-      {thread.modes && (
-        <ChipRow
-          label="modes"
-          items={thread.modes.availableModes.map((m) => m.id)}
-          current={thread.modes.currentModeId}
-        />
-      )}
-      {thread.models && (
-        <ChipRow
-          label="models"
-          items={thread.models.availableModels.map((m) => m.modelId)}
-          current={thread.models.currentModelId}
-        />
-      )}
-    </div>
-  )
-}
-
-function ChipRow({
-  label,
-  items,
-  current,
-}: {
-  label: string
-  items: string[]
-  current: string
-}): JSX.Element {
-  return (
-    <div className="chips">
-      <span className="chips__label">{label}</span>
-      <div className="chips__list">
-        {items.map((item) => (
-          <span key={item} className={item === current ? 'chip chip--active' : 'chip'}>
-            {item}
-          </span>
-        ))}
-      </div>
     </div>
   )
 }

--- a/src/renderer/src/conversation/Conversation.tsx
+++ b/src/renderer/src/conversation/Conversation.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useReducer, useRef, useState, type JSX, type KeyboardEvent } from 'react'
+import type { ThreadConnection } from '../../../shared/ipc'
+import {
+  conversationReducer,
+  initialConversationState,
+  type AssistantItem,
+  type ConversationItem,
+  type FallbackItem,
+  type ReasoningItem,
+  type UserItem,
+} from './reducer'
+
+/** Process-local counter for unique echoed-prompt ids. */
+let promptSeq = 0
+
+/**
+ * A connected Thread: subscribes to the agent's `acp:event` stream, reduces it
+ * into conversation items (reducer.ts), and lets the user send prompts. Reads
+ * are served transparently in main, so a read-only turn streams reasoning + an
+ * answer and completes without any approval UI (that's TB3).
+ */
+export function Conversation({ thread }: { thread: ThreadConnection }): JSX.Element {
+  const [state, dispatch] = useReducer(conversationReducer, initialConversationState)
+  const [draft, setDraft] = useState('')
+  const listRef = useRef<HTMLDivElement>(null)
+
+  // Subscribe once per agent; ignore events from other agents sharing the channel.
+  useEffect(() => {
+    return window.api.onAcpEvent((event) => {
+      if (event.agentId !== thread.agentId) return
+      dispatch({ type: 'acp-event', payload: event.payload })
+    })
+  }, [thread.agentId])
+
+  // Keep the latest item in view as the answer streams in.
+  useEffect(() => {
+    const list = listRef.current
+    if (list) list.scrollTop = list.scrollHeight
+  }, [state.items])
+
+  async function send(): Promise<void> {
+    const text = draft.trim()
+    if (!text || state.isProcessing) return
+    setDraft('')
+    dispatch({ type: 'send-prompt', id: `user:${promptSeq++}`, text })
+    try {
+      await window.api.sendPrompt({
+        agentId: thread.agentId,
+        sessionId: thread.sessionId,
+        text,
+      })
+    } finally {
+      // The turn's stopReason resolves sendPrompt; flip back to the user's turn.
+      dispatch({ type: 'turn-complete' })
+    }
+  }
+
+  function onKeyDown(e: KeyboardEvent<HTMLTextAreaElement>): void {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      void send()
+    }
+  }
+
+  const title = state.title ?? thread.title ?? 'Untitled Thread'
+
+  return (
+    <div className="conv">
+      <div className="conv__head">
+        <span className="dot dot--ok" aria-hidden />
+        <span className="conv__title">{title}</span>
+        <span className="badge">{state.isProcessing ? 'thinking…' : 'connected'}</span>
+      </div>
+
+      <UsageBar state={state} />
+
+      <div className="messages" ref={listRef}>
+        {state.items.length === 0 && (
+          <p className="hint">Send a prompt to start the conversation.</p>
+        )}
+        {state.items.map((item) => (
+          <Item key={item.id} item={item} />
+        ))}
+      </div>
+
+      <div className="composer">
+        <textarea
+          className="composer__input"
+          placeholder="Ask Vibe… (Enter to send, Shift+Enter for a newline)"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={onKeyDown}
+          rows={2}
+        />
+        <button
+          className="btn"
+          onClick={() => void send()}
+          disabled={state.isProcessing || draft.trim().length === 0}
+        >
+          {state.isProcessing ? 'Sending…' : 'Send'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function UsageBar({ state }: { state: { usage: { used: number; size: number } | null; cost: { amount: number; currency: string } | null } }): JSX.Element | null {
+  if (!state.usage && !state.cost) return null
+  return (
+    <div className="usage">
+      {state.usage && (
+        <span className="usage__item">
+          context <strong>{state.usage.used.toLocaleString()}</strong> /{' '}
+          {state.usage.size.toLocaleString()} tokens
+        </span>
+      )}
+      {state.cost && (
+        <span className="usage__item">
+          cost <strong>{formatCost(state.cost.amount, state.cost.currency)}</strong>
+        </span>
+      )}
+    </div>
+  )
+}
+
+function Item({ item }: { item: ConversationItem }): JSX.Element {
+  switch (item.kind) {
+    case 'user':
+      return <UserRow item={item} />
+    case 'reasoning':
+      return <ReasoningRow item={item} />
+    case 'assistant':
+      return <AssistantRow item={item} />
+    case 'fallback':
+      return <FallbackRow item={item} />
+  }
+}
+
+function UserRow({ item }: { item: UserItem }): JSX.Element {
+  return (
+    <div className="msg msg--user">
+      <div className="msg__role">You</div>
+      <div className="msg__body">{item.text}</div>
+    </div>
+  )
+}
+
+function AssistantRow({ item }: { item: AssistantItem }): JSX.Element {
+  return (
+    <div className="msg msg--assistant">
+      <div className="msg__role">Vibe</div>
+      <div className="msg__body">{item.text}</div>
+    </div>
+  )
+}
+
+function ReasoningRow({ item }: { item: ReasoningItem }): JSX.Element {
+  return (
+    <details className="reasoning" open>
+      <summary className="reasoning__summary">Reasoning</summary>
+      <div className="reasoning__body">{item.text}</div>
+    </details>
+  )
+}
+
+function FallbackRow({ item }: { item: FallbackItem }): JSX.Element {
+  return (
+    <details className="fallback">
+      <summary className="fallback__summary">{item.sessionUpdate}</summary>
+      <pre className="fallback__body mono">{JSON.stringify(item.raw, null, 2)}</pre>
+    </details>
+  )
+}
+
+function formatCost(amount: number, currency: string): string {
+  const symbol = currency.toUpperCase() === 'USD' ? '$' : `${currency} `
+  return `${symbol}${amount.toFixed(4)}`
+}

--- a/src/renderer/src/conversation/reducer.test.ts
+++ b/src/renderer/src/conversation/reducer.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest'
+import {
+  conversationReducer,
+  initialConversationState,
+  type AssistantItem,
+  type ConversationState,
+  type FallbackItem,
+  type ReasoningItem,
+} from './reducer'
+
+/**
+ * Seam A: the pure reducer. We feed the captured read-turn `session/update`
+ * sequence (verbatim shapes from docs/acp-capture.md §3–4) and assert the
+ * ordered items, streamed reasoning + answer (accumulated by messageId), the
+ * title, usage/cost, and the never-dropped generic fallback.
+ */
+
+const SESSION_ID = '8b7044cf-19d1-7a23-8da1-929c81b23170'
+
+/** Wrap an `update` object in the `session/update` notification frame. */
+function update(u: Record<string, unknown>): unknown {
+  return { jsonrpc: '2.0', method: 'session/update', params: { sessionId: SESSION_ID, update: u } }
+}
+
+function feed(state: ConversationState, payload: unknown): ConversationState {
+  return conversationReducer(state, { type: 'acp-event', payload })
+}
+
+/** The verbatim read-turn stream: title, reasoning x2, answer x2, a read tool
+ *  (no dedicated renderer in TB2 → fallback), then usage. */
+const READ_TURN: unknown[] = [
+  update({ sessionUpdate: 'session_info_update', title: 'Read the README' }),
+  update({
+    sessionUpdate: 'agent_thought_chunk',
+    content: { type: 'text', text: 'Let me ' },
+    messageId: 'r1',
+  }),
+  update({
+    sessionUpdate: 'agent_thought_chunk',
+    content: { type: 'text', text: 'check the file.' },
+    messageId: 'r1',
+  }),
+  update({
+    sessionUpdate: 'tool_call',
+    toolCallId: 'EcjzekVw0',
+    kind: 'read',
+    status: 'pending',
+    title: 'Read README.md',
+  }),
+  update({
+    sessionUpdate: 'agent_message_chunk',
+    content: { type: 'text', text: 'The README ' },
+    messageId: 'a1',
+  }),
+  update({
+    sessionUpdate: 'agent_message_chunk',
+    content: { type: 'text', text: 'describes vibe-monitor.' },
+    messageId: 'a1',
+  }),
+  update({
+    sessionUpdate: 'usage_update',
+    used: 21047,
+    size: 128000,
+    cost: { amount: 0.0123, currency: 'USD' },
+  }),
+]
+
+describe('conversationReducer (Seam A)', () => {
+  it('reduces the captured read-turn stream into ordered items, title, and usage/cost', () => {
+    const state = READ_TURN.reduce<ConversationState>(feed, initialConversationState)
+
+    // Title from session_info_update.
+    expect(state.title).toBe('Read the README')
+
+    // Usage + cost from usage_update.
+    expect(state.usage).toEqual({ used: 21047, size: 128000 })
+    expect(state.cost).toEqual({ amount: 0.0123, currency: 'USD' })
+
+    // Ordered items: reasoning (1, accumulated), tool_call fallback, assistant (1, accumulated).
+    expect(state.items.map((i) => i.kind)).toEqual(['reasoning', 'fallback', 'assistant'])
+
+    const reasoning = state.items[0] as ReasoningItem
+    expect(reasoning.messageId).toBe('r1')
+    expect(reasoning.text).toBe('Let me check the file.')
+
+    const assistant = state.items[2] as AssistantItem
+    expect(assistant.messageId).toBe('a1')
+    expect(assistant.text).toBe('The README describes vibe-monitor.')
+  })
+
+  it('accumulates deltas by messageId and keeps reasoning separate from the answer', () => {
+    const state = READ_TURN.reduce<ConversationState>(feed, initialConversationState)
+    const reasoning = state.items.filter((i) => i.kind === 'reasoning')
+    const assistant = state.items.filter((i) => i.kind === 'assistant')
+    // Each messageId collapses to exactly one item, regardless of chunk count.
+    expect(reasoning).toHaveLength(1)
+    expect(assistant).toHaveLength(1)
+  })
+
+  it('renders an unknown sessionUpdate as a generic fallback item (never dropped)', () => {
+    const state = feed(
+      initialConversationState,
+      update({ sessionUpdate: 'some_future_kind', payloadField: 42 }),
+    )
+    expect(state.items).toHaveLength(1)
+    const fallback = state.items[0] as FallbackItem
+    expect(fallback.kind).toBe('fallback')
+    expect(fallback.sessionUpdate).toBe('some_future_kind')
+    expect(fallback.raw).toMatchObject({ sessionUpdate: 'some_future_kind', payloadField: 42 })
+  })
+
+  it('echoes the user prompt immediately and tracks turn lifecycle', () => {
+    let state = conversationReducer(initialConversationState, {
+      type: 'send-prompt',
+      id: 'user:0',
+      text: 'read the readme',
+    })
+    expect(state.items[0]).toMatchObject({ kind: 'user', text: 'read the readme' })
+    expect(state.isProcessing).toBe(true)
+
+    state = conversationReducer(state, { type: 'turn-complete' })
+    expect(state.isProcessing).toBe(false)
+  })
+
+  it('ignores non-session/update payloads (lifecycle, server requests)', () => {
+    const before = initialConversationState
+    const after = [
+      { type: 'stderr', text: 'warning' },
+      { jsonrpc: '2.0', id: 0, method: 'fs/read_text_file', params: { path: '/x' } },
+      { method: 'session/update', params: {} }, // malformed: no update
+    ].reduce<ConversationState>(feed, before)
+    expect(after.items).toHaveLength(0)
+    expect(after).toEqual(before)
+  })
+
+  it('available_commands_update is stored, not rendered', () => {
+    const state = feed(
+      initialConversationState,
+      update({
+        sessionUpdate: 'available_commands_update',
+        availableCommands: [{ name: 'init', description: 'Initialize' }, { name: 'compact' }],
+      }),
+    )
+    expect(state.items).toHaveLength(0)
+    expect(state.availableCommands).toEqual([
+      { name: 'init', description: 'Initialize' },
+      { name: 'compact', description: undefined },
+    ])
+  })
+})

--- a/src/renderer/src/conversation/reducer.test.ts
+++ b/src/renderer/src/conversation/reducer.test.ts
@@ -97,6 +97,28 @@ describe('conversationReducer (Seam A)', () => {
     expect(assistant).toHaveLength(1)
   })
 
+  it('keeps interleaved messageIds as distinct items in first-arrival order, each accumulated', () => {
+    // thoughtA, thoughtB, thoughtA — proves findIndex-by-(kind+messageId) routes
+    // deltas to the right item rather than the most recent one.
+    const state = [
+      update({ sessionUpdate: 'agent_thought_chunk', content: { type: 'text', text: 'A1 ' }, messageId: 'a' }),
+      update({ sessionUpdate: 'agent_thought_chunk', content: { type: 'text', text: 'B1 ' }, messageId: 'b' }),
+      update({ sessionUpdate: 'agent_thought_chunk', content: { type: 'text', text: 'A2' }, messageId: 'a' }),
+      // Two assistant messages in sequence → two assistant items.
+      update({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'first' }, messageId: 'm1' }),
+      update({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'second' }, messageId: 'm2' }),
+    ].reduce<ConversationState>(feed, initialConversationState)
+
+    const reasoning = state.items.filter((i): i is ReasoningItem => i.kind === 'reasoning')
+    expect(reasoning.map((r) => r.messageId)).toEqual(['a', 'b']) // first-arrival order
+    expect(reasoning[0].text).toBe('A1 A2') // accumulated despite the interleaved 'b'
+    expect(reasoning[1].text).toBe('B1 ')
+
+    const assistant = state.items.filter((i): i is AssistantItem => i.kind === 'assistant')
+    expect(assistant.map((a) => a.messageId)).toEqual(['m1', 'm2'])
+    expect(assistant.map((a) => a.text)).toEqual(['first', 'second'])
+  })
+
   it('renders an unknown sessionUpdate as a generic fallback item (never dropped)', () => {
     const state = feed(
       initialConversationState,

--- a/src/renderer/src/conversation/reducer.ts
+++ b/src/renderer/src/conversation/reducer.ts
@@ -1,0 +1,208 @@
+/**
+ * Conversation reducer — the heart of TB2. A PURE function (no React, no IPC)
+ * that folds the streamed ACP `acp:event` payloads for one Thread into an
+ * ordered list of conversation items, plus the Thread title and live
+ * usage/cost. Per ADR-0001 the renderer owns this interpretation; main forwards
+ * `session/update` raw.
+ *
+ * Mapping (discriminated on `update.sessionUpdate`, from docs/acp-capture.md §4):
+ *   agent_thought_chunk      -> reasoning item,  append content.text, keyed by messageId
+ *   agent_message_chunk      -> assistant item,  append content.text, keyed by messageId
+ *   session_info_update      -> set title
+ *   usage_update             -> set context usage {used,size} + cost {amount,currency}
+ *   available_commands_update-> store commands (not rendered this slice)
+ *   (any other sessionUpdate) -> generic fallback item, never dropped
+ *
+ * The user's own prompt is echoed via `send-prompt`; `turn-complete` clears the
+ * optimistic processing flag (driven by the `session/prompt` response).
+ */
+
+export interface UserItem {
+  kind: 'user'
+  id: string
+  text: string
+}
+
+export interface ReasoningItem {
+  kind: 'reasoning'
+  id: string
+  /** ACP `messageId` the deltas accumulate under. */
+  messageId: string
+  text: string
+}
+
+export interface AssistantItem {
+  kind: 'assistant'
+  id: string
+  messageId: string
+  text: string
+}
+
+/** Any `session/update` kind without a dedicated renderer — nothing is invisible. */
+export interface FallbackItem {
+  kind: 'fallback'
+  id: string
+  sessionUpdate: string
+  raw: unknown
+}
+
+export type ConversationItem = UserItem | ReasoningItem | AssistantItem | FallbackItem
+
+export interface ContextUsage {
+  used: number
+  size: number
+}
+
+export interface Cost {
+  amount: number
+  currency: string
+}
+
+export interface AcpCommand {
+  name: string
+  description?: string
+}
+
+export interface ConversationState {
+  /** Ordered conversation items in arrival order. */
+  items: ConversationItem[]
+  title: string | null
+  usage: ContextUsage | null
+  cost: Cost | null
+  /** Slash commands / skills (stored, not rendered this slice). */
+  availableCommands: AcpCommand[]
+  /** True between sending a prompt and the turn completing. */
+  isProcessing: boolean
+  /** Monotonic counter for stable generic-fallback item ids. */
+  fallbackSeq: number
+}
+
+export const initialConversationState: ConversationState = {
+  items: [],
+  title: null,
+  usage: null,
+  cost: null,
+  availableCommands: [],
+  isProcessing: false,
+  fallbackSeq: 0,
+}
+
+export type ConversationAction =
+  | { type: 'send-prompt'; id: string; text: string }
+  | { type: 'acp-event'; payload: unknown }
+  | { type: 'turn-complete' }
+
+export function conversationReducer(
+  state: ConversationState,
+  action: ConversationAction,
+): ConversationState {
+  switch (action.type) {
+    case 'send-prompt':
+      return {
+        ...state,
+        isProcessing: true,
+        items: [...state.items, { kind: 'user', id: action.id, text: action.text }],
+      }
+    case 'turn-complete':
+      return { ...state, isProcessing: false }
+    case 'acp-event':
+      return reduceAcpEvent(state, action.payload)
+  }
+}
+
+// --- ACP event handling ----------------------------------------------------
+
+interface SessionUpdate {
+  sessionUpdate: string
+  content?: { type?: string; text?: string }
+  messageId?: string
+  title?: string
+  used?: number
+  size?: number
+  cost?: { amount?: number; currency?: string }
+  availableCommands?: Array<{ name?: string; description?: string }>
+}
+
+function reduceAcpEvent(state: ConversationState, payload: unknown): ConversationState {
+  const update = extractSessionUpdate(payload)
+  if (!update) return state // lifecycle/server-request payloads aren't conversation items
+
+  switch (update.sessionUpdate) {
+    case 'agent_thought_chunk':
+      return appendChunk(state, 'reasoning', update)
+    case 'agent_message_chunk':
+      return appendChunk(state, 'assistant', update)
+    case 'session_info_update':
+      return typeof update.title === 'string' ? { ...state, title: update.title } : state
+    case 'usage_update':
+      return applyUsage(state, update)
+    case 'available_commands_update':
+      return { ...state, availableCommands: extractCommands(update) }
+    default:
+      return appendFallback(state, update)
+  }
+}
+
+/** Narrow a raw `acp:event` payload to a `session/update`'s `update` object. */
+function extractSessionUpdate(payload: unknown): SessionUpdate | null {
+  if (!payload || typeof payload !== 'object') return null
+  const message = payload as { method?: unknown; params?: unknown }
+  if (message.method !== 'session/update') return null
+  const params = message.params as { update?: unknown } | undefined
+  const update = params?.update
+  if (!update || typeof update !== 'object') return null
+  if (typeof (update as { sessionUpdate?: unknown }).sessionUpdate !== 'string') return null
+  return update as SessionUpdate
+}
+
+function appendChunk(
+  state: ConversationState,
+  kind: 'reasoning' | 'assistant',
+  update: SessionUpdate,
+): ConversationState {
+  const messageId = update.messageId ?? ''
+  const text = update.content?.text ?? ''
+
+  const index = state.items.findIndex(
+    (item) => item.kind === kind && item.messageId === messageId,
+  )
+  if (index >= 0) {
+    const existing = state.items[index] as ReasoningItem | AssistantItem
+    const items = state.items.slice()
+    items[index] = { ...existing, text: existing.text + text }
+    return { ...state, items }
+  }
+
+  const item: ReasoningItem | AssistantItem = { kind, id: `${kind}:${messageId}`, messageId, text }
+  return { ...state, items: [...state.items, item] }
+}
+
+function applyUsage(state: ConversationState, update: SessionUpdate): ConversationState {
+  const usage =
+    typeof update.used === 'number' && typeof update.size === 'number'
+      ? { used: update.used, size: update.size }
+      : state.usage
+  const cost =
+    update.cost && typeof update.cost.amount === 'number' && typeof update.cost.currency === 'string'
+      ? { amount: update.cost.amount, currency: update.cost.currency }
+      : state.cost
+  return { ...state, usage, cost }
+}
+
+function appendFallback(state: ConversationState, update: SessionUpdate): ConversationState {
+  const item: FallbackItem = {
+    kind: 'fallback',
+    id: `fallback:${state.fallbackSeq}`,
+    sessionUpdate: update.sessionUpdate,
+    raw: update,
+  }
+  return { ...state, items: [...state.items, item], fallbackSeq: state.fallbackSeq + 1 }
+}
+
+function extractCommands(update: SessionUpdate): AcpCommand[] {
+  const list = update.availableCommands
+  if (!Array.isArray(list)) return []
+  return list
+    .filter((c): c is { name: string; description?: string } => typeof c?.name === 'string')
+    .map((c) => ({ name: c.name, description: typeof c.description === 'string' ? c.description : undefined }))
+}

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -224,3 +224,137 @@ body {
   font-size: 12px;
   line-height: 1.4;
 }
+
+/* --- Conversation (TB2) --- */
+
+.conv {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.conv__head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.conv__title {
+  flex: 1;
+  font-weight: 600;
+}
+
+.usage {
+  display: flex;
+  gap: 16px;
+  font-size: 12px;
+  color: var(--muted);
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--border);
+}
+
+.usage strong {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.messages {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: 360px;
+  overflow-y: auto;
+  padding: 4px 2px;
+}
+
+.msg {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.msg__role {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+
+.msg__body {
+  font-size: 14px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.msg--user .msg__body {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px 12px;
+  align-self: flex-start;
+}
+
+.msg--assistant .msg__role {
+  color: var(--accent);
+}
+
+.reasoning {
+  border-left: 2px solid var(--border);
+  padding-left: 10px;
+}
+
+.reasoning__summary,
+.fallback__summary {
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--muted);
+  user-select: none;
+}
+
+.reasoning__body {
+  margin-top: 6px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--muted);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.fallback {
+  border: 1px dashed var(--border);
+  border-radius: 6px;
+  padding: 6px 10px;
+}
+
+.fallback__body {
+  margin: 6px 0 0;
+  font-size: 11px;
+  color: var(--muted);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.composer {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+}
+
+.composer__input {
+  flex: 1;
+  resize: vertical;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-family: inherit;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.composer__input:focus {
+  outline: none;
+  border-color: var(--accent);
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -12,6 +12,8 @@ export const IPC = {
   startThread: 'thread:start',
   /** Stop / dispose a Workspace agent (and its Threads). */
   stopAgent: 'agent:stop',
+  /** Send a prompt to a Thread (`session/prompt`); resolves on turn completion. */
+  sendPrompt: 'thread:prompt',
   /** Main -> renderer: streamed ACP event tagged by the owning agent. */
   acpEvent: 'acp:event',
 } as const
@@ -80,3 +82,30 @@ export interface AcpEvent {
   /** Raw ACP / JSON-RPC payload (or a serialized child lifecycle event). */
   payload: unknown
 }
+
+/** Token usage for a completed turn (`session/prompt` response). */
+export interface PromptUsage {
+  inputTokens?: number
+  outputTokens?: number
+  totalTokens?: number
+}
+
+/** The `session/prompt` response — arrives when the turn ends. */
+export interface PromptResult {
+  stopReason: string
+  usage?: PromptUsage
+  userMessageId?: string
+}
+
+export interface SendPromptArgs {
+  /** Id of the Workspace agent (one `vibe-acp` process) hosting the Thread. */
+  agentId: string
+  /** ACP session id of the Thread to prompt. */
+  sessionId: string
+  /** The user's prompt text. */
+  text: string
+}
+
+export type SendPromptResult =
+  | { ok: true; result: PromptResult }
+  | { ok: false; error: string }


### PR DESCRIPTION
Closes #3

## Summary

A real conversation for prompts that need no approval. The user types a prompt in a composer and sends it; it appears immediately as a user message. The agent's reasoning and final answer stream into a Messages view as they arrive, the Thread title appears, and live context usage + running cost are shown. The turn ends cleanly and the user can type again. Read-only `fs/read_text_file` requests are served transparently so a read prompt completes without stalling and without any approval UI (that's TB3).

Layering follows ADR-0001: main stays a thin forwarder, the renderer owns a pure reducer.

## What changed

**Main (thin protocol layer)**
- `src/main/acp/client.ts` — `respond` / `respondError` to answer server-initiated requests by id.
- `src/main/acp/fs-read.ts` — pure `handleFsReadTextFile` over an injectable reader; returns `{result:{content}}` or a JSON-RPC `{error}` (never throws). Honours `limit` as a line cap.
- `src/main/workspace-agent.ts` — `prompt(sessionId, text)` sends `session/prompt` with `{sessionId, prompt:[{type:'text',text}]}` and resolves on `{stopReason, usage, userMessageId}`; intercepts `fs/read_text_file` server requests and serves them (still forwards every server request raw). `request_permission` / writes are forwarded but not answered (TB3) — no crash.
- `src/shared/ipc.ts` + `src/preload/index.ts` + `src/main/index.ts` — `sendPrompt` IPC (`{agentId, sessionId, text}` → `{ok, result}` / `{ok:false, error}`).

**Renderer (owns conversation state)**
- `src/renderer/src/conversation/reducer.ts` — PURE reducer folding `acp:event` payloads into ordered items. Discriminates on `update.sessionUpdate`: `agent_thought_chunk` → reasoning (accumulated by `messageId`), `agent_message_chunk` → assistant (accumulated by `messageId`), `session_info_update` → title, `usage_update` → `{used,size}` + cost, `available_commands_update` → stored, anything else → generic fallback (never dropped). Echoes the user prompt on send; `turn-complete` clears the processing flag.
- `src/renderer/src/conversation/Conversation.tsx` — subscribes to `acp:event` (filtered by agentId), composer (Enter to send), Messages view with distinct collapsible reasoning, streamed answer, live title, and a context-usage + cost indicator.
- `App.tsx` / `styles.css` — render `Conversation` on connect (replaces TB1's static `ThreadPanel`).

## Tests (vitest)

- **Seam A** (`conversation/reducer.test.ts`) — feeds the captured read-turn `session/update` sequence; asserts ordered items, reasoning/answer accumulated by `messageId`, title, usage/cost, the never-dropped fallback, prompt echo + turn lifecycle, and that non-`session/update` payloads are ignored.
- **Seam C** (`acp/fs-read.test.ts`) — `{content}` for a readable temp file, error result for an unreadable path / missing param, and the line-limit path.
- `workspace-agent.test.ts` — new block covering `prompt()` framing + turn resolution, unknown-session rejection, and `fs/read_text_file` serving end-to-end.

## Verification

```
bun run typecheck   # clean (tsc node + web)
bun run build       # ✓ built
bun run test        # Test Files 4 passed (4) · Tests 24 passed (24)
```

(TB1 had 11 tests; 13 added — 6 reducer, 4 fs-read, 3 workspace-agent.)

## For the reviewer

- Reducer item identity/accumulation: reasoning/assistant keyed by `${kind}:${messageId}`, found by scanning `items` and appending in place (preserves order); new `messageId` appends at the end. Generic fallbacks get a monotonic `fallback:${seq}` id (so a `tool_call` and its `tool_call_update` render as two separate fallback rows this slice — acceptable, "never dropped").
- `fs/read` handler returns a JSON-RPC outcome rather than throwing; `WorkspaceAgent.serveFsRead` routes it to `respond`/`respondError`. `limit` is applied as a line cap (the capture sends `2001`) — confirm that matches Vibe's intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)