### PR TITLE
Auth TB3 — Sign in via browser (browser-auth-delegated)

### DIFF
--- a/docs/acp-capture.md
+++ b/docs/acp-capture.md
@@ -223,17 +223,36 @@ authenticate(method_id, **kwargs) -> AuthenticateResponse
    >>> {"id":30,"method":"authenticate","params":{"methodId":"browser-auth"}}
    <<< {"id":30,"result":{"_meta":{"browser-auth":{"persistResult":"completed","status":"completed"}}}}
    ```
-2. **`browser-auth-delegated` (client-driven, two-step)** — advertised only if the client advertises the
-   `browser-auth-delegated` capability (in `clientCapabilities` field-meta). The CLIENT opens the URL.
-   (From source; confirm live when building #12.)
+2. **`browser-auth-delegated` (client-driven, two-step)** — ✅ **live-confirmed 2026-06-29** (probe was
+   non-destructive: only `start` was called, never `complete`, so nothing was signed in/out and the
+   keyring was untouched). Advertised only if the client opts in via `clientCapabilities._meta`
+   (`field_meta` in `vibe/acp/acp_agent_loop.py::_supports_delegated_browser_auth`). The CLIENT opens the URL.
    ```
-   authenticate({methodId:"browser-auth-delegated", action:"start"})
-     -> {_meta:{"browser-auth-delegated":{attemptId, expiresAt, signInUrl}}}   // client opens signInUrl
-   authenticate({methodId:"browser-auth-delegated", action:"complete", attemptId})
-     -> {_meta:{"browser-auth-delegated":{attemptId, persistResult, status:"completed"}}}
+   // initialize MUST advertise the capability or the method is absent from authMethods:
+   initialize.params.clientCapabilities = { fs:{…}, _meta:{ "browser-auth-delegated": true } }
+   // → initialize.result.authMethods then includes BOTH:
+   //   {id:"browser-auth", name:"Sign in through Mistral AI Studio"}
+   //   {id:"browser-auth-delegated", name:"Sign in through Mistral AI Studio"}
+
+   // start — returns IMMEDIATELY (non-blocking); client then opens signInUrl in the system browser:
+   >>> {"id":2,"method":"authenticate","params":{"methodId":"browser-auth-delegated","action":"start"}}
+   <<< {"id":2,"result":{"_meta":{"browser-auth-delegated":{
+         "attemptId":"fb067327-…",
+         "expiresAt":"2026-06-29T11:22:26.037185Z",
+         "signInUrl":"https://console.mistral.ai/codestral/cli/authenticate?process_id=fb067327-…"}}}}
+
+   // complete — call AFTER the user finishes in the browser; THIS is the call that awaits/persists
+   // (source: _complete_delegated_browser_auth). Unknown/expired attemptId → InvalidRequestError (-32602):
+   >>> authenticate({methodId:"browser-auth-delegated", action:"complete", attemptId})
+   <<< {_meta:{"browser-auth-delegated":{attemptId, persistResult, status:"completed"}}}
    ```
+   Source facts (`acp_agent_loop.py`): `start` calls `start_attempt()` (mints the URL, stores a pending
+   attempt by `attemptId`); `complete` requires that `attemptId` (else `InvalidRequestError`), calls
+   `complete_attempt()` (blocks until the browser flow resolves), then persists to the keyring. So `start`
+   is cheap/non-blocking and `complete` is the long-poll — orchestrate accordingly.
    **This delegated mode is the right fit for vibe-monitor** (we open the URL via the system opener,
-   show progress, stay non-blocking) — it mirrors CodexMonitor's `login/start → open authUrl → complete`.
+   show progress, stay non-blocking) — it mirrors CodexMonitor's `login/start → open authUrl → complete`,
+   and is the **primary** path per ADR-0003 (blocking `browser-auth` is the fallback).
 
 ### `_auth/signOut` — sign out (ACP extension method)
 Removes the API key from the keyring; errors if `signOutAvailable` is false:

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,6 +5,8 @@ import {
   type RespondPermissionArgs,
   type SendPromptArgs,
   type SendPromptResult,
+  type SignInArgs,
+  type SignInResult,
   type StartThreadArgs,
   type StartThreadResult,
 } from '../shared/ipc'
@@ -66,7 +68,12 @@ function registerIpc(): void {
     // workspace would orphan the previous not-signed-in agent (its child
     // lingers). #12 must reuse or stop the existing agent for this workspace.
     const agentId = `a${++agentCounterSeed}`
-    const agent = new WorkspaceAgent({ workspaceDir: args.workspaceDir, env: getShellEnv() })
+    const agent = new WorkspaceAgent({
+      workspaceDir: args.workspaceDir,
+      env: getShellEnv(),
+      // Delegated sign-in (#12): open the returned signInUrl in the system browser.
+      openUrl: (url) => void shell.openExternal(url),
+    })
 
     agent.on('event', (payload: unknown) => {
       if (!event.sender.isDestroyed()) {
@@ -134,6 +141,20 @@ function registerIpc(): void {
     // approve/deny decision lives in the renderer (ADR-0001).
     const agent = agents.get(args.agentId)
     agent?.respondPermission(args.requestId, args.optionId)
+  })
+
+  ipcMain.handle(IPC.signIn, async (_event, args: SignInArgs): Promise<SignInResult> => {
+    // Drive Vibe's browser sign-in on the agent retained from startThread; main
+    // orchestrates + relays the resulting AuthState, the renderer owns the view
+    // state (ADR-0001). Credentials never touch us — Vibe owns the keyring (ADR-0003).
+    const agent = agents.get(args.agentId)
+    if (!agent) return { ok: false, error: `No active agent for id ${args.agentId}.` }
+    try {
+      const authState = await agent.signIn(args.methodId)
+      return { ok: true, authState }
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) }
+    }
   })
 
   ipcMain.handle(IPC.stopAgent, (_event, agentId: string) => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -61,12 +61,12 @@ function registerIpc(): void {
   })
 
   ipcMain.handle(IPC.startThread, async (event, args: StartThreadArgs): Promise<StartThreadResult> => {
-    // TODO(#12): a retained not-signed-in agent (below) is NOT deduped by
+    // TODO(#13): a retained not-signed-in agent (below) is NOT deduped by
     // workspaceDir — we always mint a fresh agentId + spawn a new
-    // WorkspaceAgent. Not reachable in this slice (the sign-in button is
-    // inert), but once #12 makes it actionable a re-Connect to the same
-    // workspace would orphan the previous not-signed-in agent (its child
-    // lingers). #12 must reuse or stop the existing agent for this workspace.
+    // WorkspaceAgent. Sign-in (#12) reuses the same agent by agentId, so this
+    // doesn't bite yet; but #13 (route Open-project through sign-in) re-Connects
+    // to the same workspace and would orphan the previous not-signed-in agent
+    // (its child lingers). #13 must reuse or stop the existing agent.
     const agentId = `a${++agentCounterSeed}`
     const agent = new WorkspaceAgent({
       workspaceDir: args.workspaceDir,
@@ -103,13 +103,13 @@ function registerIpc(): void {
       return { ok: true, thread: { agentId, workspaceDir: args.workspaceDir, ...thread } }
     } catch (err) {
       agent.stop()
-      // TODO(#12): fallback UX gap. When `_auth/status` returned `unknown` but
+      // TODO(#13): fallback UX gap. When `_auth/status` returned `unknown` but
       // the user is actually signed out, `session/new` (openThread) fails with
       // -32000 and lands here — we surface it as a generic error alert (still
       // carrying AUTH_HINT) rather than the SignInPanel. Routing this auth-error
       // path to the panel requires keeping the agent alive (not stop()-ing it)
       // so the sign-in flow can drive it, which is coupled to the
-      // agent-dedup/lifecycle work in #12.
+      // agent-dedup/lifecycle work deferred to #13.
       if (err instanceof WorkspaceAgentError) {
         return { ok: false, kind: 'error', error: err.message, hint: err.hint }
       }

--- a/src/main/workspace-agent.test.ts
+++ b/src/main/workspace-agent.test.ts
@@ -337,6 +337,38 @@ describe('WorkspaceAgent — sign in (browser-auth-delegated)', () => {
 
     await expect(signingIn).rejects.toBeInstanceOf(WorkspaceAgentError)
   })
+
+  it('fails fast with a clear message when start returns no attemptId (sends no complete)', async () => {
+    const fake = makeCapturingFake()
+    const opened: string[] = []
+    const agent = await connectSignedOut(fake, (url) => opened.push(url))
+
+    const signingIn = agent.signIn(DELEGATED)
+    const settled = signingIn.catch((e: unknown) => e)
+
+    await new Promise((r) => setTimeout(r, 0))
+    const startReq = authSent(fake).find((m) => m.params?.action === 'start')
+    // Misshaped start result: no `_meta`, so no attemptId.
+    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: startReq?.id, result: {} }) + '\n')
+
+    const err = await settled
+    expect(err).toBeInstanceOf(WorkspaceAgentError)
+    expect((err as WorkspaceAgentError).message).toMatch(/could not start/i)
+    // No doomed `complete` with attemptId:undefined, and the browser never opened.
+    expect(authSent(fake).some((m) => m.params?.action === 'complete')).toBe(false)
+    expect(opened).toEqual([])
+  })
+
+  it('rejects a non-delegated methodId with a clear message (no requests sent)', async () => {
+    const fake = makeCapturingFake()
+    const agent = await connectSignedOut(fake, () => {})
+
+    const err = await agent.signIn('browser-auth').catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(WorkspaceAgentError)
+    expect((err as WorkspaceAgentError).message).toMatch(/delegated/i)
+    // It never round-trips delegated-shaped requests to the blocking method.
+    expect(authSent(fake)).toEqual([])
+  })
 })
 
 // --- TB2: prompt + fs/read serving (a writes-capturing fake) ----------------

--- a/src/main/workspace-agent.test.ts
+++ b/src/main/workspace-agent.test.ts
@@ -201,6 +201,144 @@ describe('WorkspaceAgent — auth detection (_auth/status)', () => {
   })
 })
 
+// --- TB3: browser-auth-delegated sign-in ------------------------------------
+
+interface InitParams {
+  clientCapabilities?: { fs?: unknown; _meta?: Record<string, unknown> }
+}
+
+const DELEGATED = 'browser-auth-delegated'
+const SIGN_IN_URL =
+  'https://console.mistral.ai/codestral/cli/authenticate?process_id=fb067327-aaaa-bbbb-cccc-dddddddddddd'
+const ATTEMPT_ID = 'fb067327-aaaa-bbbb-cccc-dddddddddddd'
+
+interface AuthRpc {
+  id?: number
+  method?: string
+  params?: { methodId?: string; action?: string; attemptId?: string }
+}
+
+function authSent(fake: CapturingFake): AuthRpc[] {
+  return fake.writes.map((w) => JSON.parse(w) as AuthRpc).filter((m) => m.method === 'authenticate')
+}
+
+/** Drive start() to a ready, signed-out agent with an injected URL opener. */
+async function connectSignedOut(
+  fake: CapturingFake,
+  openUrl: (url: string) => void,
+): Promise<WorkspaceAgent> {
+  const agent = new WorkspaceAgent({ workspaceDir: '/abs/workspace', spawn: () => fake.child, openUrl })
+  const started = agent.start()
+  fake.feed(JSON.stringify({ jsonrpc: '2.0', id: 1, result: INITIALIZE_RESULT }) + '\n')
+  await new Promise((r) => setTimeout(r, 0))
+  fake.feed(
+    JSON.stringify({ jsonrpc: '2.0', id: 2, result: { authenticated: false, authState: 'signed_out' } }) +
+      '\n',
+  )
+  await started
+  return agent
+}
+
+/** The delegated `start` response (acp-capture §8) — verbatim shape. */
+function startResult(): unknown {
+  return {
+    _meta: { [DELEGATED]: { attemptId: ATTEMPT_ID, expiresAt: '2026-06-29T11:22:26Z', signInUrl: SIGN_IN_URL } },
+  }
+}
+
+/** The delegated `complete` response (acp-capture §8). */
+function completeResult(): unknown {
+  return { _meta: { [DELEGATED]: { attemptId: ATTEMPT_ID, persistResult: 'completed', status: 'completed' } } }
+}
+
+describe('WorkspaceAgent — sign in (browser-auth-delegated)', () => {
+  it('advertises the browser-auth-delegated capability in initialize', async () => {
+    const fake = makeCapturingFake()
+    await startWithAuthStatus(fake, { authenticated: false, authState: 'signed_out' })
+
+    // The agent only offers the delegated method if we opt in via
+    // clientCapabilities._meta (acp-capture §8).
+    const init = fake.writes
+      .map((w) => JSON.parse(w) as { method?: string; params?: InitParams })
+      .find((m) => m.method === 'initialize')
+    expect(init?.params?.clientCapabilities?._meta?.['browser-auth-delegated']).toBe(true)
+  })
+
+  it('runs start → open URL → complete → re-detect and resolves signed-in', async () => {
+    const fake = makeCapturingFake()
+    const opened: string[] = []
+    const agent = await connectSignedOut(fake, (url) => opened.push(url))
+
+    const signingIn = agent.signIn(DELEGATED)
+
+    // start is sent immediately (non-blocking); answer it.
+    await new Promise((r) => setTimeout(r, 0))
+    const startReq = authSent(fake).find((m) => m.params?.action === 'start')
+    expect(startReq?.params).toMatchObject({ methodId: DELEGATED, action: 'start' })
+    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: startReq?.id, result: startResult() }) + '\n')
+
+    // The client opens the returned signInUrl, then long-polls `complete`.
+    await new Promise((r) => setTimeout(r, 0))
+    expect(opened).toEqual([SIGN_IN_URL])
+    const completeReq = authSent(fake).find((m) => m.params?.action === 'complete')
+    expect(completeReq?.params).toMatchObject({ methodId: DELEGATED, action: 'complete', attemptId: ATTEMPT_ID })
+    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: completeReq?.id, result: completeResult() }) + '\n')
+
+    // After complete, it re-queries _auth/status to confirm signed-in.
+    await new Promise((r) => setTimeout(r, 0))
+    const statusReqs = sent(fake).filter((m) => m.method === '_auth/status')
+    fake.feed(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: statusReqs[statusReqs.length - 1]?.id,
+        result: { authenticated: true, authState: 'os_keyring', signOutAvailable: true },
+      }) + '\n',
+    )
+
+    await expect(signingIn).resolves.toBe('signed-in')
+    expect(agent.authState).toBe('signed-in')
+  })
+
+  it('rejects (recoverably) when complete fails for an expired/unknown attempt (-32602)', async () => {
+    const fake = makeCapturingFake()
+    const agent = await connectSignedOut(fake, () => {})
+
+    const signingIn = agent.signIn(DELEGATED)
+    signingIn.catch(() => {}) // avoid an unhandled rejection before we assert
+
+    await new Promise((r) => setTimeout(r, 0))
+    const startReq = authSent(fake).find((m) => m.params?.action === 'start')
+    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: startReq?.id, result: startResult() }) + '\n')
+
+    await new Promise((r) => setTimeout(r, 0))
+    const completeReq = authSent(fake).find((m) => m.params?.action === 'complete')
+    fake.feed(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: completeReq?.id,
+        error: { code: -32602, message: 'Invalid request' },
+      }) + '\n',
+    )
+
+    await expect(signingIn).rejects.toBeInstanceOf(WorkspaceAgentError)
+    // The failure leaves auth state untouched (still signed-out) — never wedged.
+    expect(agent.authState).toBe('not-signed-in')
+  })
+
+  it('rejects when the process exits mid sign-in (no wedge)', async () => {
+    const fake = makeCapturingFake()
+    const agent = await connectSignedOut(fake, () => {})
+
+    const signingIn = agent.signIn(DELEGATED)
+    signingIn.catch(() => {})
+
+    // Die while `start` is still in flight.
+    fake.emitExit(1)
+
+    await expect(signingIn).rejects.toBeInstanceOf(WorkspaceAgentError)
+  })
+})
+
 // --- TB2: prompt + fs/read serving (a writes-capturing fake) ----------------
 
 interface CapturingFake extends FakeChild {
@@ -209,6 +347,8 @@ interface CapturingFake extends FakeChild {
 
 function makeCapturingFake(): CapturingFake {
   const stdoutListeners: Array<(chunk: string) => void> = []
+  const exitListeners: Array<(code: number | null, signal: NodeJS.Signals | null) => void> = []
+  const errorListeners: Array<(err: Error) => void> = []
   const writes: string[] = []
   const child: ChildProcessLike = {
     stdout: {
@@ -224,15 +364,18 @@ function makeCapturingFake(): CapturingFake {
       },
     },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    on: () => {},
+    on: (event: 'error' | 'exit', listener: (...args: any[]) => void) => {
+      if (event === 'exit') exitListeners.push(listener)
+      else errorListeners.push(listener)
+    },
     kill: () => {},
   }
   return {
     child,
     writes,
     feed: (chunk) => stdoutListeners.forEach((l) => l(chunk)),
-    emitExit: () => {},
-    emitError: () => {},
+    emitExit: (code, signal = null) => exitListeners.forEach((l) => l(code, signal)),
+    emitError: (err) => errorListeners.forEach((l) => l(err)),
   }
 }
 

--- a/src/main/workspace-agent.ts
+++ b/src/main/workspace-agent.ts
@@ -68,6 +68,8 @@ export interface WorkspaceAgentOptions {
   readTextFile?: ReadTextFn
   /** Override the file writer used to serve `fs/write_text_file` (testing). */
   writeTextFile?: WriteTextFn
+  /** Open a URL in the system browser (delegated sign-in). Injected for testing. */
+  openUrl?: (url: string) => void
 }
 
 export class WorkspaceAgent extends EventEmitter {
@@ -75,6 +77,7 @@ export class WorkspaceAgent extends EventEmitter {
   private readonly workspaceDir: string
   private readonly readTextFile?: ReadTextFn
   private readonly writeTextFile?: WriteTextFn
+  private readonly openUrl?: (url: string) => void
   /** Threads hosted by this agent, keyed by their ACP `sessionId`. */
   private readonly threads = new Map<string, ThreadInfo>()
   private initialized = false
@@ -88,6 +91,7 @@ export class WorkspaceAgent extends EventEmitter {
     this.workspaceDir = options.workspaceDir
     this.readTextFile = options.readTextFile
     this.writeTextFile = options.writeTextFile
+    this.openUrl = options.openUrl
     this.client = new AcpClient({
       command: options.command,
       cwd: options.workspaceDir,
@@ -140,7 +144,13 @@ export class WorkspaceAgent extends EventEmitter {
       const init = await Promise.race([
         this.client.request<InitializeResult>('initialize', {
           protocolVersion: PROTOCOL_VERSION,
-          clientCapabilities: { fs: { readTextFile: true, writeTextFile: true } },
+          clientCapabilities: {
+            fs: { readTextFile: true, writeTextFile: true },
+            // Opt in to client-driven sign-in; without this `_meta` flag the
+            // agent never advertises the `browser-auth-delegated` method
+            // (acp-capture §8).
+            _meta: { 'browser-auth-delegated': true },
+          },
           clientInfo: CLIENT_INFO,
         }),
         earlyFailure,
@@ -180,6 +190,39 @@ export class WorkspaceAgent extends EventEmitter {
     } catch (err) {
       if (err instanceof WorkspaceAgentError) throw err
       this.authStateValue = 'unknown'
+    }
+  }
+
+  /**
+   * Drive Vibe's client-driven browser sign-in (`browser-auth-delegated`, the
+   * ADR-0003 primary path; acp-capture §8). Non-blocking `start` mints a
+   * `signInUrl` we open in the system browser; the long-poll `complete` awaits
+   * the user finishing in the browser and persists the key to Vibe's keyring;
+   * we then re-query `_auth/status` to confirm. We never see or store the
+   * credential. Returns the post-sign-in `AuthState` (`signed-in` on success);
+   * rejects (without wedging) on failure, cancel, an expired/unknown attempt
+   * (-32602), or early process exit.
+   */
+  async signIn(methodId: string): Promise<AuthState> {
+    if (!this.initialized) {
+      throw new WorkspaceAgentError('Agent is not initialized; call start() first.')
+    }
+    try {
+      const started = await this.client.request('authenticate', { methodId, action: 'start' })
+      const meta = extractDelegatedMeta(started, methodId)
+      if (meta?.signInUrl) this.openUrl?.(meta.signInUrl)
+
+      await this.client.request('authenticate', {
+        methodId,
+        action: 'complete',
+        attemptId: meta?.attemptId,
+      })
+
+      const status = await this.client.request('_auth/status')
+      this.authStateValue = classifyAuthStatus(status)
+      return this.authStateValue
+    } catch (err) {
+      throw this.toAgentError(err)
     }
   }
 
@@ -319,6 +362,24 @@ export class WorkspaceAgent extends EventEmitter {
     }
     return new WorkspaceAgentError(message)
   }
+}
+
+interface DelegatedMeta {
+  attemptId?: string
+  signInUrl?: string
+}
+
+/**
+ * Pull the `browser-auth-delegated` payload out of an `authenticate` response.
+ * The agent keys its `_meta` by the method id (acp-capture §8): both `start`
+ * (`{attemptId, signInUrl, expiresAt}`) and `complete` (`{attemptId, status}`)
+ * use this envelope.
+ */
+function extractDelegatedMeta(response: unknown, methodId: string): DelegatedMeta | null {
+  const meta = (response as { _meta?: Record<string, unknown> } | null)?._meta
+  const entry = meta?.[methodId]
+  if (!entry || typeof entry !== 'object') return null
+  return entry as DelegatedMeta
 }
 
 /** Pull the well-formed `authMethods` out of an `initialize` result. */

--- a/src/main/workspace-agent.ts
+++ b/src/main/workspace-agent.ts
@@ -3,6 +3,7 @@ import { AcpClient, type SpawnFn } from './acp/client'
 import { handleFsReadTextFile, type ReadTextFn } from './acp/fs-read'
 import { handleFsWriteTextFile, type WriteTextFn } from './acp/fs-write'
 import { classifyAuthError, classifyAuthStatus } from './auth/auth-state'
+import { DELEGATED_AUTH_METHOD_ID } from '../shared/ipc'
 import type {
   AuthMethod,
   AuthState,
@@ -207,23 +208,47 @@ export class WorkspaceAgent extends EventEmitter {
     if (!this.initialized) {
       throw new WorkspaceAgentError('Agent is not initialized; call start() first.')
     }
+    // We only drive the delegated two-step. Sending `action:start/complete` to
+    // the blocking `browser-auth` method would fail silently, so reject any
+    // other method up front. (The blocking fallback is a separate slice.)
+    if (methodId !== DELEGATED_AUTH_METHOD_ID) {
+      throw new WorkspaceAgentError(
+        'Delegated browser sign-in is unavailable for this agent.',
+        AUTH_HINT,
+      )
+    }
+    // Unlike start(), this does NOT race `earlyFailure`; its no-wedge property
+    // relies on AcpClient.rejectAllPending firing on `exit`/`stop`, which rejects
+    // any in-flight authenticate/_auth/status request. Keep that on refactor.
     try {
       const started = await this.client.request('authenticate', { methodId, action: 'start' })
       const meta = extractDelegatedMeta(started, methodId)
-      if (meta?.signInUrl) this.openUrl?.(meta.signInUrl)
+      // Fail fast before opening the browser or sending a doomed `complete`
+      // (which would surface a raw -32602) if `start` returned no attempt.
+      if (!meta?.attemptId) {
+        throw new WorkspaceAgentError('Sign-in could not start — Vibe returned no attempt.', AUTH_HINT)
+      }
+      if (meta.signInUrl) this.openUrl?.(meta.signInUrl)
 
       await this.client.request('authenticate', {
         methodId,
         action: 'complete',
-        attemptId: meta?.attemptId,
+        attemptId: meta.attemptId,
       })
 
       const status = await this.client.request('_auth/status')
       this.authStateValue = classifyAuthStatus(status)
       return this.authStateValue
     } catch (err) {
-      throw this.toAgentError(err)
+      throw this.toSignInError(err)
     }
+  }
+
+  /** Map a sign-in failure to a clear message (not a bare RPC string). */
+  private toSignInError(err: unknown): WorkspaceAgentError {
+    if (err instanceof WorkspaceAgentError) return err
+    const detail = (err as { message?: string })?.message ?? (err instanceof Error ? err.message : String(err))
+    return new WorkspaceAgentError(`Sign-in failed: ${detail}`, AUTH_HINT)
   }
 
   /**

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -5,6 +5,8 @@ import {
   type RespondPermissionArgs,
   type SendPromptArgs,
   type SendPromptResult,
+  type SignInArgs,
+  type SignInResult,
   type StartThreadArgs,
   type StartThreadResult,
   type VibeDetectResult,
@@ -19,6 +21,7 @@ const api = {
     ipcRenderer.invoke(IPC.sendPrompt, args),
   respondPermission: (args: RespondPermissionArgs): Promise<void> =>
     ipcRenderer.invoke(IPC.respondPermission, args),
+  signIn: (args: SignInArgs): Promise<SignInResult> => ipcRenderer.invoke(IPC.signIn, args),
   stopAgent: (agentId: string): Promise<void> => ipcRenderer.invoke(IPC.stopAgent, agentId),
   onAcpEvent: (listener: (event: AcpEvent) => void): (() => void) => {
     const handler = (_e: unknown, payload: AcpEvent): void => listener(payload)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState, type JSX } from 'react'
+import { useEffect, useReducer, useState, type JSX } from 'react'
 import type { AuthMethod, ThreadConnection, VibeDetectResult } from '../../shared/ipc'
-import { selectAuthView } from './auth/auth-view'
+import { authReducer, initialAuthViewState, selectAuthView } from './auth/auth-view'
 import { Conversation } from './conversation/Conversation'
 
 type ConnectState =
@@ -97,7 +97,11 @@ export function App(): JSX.Element {
           )}
 
           {connect.status === 'not-signed-in' && (
-            <SignInPanel authMethods={connect.authMethods} />
+            <SignInPanel
+              key={connect.agentId}
+              agentId={connect.agentId}
+              authMethods={connect.authMethods}
+            />
           )}
 
           {connect.status === 'error' && (
@@ -121,19 +125,63 @@ export function App(): JSX.Element {
 
 /**
  * The not-signed-in panel: visibly distinct from the binary-missing status and
- * the generic-error alert. Renders the agent's advertised sign-in method name
- * and a Sign-in button. The button is intentionally inert here — its click
- * handler is wired in #12 (browser-auth-delegated).
+ * the generic-error alert. Clicking Sign-in drives Vibe's delegated browser
+ * sign-in via main (#12) — the system browser opens, and on success the panel
+ * transitions to a signed-in confirmation. The auth lifecycle (signing-in /
+ * signed-in / error) is the pure `authReducer`; this component is the glue.
  */
-function SignInPanel({ authMethods }: { authMethods: AuthMethod[] }): JSX.Element | null {
-  const view = selectAuthView({ authState: 'not-signed-in', authMethods })
-  if (view.kind !== 'sign-in') return null
+function SignInPanel({
+  agentId,
+  authMethods,
+}: {
+  agentId: string
+  authMethods: AuthMethod[]
+}): JSX.Element {
+  const [state, dispatch] = useReducer(authReducer, authMethods, initialAuthViewState)
+  const view = selectAuthView(state)
+
+  async function signIn(methodId: string): Promise<void> {
+    dispatch({ type: 'sign-in-start' })
+    const result = await window.api.signIn({ agentId, methodId })
+    if (result.ok && result.authState === 'signed-in') {
+      dispatch({ type: 'sign-in-success' })
+    } else {
+      dispatch({
+        type: 'sign-in-error',
+        message: result.ok ? 'Sign-in did not complete. Please try again.' : result.error,
+      })
+    }
+  }
+
+  if (view.kind === 'none') {
+    // Reaching `none` in this panel means we just signed in.
+    return (
+      <div className="signin signin--done">
+        <div className="signin__title">Signed in to Mistral Vibe</div>
+      </div>
+    )
+  }
+
+  if (view.kind === 'signing-in') {
+    return (
+      <div className="signin">
+        <div className="signin__title">Signing in…</div>
+        <div className="signin__message">Complete sign-in in your browser, then return here.</div>
+      </div>
+    )
+  }
+
+  // sign-in or error: both render the (clickable) Sign-in button so the error
+  // state stays recoverable.
   return (
     <div className="signin">
       <div className="signin__title">Not signed in to Mistral Vibe</div>
-      {view.description && <div className="signin__message">{view.description}</div>}
-      <button className="btn signin__action" onClick={() => {}}>
-        {view.methodName}
+      {view.kind === 'sign-in' && view.description && (
+        <div className="signin__message">{view.description}</div>
+      )}
+      {view.kind === 'error' && <div className="signin__error">{view.message}</div>}
+      <button className="btn signin__action" onClick={() => void signIn(view.methodId)}>
+        {view.kind === 'error' ? `Retry — ${view.methodName}` : view.methodName}
       </button>
     </div>
   )

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useReducer, useState, type JSX } from 'react'
+import { useEffect, useReducer, useRef, useState, type JSX } from 'react'
 import type { AuthMethod, ThreadConnection, VibeDetectResult } from '../../shared/ipc'
 import { authReducer, initialAuthViewState, selectAuthView } from './auth/auth-view'
 import { Conversation } from './conversation/Conversation'
@@ -138,11 +138,18 @@ function SignInPanel({
   authMethods: AuthMethod[]
 }): JSX.Element {
   const [state, dispatch] = useReducer(authReducer, authMethods, initialAuthViewState)
+  // Generation counter: bumped on every attempt start and on cancel. The
+  // delegated `complete` long-poll can't be aborted over ACP, so a cancelled (or
+  // superseded) attempt's eventual result must be ignored rather than clobber
+  // the panel — we only apply a result whose generation is still current.
+  const attemptRef = useRef(0)
   const view = selectAuthView(state)
 
   async function signIn(methodId: string): Promise<void> {
+    const attempt = ++attemptRef.current
     dispatch({ type: 'sign-in-start' })
     const result = await window.api.signIn({ agentId, methodId })
+    if (attempt !== attemptRef.current) return // cancelled/superseded — drop the stale result
     if (result.ok && result.authState === 'signed-in') {
       dispatch({ type: 'sign-in-success' })
     } else {
@@ -153,8 +160,15 @@ function SignInPanel({
     }
   }
 
+  function cancel(): void {
+    attemptRef.current++ // invalidate the in-flight attempt; its result is dropped
+    dispatch({ type: 'sign-in-cancel' })
+  }
+
   if (view.kind === 'none') {
-    // Reaching `none` in this panel means we just signed in.
+    // Reaching `none` in this panel means we just signed in. This terminal
+    // confirmation is #12's end state; opening a Thread from here (routing
+    // Open-project through sign-in) is #13.
     return (
       <div className="signin signin--done">
         <div className="signin__title">Signed in to Mistral Vibe</div>
@@ -167,6 +181,9 @@ function SignInPanel({
       <div className="signin">
         <div className="signin__title">Signing in…</div>
         <div className="signin__message">Complete sign-in in your browser, then return here.</div>
+        <button className="btn btn--ghost signin__action" onClick={cancel}>
+          Cancel
+        </button>
       </div>
     )
   }

--- a/src/renderer/src/auth/auth-view.test.ts
+++ b/src/renderer/src/auth/auth-view.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { selectAuthView } from './auth-view'
+import { authReducer, initialAuthViewState, selectAuthView } from './auth-view'
 import type { AuthMethod } from '../../../shared/ipc'
 
 /**
@@ -15,30 +15,81 @@ const BROWSER_AUTH: AuthMethod = {
   description: 'Sign into Mistral Vibe through your Mistral AI Studio account.',
 }
 
+const DELEGATED: AuthMethod = {
+  id: 'browser-auth-delegated',
+  name: 'Sign in through Mistral AI Studio',
+}
+
+describe('authReducer', () => {
+  it('transitions not-signed-in → signing-in on sign-in-start', () => {
+    const state = authReducer(initialAuthViewState([BROWSER_AUTH]), { type: 'sign-in-start' })
+    expect(state.phase).toBe('signing-in')
+    expect(state.error).toBeNull()
+  })
+
+  it('transitions signing-in → signed-in on success without persisting any credential', () => {
+    let state = authReducer(initialAuthViewState([BROWSER_AUTH]), { type: 'sign-in-start' })
+    state = authReducer(state, { type: 'sign-in-success' })
+    expect(state.phase).toBe('signed-in')
+    // ADR-0003: we only reflect state — the view state carries no token/secret.
+    // Its keys are exactly the lifecycle fields, nothing credential-shaped.
+    expect(Object.keys(state).sort()).toEqual(['authMethods', 'error', 'phase'])
+  })
+
+  it('transitions signing-in → error on failure, carrying a recoverable message', () => {
+    let state = authReducer(initialAuthViewState([BROWSER_AUTH]), { type: 'sign-in-start' })
+    state = authReducer(state, { type: 'sign-in-error', message: 'Sign-in failed.' })
+    expect(state.phase).toBe('error')
+    expect(state.error).toBe('Sign-in failed.')
+  })
+
+  it('allows retry from error (sign-in-start clears the error → signing-in)', () => {
+    let state = authReducer(initialAuthViewState([BROWSER_AUTH]), { type: 'sign-in-start' })
+    state = authReducer(state, { type: 'sign-in-error', message: 'boom' })
+    state = authReducer(state, { type: 'sign-in-start' })
+    expect(state.phase).toBe('signing-in')
+    expect(state.error).toBeNull()
+  })
+})
+
 describe('selectAuthView', () => {
-  it('shows a sign-in panel with the advertised method name when not signed in', () => {
-    const view = selectAuthView({ authState: 'not-signed-in', authMethods: [BROWSER_AUTH] })
+  it('shows a sign-in panel preferring the delegated method when not signed in', () => {
+    // Both methods are advertised (same display name); we must pick the
+    // client-driven `browser-auth-delegated`, not just authMethods[0].
+    const view = selectAuthView(initialAuthViewState([BROWSER_AUTH, DELEGATED]))
     expect(view).toEqual({
       kind: 'sign-in',
-      methodId: 'browser-auth',
+      methodId: 'browser-auth-delegated',
       methodName: 'Sign in through Mistral AI Studio',
-      description: 'Sign into Mistral Vibe through your Mistral AI Studio account.',
+      description: null,
     })
   })
 
-  it('shows no auth panel when signed in (incl. BYOK)', () => {
-    expect(selectAuthView({ authState: 'signed-in', authMethods: [BROWSER_AUTH] })).toEqual({
-      kind: 'none',
-    })
+  it('shows a signing-in view during the browser step', () => {
+    const state = authReducer(initialAuthViewState([DELEGATED]), { type: 'sign-in-start' })
+    expect(selectAuthView(state)).toEqual({ kind: 'signing-in' })
   })
 
-  it('shows no auth panel while the state is still unknown', () => {
-    expect(selectAuthView({ authState: 'unknown' })).toEqual({ kind: 'none' })
+  it('shows no auth panel once signed in', () => {
+    let state = authReducer(initialAuthViewState([DELEGATED]), { type: 'sign-in-start' })
+    state = authReducer(state, { type: 'sign-in-success' })
+    expect(selectAuthView(state)).toEqual({ kind: 'none' })
+  })
+
+  it('shows a recoverable error view (with the method to retry) on failure', () => {
+    let state = authReducer(initialAuthViewState([BROWSER_AUTH, DELEGATED]), { type: 'sign-in-start' })
+    state = authReducer(state, { type: 'sign-in-error', message: 'Sign-in failed.' })
+    expect(selectAuthView(state)).toEqual({
+      kind: 'error',
+      message: 'Sign-in failed.',
+      methodId: 'browser-auth-delegated',
+      methodName: 'Sign in through Mistral AI Studio',
+    })
   })
 
   it('falls back to a generic sign-in label when no authMethods are advertised', () => {
     // Defensive: never strand the user without a way back in if authMethods is empty.
-    expect(selectAuthView({ authState: 'not-signed-in', authMethods: [] })).toEqual({
+    expect(selectAuthView(initialAuthViewState([]))).toEqual({
       kind: 'sign-in',
       methodId: '',
       methodName: 'Sign in',

--- a/src/renderer/src/auth/auth-view.test.ts
+++ b/src/renderer/src/auth/auth-view.test.ts
@@ -50,6 +50,13 @@ describe('authReducer', () => {
     expect(state.phase).toBe('signing-in')
     expect(state.error).toBeNull()
   })
+
+  it('returns signing-in → not-signed-in on cancel (escape hatch, never stranded)', () => {
+    let state = authReducer(initialAuthViewState([BROWSER_AUTH]), { type: 'sign-in-start' })
+    state = authReducer(state, { type: 'sign-in-cancel' })
+    expect(state.phase).toBe('not-signed-in')
+    expect(state.error).toBeNull()
+  })
 })
 
 describe('selectAuthView', () => {

--- a/src/renderer/src/auth/auth-view.ts
+++ b/src/renderer/src/auth/auth-view.ts
@@ -1,4 +1,4 @@
-import type { AuthMethod } from '../../../shared/ipc'
+import { DELEGATED_AUTH_METHOD_ID, type AuthMethod } from '../../../shared/ipc'
 
 /**
  * Pure auth view-state selector (no React, no IPC). Maps the detected
@@ -30,12 +30,15 @@ export type AuthAction =
   | { type: 'sign-in-start' }
   | { type: 'sign-in-success' }
   | { type: 'sign-in-error'; message: string }
+  | { type: 'sign-in-cancel' }
 
 /**
  * Fold a sign-in lifecycle action into the panel's view state. Pure (no React,
  * no IPC). `sign-in-start` is allowed from both `not-signed-in` and `error` so
  * the error state stays recoverable (retry); a failure can never leave the
- * panel stuck in `signing-in`.
+ * panel stuck in `signing-in`. `sign-in-cancel` is the user's escape hatch out
+ * of `signing-in` (the browser long-poll itself can't be aborted — see
+ * SignInPanel); it just abandons the attempt and returns to `not-signed-in`.
  */
 export function authReducer(state: AuthViewState, action: AuthAction): AuthViewState {
   switch (action.type) {
@@ -45,6 +48,8 @@ export function authReducer(state: AuthViewState, action: AuthAction): AuthViewS
       return { ...state, phase: 'signed-in', error: null }
     case 'sign-in-error':
       return { ...state, phase: 'error', error: action.message }
+    case 'sign-in-cancel':
+      return { ...state, phase: 'not-signed-in', error: null }
   }
 }
 
@@ -77,17 +82,12 @@ export interface NoAuthView {
 export type AuthView = SignInView | SigningInView | SignInErrorView | NoAuthView
 
 /**
- * The id Vibe's client-driven (delegated) browser sign-in is advertised under
- * (acp-capture §8). Preferred over the blocking `browser-auth` per ADR-0003.
- */
-export const DELEGATED_METHOD_ID = 'browser-auth-delegated'
-
-/**
- * Pick the sign-in method to drive: prefer the delegated method, else the first
- * advertised, else a generic fallback so the user is never stranded.
+ * Pick the sign-in method to drive: prefer the delegated method (the one main's
+ * `signIn` accepts), else the first advertised, else a generic fallback so the
+ * user is never stranded.
  */
 function preferredMethod(authMethods: AuthMethod[]): { id: string; name: string; description: string | null } {
-  const method = authMethods.find((m) => m.id === DELEGATED_METHOD_ID) ?? authMethods[0]
+  const method = authMethods.find((m) => m.id === DELEGATED_AUTH_METHOD_ID) ?? authMethods[0]
   return {
     id: method?.id ?? '',
     name: method?.name ?? 'Sign in',

--- a/src/renderer/src/auth/auth-view.ts
+++ b/src/renderer/src/auth/auth-view.ts
@@ -1,4 +1,4 @@
-import type { AuthMethod, AuthState } from '../../../shared/ipc'
+import type { AuthMethod } from '../../../shared/ipc'
 
 /**
  * Pure auth view-state selector (no React, no IPC). Maps the detected
@@ -7,7 +7,48 @@ import type { AuthMethod, AuthState } from '../../../shared/ipc'
  * ADR-0001 the renderer owns this; main classifies + relays the AuthState.
  */
 
-/** Render a sign-in panel — the method name + a (not-yet-wired) Sign-in button. */
+/**
+ * The renderer's auth-panel lifecycle phase. `not-signed-in` is the entry (main
+ * detected it); `signing-in` is the in-flight browser step; `signed-in` is the
+ * success terminal; `error` is a recoverable failure the user can retry from.
+ */
+export type AuthPhase = 'not-signed-in' | 'signing-in' | 'signed-in' | 'error'
+
+/** Pure view state for the sign-in panel — folded by `authReducer`. */
+export interface AuthViewState {
+  phase: AuthPhase
+  authMethods: AuthMethod[]
+  /** Recoverable failure message; set only while `phase === 'error'`. */
+  error: string | null
+}
+
+export function initialAuthViewState(authMethods: AuthMethod[]): AuthViewState {
+  return { phase: 'not-signed-in', authMethods, error: null }
+}
+
+export type AuthAction =
+  | { type: 'sign-in-start' }
+  | { type: 'sign-in-success' }
+  | { type: 'sign-in-error'; message: string }
+
+/**
+ * Fold a sign-in lifecycle action into the panel's view state. Pure (no React,
+ * no IPC). `sign-in-start` is allowed from both `not-signed-in` and `error` so
+ * the error state stays recoverable (retry); a failure can never leave the
+ * panel stuck in `signing-in`.
+ */
+export function authReducer(state: AuthViewState, action: AuthAction): AuthViewState {
+  switch (action.type) {
+    case 'sign-in-start':
+      return { ...state, phase: 'signing-in', error: null }
+    case 'sign-in-success':
+      return { ...state, phase: 'signed-in', error: null }
+    case 'sign-in-error':
+      return { ...state, phase: 'error', error: action.message }
+  }
+}
+
+/** Render a sign-in panel — the method name + a clickable Sign-in button. */
 export interface SignInView {
   kind: 'sign-in'
   methodId: string
@@ -15,26 +56,56 @@ export interface SignInView {
   description: string | null
 }
 
-/** Render nothing auth-related (signed in, or state not yet known). */
+/** Render the in-flight browser step (a spinner / progress, no button). */
+export interface SigningInView {
+  kind: 'signing-in'
+}
+
+/** Render a recoverable failure — the message plus the method to retry with. */
+export interface SignInErrorView {
+  kind: 'error'
+  message: string
+  methodId: string
+  methodName: string
+}
+
+/** Render nothing auth-related (signed in). */
 export interface NoAuthView {
   kind: 'none'
 }
 
-export type AuthView = SignInView | NoAuthView
+export type AuthView = SignInView | SigningInView | SignInErrorView | NoAuthView
 
-export interface AuthViewInput {
-  authState: AuthState
-  authMethods?: AuthMethod[]
+/**
+ * The id Vibe's client-driven (delegated) browser sign-in is advertised under
+ * (acp-capture §8). Preferred over the blocking `browser-auth` per ADR-0003.
+ */
+export const DELEGATED_METHOD_ID = 'browser-auth-delegated'
+
+/**
+ * Pick the sign-in method to drive: prefer the delegated method, else the first
+ * advertised, else a generic fallback so the user is never stranded.
+ */
+function preferredMethod(authMethods: AuthMethod[]): { id: string; name: string; description: string | null } {
+  const method = authMethods.find((m) => m.id === DELEGATED_METHOD_ID) ?? authMethods[0]
+  return {
+    id: method?.id ?? '',
+    name: method?.name ?? 'Sign in',
+    description: method?.description ?? null,
+  }
 }
 
-export function selectAuthView(input: AuthViewInput): AuthView {
-  if (input.authState !== 'not-signed-in') return { kind: 'none' }
-
-  const method = input.authMethods?.[0]
-  return {
-    kind: 'sign-in',
-    methodId: method?.id ?? '',
-    methodName: method?.name ?? 'Sign in',
-    description: method?.description ?? null,
+/** Project the auth view-state to what the renderer shows. */
+export function selectAuthView(state: AuthViewState): AuthView {
+  const method = preferredMethod(state.authMethods)
+  switch (state.phase) {
+    case 'not-signed-in':
+      return { kind: 'sign-in', methodId: method.id, methodName: method.name, description: method.description }
+    case 'signing-in':
+      return { kind: 'signing-in' }
+    case 'error':
+      return { kind: 'error', message: state.error ?? 'Sign-in failed.', methodId: method.id, methodName: method.name }
+    case 'signed-in':
+      return { kind: 'none' }
   }
 }

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -263,6 +263,21 @@ body {
   color: var(--muted);
 }
 
+.signin__error {
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--bad);
+}
+
+.signin--done {
+  border-color: rgba(63, 185, 80, 0.4);
+  background: rgba(63, 185, 80, 0.08);
+}
+
+.signin--done .signin__title {
+  color: var(--ok);
+}
+
 .signin__action {
   margin-top: 2px;
 }

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -22,6 +22,12 @@ export const IPC = {
   acpEvent: 'acp:event',
 } as const
 
+/**
+ * The `authMethods` id for Vibe's client-driven (delegated) browser sign-in
+ * (acp-capture §8) — the ADR-0003 primary path. The only method `signIn` drives.
+ */
+export const DELEGATED_AUTH_METHOD_ID = 'browser-auth-delegated'
+
 export interface VibeDetectResult {
   vibeFound: boolean
   vibeAcpFound: boolean

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -16,6 +16,8 @@ export const IPC = {
   sendPrompt: 'thread:prompt',
   /** Answer a `session/request_permission` by its JSON-RPC request id. */
   respondPermission: 'permission:respond',
+  /** Drive Vibe's browser sign-in on a not-signed-in agent (`authenticate`). */
+  signIn: 'auth:sign-in',
   /** Main -> renderer: streamed ACP event tagged by the owning agent. */
   acpEvent: 'acp:event',
 } as const
@@ -139,3 +141,19 @@ export interface RespondPermissionArgs {
   /** The `optionId` of the option the user selected. */
   optionId: string
 }
+
+/** Trigger browser sign-in on the not-signed-in agent retained from startThread. */
+export interface SignInArgs {
+  /** Id of the Workspace agent (one `vibe-acp` process) to authenticate. */
+  agentId: string
+  /** The `authMethods` id to sign in with (prefer `browser-auth-delegated`). */
+  methodId: string
+}
+
+/**
+ * Result of a sign-in attempt. `authState` is the post-sign-in state (re-queried
+ * via `_auth/status`); failures are recoverable — the renderer can retry.
+ */
+export type SignInResult =
+  | { ok: true; authState: AuthState }
+  | { ok: false; error: string }


### PR DESCRIPTION
Closes #12.

## Summary

The Sign-in button from #11 is now live. Clicking it drives Vibe's **client-driven `browser-auth-delegated`** flow (the ADR-0003 primary path; blocking `browser-auth` remains the documented fallback): main calls `authenticate(start)`, the system browser opens the returned `signInUrl`, main long-polls `authenticate(complete, attemptId)`, then re-queries `_auth/status` to confirm. The UI transitions `not-signed-in → signing-in → signed-in`, or to a **recoverable** error on failure/cancel/early-exit. We never see or store the credential — Vibe owns the keyring (ADR-0003).

Built with strict vertical TDD (one behavior → one impl). Behaviors driven, in order:

**Seam 2 — main orchestration** (`src/main/workspace-agent.ts`, injected `SpawnFn` + injected opener)
1. `initialize` now advertises `clientCapabilities._meta:{ "browser-auth-delegated": true }` — without it the agent never offers the delegated method (acp-capture §8).
2. `signIn(methodId)` happy path: sends `authenticate({methodId, action:"start"})`, invokes the injected opener with the returned `signInUrl`, sends `authenticate({…, action:"complete", attemptId})` with the attemptId from start, re-queries `_auth/status`, resolves `signed-in`.
3. A failed `complete` (`-32602` expired/unknown attempt) rejects as a recoverable `WorkspaceAgentError`; auth state stays `not-signed-in` (never wedged).
4. Early process exit mid-sign-in rejects (no wedge).

**Seam 3 — renderer view-state** (`src/renderer/src/auth/auth-view.ts`, pure)
5. `authReducer`: `not-signed-in → signing-in` (start), `→ signed-in` (success), `→ error` (failure, carries message), and **retry** from error (`sign-in-start` clears the error).
6. `selectAuthView` redesigned to project the view-state and **prefer the delegated method** (not `authMethods[0]`, which is the blocking `browser-auth`); covers signing-in / signed-in / error views.
7. ADR-0003 guard: the view state holds no credential — keys are exactly `{phase, authMethods, error}`.

**Wiring** (`src/shared/ipc.ts`, `src/preload/index.ts`, `src/main/index.ts`, `src/renderer/src/App.tsx`)
- New `signIn({agentId, methodId})` IPC → discriminated `SignInResult`. `index.ts` injects `shell.openExternal` as the agent's `openUrl` and relays the resulting `AuthState`. `SignInPanel` uses `useReducer(authReducer)` — click drives sign-in, shows `signing-in…`, a signed-in confirmation, and a recoverable error + retry. The invoke result is the auth-state-change signal (no extra channel needed).

## Scope boundary

Reaches **signed-in** only. Routing Open-project through sign-in / opening a Thread post-sign-in is **#13** and is intentionally not built here.

## Verification

```
bun run typecheck   # clean (strict TS, noUnusedLocals/Params)
bun run build       # ✓ built
bun run test        # Test Files 7 passed (7) · Tests 63 passed (63)
```

(`bun run lint` is a no-op in this repo — eslint isn't in devDependencies; pre-existing, untouched.)

## Notes for reviewers

- **`signIn` orchestration** (`workspace-agent.ts`) — the start→open→complete→re-detect sequence, the `_meta`-keyed-by-methodId envelope parsing (`extractDelegatedMeta`), and the no-wedge error/exit handling (rejects via `toAgentError`; AcpClient rejects pending on exit).
- **Method preference** (`selectAuthView` / `preferredMethod`) — confirm `browser-auth-delegated` is chosen over `browser-auth` when both are advertised.
- **No credential storage** (ADR-0003) — `SignInResult` carries only `authState`; the reducer state carries no token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)