### PR TITLE
Auth TB2 — Detect & surface not-signed-in

### DIFF
--- a/src/main/auth/auth-state.test.ts
+++ b/src/main/auth/auth-state.test.ts
@@ -36,4 +36,10 @@ describe('classifyAuthStatus', () => {
       classifyAuthStatus({ authenticated: true, authState: 'os_keyring', signOutAvailable: true }),
     ).toBe('signed-in')
   })
+
+  it('returns unknown for a malformed status missing the authenticated field', () => {
+    // Defensive: never guess sign-in state from a shape we don't recognize.
+    expect(classifyAuthStatus({})).toBe('unknown')
+    expect(classifyAuthStatus({ authState: 'os_keyring' })).toBe('unknown')
+  })
 })

--- a/src/main/auth/auth-state.test.ts
+++ b/src/main/auth/auth-state.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { classifyAuthError, classifyAuthStatus } from './auth-state'
+
+/**
+ * Seam 1: the pure auth-state classifier. It maps an ACP failure/outcome to an
+ * `AuthState`. These cases pin the captured shapes from docs/acp-capture.md §8 —
+ * crucially that we key the unauthenticated signal on the JSON-RPC *code*
+ * (`-32000`, reserved exclusively for `UnauthenticatedError`), NOT the message.
+ */
+
+describe('classifyAuthError', () => {
+  it('classifies a JSON-RPC -32000 error as not-signed-in', () => {
+    expect(classifyAuthError({ code: -32000, message: 'Missing API key for mistral provider.' })).toBe(
+      'not-signed-in',
+    )
+  })
+
+  it('does NOT classify a non--32000 error as not-signed-in', () => {
+    // -32603 internal, -31002 configuration: real but unrelated failures. We
+    // can't conclude auth state from them, so they are `unknown`, never
+    // not-signed-in (the bug the old message regex risked the other way).
+    expect(classifyAuthError({ code: -32603, message: 'internal error' })).toBe('unknown')
+    expect(classifyAuthError({ code: -31002, message: 'configuration error' })).toBe('unknown')
+  })
+})
+
+describe('classifyAuthStatus', () => {
+  it('maps a signed-out _auth/status result to not-signed-in', () => {
+    expect(
+      classifyAuthStatus({ authenticated: false, authState: 'signed_out', signOutAvailable: false }),
+    ).toBe('not-signed-in')
+  })
+
+  it('maps a signed-in _auth/status result to signed-in', () => {
+    expect(
+      classifyAuthStatus({ authenticated: true, authState: 'os_keyring', signOutAvailable: true }),
+    ).toBe('signed-in')
+  })
+})

