### PR TITLE
Auth TB4 — Signed-in status, sign out & route Open-project through sign-in

### DIFF
--- a/src/main/auth/auth-state.ts
+++ b/src/main/auth/auth-state.ts
@@ -31,3 +31,12 @@ export function classifyAuthStatus(status: unknown): AuthState {
   if (authenticated === false) return 'not-signed-in'
   return 'unknown'
 }
+
+/**
+ * Whether `_auth/status` reports sign-out is available (`signOutAvailable`).
+ * Gates the renderer's Sign-out control — only `true` enables it (acp-capture §8;
+ * `_auth/signOut` errors -32602 when it's false).
+ */
+export function extractSignOutAvailable(status: unknown): boolean {
+  return (status as { signOutAvailable?: unknown } | null)?.signOutAvailable === true
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -35,8 +35,8 @@ function connectionFor(agentId: string, agent: WorkspaceAgent, thread: ThreadInf
 
 /**
  * Map a thread-open failure to a result. An auth-classified error (a -32000
- * mid-session/expiry) keeps the agent ALIVE and routes to the sign-in panel
- * (TODO(#13) C); any other failure stops + disposes the agent.
+ * mid-session/expiry) keeps the agent ALIVE and routes to the sign-in panel;
+ * any other failure stops + disposes the agent.
  */
 function threadFailureResult(agentId: string, agent: WorkspaceAgent, err: unknown): StartThreadResult {
   if (err instanceof WorkspaceAgentError && err.authState === 'not-signed-in') {
@@ -102,8 +102,7 @@ function registerIpc(): void {
 
   ipcMain.handle(IPC.startThread, async (event, args: StartThreadArgs): Promise<StartThreadResult> => {
     // Dedup: dispose any existing agent for this workspace before spawning, so a
-    // re-Connect (e.g. after a not-signed-in panel) can't orphan the previous
-    // child (TODO(#13) #1).
+    // re-Connect (e.g. after a not-signed-in panel) can't orphan the previous child.
     disposeAgentsForWorkspace(args.workspaceDir)
 
     const agentId = `a${++agentCounterSeed}`
@@ -161,7 +160,7 @@ function registerIpc(): void {
         return { ok: true, result }
       } catch (err) {
         // Mid-session expiry (-32000): keep the agent alive so the renderer can
-        // re-auth in place on the same agent (TODO(#13) D); don't stop it.
+        // re-auth in place on the same agent; don't stop it.
         if (err instanceof WorkspaceAgentError && err.authState === 'not-signed-in') {
           return { ok: false, kind: 'not-signed-in', agentId: args.agentId, authMethods: agent.authMethods }
         }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -40,6 +40,11 @@ function connectionFor(agentId: string, agent: WorkspaceAgent, thread: ThreadInf
  */
 function threadFailureResult(agentId: string, agent: WorkspaceAgent, err: unknown): StartThreadResult {
   if (err instanceof WorkspaceAgentError && err.authState === 'not-signed-in') {
+    // Keep the agent alive AND registered so the renderer's follow-up
+    // signIn({agentId}) finds it. Idempotent: startThread already registers on a
+    // successful start(), but a -32000 thrown from start() itself reaches here
+    // before that, so without this the child would leak + the button would dead-end.
+    agents.set(agentId, agent)
     return { ok: false, kind: 'not-signed-in', agentId, workspaceDir: agent.workspaceDir, authMethods: agent.authMethods }
   }
   agent.stop()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,13 +2,18 @@ import { app, BrowserWindow, dialog, ipcMain, shell } from 'electron'
 import { join } from 'node:path'
 import {
   IPC,
+  type OpenThreadArgs,
   type RespondPermissionArgs,
   type SendPromptArgs,
   type SendPromptResult,
   type SignInArgs,
   type SignInResult,
+  type SignOutArgs,
+  type SignOutResult,
   type StartThreadArgs,
   type StartThreadResult,
+  type ThreadConnection,
+  type ThreadInfo,
 } from '../shared/ipc'
 import { detectVibe } from './vibe-detect'
 import { getShellEnv } from './shell-env'
@@ -16,6 +21,41 @@ import { WorkspaceAgent, WorkspaceAgentError } from './workspace-agent'
 
 /** Active Workspace agents keyed by a generated agent id. */
 const agents = new Map<string, WorkspaceAgent>()
+
+/** Build the renderer-facing connection (carries the sign-out gate + methods). */
+function connectionFor(agentId: string, agent: WorkspaceAgent, thread: ThreadInfo): ThreadConnection {
+  return {
+    agentId,
+    workspaceDir: agent.workspaceDir,
+    ...thread,
+    signOutAvailable: agent.signOutAvailable,
+    authMethods: agent.authMethods,
+  }
+}
+
+/**
+ * Map a thread-open failure to a result. An auth-classified error (a -32000
+ * mid-session/expiry) keeps the agent ALIVE and routes to the sign-in panel
+ * (TODO(#13) C); any other failure stops + disposes the agent.
+ */
+function threadFailureResult(agentId: string, agent: WorkspaceAgent, err: unknown): StartThreadResult {
+  if (err instanceof WorkspaceAgentError && err.authState === 'not-signed-in') {
+    return { ok: false, kind: 'not-signed-in', agentId, workspaceDir: agent.workspaceDir, authMethods: agent.authMethods }
+  }
+  agent.stop()
+  agents.delete(agentId)
+  if (err instanceof WorkspaceAgentError) return { ok: false, kind: 'error', error: err.message, hint: err.hint }
+  return { ok: false, kind: 'error', error: err instanceof Error ? err.message : String(err), hint: null }
+}
+
+/** Stop + drop any live agent bound to this workspace (dedup before re-spawn). */
+function disposeAgentsForWorkspace(workspaceDir: string): void {
+  for (const [id, agent] of agents) {
+    if (agent.workspaceDir !== workspaceDir) continue
+    agent.stop()
+    agents.delete(id)
+  }
+}
 let agentCounterSeed = 0
 
 function createWindow(): void {
@@ -61,12 +101,11 @@ function registerIpc(): void {
   })
 
   ipcMain.handle(IPC.startThread, async (event, args: StartThreadArgs): Promise<StartThreadResult> => {
-    // TODO(#13): a retained not-signed-in agent (below) is NOT deduped by
-    // workspaceDir — we always mint a fresh agentId + spawn a new
-    // WorkspaceAgent. Sign-in (#12) reuses the same agent by agentId, so this
-    // doesn't bite yet; but #13 (route Open-project through sign-in) re-Connects
-    // to the same workspace and would orphan the previous not-signed-in agent
-    // (its child lingers). #13 must reuse or stop the existing agent.
+    // Dedup: dispose any existing agent for this workspace before spawning, so a
+    // re-Connect (e.g. after a not-signed-in panel) can't orphan the previous
+    // child (TODO(#13) #1).
+    disposeAgentsForWorkspace(args.workspaceDir)
+
     const agentId = `a${++agentCounterSeed}`
     const agent = new WorkspaceAgent({
       workspaceDir: args.workspaceDir,
@@ -83,42 +122,32 @@ function registerIpc(): void {
 
     try {
       await agent.start()
+      agents.set(agentId, agent)
 
-      // Detected not-signed-in: keep the agent (the sign-in flow will drive it)
-      // but don't open a Thread — session/new would fail with -32000. The
-      // renderer shows the sign-in panel (ADR-0003: detection only here).
+      // Detected not-signed-in: keep the agent (the sign-in flow drives it) but
+      // don't open a Thread — session/new would fail with -32000. The renderer
+      // shows the sign-in panel and re-tries openThread after sign-in.
       if (agent.authState === 'not-signed-in') {
-        agents.set(agentId, agent)
-        return {
-          ok: false,
-          kind: 'not-signed-in',
-          agentId,
-          workspaceDir: args.workspaceDir,
-          authMethods: agent.authMethods,
-        }
+        return { ok: false, kind: 'not-signed-in', agentId, workspaceDir: args.workspaceDir, authMethods: agent.authMethods }
       }
 
       const thread = await agent.openThread()
-      agents.set(agentId, agent)
-      return { ok: true, thread: { agentId, workspaceDir: args.workspaceDir, ...thread } }
+      return { ok: true, thread: connectionFor(agentId, agent, thread) }
     } catch (err) {
-      agent.stop()
-      // TODO(#13): fallback UX gap. When `_auth/status` returned `unknown` but
-      // the user is actually signed out, `session/new` (openThread) fails with
-      // -32000 and lands here — we surface it as a generic error alert (still
-      // carrying AUTH_HINT) rather than the SignInPanel. Routing this auth-error
-      // path to the panel requires keeping the agent alive (not stop()-ing it)
-      // so the sign-in flow can drive it, which is coupled to the
-      // agent-dedup/lifecycle work deferred to #13.
-      if (err instanceof WorkspaceAgentError) {
-        return { ok: false, kind: 'error', error: err.message, hint: err.hint }
-      }
-      return {
-        ok: false,
-        kind: 'error',
-        error: err instanceof Error ? err.message : String(err),
-        hint: null,
-      }
+      return threadFailureResult(agentId, agent, err)
+    }
+  })
+
+  ipcMain.handle(IPC.openThread, async (_event, args: OpenThreadArgs): Promise<StartThreadResult> => {
+    // Open a Thread on an agent already started + signed in (after sign-in or an
+    // in-place re-auth). Reuses the retained agent — no re-spawn.
+    const agent = agents.get(args.agentId)
+    if (!agent) return { ok: false, kind: 'error', error: `No active agent for id ${args.agentId}.`, hint: null }
+    try {
+      const thread = await agent.openThread()
+      return { ok: true, thread: connectionFor(args.agentId, agent, thread) }
+    } catch (err) {
+      return threadFailureResult(args.agentId, agent, err)
     }
   })
 
@@ -126,12 +155,17 @@ function registerIpc(): void {
     IPC.sendPrompt,
     async (_event, args: SendPromptArgs): Promise<SendPromptResult> => {
       const agent = agents.get(args.agentId)
-      if (!agent) return { ok: false, error: `No active agent for id ${args.agentId}.` }
+      if (!agent) return { ok: false, kind: 'error', error: `No active agent for id ${args.agentId}.` }
       try {
         const result = await agent.prompt(args.sessionId, args.text)
         return { ok: true, result }
       } catch (err) {
-        return { ok: false, error: err instanceof Error ? err.message : String(err) }
+        // Mid-session expiry (-32000): keep the agent alive so the renderer can
+        // re-auth in place on the same agent (TODO(#13) D); don't stop it.
+        if (err instanceof WorkspaceAgentError && err.authState === 'not-signed-in') {
+          return { ok: false, kind: 'not-signed-in', agentId: args.agentId, authMethods: agent.authMethods }
+        }
+        return { ok: false, kind: 'error', error: err instanceof Error ? err.message : String(err) }
       }
     },
   )
@@ -152,6 +186,19 @@ function registerIpc(): void {
     try {
       const authState = await agent.signIn(args.methodId)
       return { ok: true, authState }
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) }
+    }
+  })
+
+  ipcMain.handle(IPC.signOut, async (_event, args: SignOutArgs): Promise<SignOutResult> => {
+    // Sign out via Vibe's keyring removal and relay the new state; the agent
+    // stays alive so the user can sign a different account back in (ADR-0003).
+    const agent = agents.get(args.agentId)
+    if (!agent) return { ok: false, error: `No active agent for id ${args.agentId}.` }
+    try {
+      const authState = await agent.signOut()
+      return { ok: true, authState, authMethods: agent.authMethods }
     } catch (err) {
       return { ok: false, error: err instanceof Error ? err.message : String(err) }
     }

--- a/src/main/workspace-agent.test.ts
+++ b/src/main/workspace-agent.test.ts
@@ -199,6 +199,24 @@ describe('WorkspaceAgent — auth detection (_auth/status)', () => {
       },
     ])
   })
+
+  it('surfaces signOutAvailable from _auth/status (gates the sign-out control)', async () => {
+    const fakeIn = makeCapturingFake()
+    const signedIn = await startWithAuthStatus(fakeIn, {
+      authenticated: true,
+      authState: 'os_keyring',
+      signOutAvailable: true,
+    })
+    expect(signedIn.signOutAvailable).toBe(true)
+
+    const fakeOut = makeCapturingFake()
+    const signedOut = await startWithAuthStatus(fakeOut, {
+      authenticated: false,
+      authState: 'signed_out',
+      signOutAvailable: false,
+    })
+    expect(signedOut.signOutAvailable).toBe(false)
+  })
 })
 
 // --- TB3: browser-auth-delegated sign-in ------------------------------------
@@ -368,6 +386,81 @@ describe('WorkspaceAgent — sign in (browser-auth-delegated)', () => {
     expect((err as WorkspaceAgentError).message).toMatch(/delegated/i)
     // It never round-trips delegated-shaped requests to the blocking method.
     expect(authSent(fake)).toEqual([])
+  })
+})
+
+/** Drive start() to a ready, signed-in agent (signOut available). */
+async function connectSignedIn(fake: CapturingFake): Promise<WorkspaceAgent> {
+  return startWithAuthStatus(fake, {
+    authenticated: true,
+    authState: 'os_keyring',
+    signOutAvailable: true,
+  })
+}
+
+describe('WorkspaceAgent — sign out (_auth/signOut)', () => {
+  it('sends _auth/signOut, re-queries status, and transitions signed-in → not-signed-in', async () => {
+    const fake = makeCapturingFake()
+    const agent = await connectSignedIn(fake)
+
+    const out = agent.signOut()
+
+    await new Promise((r) => setTimeout(r, 0))
+    const signOutReq = sent(fake).find((m) => m.method === '_auth/signOut')
+    expect(signOutReq).toBeDefined() // extension method, leading underscore on the wire
+    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: signOutReq?.id, result: {} }) + '\n')
+
+    await new Promise((r) => setTimeout(r, 0))
+    const statusReqs = sent(fake).filter((m) => m.method === '_auth/status')
+    fake.feed(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: statusReqs[statusReqs.length - 1]?.id,
+        result: { authenticated: false, authState: 'signed_out', signOutAvailable: false },
+      }) + '\n',
+    )
+
+    await expect(out).resolves.toBe('not-signed-in')
+    expect(agent.authState).toBe('not-signed-in')
+    expect(agent.signOutAvailable).toBe(false)
+  })
+
+  it('refuses (and sends nothing) when signOutAvailable is false', async () => {
+    const fake = makeCapturingFake()
+    const agent = await startWithAuthStatus(fake, {
+      authenticated: true,
+      authState: 'os_keyring',
+      signOutAvailable: false,
+    })
+
+    const err = await agent.signOut().catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(WorkspaceAgentError)
+    expect((err as WorkspaceAgentError).message).toMatch(/not available/i)
+    expect(sent(fake).some((m) => m.method === '_auth/signOut')).toBe(false)
+  })
+
+  it('rejects with a clear message when the keyring removal fails (-32603)', async () => {
+    const fake = makeCapturingFake()
+    const agent = await connectSignedIn(fake)
+
+    const out = agent.signOut()
+    const settled = out.catch((e: unknown) => e)
+
+    await new Promise((r) => setTimeout(r, 0))
+    const signOutReq = sent(fake).find((m) => m.method === '_auth/signOut')
+    fake.feed(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: signOutReq?.id,
+        error: { code: -32603, message: 'keyring error' },
+      }) + '\n',
+    )
+
+    const err = await settled
+    expect(err).toBeInstanceOf(WorkspaceAgentError)
+    expect((err as WorkspaceAgentError).message).toMatch(/sign-out failed/i)
+    // Failed sign-out leaves the session signed-in — never wedged.
+    expect(agent.authState).toBe('signed-in')
   })
 })
 

