### PR TITLE
chore: set up ESLint flat config (eslint 10 + typescript-eslint)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,76 @@
+// ESLint 9/10 flat config for vibe-mistro.
+//
+// Scope of this config: a pragmatic, non-type-checked safety net.
+// We intentionally use typescript-eslint's *recommended* preset (syntax-only,
+// no `parserOptions.project`) rather than `recommendedTypeChecked` /
+// `strictTypeChecked`. Type-checked rules are a reasonable follow-up but would
+// flood this existing codebase and require wiring the TS project graph here.
+import js from '@eslint/js'
+import tseslint from 'typescript-eslint'
+import reactHooks from 'eslint-plugin-react-hooks'
+import globals from 'globals'
+
+export default tseslint.config(
+  // Things ESLint should never look at.
+  {
+    ignores: [
+      'out/**',
+      'dist*/**',
+      'node_modules/**',
+      'coverage/**',
+      '**/*.gen.*',
+      '*.tsbuildinfo',
+    ],
+  },
+
+  // Base recommended rules for every TS/TSX file.
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+
+  // Main + preload run in a Node/Electron context.
+  {
+    files: ['src/main/**/*.{ts,tsx}', 'src/preload/**/*.{ts,tsx}'],
+    languageOptions: {
+      globals: { ...globals.node },
+    },
+  },
+
+  // Renderer runs in the browser; React 19 (no react-in-jsx-scope needed).
+  //
+  // We register eslint-plugin-react-hooks manually and enable just the two
+  // classic, high-signal rules. v7's `recommended` preset also turns on a large
+  // batch of experimental React Compiler rules (purity, immutability,
+  // set-state-in-render, ...) which are noisy on an existing codebase; enabling
+  // those is a possible follow-up. Its `recommended` configs are also still in
+  // legacy eslintrc (array-`plugins`) format and don't drop into flat config.
+  {
+    files: ['src/renderer/**/*.{ts,tsx}'],
+    plugins: { 'react-hooks': reactHooks },
+    languageOptions: {
+      globals: { ...globals.browser },
+    },
+    rules: {
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'warn',
+    },
+  },
+
+  // Shared code is environment-agnostic; give it both global sets so it lints
+  // cleanly regardless of which side consumes it.
+  {
+    files: ['src/shared/**/*.{ts,tsx}'],
+    languageOptions: {
+      globals: { ...globals.node, ...globals.browser },
+    },
+  },
+
+  // Tests: vitest globals. The handful of intentional `any` casts in tests are
+  // scoped with inline `// eslint-disable-next-line` directives at their use
+  // sites, so we keep the base rule set here rather than blanket-relaxing it.
+  {
+    files: ['**/*.test.{ts,tsx}'],
+    languageOptions: {
+      globals: { ...globals.node },
+    },
+  },
+)

--- a/package.json
+++ b/package.json
@@ -15,20 +15,25 @@
     "typecheck": "tsc --noEmit -p tsconfig.node.json && tsc --noEmit -p tsconfig.web.json",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "eslint . --ext .ts,.tsx"
+    "lint": "eslint ."
   },
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
+    "@eslint/js": "10.0.1",
     "@types/node": "^22.10.0",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
     "@vitejs/plugin-react": "^4.3.4",
     "electron": "^33.2.1",
     "electron-vite": "^2.3.0",
+    "eslint": "10.6.0",
+    "eslint-plugin-react-hooks": "7.1.1",
+    "globals": "^17.7.0",
     "typescript": "^5.7.2",
+    "typescript-eslint": "8.62.0",
     "vite": "^5.4.11",
     "vitest": "^4.1.9"
   }


### PR DESCRIPTION
## What & why

`package.json` had `"lint": "eslint . --ext .ts,.tsx"` but **eslint was never installed**, so `bun run lint` exited 127 — zero static analysis. This wires up a real, pragmatic ESLint safety net and makes `bun run lint` pass clean (exit 0), with **no application behavior change**.

## Changes

- **devDeps** (via `bun add -d`): `eslint@10.6.0`, `@eslint/js@10.0.1`, `typescript-eslint@8.62.0`, `eslint-plugin-react-hooks@7.1.1`, `globals@17`.
  - Skipped `eslint-plugin-react`: its peer range stops at `eslint ^9.7` (incompatible with eslint 10) and React 19 needs no `react-in-jsx-scope`. The hooks plugin carries the real value.
- **`eslint.config.mjs`** (ESLint 9/10 flat config, not legacy `.eslintrc`):
  - Ignores: `out/`, `dist*/`, `node_modules/`, `coverage/`, `**/*.gen.*`, `*.tsbuildinfo`.
  - Base: `@eslint/js` recommended + `typescript-eslint` **recommended (non type-checked)**. Type-checked rules (`recommendedTypeChecked`/`strictTypeChecked`) intentionally deferred — noted inline as a follow-up.
  - Renderer (`src/renderer/**`): `react-hooks/rules-of-hooks` (error) + `react-hooks/exhaustive-deps` (warn), browser globals.
  - Per-area globals: node for main/preload, browser for renderer, both for shared, node for tests.
- **`package.json`**: `lint` script → `eslint .` (flat config drops `--ext`).

## Violations

**Zero** real violations across the codebase — it's strict TS (`noUnusedLocals`/`noUnusedParameters`/`strict`), so typescript-eslint recommended found nothing new. **No rules turned off, no blanket relaxations, no new disables added.** The only pre-existing inline `// eslint-disable-next-line @typescript-eslint/no-explicit-any` directives (3, in test files) now correctly do their job. Verified ESLint actually scans (29 files) by injecting a probe violation and confirming it's caught.

## Gates (all green)

- `bun run lint` → exit 0
- `bun run typecheck` → exit 0
- `bun run build` → exit 0
- `bun run test` → exit 0 (**90 passed**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)