--- a/src/main/auth/auth-state.ts
+++ b/src/main/auth/auth-state.ts
@@ -1,0 +1,33 @@
+import type { AuthState } from '../../shared/ipc'
+
+/**
+ * Pure auth-state classification for Mistral Vibe (docs/acp-capture.md §8).
+ *
+ * The unauthenticated signal is the JSON-RPC error *code* `-32000`, which Vibe
+ * reserves EXCLUSIVELY for `UnauthenticatedError`. We deliberately do not match
+ * on the message: the real text is "Missing API key for <provider> provider",
+ * which a "sign in / unauthenticated" word-match would miss. (This replaces the
+ * earlier message-regex heuristic in WorkspaceAgent.)
+ */
+
+/** JSON-RPC error code Vibe reserves exclusively for `UnauthenticatedError`. */
+export const UNAUTHENTICATED_CODE = -32000
+
+/** Map an ACP request failure to an `AuthState`. */
+export function classifyAuthError(error: unknown): AuthState {
+  const code = (error as { code?: unknown } | null)?.code
+  if (code === UNAUTHENTICATED_CODE) return 'not-signed-in'
+  return 'unknown'
+}
+
+/**
+ * Map an `_auth/status` result (`{authenticated, authState, signOutAvailable}`)
+ * to an `AuthState`. Any `authenticated:true` is signed in regardless of
+ * `authState` (covers BYOK env/api-key, not just `os_keyring`) — see ADR-0003.
+ */
+export function classifyAuthStatus(status: unknown): AuthState {
+  const authenticated = (status as { authenticated?: unknown } | null)?.authenticated
+  if (authenticated === true) return 'signed-in'
+  if (authenticated === false) return 'not-signed-in'
+  return 'unknown'
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -70,15 +70,35 @@ function registerIpc(): void {
 
     try {
       await agent.start()
+
+      // Detected not-signed-in: keep the agent (the sign-in flow will drive it)
+      // but don't open a Thread — session/new would fail with -32000. The
+      // renderer shows the sign-in panel (ADR-0003: detection only here).
+      if (agent.authState === 'not-signed-in') {
+        agents.set(agentId, agent)
+        return {
+          ok: false,
+          kind: 'not-signed-in',
+          agentId,
+          workspaceDir: args.workspaceDir,
+          authMethods: agent.authMethods,
+        }
+      }
+
       const thread = await agent.openThread()
       agents.set(agentId, agent)
       return { ok: true, thread: { agentId, workspaceDir: args.workspaceDir, ...thread } }
     } catch (err) {
       agent.stop()
       if (err instanceof WorkspaceAgentError) {
-        return { ok: false, error: err.message, hint: err.hint }
+        return { ok: false, kind: 'error', error: err.message, hint: err.hint }
       }
-      return { ok: false, error: err instanceof Error ? err.message : String(err), hint: null }
+      return {
+        ok: false,
+        kind: 'error',
+        error: err instanceof Error ? err.message : String(err),
+        hint: null,
+      }
     }
   })
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -59,6 +59,12 @@ function registerIpc(): void {
   })
 
   ipcMain.handle(IPC.startThread, async (event, args: StartThreadArgs): Promise<StartThreadResult> => {
+    // TODO(#12): a retained not-signed-in agent (below) is NOT deduped by
+    // workspaceDir — we always mint a fresh agentId + spawn a new
+    // WorkspaceAgent. Not reachable in this slice (the sign-in button is
+    // inert), but once #12 makes it actionable a re-Connect to the same
+    // workspace would orphan the previous not-signed-in agent (its child
+    // lingers). #12 must reuse or stop the existing agent for this workspace.
     const agentId = `a${++agentCounterSeed}`
     const agent = new WorkspaceAgent({ workspaceDir: args.workspaceDir, env: getShellEnv() })
 
@@ -90,6 +96,13 @@ function registerIpc(): void {
       return { ok: true, thread: { agentId, workspaceDir: args.workspaceDir, ...thread } }
     } catch (err) {
       agent.stop()
+      // TODO(#12): fallback UX gap. When `_auth/status` returned `unknown` but
+      // the user is actually signed out, `session/new` (openThread) fails with
+      // -32000 and lands here — we surface it as a generic error alert (still
+      // carrying AUTH_HINT) rather than the SignInPanel. Routing this auth-error
+      // path to the panel requires keeping the agent alive (not stop()-ing it)
+      // so the sign-in flow can drive it, which is coupled to the
+      // agent-dedup/lifecycle work in #12.
       if (err instanceof WorkspaceAgentError) {
         return { ok: false, kind: 'error', error: err.message, hint: err.hint }
       }

--- a/src/main/workspace-agent.test.ts
+++ b/src/main/workspace-agent.test.ts
@@ -85,44 +85,48 @@ describe('WorkspaceAgent.start()', () => {
     expect((err as WorkspaceAgentError).hint).toBe(SPAWN_HINT)
   })
 
-  it('does NOT classify a generic (non-auth) initialize error as unauthenticated', async () => {
+  it('does NOT classify a generic (non--32000) initialize error as unauthenticated', async () => {
     const fake = makeFakeChild()
     const agent = makeAgent(fake)
 
     const pending = startAndCatch(agent)
-    // initialize is request id 1.
+    // A genuine non-auth failure (internal error). The discriminator is the
+    // JSON-RPC code, not the message — so this must NOT read as not-signed-in.
     fake.feed(
       JSON.stringify({
         jsonrpc: '2.0',
         id: 1,
-        error: { code: -32000, message: 'workspace trust required' },
+        error: { code: -32603, message: 'internal error' },
       }) + '\n',
     )
 
     const err = await pending
     expect(err).toBeInstanceOf(WorkspaceAgentError)
-    expect((err as WorkspaceAgentError).message).toBe('workspace trust required')
+    expect((err as WorkspaceAgentError).message).toBe('internal error')
     expect((err as WorkspaceAgentError).message).not.toMatch(/not signed in/i)
     expect((err as WorkspaceAgentError).hint).toBeNull()
   })
 
-  it('classifies an auth-style initialize error as unauthenticated + AUTH_HINT', async () => {
+  it('classifies a -32000 error as unauthenticated + AUTH_HINT (by code, not message)', async () => {
     const fake = makeFakeChild()
     const agent = makeAgent(fake)
 
     const pending = startAndCatch(agent)
+    // The real UnauthenticatedError message (docs/acp-capture.md §8) — which the
+    // old "sign in / unauthenticated" regex would have MISSED. Code -32000 is
+    // the reliable signal.
     fake.feed(
       JSON.stringify({
         jsonrpc: '2.0',
         id: 1,
-        error: { code: -32000, message: 'authentication required' },
+        error: { code: -32000, message: 'Missing API key for mistral provider.' },
       }) + '\n',
     )
 
     const err = await pending
     expect(err).toBeInstanceOf(WorkspaceAgentError)
     expect((err as WorkspaceAgentError).message).toMatch(/not signed in/i)
-    expect((err as WorkspaceAgentError).message).toContain('authentication required')
+    expect((err as WorkspaceAgentError).message).toContain('Missing API key for mistral provider.')
     expect((err as WorkspaceAgentError).hint).toBe(AUTH_HINT)
   })
 })

--- a/src/main/workspace-agent.test.ts
+++ b/src/main/workspace-agent.test.ts
@@ -131,6 +131,76 @@ describe('WorkspaceAgent.start()', () => {
   })
 })
 
+// --- Auth detection over the wire (_auth/status) ----------------------------
+
+/** Initialize result carrying the captured browser-auth method (acp-capture §1/§8). */
+const INITIALIZE_RESULT = {
+  protocolVersion: 1,
+  agentInfo: { name: '@mistralai/mistral-vibe', title: 'Mistral Vibe', version: '2.18.0' },
+  authMethods: [
+    {
+      id: 'browser-auth',
+      name: 'Sign in through Mistral AI Studio',
+      description: 'Sign into Mistral Vibe through your Mistral AI Studio account.',
+    },
+  ],
+}
+
+/**
+ * Drive start() to completion over a capturing fake, answering `initialize`
+ * (id 1) then `_auth/status` (id 2) with the supplied status result. Returns the
+ * ready agent so the test can read its detected `authState`.
+ */
+async function startWithAuthStatus(
+  fake: CapturingFake,
+  statusResult: Record<string, unknown>,
+): Promise<WorkspaceAgent> {
+  const agent = new WorkspaceAgent({ workspaceDir: '/abs/workspace', spawn: () => fake.child })
+  const started = agent.start()
+  fake.feed(JSON.stringify({ jsonrpc: '2.0', id: 1, result: INITIALIZE_RESULT }) + '\n')
+  // Let initialize resolve so the agent issues its _auth/status follow-up.
+  await new Promise((r) => setTimeout(r, 0))
+  const statusReq = sent(fake).find((m) => m.method === '_auth/status')
+  fake.feed(JSON.stringify({ jsonrpc: '2.0', id: statusReq?.id, result: statusResult }) + '\n')
+  await started
+  return agent
+}
+
+describe('WorkspaceAgent — auth detection (_auth/status)', () => {
+  it('queries _auth/status after initialize and reports not-signed-in when signed out', async () => {
+    const fake = makeCapturingFake()
+    const agent = await startWithAuthStatus(fake, {
+      authenticated: false,
+      authState: 'signed_out',
+      signOutAvailable: false,
+    })
+
+    // The extension method is sent verbatim with its leading underscore.
+    const statusReq = sent(fake).find((m) => m.method === '_auth/status')
+    expect(statusReq).toBeDefined()
+    expect(agent.authState).toBe('not-signed-in')
+  })
+
+  it('reports signed-in for an authenticated status and exposes the advertised authMethods', async () => {
+    const fake = makeCapturingFake()
+    const agent = await startWithAuthStatus(fake, {
+      authenticated: true,
+      authState: 'os_keyring',
+      signOutAvailable: true,
+    })
+
+    expect(agent.authState).toBe('signed-in')
+    // The sign-in method name the renderer renders comes from initialize.
+    expect(agent.authMethods).toEqual([
+      {
+        id: 'browser-auth',
+        name: 'Sign in through Mistral AI Studio',
+        description: 'Sign into Mistral Vibe through your Mistral AI Studio account.',
+      },
+    ])
+  })
+})
+
 // --- TB2: prompt + fs/read serving (a writes-capturing fake) ----------------
 
 interface CapturingFake extends FakeChild {
@@ -192,9 +262,16 @@ async function connect(
   })
   const started = agent.start()
   fake.feed(JSON.stringify({ jsonrpc: '2.0', id: 1, result: { protocolVersion: 1 } }) + '\n')
+  // start() now follows initialize with an _auth/status query (id 2); answer
+  // signed-in so the connect flow proceeds. session/new is therefore id 3.
+  await new Promise((r) => setTimeout(r, 0))
+  fake.feed(
+    JSON.stringify({ jsonrpc: '2.0', id: 2, result: { authenticated: true, authState: 'os_keyring' } }) +
+      '\n',
+  )
   await started
   const opened = agent.openThread()
-  fake.feed(JSON.stringify({ jsonrpc: '2.0', id: 2, result: { sessionId: SESSION_ID } }) + '\n')
+  fake.feed(JSON.stringify({ jsonrpc: '2.0', id: 3, result: { sessionId: SESSION_ID } }) + '\n')
   await opened
   return agent
 }
@@ -261,9 +338,15 @@ async function connectWriting(
   })
   const started = agent.start()
   fake.feed(JSON.stringify({ jsonrpc: '2.0', id: 1, result: { protocolVersion: 1 } }) + '\n')
+  // start() follows initialize with an _auth/status query (id 2); session/new is id 3.
+  await new Promise((r) => setTimeout(r, 0))
+  fake.feed(
+    JSON.stringify({ jsonrpc: '2.0', id: 2, result: { authenticated: true, authState: 'os_keyring' } }) +
+      '\n',
+  )
   await started
   const opened = agent.openThread()
-  fake.feed(JSON.stringify({ jsonrpc: '2.0', id: 2, result: { sessionId: SESSION_ID } }) + '\n')
+  fake.feed(JSON.stringify({ jsonrpc: '2.0', id: 3, result: { sessionId: SESSION_ID } }) + '\n')
   await opened
   return agent
 }

