### PR TITLE
Auth TB1 — Spike: capture the real Vibe auth protocol

### DIFF
--- a/docs/acp-capture.md
+++ b/docs/acp-capture.md
@@ -174,3 +174,87 @@ Read turn is the same minus the permission step.
 - **Default mode** (not "chat") is correct for slice #1 — it gates writes/commands behind the prompt.
 - **Still to verify:** method to change mode / grant workspace trust; `session/load` (resume) and
   `session/cancel` shapes.
+
+---
+
+## 8. Authentication (captured 2026-06-29, vibe-acp 2.18.0)
+
+Captured by driving `vibe-acp` after deleting the macOS Keychain credential (signed out), then
+re-authenticating. Corroborated by reading Vibe's installed source (`site-packages/vibe/acp/`,
+which is plain Python).
+
+### Auth state is NOT in `initialize`
+`initialize` is byte-identical signed-in vs signed-out — `authMethods:[{id:"browser-auth", …}]` is
+always present. So you cannot detect auth state from the handshake. Use `auth/status` (below).
+
+### `_auth/status` — clean detection (ACP extension method)
+Extension methods are sent with a leading `_` on the wire (ACP strips it before dispatch):
+```
+>>> {"id":20,"method":"_auth/status"}
+<<< {"id":20,"result":{"authenticated":false,"authState":"signed_out","signOutAvailable":false}}   // signed out
+<<< {"id":40,"result":{"authenticated":true, "authState":"os_keyring","signOutAvailable":true }}    // signed in
+```
+`authState` values seen: `signed_out`, `os_keyring`. (Source implies others for BYOK env/api-key.)
+**This is the detection call** — no need to force an error.
+
+### The real `UnauthenticatedError`
+When signed out, `session/new` fails (the error surfaces there, not at `session/prompt`):
+```
+>>> {"id":2,"method":"session/new","params":{"cwd":"…","mcpServers":[]}}
+<<< {"id":2,"error":{"code":-32000,"message":"Missing API key for mistral provider.","data":null}}
+```
+**`-32000` is reserved EXCLUSIVELY for `UnauthenticatedError` in Vibe** (per `vibe/acp/exceptions.py`):
+other Vibe errors use `-31xxx` application codes (rate-limited `-31001`, configuration `-31002`,
+conversation-limit `-31003`, context-too-long `-31004`, refusal `-31005`, compaction-failed `-31006`,
+invalid-image `-31007`, images-unsupported `-31008`) and standard JSON-RPC `-326xx`
+(`-32601` method-not-found, `-32602` invalid-params, `-32603` internal). So **code `-32000` is the
+reliable unauthenticated signal** — this REVERSES the TB1 decision (#2) that dropped the `-32000`
+check on the (then-unconfirmed) assumption it was a generic code. The message is framed as
+"Missing API key for <provider> provider", which a "sign in / unauthenticated" regex would miss — so
+classify on the **code**, not the message.
+
+### `authenticate` — two modes
+```
+authenticate(method_id, **kwargs) -> AuthenticateResponse
+```
+1. **`browser-auth` (agent-driven, blocking)** — the AGENT opens the browser and blocks until the user
+   completes sign-in, then persists the key to the OS keyring:
+   ```
+   >>> {"id":30,"method":"authenticate","params":{"methodId":"browser-auth"}}
+   <<< {"id":30,"result":{"_meta":{"browser-auth":{"persistResult":"completed","status":"completed"}}}}
+   ```
+2. **`browser-auth-delegated` (client-driven, two-step)** — advertised only if the client advertises the
+   `browser-auth-delegated` capability (in `clientCapabilities` field-meta). The CLIENT opens the URL.
+   (From source; confirm live when building #12.)
+   ```
+   authenticate({methodId:"browser-auth-delegated", action:"start"})
+     -> {_meta:{"browser-auth-delegated":{attemptId, expiresAt, signInUrl}}}   // client opens signInUrl
+   authenticate({methodId:"browser-auth-delegated", action:"complete", attemptId})
+     -> {_meta:{"browser-auth-delegated":{attemptId, persistResult, status:"completed"}}}
+   ```
+   **This delegated mode is the right fit for vibe-monitor** (we open the URL via the system opener,
+   show progress, stay non-blocking) — it mirrors CodexMonitor's `login/start → open authUrl → complete`.
+
+### `_auth/signOut` — sign out (ACP extension method)
+Removes the API key from the keyring; errors if `signOutAvailable` is false:
+```
+>>> {"id":N,"method":"_auth/signOut"}
+<<< {"id":N,"result":{}}
+```
+
+### Credentials live in the OS keyring
+`authState:"os_keyring"`. A fresh empty `VIBE_HOME` stays authenticated; there was no `MISTRAL_API_KEY`
+in the environment. vibe-monitor never stores credentials — Vibe owns them (keyring). See ADR-0003.
+
+### Bonus (resolves earlier unknowns)
+Vibe also exposes these ACP extension methods (all `_`-prefixed on the wire): `trust/status`,
+`trust/decision` (the workspace-trust grant we flagged as unconfirmed), `session/set_title`,
+`session/delete`.
+
+### What this means for the auth slices (#11–#13)
+- **#11 Detect:** call `_auth/status` after `initialize`; classify on `authenticated`/`authState`.
+  Treat a `-32000` error mid-session as expiry → re-detect/offer sign-in.
+- **#12 Sign in:** advertise the `browser-auth-delegated` capability, `authenticate(start)` → open
+  `signInUrl` via the system opener → `authenticate(complete, attemptId)`. (Fallback: blocking
+  `browser-auth`.)
+- **#13 Sign out / status:** `_auth/signOut`, gated on `signOutAvailable`; show `authState`.

--- a/docs/adr/0003-auth-delegated-to-vibe.md
+++ b/docs/adr/0003-auth-delegated-to-vibe.md
@@ -1,0 +1,35 @@
+# Authentication is delegated to the `vibe` binary; vibe-monitor never stores credentials
+
+vibe-monitor does not implement authentication or store any credentials. Vibe owns auth: it keeps the
+credential in the **OS keyring** (`authState: "os_keyring"`) and exposes the whole surface over ACP
+extension methods, which vibe-monitor merely drives and reflects:
+
+- **Detect** with `_auth/status` → `{ authenticated, authState, signOutAvailable }`. Auth state is NOT
+  derivable from `initialize` (its `authMethods` list is always present), so `auth/status` is the
+  source of truth. A mid-session `UnauthenticatedError` (JSON-RPC code **-32000**, which Vibe reserves
+  exclusively for unauthenticated — see `docs/acp-capture.md` §8) is treated as expiry.
+- **Sign in** via the **`browser-auth-delegated`** method (`authenticate(start)` → `signInUrl` → open in
+  the system browser → `authenticate(complete, attemptId)`), mirroring CodexMonitor's
+  `login/start → open authUrl → complete`. The blocking agent-driven `browser-auth` is the fallback.
+- **Sign out** via `_auth/signOut` (gated on `signOutAvailable`); it clears the keyring entry.
+
+This is the auth-specific application of ADR-0002's thin-orchestrator stance: agent capabilities
+(including credential storage) belong to Vibe, not the shell.
+
+## Considered options
+
+- **Store/manage credentials in vibe-monitor** (e.g. our own keychain entry or token cache) — rejected.
+  It would duplicate secrets insecurely, diverge from Vibe's source of truth, and break the moment Vibe
+  rotates/relocates them. Vibe already owns the keyring entry.
+- **Delegate entirely to the `vibe` binary** (chosen) — we only trigger sign-in/out and read
+  `auth/status`. We never see a token.
+
+## Consequences
+
+- vibe-monitor has no credential storage and no secrets at rest. Signing out is Vibe's keyring removal;
+  we just call `_auth/signOut`.
+- We depend on Vibe's ACP auth extension methods (`_auth/status`, `_auth/signOut`, `authenticate`).
+  These are `_`-prefixed extension methods (unstable surface) — pin behavior against the captured
+  shapes in `docs/acp-capture.md` §8 and re-verify on Vibe upgrades.
+- BYOK (a `MISTRAL_API_KEY` env var or `~/.vibe/.env`) authenticates without our sign-in flow; we treat
+  any `authenticated: true` from `auth/status` as signed in regardless of `authState`.

--- a/docs/vibe-acp-protocol.md
+++ b/docs/vibe-acp-protocol.md
@@ -96,11 +96,11 @@ Vibe is **not** API-key-only. Per Mistral's
 **We never store credentials.** Like CodexMonitor with Codex, vibe-monitor delegates all auth and
 token storage to the `vibe` binary (`~/.vibe`). We only detect signed-in vs not.
 
-**Over ACP:** `initialize` advertises `auth_method: vibe-setup` (when the client supports
-`terminal-auth`). An in-app sign-in would mirror CodexMonitor's Codex OAuth orchestration
-(`account/login/start` → open `authUrl` in the system browser → `account/login/completed`), likely
-via ACP's `authenticate` method. ⚠️ **Unconfirmed** — verify the exact ACP auth mechanism against the
-live `vibe-acp` binary before building any in-app flow.
+**Over ACP — now captured (see [acp-capture.md](./acp-capture.md) §8):** detect with `_auth/status`
+(`initialize` can't reveal auth state); sign in via `authenticate` (`browser-auth-delegated`:
+`start → signInUrl → complete`, or blocking `browser-auth`); sign out via `_auth/signOut`. The
+unauthenticated error is JSON-RPC code **-32000** (reserved exclusively for unauthenticated). Credentials
+live in the OS keyring; we never store them (see [adr/0003](./adr/0003-auth-delegated-to-vibe.md)).
 
 **Slice #1 stance:** assume the user is **already authenticated** (browser sign-in *or* API key);
 do not build the flow; surface `UnauthenticatedError` with a hint to run `vibe` / `vibe --setup`.


### PR DESCRIPTION
Closes #10.

The capture spike for in-app auth (PRD #9). Driven against a genuinely signed-out `vibe-acp` 2.18.0 (Keychain credential removed, then re-authenticated) and corroborated by reading Vibe's installed source.

## Captured (docs/acp-capture.md §8)
- **Detection:** `_auth/status` → `{authenticated, authState, signOutAvailable}`. `initialize` can't reveal auth state (`authMethods` always present).
- **UnauthenticatedError:** JSON-RPC code **-32000** (Vibe reserves it exclusively for unauthenticated; other errors use -31xxx/-326xx). **Reverses the TB1 #2 decision** that dropped the -32000 check — key on the code, not a message regex (the message is "Missing API key for <provider> provider").
- **Sign in:** `authenticate` — `browser-auth` (agent opens browser, blocks) and **`browser-auth-delegated`** (`start → signInUrl → complete`); delegated fits the GUI → use it for #12.
- **Sign out:** `_auth/signOut`, gated on `signOutAvailable`.
- **Bonus:** `trust/status` / `trust/decision` resolve the earlier workspace-trust unknown.

## Added
- `docs/acp-capture.md` §8 (verbatim auth captures) + pointer from `vibe-acp-protocol.md`.
- **ADR-0003** — auth delegated to the `vibe` binary; vibe-monitor never stores credentials.

No app code — this is a documentation/decision spike. Unblocks #11–#13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)