--- a/src/main/workspace-agent.test.ts
+++ b/src/main/workspace-agent.test.ts
@@ -398,6 +398,53 @@ async function connectSignedIn(fake: CapturingFake): Promise<WorkspaceAgent> {
   })
 }
 
+describe('WorkspaceAgent — mid-session expiry (-32000)', () => {
+  it('tags an openThread -32000 as not-signed-in and flips the cached auth state', async () => {
+    const fake = makeCapturingFake()
+    const agent = await connectSignedIn(fake)
+    expect(agent.authState).toBe('signed-in')
+
+    const opening = agent.openThread()
+    const settled = opening.catch((e: unknown) => e)
+    await new Promise((r) => setTimeout(r, 0))
+    const sessReq = sent(fake).find((m) => m.method === 'session/new')
+    fake.feed(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: sessReq?.id,
+        error: { code: -32000, message: 'Missing API key for mistral provider.' },
+      }) + '\n',
+    )
+
+    const err = await settled
+    expect(err).toBeInstanceOf(WorkspaceAgentError)
+    expect((err as WorkspaceAgentError).authState).toBe('not-signed-in')
+    // Expiry detected: the agent now reports not-signed-in so the caller can
+    // keep it alive and route to the sign-in panel.
+    expect(agent.authState).toBe('not-signed-in')
+  })
+
+  it('tags a prompt -32000 (turn expiry) as not-signed-in without killing the agent', async () => {
+    const fake = makeCapturingFake()
+    const agent = await connect(fake)
+
+    const turn = agent.prompt(SESSION_ID, 'hi')
+    const settled = turn.catch((e: unknown) => e)
+    const promptReq = sent(fake).find((m) => m.method === 'session/prompt')
+    fake.feed(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: promptReq?.id,
+        error: { code: -32000, message: 'Missing API key for mistral provider.' },
+      }) + '\n',
+    )
+
+    const err = await settled
+    expect((err as WorkspaceAgentError).authState).toBe('not-signed-in')
+    expect(agent.authState).toBe('not-signed-in')
+  })
+})
+
 describe('WorkspaceAgent — sign out (_auth/signOut)', () => {
   it('sends _auth/signOut, re-queries status, and transitions signed-in → not-signed-in', async () => {
     const fake = makeCapturingFake()

--- a/src/main/workspace-agent.ts
+++ b/src/main/workspace-agent.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'node:events'
 import { AcpClient, type SpawnFn } from './acp/client'
 import { handleFsReadTextFile, type ReadTextFn } from './acp/fs-read'
 import { handleFsWriteTextFile, type WriteTextFn } from './acp/fs-write'
-import { classifyAuthError, classifyAuthStatus } from './auth/auth-state'
+import { classifyAuthError, classifyAuthStatus, extractSignOutAvailable } from './auth/auth-state'
 import { DELEGATED_AUTH_METHOD_ID } from '../shared/ipc'
 import type {
   AuthMethod,
@@ -86,6 +86,8 @@ export class WorkspaceAgent extends EventEmitter {
   private authStateValue: AuthState = 'unknown'
   /** Sign-in methods advertised by `initialize` (e.g. `browser-auth`). */
   private authMethodsValue: AuthMethod[] = []
+  /** Whether `_auth/status` reports sign-out is available — gates the control. */
+  private signOutAvailableValue = false
 
   constructor(options: WorkspaceAgentOptions) {
     super()
@@ -178,6 +180,18 @@ export class WorkspaceAgent extends EventEmitter {
     return this.authMethodsValue
   }
 
+  /** Whether sign-out is currently available (from the last `_auth/status`). */
+  get signOutAvailable(): boolean {
+    return this.signOutAvailableValue
+  }
+
+  /** Fold a fresh `_auth/status` result into the cached auth state + sign-out gate. */
+  private applyAuthStatus(status: unknown): AuthState {
+    this.authStateValue = classifyAuthStatus(status)
+    this.signOutAvailableValue = extractSignOutAvailable(status)
+    return this.authStateValue
+  }
+
   /**
    * Query the `_auth/status` extension method and classify the result. Process
    * death during the call is fatal (races `earlyFailure`); a plain RPC failure
@@ -187,7 +201,7 @@ export class WorkspaceAgent extends EventEmitter {
   private async detectAuthState(earlyFailure: Promise<never>): Promise<void> {
     try {
       const status = await Promise.race([this.client.request('_auth/status'), earlyFailure])
-      this.authStateValue = classifyAuthStatus(status)
+      this.applyAuthStatus(status)
     } catch (err) {
       if (err instanceof WorkspaceAgentError) throw err
       this.authStateValue = 'unknown'
@@ -237,11 +251,41 @@ export class WorkspaceAgent extends EventEmitter {
       })
 
       const status = await this.client.request('_auth/status')
-      this.authStateValue = classifyAuthStatus(status)
-      return this.authStateValue
+      return this.applyAuthStatus(status)
     } catch (err) {
       throw this.toSignInError(err)
     }
+  }
+
+  /**
+   * Sign out via the `_auth/signOut` extension method (acp-capture §8): Vibe
+   * removes the api key from its keyring (we never see it). On `{}` we re-query
+   * `_auth/status` and transition `signed-in → not-signed-in`. Gated on the last
+   * known `signOutAvailable` so we don't round-trip a call the agent will reject
+   * (-32602). Resolves the post-sign-out `AuthState`; rejects (no wedge) on a
+   * keyring failure (-32603) or early exit.
+   */
+  async signOut(): Promise<AuthState> {
+    if (!this.initialized) {
+      throw new WorkspaceAgentError('Agent is not initialized; call start() first.')
+    }
+    if (!this.signOutAvailableValue) {
+      throw new WorkspaceAgentError('Sign-out is not available for this session.', AUTH_HINT)
+    }
+    try {
+      await this.client.request('_auth/signOut')
+      const status = await this.client.request('_auth/status')
+      return this.applyAuthStatus(status)
+    } catch (err) {
+      throw this.toSignOutError(err)
+    }
+  }
+
+  /** Map a sign-out failure to a clear message (not a bare RPC string). */
+  private toSignOutError(err: unknown): WorkspaceAgentError {
+    if (err instanceof WorkspaceAgentError) return err
+    const detail = (err as { message?: string })?.message ?? (err instanceof Error ? err.message : String(err))
+    return new WorkspaceAgentError(`Sign-out failed: ${detail}`, AUTH_HINT)
   }
 
   /** Map a sign-in failure to a clear message (not a bare RPC string). */

--- a/src/main/workspace-agent.ts
+++ b/src/main/workspace-agent.ts
@@ -171,7 +171,7 @@ export class WorkspaceAgent extends EventEmitter {
       await this.detectAuthState(earlyFailure)
       this.initialized = true
     } catch (err) {
-      throw this.toAgentError(err)
+      throw this.mapErrorAndCacheAuth(err)
     } finally {
       this.detachStartGuards(onError, onExit)
     }
@@ -321,7 +321,7 @@ export class WorkspaceAgent extends EventEmitter {
         mcpServers: [],
       })
     } catch (err) {
-      throw this.toAgentError(err)
+      throw this.mapErrorAndCacheAuth(err)
     }
 
     const thread: ThreadInfo = {
@@ -356,7 +356,7 @@ export class WorkspaceAgent extends EventEmitter {
         prompt: [{ type: 'text', text }],
       })
     } catch (err) {
-      throw this.toAgentError(err)
+      throw this.mapErrorAndCacheAuth(err)
     }
   }
 
@@ -428,8 +428,14 @@ export class WorkspaceAgent extends EventEmitter {
     return new WorkspaceAgentError(`Failed to launch vibe-acp: ${message}`, SPAWN_HINT)
   }
 
-  /** Map a request rejection (JSON-RPC error, early failure) to a clear error. */
-  private toAgentError(err: unknown): WorkspaceAgentError {
+  /**
+   * Map a request rejection (JSON-RPC error, early failure) to a clear error.
+   * SIDE EFFECT: a -32000 UnauthenticatedError also caches the agent's auth
+   * state as `not-signed-in` (mid-session expiry) — call only from a real
+   * request-failure path, never to map an error read-only (e.g. for logging),
+   * or you'd silently mark a live agent signed-out.
+   */
+  private mapErrorAndCacheAuth(err: unknown): WorkspaceAgentError {
     if (err instanceof WorkspaceAgentError) return err
 
     const rpc = err as { code?: number; message?: string; data?: unknown }

--- a/src/main/workspace-agent.ts
+++ b/src/main/workspace-agent.ts
@@ -35,10 +35,17 @@ export const SPAWN_HINT =
 /** A failure surfaced to the renderer, optionally with an actionable hint. */
 export class WorkspaceAgentError extends Error {
   readonly hint: string | null
-  constructor(message: string, hint: string | null = null) {
+  /**
+   * Auth classification of this failure, when known. `not-signed-in` marks a
+   * -32000 UnauthenticatedError (mid-session expiry) so callers route to the
+   * sign-in panel and keep the agent alive instead of treating it as generic.
+   */
+  readonly authState: AuthState | null
+  constructor(message: string, hint: string | null = null, authState: AuthState | null = null) {
     super(message)
     this.name = 'WorkspaceAgentError'
     this.hint = hint
+    this.authState = authState
   }
 }
 
@@ -75,7 +82,7 @@ export interface WorkspaceAgentOptions {
 
 export class WorkspaceAgent extends EventEmitter {
   private readonly client: AcpClient
-  private readonly workspaceDir: string
+  private readonly workspaceDirValue: string
   private readonly readTextFile?: ReadTextFn
   private readonly writeTextFile?: WriteTextFn
   private readonly openUrl?: (url: string) => void
@@ -91,7 +98,7 @@ export class WorkspaceAgent extends EventEmitter {
 
   constructor(options: WorkspaceAgentOptions) {
     super()
-    this.workspaceDir = options.workspaceDir
+    this.workspaceDirValue = options.workspaceDir
     this.readTextFile = options.readTextFile
     this.writeTextFile = options.writeTextFile
     this.openUrl = options.openUrl
@@ -183,6 +190,11 @@ export class WorkspaceAgent extends EventEmitter {
   /** Whether sign-out is currently available (from the last `_auth/status`). */
   get signOutAvailable(): boolean {
     return this.signOutAvailableValue
+  }
+
+  /** The absolute Workspace directory this agent operates in (for dedup). */
+  get workspaceDir(): string {
+    return this.workspaceDirValue
   }
 
   /** Fold a fresh `_auth/status` result into the cached auth state + sign-out gate. */
@@ -305,7 +317,7 @@ export class WorkspaceAgent extends EventEmitter {
     let result: SessionNewResult
     try {
       result = await this.client.request<SessionNewResult>('session/new', {
-        cwd: this.workspaceDir,
+        cwd: this.workspaceDirValue,
         mcpServers: [],
       })
     } catch (err) {
@@ -386,7 +398,7 @@ export class WorkspaceAgent extends EventEmitter {
   private async serveFsWrite(id: number | string, params: unknown): Promise<void> {
     const outcome = await handleFsWriteTextFile(params, {
       write: this.writeTextFile,
-      workspaceDir: this.workspaceDir,
+      workspaceDir: this.workspaceDirValue,
     })
     if ('result' in outcome) this.client.respond(id, outcome.result)
     else this.client.respondError(id, outcome.error)
@@ -427,7 +439,16 @@ export class WorkspaceAgent extends EventEmitter {
     // UnauthenticatedError (docs/acp-capture.md §8). This replaces the earlier
     // message-regex heuristic, which missed the real "Missing API key" wording.
     if (classifyAuthError(rpc) === 'not-signed-in') {
-      return new WorkspaceAgentError(`Not signed in to Mistral Vibe: ${message}`, AUTH_HINT)
+      // Mid-session expiry: flip the cached auth state so callers keep the agent
+      // alive and route to the sign-in panel, and tag the error so they can tell
+      // it apart from a generic failure.
+      this.authStateValue = 'not-signed-in'
+      this.signOutAvailableValue = false
+      return new WorkspaceAgentError(
+        `Not signed in to Mistral Vibe: ${message}`,
+        AUTH_HINT,
+        'not-signed-in',
+      )
     }
     return new WorkspaceAgentError(message)
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3,10 +3,13 @@ import {
   IPC,
   type AcpEvent,
   type RespondPermissionArgs,
+  type OpenThreadArgs,
   type SendPromptArgs,
   type SendPromptResult,
   type SignInArgs,
   type SignInResult,
+  type SignOutArgs,
+  type SignOutResult,
   type StartThreadArgs,
   type StartThreadResult,
   type VibeDetectResult,
@@ -17,11 +20,14 @@ const api = {
   openWorkspaceDialog: (): Promise<string | null> => ipcRenderer.invoke(IPC.openWorkspaceDialog),
   startThread: (args: StartThreadArgs): Promise<StartThreadResult> =>
     ipcRenderer.invoke(IPC.startThread, args),
+  openThread: (args: OpenThreadArgs): Promise<StartThreadResult> =>
+    ipcRenderer.invoke(IPC.openThread, args),
   sendPrompt: (args: SendPromptArgs): Promise<SendPromptResult> =>
     ipcRenderer.invoke(IPC.sendPrompt, args),
   respondPermission: (args: RespondPermissionArgs): Promise<void> =>
     ipcRenderer.invoke(IPC.respondPermission, args),
   signIn: (args: SignInArgs): Promise<SignInResult> => ipcRenderer.invoke(IPC.signIn, args),
+  signOut: (args: SignOutArgs): Promise<SignOutResult> => ipcRenderer.invoke(IPC.signOut, args),
   stopAgent: (agentId: string): Promise<void> => ipcRenderer.invoke(IPC.stopAgent, agentId),
   onAcpEvent: (listener: (event: AcpEvent) => void): (() => void) => {
     const handler = (_e: unknown, payload: AcpEvent): void => listener(payload)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -165,13 +165,20 @@ function SignInPanel({
     dispatch({ type: 'sign-in-cancel' })
   }
 
-  if (view.kind === 'none') {
-    // Reaching `none` in this panel means we just signed in. This terminal
-    // confirmation is #12's end state; opening a Thread from here (routing
-    // Open-project through sign-in) is #13.
+  if (view.kind === 'signed-in') {
+    // Interim terminal confirmation; behavior B replaces this with auto-opening
+    // a Thread on the same retained agent (routing Open-project through sign-in).
     return (
       <div className="signin signin--done">
         <div className="signin__title">Signed in to Mistral Vibe</div>
+      </div>
+    )
+  }
+
+  if (view.kind === 'signing-out') {
+    return (
+      <div className="signin">
+        <div className="signin__title">Signing out…</div>
       </div>
     )
   }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -113,7 +113,11 @@ export function App(): JSX.Element {
 
           {connect.status === 'connected' && (
             <>
+              {/* Key by agentId (like Conversation) so its useReducer seed resets
+                  across connections — a new agent can't inherit the prior
+                  session's sign-out gate. */}
               <SignedInBar
+                key={connect.thread.agentId}
                 agentId={connect.thread.agentId}
                 authMethods={connect.thread.authMethods}
                 signOutAvailable={connect.thread.signOutAvailable}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,14 +1,13 @@
 import { useEffect, useReducer, useRef, useState, type JSX } from 'react'
-import type { AuthMethod, ThreadConnection, VibeDetectResult } from '../../shared/ipc'
-import { authReducer, initialAuthViewState, selectAuthView } from './auth/auth-view'
+import type { AuthMethod, VibeDetectResult } from '../../shared/ipc'
+import {
+  authReducer,
+  initialAuthViewState,
+  selectAuthView,
+  signedInAuthViewState,
+} from './auth/auth-view'
+import { routeThreadResult, type ConnectState } from './connection/routing'
 import { Conversation } from './conversation/Conversation'
-
-type ConnectState =
-  | { status: 'idle' }
-  | { status: 'connecting'; workspaceDir: string }
-  | { status: 'connected'; thread: ThreadConnection }
-  | { status: 'not-signed-in'; agentId: string; workspaceDir: string; authMethods: AuthMethod[] }
-  | { status: 'error'; message: string; hint: string | null }
 
 export function App(): JSX.Element {
   const [detect, setDetect] = useState<VibeDetectResult | null>(null)
@@ -29,21 +28,20 @@ export function App(): JSX.Element {
   async function openProject(): Promise<void> {
     const workspaceDir = await window.api.openWorkspaceDialog()
     if (!workspaceDir) return
-
     setConnect({ status: 'connecting', workspaceDir })
-    const result = await window.api.startThread({ workspaceDir })
-    if (result.ok) {
-      setConnect({ status: 'connected', thread: result.thread })
-    } else if (result.kind === 'not-signed-in') {
-      setConnect({
-        status: 'not-signed-in',
-        agentId: result.agentId,
-        workspaceDir: result.workspaceDir,
-        authMethods: result.authMethods,
-      })
-    } else {
-      setConnect({ status: 'error', message: result.error, hint: result.hint })
-    }
+    setConnect(routeThreadResult(await window.api.startThread({ workspaceDir })))
+  }
+
+  // After sign-in (or in-place re-auth) the agent is already started + signed in;
+  // open a Thread on it and land in a connected conversation.
+  async function continueToThread(agentId: string, workspaceDir: string): Promise<void> {
+    setConnect({ status: 'connecting', workspaceDir })
+    setConnect(routeThreadResult(await window.api.openThread({ agentId })))
+  }
+
+  /** Sign-out / mid-session expiry: drop back to the sign-in panel (same agent). */
+  function toSignInPanel(agentId: string, workspaceDir: string, authMethods: AuthMethod[]): void {
+    setConnect({ status: 'not-signed-in', agentId, workspaceDir, authMethods })
   }
 
   const connecting = connect.status === 'connecting'
@@ -101,6 +99,7 @@ export function App(): JSX.Element {
               key={connect.agentId}
               agentId={connect.agentId}
               authMethods={connect.authMethods}
+              onSignedIn={() => void continueToThread(connect.agentId, connect.workspaceDir)}
             />
           )}
 
@@ -113,9 +112,24 @@ export function App(): JSX.Element {
           )}
 
           {connect.status === 'connected' && (
-            // Key by agentId so the Conversation's useReducer state can't bleed
-            // across Threads — a new Thread gets a fresh reducer, not the old one.
-            <Conversation key={connect.thread.agentId} thread={connect.thread} />
+            <>
+              <SignedInBar
+                agentId={connect.thread.agentId}
+                authMethods={connect.thread.authMethods}
+                signOutAvailable={connect.thread.signOutAvailable}
+                onSignedOut={(authMethods) =>
+                  toSignInPanel(connect.thread.agentId, connect.thread.workspaceDir, authMethods)
+                }
+              />
+              {/* Key by agentId so the Conversation's reducer can't bleed across Threads. */}
+              <Conversation
+                key={connect.thread.agentId}
+                thread={connect.thread}
+                onAuthExpired={(authMethods) =>
+                  toSignInPanel(connect.thread.agentId, connect.thread.workspaceDir, authMethods)
+                }
+              />
+            </>
           )}
         </section>
       </main>
@@ -124,18 +138,19 @@ export function App(): JSX.Element {
 }
 
 /**
- * The not-signed-in panel: visibly distinct from the binary-missing status and
- * the generic-error alert. Clicking Sign-in drives Vibe's delegated browser
- * sign-in via main (#12) — the system browser opens, and on success the panel
- * transitions to a signed-in confirmation. The auth lifecycle (signing-in /
- * signed-in / error) is the pure `authReducer`; this component is the glue.
+ * The not-signed-in panel: clicking Sign-in drives Vibe's delegated browser
+ * sign-in via main; on success it bubbles up (`onSignedIn`) so the app opens a
+ * Thread on the same retained agent and lands in a connected conversation. The
+ * auth lifecycle (signing-in / signed-in / error) is the pure `authReducer`.
  */
 function SignInPanel({
   agentId,
   authMethods,
+  onSignedIn,
 }: {
   agentId: string
   authMethods: AuthMethod[]
+  onSignedIn: () => void
 }): JSX.Element {
   const [state, dispatch] = useReducer(authReducer, authMethods, initialAuthViewState)
   // Generation counter: bumped on every attempt start and on cancel. The
@@ -152,6 +167,7 @@ function SignInPanel({
     if (attempt !== attemptRef.current) return // cancelled/superseded — drop the stale result
     if (result.ok && result.authState === 'signed-in') {
       dispatch({ type: 'sign-in-success' })
+      onSignedIn() // continue to a connected Thread on the same agent
     } else {
       dispatch({
         type: 'sign-in-error',
@@ -166,11 +182,9 @@ function SignInPanel({
   }
 
   if (view.kind === 'signed-in') {
-    // Interim terminal confirmation; behavior B replaces this with auto-opening
-    // a Thread on the same retained agent (routing Open-project through sign-in).
     return (
       <div className="signin signin--done">
-        <div className="signin__title">Signed in to Mistral Vibe</div>
+        <div className="signin__title">Signed in — opening your workspace…</div>
       </div>
     )
   }
@@ -207,6 +221,66 @@ function SignInPanel({
       <button className="btn signin__action" onClick={() => void signIn(view.methodId)}>
         {view.kind === 'error' ? `Retry — ${view.methodName}` : view.methodName}
       </button>
+    </div>
+  )
+}
+
+/**
+ * The signed-in indicator shown while connected: status + a Sign-out control
+ * gated on `signOutAvailable` (Vibe exposes no account identity, so none is
+ * shown). Sign-out returns to the sign-in panel (`onSignedOut`) for an account
+ * switch. The sign-out lifecycle is the pure `authReducer`.
+ */
+function SignedInBar({
+  agentId,
+  authMethods,
+  signOutAvailable,
+  onSignedOut,
+}: {
+  agentId: string
+  authMethods: AuthMethod[]
+  signOutAvailable: boolean
+  onSignedOut: (authMethods: AuthMethod[]) => void
+}): JSX.Element | null {
+  const [state, dispatch] = useReducer(
+    authReducer,
+    signedInAuthViewState(authMethods, signOutAvailable),
+  )
+  const view = selectAuthView(state)
+
+  async function signOut(): Promise<void> {
+    dispatch({ type: 'sign-out-start' })
+    const result = await window.api.signOut({ agentId })
+    if (result.ok) {
+      dispatch({ type: 'sign-out-success' })
+      onSignedOut(result.authMethods)
+    } else {
+      dispatch({ type: 'sign-out-error', message: result.error })
+    }
+  }
+
+  if (view.kind === 'signing-out') {
+    return (
+      <div className="signedin">
+        <span className="signedin__label">Signing out…</span>
+      </div>
+    )
+  }
+
+  if (view.kind !== 'signed-in') return null
+
+  return (
+    <div className="signedin">
+      <span className="dot dot--ok" aria-hidden />
+      <span className="signedin__label">Signed in to Mistral Vibe</span>
+      {view.identity && <span className="signedin__identity">{view.identity}</span>}
+      {view.error && <span className="signedin__error">{view.error}</span>}
+      <span className="signedin__spacer" />
+      {view.signOutAvailable && (
+        <button className="btn btn--ghost" onClick={() => void signOut()}>
+          Sign out
+        </button>
+      )}
     </div>
   )
 }

--- a/src/renderer/src/auth/auth-view.test.ts
+++ b/src/renderer/src/auth/auth-view.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { authReducer, initialAuthViewState, selectAuthView } from './auth-view'
+import {
+  authReducer,
+  initialAuthViewState,
+  selectAuthView,
+  signedInAuthViewState,
+} from './auth-view'
 import type { AuthMethod } from '../../../shared/ipc'
 
 /**
@@ -32,8 +37,14 @@ describe('authReducer', () => {
     state = authReducer(state, { type: 'sign-in-success' })
     expect(state.phase).toBe('signed-in')
     // ADR-0003: we only reflect state — the view state carries no token/secret.
-    // Its keys are exactly the lifecycle fields, nothing credential-shaped.
-    expect(Object.keys(state).sort()).toEqual(['authMethods', 'error', 'phase'])
+    // Its keys are exactly the lifecycle/display fields, nothing credential-shaped.
+    expect(Object.keys(state).sort()).toEqual([
+      'authMethods',
+      'error',
+      'identity',
+      'phase',
+      'signOutAvailable',
+    ])
   })
 
   it('transitions signing-in → error on failure, carrying a recoverable message', () => {
@@ -57,6 +68,26 @@ describe('authReducer', () => {
     expect(state.phase).toBe('not-signed-in')
     expect(state.error).toBeNull()
   })
+
+  it('signs out: signed-in → signing-out → not-signed-in (account switch entry)', () => {
+    let state = signedInAuthViewState([BROWSER_AUTH, DELEGATED], true)
+    expect(state.phase).toBe('signed-in')
+    state = authReducer(state, { type: 'sign-out-start' })
+    expect(state.phase).toBe('signing-out')
+    state = authReducer(state, { type: 'sign-out-success' })
+    // Back to not-signed-in so the same panel can sign a (possibly different)
+    // account back in — the authMethods are preserved for that.
+    expect(state.phase).toBe('not-signed-in')
+    expect(state.authMethods).toEqual([BROWSER_AUTH, DELEGATED])
+    expect(state.error).toBeNull()
+  })
+
+  it('keeps the user signed in (recoverably) when sign-out fails', () => {
+    let state = authReducer(signedInAuthViewState([BROWSER_AUTH], true), { type: 'sign-out-start' })
+    state = authReducer(state, { type: 'sign-out-error', message: 'Sign-out failed.' })
+    expect(state.phase).toBe('signed-in')
+    expect(state.error).toBe('Sign-out failed.')
+  })
 })
 
 describe('selectAuthView', () => {
@@ -77,10 +108,30 @@ describe('selectAuthView', () => {
     expect(selectAuthView(state)).toEqual({ kind: 'signing-in' })
   })
 
-  it('shows no auth panel once signed in', () => {
-    let state = authReducer(initialAuthViewState([DELEGATED]), { type: 'sign-in-start' })
-    state = authReducer(state, { type: 'sign-in-success' })
-    expect(selectAuthView(state)).toEqual({ kind: 'none' })
+  it('shows a signed-in indicator with the sign-out control gated on signOutAvailable', () => {
+    const state = signedInAuthViewState([DELEGATED], true)
+    expect(selectAuthView(state)).toEqual({
+      kind: 'signed-in',
+      signOutAvailable: true,
+      identity: null, // Vibe exposes no identity — omitted gracefully
+      error: null,
+    })
+  })
+
+  it('hides the sign-out control when signOutAvailable is false', () => {
+    const view = selectAuthView(signedInAuthViewState([DELEGATED], false))
+    expect(view).toMatchObject({ kind: 'signed-in', signOutAvailable: false })
+  })
+
+  it('surfaces an account identity in the signed-in view when one is present', () => {
+    // Forward-compatible: if Vibe ever supplies identity, the selector shows it.
+    const state = { ...signedInAuthViewState([DELEGATED], true), identity: 'jane@acme.test' }
+    expect(selectAuthView(state)).toMatchObject({ kind: 'signed-in', identity: 'jane@acme.test' })
+  })
+
+  it('shows a signing-out view during the sign-out step', () => {
+    const state = authReducer(signedInAuthViewState([DELEGATED], true), { type: 'sign-out-start' })
+    expect(selectAuthView(state)).toEqual({ kind: 'signing-out' })
   })
 
   it('shows a recoverable error view (with the method to retry) on failure', () => {

--- a/src/renderer/src/auth/auth-view.ts
+++ b/src/renderer/src/auth/auth-view.ts
@@ -8,22 +8,41 @@ import { DELEGATED_AUTH_METHOD_ID, type AuthMethod } from '../../../shared/ipc'
  */
 
 /**
- * The renderer's auth-panel lifecycle phase. `not-signed-in` is the entry (main
- * detected it); `signing-in` is the in-flight browser step; `signed-in` is the
- * success terminal; `error` is a recoverable failure the user can retry from.
+ * The renderer's auth lifecycle phase. `not-signed-in` is the entry (main
+ * detected it); `signing-in` is the in-flight browser step; `signed-in` is
+ * signed in (shows the indicator + sign-out); `signing-out` is the in-flight
+ * sign-out; `error` is a recoverable sign-in failure the user can retry from.
  */
-export type AuthPhase = 'not-signed-in' | 'signing-in' | 'signed-in' | 'error'
+export type AuthPhase = 'not-signed-in' | 'signing-in' | 'signed-in' | 'signing-out' | 'error'
 
-/** Pure view state for the sign-in panel — folded by `authReducer`. */
+/** Pure view state for the auth panel/indicator — folded by `authReducer`. */
 export interface AuthViewState {
   phase: AuthPhase
   authMethods: AuthMethod[]
-  /** Recoverable failure message; set only while `phase === 'error'`. */
+  /** Whether Vibe reports sign-out is available — gates the Sign-out control. */
+  signOutAvailable: boolean
+  /**
+   * Account identity to show beside the signed-in indicator, when known. Vibe's
+   * `_auth/status` exposes none today (acp-capture §8), so this is always null;
+   * the field exists so the selector omits identity gracefully (and is ready if
+   * Vibe ever adds one) — we never fetch identity ourselves.
+   */
+  identity: string | null
+  /** Recoverable failure message; set on a sign-in `error` or a failed sign-out. */
   error: string | null
 }
 
+/** Seed the not-signed-in entry (panel) with the advertised sign-in methods. */
 export function initialAuthViewState(authMethods: AuthMethod[]): AuthViewState {
-  return { phase: 'not-signed-in', authMethods, error: null }
+  return { phase: 'not-signed-in', authMethods, signOutAvailable: false, identity: null, error: null }
+}
+
+/** Seed the signed-in entry (indicator + sign-out), gated on `signOutAvailable`. */
+export function signedInAuthViewState(
+  authMethods: AuthMethod[],
+  signOutAvailable: boolean,
+): AuthViewState {
+  return { phase: 'signed-in', authMethods, signOutAvailable, identity: null, error: null }
 }
 
 export type AuthAction =
@@ -31,14 +50,18 @@ export type AuthAction =
   | { type: 'sign-in-success' }
   | { type: 'sign-in-error'; message: string }
   | { type: 'sign-in-cancel' }
+  | { type: 'sign-out-start' }
+  | { type: 'sign-out-success' }
+  | { type: 'sign-out-error'; message: string }
 
 /**
- * Fold a sign-in lifecycle action into the panel's view state. Pure (no React,
- * no IPC). `sign-in-start` is allowed from both `not-signed-in` and `error` so
- * the error state stays recoverable (retry); a failure can never leave the
- * panel stuck in `signing-in`. `sign-in-cancel` is the user's escape hatch out
- * of `signing-in` (the browser long-poll itself can't be aborted — see
- * SignInPanel); it just abandons the attempt and returns to `not-signed-in`.
+ * Fold an auth lifecycle action into the view state. Pure (no React, no IPC).
+ * `sign-in-start` is allowed from both `not-signed-in` and `error` so the error
+ * state stays recoverable (retry); a failure can never leave the panel stuck in
+ * `signing-in`. `sign-in-cancel` is the user's escape hatch out of `signing-in`
+ * (the browser long-poll can't be aborted — see SignInPanel). `sign-out-success`
+ * returns to `not-signed-in` so the same panel can sign a different account back
+ * in (account switch); `sign-out-error` keeps the user signed-in (recoverable).
  */
 export function authReducer(state: AuthViewState, action: AuthAction): AuthViewState {
   switch (action.type) {
@@ -50,6 +73,12 @@ export function authReducer(state: AuthViewState, action: AuthAction): AuthViewS
       return { ...state, phase: 'error', error: action.message }
     case 'sign-in-cancel':
       return { ...state, phase: 'not-signed-in', error: null }
+    case 'sign-out-start':
+      return { ...state, phase: 'signing-out', error: null }
+    case 'sign-out-success':
+      return { ...state, phase: 'not-signed-in', signOutAvailable: false, identity: null, error: null }
+    case 'sign-out-error':
+      return { ...state, phase: 'signed-in', error: action.message }
   }
 }
 
@@ -66,6 +95,23 @@ export interface SigningInView {
   kind: 'signing-in'
 }
 
+/**
+ * Render the signed-in indicator. `signOutAvailable` gates the Sign-out button;
+ * `identity` is shown beside it when known (null today — omitted gracefully);
+ * `error` carries a failed sign-out message (the user stays signed in).
+ */
+export interface SignedInView {
+  kind: 'signed-in'
+  signOutAvailable: boolean
+  identity: string | null
+  error: string | null
+}
+
+/** Render the in-flight sign-out step. */
+export interface SigningOutView {
+  kind: 'signing-out'
+}
+
 /** Render a recoverable failure — the message plus the method to retry with. */
 export interface SignInErrorView {
   kind: 'error'
@@ -74,12 +120,12 @@ export interface SignInErrorView {
   methodName: string
 }
 
-/** Render nothing auth-related (signed in). */
-export interface NoAuthView {
-  kind: 'none'
-}
-
-export type AuthView = SignInView | SigningInView | SignInErrorView | NoAuthView
+export type AuthView =
+  | SignInView
+  | SigningInView
+  | SignedInView
+  | SigningOutView
+  | SignInErrorView
 
 /**
  * Pick the sign-in method to drive: prefer the delegated method (the one main's
@@ -106,6 +152,13 @@ export function selectAuthView(state: AuthViewState): AuthView {
     case 'error':
       return { kind: 'error', message: state.error ?? 'Sign-in failed.', methodId: method.id, methodName: method.name }
     case 'signed-in':
-      return { kind: 'none' }
+      return {
+        kind: 'signed-in',
+        signOutAvailable: state.signOutAvailable,
+        identity: state.identity,
+        error: state.error,
+      }
+    case 'signing-out':
+      return { kind: 'signing-out' }
   }
 }

--- a/src/renderer/src/connection/routing.test.ts
+++ b/src/renderer/src/connection/routing.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { routeThreadResult } from './routing'
+import type { AuthMethod, ThreadConnection } from '../../../shared/ipc'
+
+/**
+ * Pure routing: map a `startThread` / `openThread` result to the next
+ * ConnectState. The Open-project path consults auth state (via the result's
+ * `kind`) and routes to the sign-in panel when not-signed-in, instead of a raw
+ * error dead-end (ADR-0001: renderer owns view routing).
+ */
+
+const AUTH_METHODS: AuthMethod[] = [{ id: 'browser-auth-delegated', name: 'Sign in through Mistral AI Studio' }]
+
+const THREAD: ThreadConnection = {
+  agentId: 'a1',
+  workspaceDir: '/abs/ws',
+  sessionId: 's1',
+  title: null,
+  modes: null,
+  models: null,
+  signOutAvailable: true,
+  authMethods: AUTH_METHODS,
+}
+
+describe('routeThreadResult', () => {
+  it('routes a not-signed-in result to the sign-in panel (consults auth state)', () => {
+    const next = routeThreadResult({
+      ok: false,
+      kind: 'not-signed-in',
+      agentId: 'a1',
+      workspaceDir: '/abs/ws',
+      authMethods: AUTH_METHODS,
+    })
+    expect(next).toEqual({
+      status: 'not-signed-in',
+      agentId: 'a1',
+      workspaceDir: '/abs/ws',
+      authMethods: AUTH_METHODS,
+    })
+  })
+
+  it('routes an ok result to a connected Thread', () => {
+    expect(routeThreadResult({ ok: true, thread: THREAD })).toEqual({
+      status: 'connected',
+      thread: THREAD,
+    })
+  })
+
+  it('routes a generic error to the error state', () => {
+    expect(routeThreadResult({ ok: false, kind: 'error', error: 'boom', hint: 'try again' })).toEqual({
+      status: 'error',
+      message: 'boom',
+      hint: 'try again',
+    })
+  })
+})

--- a/src/renderer/src/connection/routing.ts
+++ b/src/renderer/src/connection/routing.ts
@@ -1,0 +1,28 @@
+import type { AuthMethod, StartThreadResult, ThreadConnection } from '../../../shared/ipc'
+
+/**
+ * Pure connection routing (no React, no IPC). Maps a `startThread` /
+ * `openThread` result to the next ConnectState — including consulting auth
+ * state to route to the sign-in panel instead of a raw error dead-end. Per
+ * ADR-0001 the renderer owns this view routing.
+ */
+export type ConnectState =
+  | { status: 'idle' }
+  | { status: 'connecting'; workspaceDir: string }
+  | { status: 'connected'; thread: ThreadConnection }
+  | { status: 'not-signed-in'; agentId: string; workspaceDir: string; authMethods: AuthMethod[] }
+  | { status: 'error'; message: string; hint: string | null }
+
+/** Route a thread-open result (start or open-on-existing) to a ConnectState. */
+export function routeThreadResult(result: StartThreadResult): ConnectState {
+  if (result.ok) return { status: 'connected', thread: result.thread }
+  if (result.kind === 'not-signed-in') {
+    return {
+      status: 'not-signed-in',
+      agentId: result.agentId,
+      workspaceDir: result.workspaceDir,
+      authMethods: result.authMethods,
+    }
+  }
+  return { status: 'error', message: result.error, hint: result.hint }
+}

--- a/src/renderer/src/conversation/Conversation.tsx
+++ b/src/renderer/src/conversation/Conversation.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useReducer, useRef, useState, type JSX, type KeyboardEvent } from 'react'
-import type { ThreadConnection } from '../../../shared/ipc'
+import type { AuthMethod, ThreadConnection } from '../../../shared/ipc'
 import {
   conversationReducer,
   initialConversationState,
@@ -23,7 +23,14 @@ let promptSeq = 0
  * are served transparently in main, so a read-only turn streams reasoning + an
  * answer and completes without any approval UI (that's TB3).
  */
-export function Conversation({ thread }: { thread: ThreadConnection }): JSX.Element {
+export function Conversation({
+  thread,
+  onAuthExpired,
+}: {
+  thread: ThreadConnection
+  /** Mid-session expiry (-32000): route to in-place re-auth with these methods. */
+  onAuthExpired: (authMethods: AuthMethod[]) => void
+}): JSX.Element {
   const [state, dispatch] = useReducer(conversationReducer, initialConversationState)
   const [draft, setDraft] = useState('')
   const listRef = useRef<HTMLDivElement>(null)
@@ -53,8 +60,13 @@ export function Conversation({ thread }: { thread: ThreadConnection }): JSX.Elem
         sessionId: thread.sessionId,
         text,
       })
-      // Surface a failed turn as a conversation item rather than dropping it.
-      if (!result.ok) dispatch({ type: 'turn-error', message: result.error })
+      // Mid-session expiry: route to in-place re-auth (the agent stays alive).
+      if (!result.ok && result.kind === 'not-signed-in') {
+        onAuthExpired(result.authMethods)
+      } else if (!result.ok) {
+        // Surface a failed turn as a conversation item rather than dropping it.
+        dispatch({ type: 'turn-error', message: result.error })
+      }
     } finally {
       // The turn's stopReason resolves sendPrompt; flip back to the user's turn.
       dispatch({ type: 'turn-complete' })

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -282,6 +282,34 @@ body {
   margin-top: 2px;
 }
 
+.signedin {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  margin-bottom: 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: rgba(63, 185, 80, 0.06);
+  font-size: 13px;
+}
+
+.signedin__label {
+  font-weight: 600;
+}
+
+.signedin__identity {
+  color: var(--muted);
+}
+
+.signedin__error {
+  color: var(--bad);
+}
+
+.signedin__spacer {
+  flex: 1;
+}
+
 /* --- Conversation (TB2) --- */
 
 .conv {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -10,6 +10,8 @@ export const IPC = {
   openWorkspaceDialog: 'workspace:open-dialog',
   /** Start a Workspace agent, run the ACP handshake, and open a Thread. */
   startThread: 'thread:start',
+  /** Open a Thread on an already-started agent (after sign-in / re-auth). */
+  openThread: 'thread:open',
   /** Stop / dispose a Workspace agent (and its Threads). */
   stopAgent: 'agent:stop',
   /** Send a prompt to a Thread (`session/prompt`); resolves on turn completion. */
@@ -18,6 +20,8 @@ export const IPC = {
   respondPermission: 'permission:respond',
   /** Drive Vibe's browser sign-in on a not-signed-in agent (`authenticate`). */
   signIn: 'auth:sign-in',
+  /** Sign out the agent's session (`_auth/signOut`). */
+  signOut: 'auth:sign-out',
   /** Main -> renderer: streamed ACP event tagged by the owning agent. */
   acpEvent: 'acp:event',
 } as const
@@ -89,11 +93,21 @@ export interface StartThreadArgs {
   workspaceDir: string
 }
 
+/** Open a Thread on an agent already started + signed in (after sign-in / re-auth). */
+export interface OpenThreadArgs {
+  /** Id of the started Workspace agent to open a Thread on. */
+  agentId: string
+}
+
 /** A Thread plus the Workspace agent that hosts it. */
 export interface ThreadConnection extends ThreadInfo {
   /** Id of the Workspace agent (one `vibe-acp` process) in main. */
   agentId: string
   workspaceDir: string
+  /** Whether sign-out is available — drives the connected signed-in indicator. */
+  signOutAvailable: boolean
+  /** Advertised sign-in methods, kept so sign-out can route back to the panel. */
+  authMethods: AuthMethod[]
 }
 
 export type StartThreadResult =
@@ -136,7 +150,10 @@ export interface SendPromptArgs {
 
 export type SendPromptResult =
   | { ok: true; result: PromptResult }
-  | { ok: false; error: string }
+  // Mid-session expiry (-32000): the agent stays alive so the renderer can route
+  // to the sign-in panel in place and re-auth on the same agent (no restart).
+  | { ok: false; kind: 'not-signed-in'; agentId: string; authMethods: AuthMethod[] }
+  | { ok: false; kind: 'error'; error: string }
 
 /** Reply to an agent `session/request_permission` with the user's choice. */
 export interface RespondPermissionArgs {
@@ -162,4 +179,19 @@ export interface SignInArgs {
  */
 export type SignInResult =
   | { ok: true; authState: AuthState }
+  | { ok: false; error: string }
+
+/** Sign out the agent's session; the agent stays alive for a re-sign-in. */
+export interface SignOutArgs {
+  /** Id of the Workspace agent to sign out. */
+  agentId: string
+}
+
+/**
+ * Result of a sign-out. On success `authState` is the post-sign-out state
+ * (not-signed-in) and `authMethods` lets the renderer show the sign-in panel for
+ * an account switch. Failures are recoverable — the user stays signed in.
+ */
+export type SignOutResult =
+  | { ok: true; authState: AuthState; authMethods: AuthMethod[] }
   | { ok: false; error: string }


### PR DESCRIPTION
Closes #13. Closes the PRD #9 auth epic.

## Summary

Rounds out auth: a signed-in indicator + sign out, and the Open-project flow now routes through sign-in (and in-place re-auth) instead of dead-ending on a raw error. Built with strict vertical TDD (one behavior → one impl), against the real acp-capture §8 shapes. **No live `_auth/signOut` was ever called** — sign-out is exercised only at Seam 2 with the injected fake stream.

### A — Signed-in indicator + sign out
- **Seam 2:** surface `signOutAvailable` from `_auth/status` (`extractSignOutAvailable` + `applyAuthStatus`); `WorkspaceAgent.signOut()` — gated on `signOutAvailable`, sends `_auth/signOut`, re-queries status, transitions `signed-in → not-signed-in`. Maps `-32603` keyring failure (and the unavailable case) to clear messages; never wedges.
- **Seam 3:** `authReducer`/`selectAuthView` gain a signed-in indicator (sign-out gated on `signOutAvailable`; **account identity omitted gracefully — Vibe exposes none**, and there's a forward-compat passthrough) and the sign-out lifecycle (`signed-in → signing-out → not-signed-in` on success; `→ signed-in + error` on failure).
- Renderer `SignedInBar` shows the indicator + Sign-out; sign-out returns to the panel for an **account switch** on the same retained agent.

### B — Route Open-project through sign-in → connected Thread
- New `openThread(agentId)` IPC opens a Thread on an already-started agent (no re-spawn); SignInPanel success bubbles up so the app continues to a **connected Thread** on the same agent.
- Pure `routeThreadResult` maps a start/open result to the next `ConnectState`, consulting auth state to route to the sign-in panel when not-signed-in (**routing test**).
- `startThread` now dedups agents by `workspaceDir` so a re-Connect can't orphan the previous child (resolves the retained-agent debt).

### C — Auth-error path → panel (not a generic alert)
- A `-32000` from `openThread` keeps the agent **alive** and returns `kind:'not-signed-in'` (resolves the fallback-UX debt). `WorkspaceAgentError` gains an `authState` tag; `toAgentError` flips the agent's cached state on expiry.

### D — Mid-session expiry → offer sign-in in place
- A `-32000` from `sendPrompt` returns `kind:'not-signed-in'` (agent stays alive); `Conversation` routes it to in-place re-auth (`onAuthExpired`) — **no restart**.

## Red→green increments (in order)
1. `signOutAvailable` surfaced from `_auth/status` (Seam 2).
2. `signOut()` transition + gating + `-32603` (Seam 2).
3. `authReducer` sign-out lifecycle (Seam 3).
4. `selectAuthView` signed-in/signing-out views + identity passthrough (Seam 3).
5. `routeThreadResult` routing (Seam 3/routing).
6. `-32000` expiry tagging on `openThread`/`prompt` (Seam 2, for C/D).
7. IPC + App wiring (openThread, signOut, dedup, SignedInBar, in-place re-auth) — typecheck/build-verified (no JSX test infra).

## Verification

```
bun run typecheck   # clean (strict TS, noUnusedLocals/Params)
bun run build       # ✓ built
bun run test        # Test Files 8 passed (8) · Tests 80 passed (80)
```

(`bun run lint` is a no-op in this repo — eslint isn't in devDependencies; pre-existing, untouched.)

## Notes for reviewers
- **No live auth mutation:** sign-out is only tested via the injected fake stream returning `{}` / the error codes. ADR-0003 guard: the view state carries no credential; `_auth/status` exposes no identity (extra="forbid"), so none is rendered and none is fetched.
- **Scrutinize:** `signOut()` gating + error mapping; the `-32000` expiry tagging side-effect (flips cached state, keeps agent alive); `threadFailureResult`/`disposeAgentsForWorkspace` (agent lifecycle); the App orchestration (`continueToThread` after sign-in, `SignedInBar` sign-out, `onAuthExpired`).
- **Did NOT** implement the blocking `browser-auth` fallback (#17) and did NOT touch the eslint script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)