--- a/src/main/workspace-agent.ts
+++ b/src/main/workspace-agent.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'node:events'
 import { AcpClient, type SpawnFn } from './acp/client'
 import { handleFsReadTextFile, type ReadTextFn } from './acp/fs-read'
 import { handleFsWriteTextFile, type WriteTextFn } from './acp/fs-write'
+import { classifyAuthError } from './auth/auth-state'
 import type { PromptResult, ThreadInfo, ThreadModes, ThreadModels } from '../shared/ipc'
 
 /**
@@ -269,20 +270,12 @@ export class WorkspaceAgent extends EventEmitter {
     const rpc = err as { code?: number; message?: string; data?: unknown }
     const message = rpc?.message ?? (err instanceof Error ? err.message : String(err))
 
-    if (this.isUnauthenticated(message)) {
+    // Classify by JSON-RPC code: Vibe reserves -32000 exclusively for
+    // UnauthenticatedError (docs/acp-capture.md §8). This replaces the earlier
+    // message-regex heuristic, which missed the real "Missing API key" wording.
+    if (classifyAuthError(rpc) === 'not-signed-in') {
       return new WorkspaceAgentError(`Not signed in to Mistral Vibe: ${message}`, AUTH_HINT)
     }
     return new WorkspaceAgentError(message)
-  }
-
-  private isUnauthenticated(message: string): boolean {
-    // The real UnauthenticatedError code is unconfirmed — we never captured one.
-    // We deliberately do NOT key on the JSON-RPC code (`-32000` is the generic
-    // server-error code, so trusting it misclassifies generic/internal errors
-    // as "Not signed in"). Match on the message only. Verify the actual auth
-    // error shape against the live binary and tighten this later.
-    return /unauthenticated|not authenticated|authentication required|requires authentication|sign[- ]?in/i.test(
-      message,
-    )
   }
 }

--- a/src/main/workspace-agent.ts
+++ b/src/main/workspace-agent.ts
@@ -2,8 +2,15 @@ import { EventEmitter } from 'node:events'
 import { AcpClient, type SpawnFn } from './acp/client'
 import { handleFsReadTextFile, type ReadTextFn } from './acp/fs-read'
 import { handleFsWriteTextFile, type WriteTextFn } from './acp/fs-write'
-import { classifyAuthError } from './auth/auth-state'
-import type { PromptResult, ThreadInfo, ThreadModes, ThreadModels } from '../shared/ipc'
+import { classifyAuthError, classifyAuthStatus } from './auth/auth-state'
+import type {
+  AuthMethod,
+  AuthState,
+  PromptResult,
+  ThreadInfo,
+  ThreadModes,
+  ThreadModels,
+} from '../shared/ipc'
 
 /**
  * A Workspace agent: one `vibe-acp` child process plus its `AcpClient`,
@@ -71,6 +78,10 @@ export class WorkspaceAgent extends EventEmitter {
   /** Threads hosted by this agent, keyed by their ACP `sessionId`. */
   private readonly threads = new Map<string, ThreadInfo>()
   private initialized = false
+  /** Sign-in state detected via `_auth/status` during start(). */
+  private authStateValue: AuthState = 'unknown'
+  /** Sign-in methods advertised by `initialize` (e.g. `browser-auth`). */
+  private authMethodsValue: AuthMethod[] = []
 
   constructor(options: WorkspaceAgentOptions) {
     super()
@@ -126,7 +137,7 @@ export class WorkspaceAgent extends EventEmitter {
     }
 
     try {
-      await Promise.race([
+      const init = await Promise.race([
         this.client.request<InitializeResult>('initialize', {
           protocolVersion: PROTOCOL_VERSION,
           clientCapabilities: { fs: { readTextFile: true, writeTextFile: true } },
@@ -134,11 +145,41 @@ export class WorkspaceAgent extends EventEmitter {
         }),
         earlyFailure,
       ])
+      this.authMethodsValue = extractAuthMethods(init)
+      // `initialize` can't reveal auth state (its authMethods is always
+      // present), so query the `_auth/status` extension method (acp-capture §8).
+      await this.detectAuthState(earlyFailure)
       this.initialized = true
     } catch (err) {
       throw this.toAgentError(err)
     } finally {
       this.detachStartGuards(onError, onExit)
+    }
+  }
+
+  /** The sign-in state detected during start() (`unknown` until started). */
+  get authState(): AuthState {
+    return this.authStateValue
+  }
+
+  /** The sign-in methods advertised by the agent's `initialize` response. */
+  get authMethods(): AuthMethod[] {
+    return this.authMethodsValue
+  }
+
+  /**
+   * Query the `_auth/status` extension method and classify the result. Process
+   * death during the call is fatal (races `earlyFailure`); a plain RPC failure
+   * is not — we fall back to `unknown` and let `session/new` surface any real
+   * auth gate (the -32000 UnauthenticatedError).
+   */
+  private async detectAuthState(earlyFailure: Promise<never>): Promise<void> {
+    try {
+      const status = await Promise.race([this.client.request('_auth/status'), earlyFailure])
+      this.authStateValue = classifyAuthStatus(status)
+    } catch (err) {
+      if (err instanceof WorkspaceAgentError) throw err
+      this.authStateValue = 'unknown'
     }
   }
 
@@ -278,4 +319,19 @@ export class WorkspaceAgent extends EventEmitter {
     }
     return new WorkspaceAgentError(message)
   }
+}
+
+/** Pull the well-formed `authMethods` out of an `initialize` result. */
+function extractAuthMethods(init: InitializeResult): AuthMethod[] {
+  const methods = init.authMethods
+  if (!Array.isArray(methods)) return []
+  return methods
+    .filter(
+      (m): m is AuthMethod => !!m && typeof m.id === 'string' && typeof m.name === 'string',
+    )
+    .map((m) => ({
+      id: m.id,
+      name: m.name,
+      description: typeof m.description === 'string' ? m.description : undefined,
+    }))
 }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState, type JSX } from 'react'
-import type { ThreadConnection, VibeDetectResult } from '../../shared/ipc'
+import type { AuthMethod, ThreadConnection, VibeDetectResult } from '../../shared/ipc'
+import { selectAuthView } from './auth/auth-view'
 import { Conversation } from './conversation/Conversation'
 
 type ConnectState =
   | { status: 'idle' }
   | { status: 'connecting'; workspaceDir: string }
   | { status: 'connected'; thread: ThreadConnection }
+  | { status: 'not-signed-in'; agentId: string; workspaceDir: string; authMethods: AuthMethod[] }
   | { status: 'error'; message: string; hint: string | null }
 
 export function App(): JSX.Element {
@@ -32,6 +34,13 @@ export function App(): JSX.Element {
     const result = await window.api.startThread({ workspaceDir })
     if (result.ok) {
       setConnect({ status: 'connected', thread: result.thread })
+    } else if (result.kind === 'not-signed-in') {
+      setConnect({
+        status: 'not-signed-in',
+        agentId: result.agentId,
+        workspaceDir: result.workspaceDir,
+        authMethods: result.authMethods,
+      })
     } else {
       setConnect({ status: 'error', message: result.error, hint: result.hint })
     }
@@ -87,6 +96,10 @@ export function App(): JSX.Element {
             </p>
           )}
 
+          {connect.status === 'not-signed-in' && (
+            <SignInPanel authMethods={connect.authMethods} />
+          )}
+
           {connect.status === 'error' && (
             <div className="alert">
               <div className="alert__title">Couldn’t connect</div>
@@ -102,6 +115,26 @@ export function App(): JSX.Element {
           )}
         </section>
       </main>
+    </div>
+  )
+}
+
+/**
+ * The not-signed-in panel: visibly distinct from the binary-missing status and
+ * the generic-error alert. Renders the agent's advertised sign-in method name
+ * and a Sign-in button. The button is intentionally inert here — its click
+ * handler is wired in #12 (browser-auth-delegated).
+ */
+function SignInPanel({ authMethods }: { authMethods: AuthMethod[] }): JSX.Element | null {
+  const view = selectAuthView({ authState: 'not-signed-in', authMethods })
+  if (view.kind !== 'sign-in') return null
+  return (
+    <div className="signin">
+      <div className="signin__title">Not signed in to Mistral Vibe</div>
+      {view.description && <div className="signin__message">{view.description}</div>}
+      <button className="btn signin__action" onClick={() => {}}>
+        {view.methodName}
+      </button>
     </div>
   )
 }

--- a/src/renderer/src/auth/auth-view.test.ts
+++ b/src/renderer/src/auth/auth-view.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { selectAuthView } from './auth-view'
+import type { AuthMethod } from '../../../shared/ipc'
+
+/**
+ * Seam 3: the pure auth view-state selector. It maps the detected `AuthState`
+ * (+ the agent's advertised `authMethods`) to what the renderer shows — a
+ * sign-in panel when not signed in, nothing otherwise. Per ADR-0001 the
+ * renderer owns this view state; main only classifies + relays.
+ */
+
+const BROWSER_AUTH: AuthMethod = {
+  id: 'browser-auth',
+  name: 'Sign in through Mistral AI Studio',
+  description: 'Sign into Mistral Vibe through your Mistral AI Studio account.',
+}
+
+describe('selectAuthView', () => {
+  it('shows a sign-in panel with the advertised method name when not signed in', () => {
+    const view = selectAuthView({ authState: 'not-signed-in', authMethods: [BROWSER_AUTH] })
+    expect(view).toEqual({
+      kind: 'sign-in',
+      methodId: 'browser-auth',
+      methodName: 'Sign in through Mistral AI Studio',
+      description: 'Sign into Mistral Vibe through your Mistral AI Studio account.',
+    })
+  })
+
+  it('shows no auth panel when signed in (incl. BYOK)', () => {
+    expect(selectAuthView({ authState: 'signed-in', authMethods: [BROWSER_AUTH] })).toEqual({
+      kind: 'none',
+    })
+  })
+
+  it('shows no auth panel while the state is still unknown', () => {
+    expect(selectAuthView({ authState: 'unknown' })).toEqual({ kind: 'none' })
+  })
+
+  it('falls back to a generic sign-in label when no authMethods are advertised', () => {
+    // Defensive: never strand the user without a way back in if authMethods is empty.
+    expect(selectAuthView({ authState: 'not-signed-in', authMethods: [] })).toEqual({
+      kind: 'sign-in',
+      methodId: '',
+      methodName: 'Sign in',
+      description: null,
+    })
+  })
+})

--- a/src/renderer/src/auth/auth-view.ts
+++ b/src/renderer/src/auth/auth-view.ts
@@ -1,0 +1,40 @@
+import type { AuthMethod, AuthState } from '../../../shared/ipc'
+
+/**
+ * Pure auth view-state selector (no React, no IPC). Maps the detected
+ * `AuthState` plus the agent's advertised `authMethods` to what the renderer
+ * renders: a distinct sign-in panel when not signed in, nothing otherwise. Per
+ * ADR-0001 the renderer owns this; main classifies + relays the AuthState.
+ */
+
+/** Render a sign-in panel — the method name + a (not-yet-wired) Sign-in button. */
+export interface SignInView {
+  kind: 'sign-in'
+  methodId: string
+  methodName: string
+  description: string | null
+}
+
+/** Render nothing auth-related (signed in, or state not yet known). */
+export interface NoAuthView {
+  kind: 'none'
+}
+
+export type AuthView = SignInView | NoAuthView
+
+export interface AuthViewInput {
+  authState: AuthState
+  authMethods?: AuthMethod[]
+}
+
+export function selectAuthView(input: AuthViewInput): AuthView {
+  if (input.authState !== 'not-signed-in') return { kind: 'none' }
+
+  const method = input.authMethods?.[0]
+  return {
+    kind: 'sign-in',
+    methodId: method?.id ?? '',
+    methodName: method?.name ?? 'Sign in',
+    description: method?.description ?? null,
+  }
+}

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -240,6 +240,33 @@ body {
   line-height: 1.4;
 }
 
+.signin {
+  border: 1px solid rgba(255, 122, 26, 0.4);
+  background: rgba(255, 122, 26, 0.08);
+  border-radius: 8px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.signin__title {
+  color: var(--accent);
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.signin__message {
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--muted);
+}
+
+.signin__action {
+  margin-top: 2px;
+}
+
 /* --- Conversation (TB2) --- */
 
 .conv {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -29,6 +29,20 @@ export interface VibeDetectResult {
   error: string | null
 }
 
+/**
+ * Whether the user is signed in to Mistral Vibe. `unknown` covers states we
+ * can't conclude from the available signal (e.g. a non-auth error). Main
+ * classifies; the renderer renders (ADR-0001, ADR-0003).
+ */
+export type AuthState = 'signed-in' | 'not-signed-in' | 'unknown'
+
+/** An advertised sign-in method from the `initialize` response (`authMethods`). */
+export interface AuthMethod {
+  id: string
+  name: string
+  description?: string
+}
+
 /** A selectable agent mode from `session/new` (e.g. `default`, `plan`). */
 export interface AcpMode {
   id: string

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -90,7 +90,11 @@ export interface ThreadConnection extends ThreadInfo {
 
 export type StartThreadResult =
   | { ok: true; thread: ThreadConnection }
-  | { ok: false; error: string; hint: string | null }
+  // Detected (via `_auth/status`) that the user is not signed in: the agent is
+  // up and registered under `agentId` so the sign-in flow (#12) can drive it,
+  // but no Thread was opened. `authMethods` feeds the sign-in panel's label.
+  | { ok: false; kind: 'not-signed-in'; agentId: string; workspaceDir: string; authMethods: AuthMethod[] }
+  | { ok: false; kind: 'error'; error: string; hint: string | null }
 
 export interface AcpEvent {
   /** Id of the Workspace agent the payload came from. */


### PR DESCRIPTION
Closes #11.

## Summary

Make vibe-monitor recognize and surface "not signed in" to Mistral Vibe as a state distinct from "vibe-acp missing" and from generic errors — detection + presentation only (the Sign-in button's click handler lands in #12).

Built with strict TDD (vertical red→green, one behavior at a time). Behaviors driven, in order:

**Seam 1 — auth-state classifier (pure, main)** · `src/main/auth/auth-state.ts`
1. JSON-RPC error `code: -32000` → `not-signed-in`.
2. A non-`-32000` error (`-32603`, `-31002`) → `unknown` (never `not-signed-in`).
3. `_auth/status` `{authenticated:false,…}` → `not-signed-in`; `{authenticated:true,…}` → `signed-in` (any `authenticated:true` is signed in regardless of `authState`, per ADR-0003).
- This **replaces** `WorkspaceAgent`'s old `isUnauthenticated` message-regex. The regex matched words like "sign in"/"unauthenticated" and would have **missed** the real `UnauthenticatedError` message ("Missing API key for mistral provider."). We now classify on the **code** (`-32000`, which Vibe reserves exclusively for unauthenticated — acp-capture §8), not the message.

**Seam 2 — detection over the wire** · `src/main/workspace-agent.ts`
4. `start()` now follows `initialize` with the `_auth/status` ACP extension method (sent verbatim with its leading underscore) and exposes `authState` + the advertised `authMethods`. Process death during detection stays fatal; a plain RPC failure falls back to `unknown` and lets `session/new` surface any real auth gate.

**Seam 3 — view-state selector (pure, renderer)** · `src/renderer/src/auth/auth-view.ts`
5. `not-signed-in` (+ `authMethods`) → a `sign-in` view carrying the method name ("Sign in through Mistral AI Studio").
6. `signed-in` / `unknown` → `none`. Empty `authMethods` falls back to a generic "Sign in" label.

**Seam 4 — wire it in** · `src/shared/ipc.ts`, `src/main/index.ts`, `src/renderer/src/App.tsx`
7. `StartThreadResult` gains a `not-signed-in` branch (keeps the agent registered under `agentId` for #12, carries `authMethods`); the error branch is tagged `kind: 'error'`. `index.ts` short-circuits before `session/new` when not signed in; `App.tsx` renders a distinct `SignInPanel` (button `onClick` is a no-op TODO for #12).

## Verification

```
bun run typecheck   # clean (strict TS, noUnusedLocals/Params)
bun run build       # ✓ built
bun run test        # Test Files 7 passed (7) · Tests 53 passed (53)
```

(`bun run lint` is a no-op in this repo — eslint isn't in devDependencies; pre-existing.)

## Notes for reviewers

- **Classifier code-vs-message logic** (`auth-state.ts`) — the crux of the slice; confirm keying on `-32000` (not the message) is right and the old regex is fully gone.
- **`_auth/status` wire handling** (`workspace-agent.ts` `detectAuthState`) — the leading-underscore method name, the id-shift (initialize=1, `_auth/status`=2, `session/new`=3, reflected in the test helpers), and the fatal-vs-best-effort error split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)