### PR TITLE
fix(fs-write): close realpath→write TOCTOU with O_NOFOLLOW through-fd writes

### DIFF
--- a/docs/adr/0004-fs-access-confinement.md
+++ b/docs/adr/0004-fs-access-confinement.md
@@ -16,6 +16,16 @@ enforcement point for what the agent can touch on disk. We adopt an **asymmetric
   nearest existing ancestor** of the target (the file itself may not exist yet) and rejects it unless
   that real path is within the real path of the Workspace — so a symlink *inside* the Workspace pointing
   outside cannot be used to escape. This closes the lexical-only gap from the TB3 (#4) review.
+  The validated write is then performed **through file descriptors opened with `O_NOFOLLOW`**
+  (`secureWriteWithinRoot`) rather than by path (#21): each intermediate component is reopened
+  `O_RDONLY | O_DIRECTORY | O_NOFOLLOW` and the final component `O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW`,
+  with the content written through the final handle. This fully closes a pre-existing **dangling
+  final-component symlink** bypass (realpath throws on it, so it stays literal and looks in-Workspace, yet
+  a path-based write would follow it out) and refuses **planted intermediate symlinks** (`ELOOP`). The one
+  irreducible residual — a sub-microsecond swap of an intermediate directory for a symlink *between* our
+  `O_NOFOLLOW` open of that component and the next — needs native `openat()` (no portable Node API) and is
+  accepted under this ADR's desktop trust model. On platforms without `O_NOFOLLOW` (e.g. Windows) the writer
+  falls back to a path-based write; the primary target is macOS/darwin.
 
 ## Considered options
 

--- a/docs/adr/0004-fs-access-confinement.md
+++ b/docs/adr/0004-fs-access-confinement.md
@@ -21,11 +21,18 @@ enforcement point for what the agent can touch on disk. We adopt an **asymmetric
   `O_RDONLY | O_DIRECTORY | O_NOFOLLOW` and the final component `O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW`,
   with the content written through the final handle. This fully closes a pre-existing **dangling
   final-component symlink** bypass (realpath throws on it, so it stays literal and looks in-Workspace, yet
-  a path-based write would follow it out) and refuses **planted intermediate symlinks** (`ELOOP`). The one
-  irreducible residual — a sub-microsecond swap of an intermediate directory for a symlink *between* our
-  `O_NOFOLLOW` open of that component and the next — needs native `openat()` (no portable Node API) and is
-  accepted under this ADR's desktop trust model. On platforms without `O_NOFOLLOW` (e.g. Windows) the writer
-  falls back to a path-based write; the primary target is macOS/darwin.
+  a path-based write would follow it out) and refuses **statically-planted intermediate symlinks** present
+  before the walk reaches them (`ELOOP`). The residual: a **live mid-walk swap** of an intermediate dir to a
+  symlink by a separate racing local process still escapes. The opens are by **absolute path** (not `openat`
+  relative to a held fd), so `O_NOFOLLOW` guards only the FINAL component of each path; once a component is
+  verified it is re-traversed as a NON-final component on every deeper open, where the kernel silently
+  follows it if it has since become a symlink. The residual window for an intermediate component therefore
+  runs from its check-open all the way to the final write-open, and the kept-open `FileHandle`s anchor
+  nothing (they are not load-bearing). Truly closing it needs native `openat()` relative to the parent fd
+  (no portable Node API), which would also make the held fds load-bearing; it is accepted under this ADR's
+  desktop trust model. On platforms without `O_NOFOLLOW` (e.g. Windows) the writer falls back to a path-based
+  write, which gets **none** of this hardening — it remains vulnerable to the static dangling-final-symlink
+  write; this is acceptable only because macOS/darwin is the primary target.
 
 ## Considered options
 

--- a/src/main/acp/fs-write.test.ts
+++ b/src/main/acp/fs-write.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterAll } from 'vitest'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { handleFsWriteTextFile, isPathWithin, type WriteTextFn } from './fs-write'
+import { handleFsWriteTextFile, isPathWithin, secureWriteWithinRoot, type WriteTextFn } from './fs-write'
 
 /**
  * Seam C: the `fs/write_text_file` handler main uses to serve the agent's
@@ -187,6 +187,97 @@ describe('handleFsWriteTextFile — symlink confinement (#8)', () => {
 
     rmSync(realRoot, { recursive: true, force: true })
     rmSync(linkRoot, { force: true })
+  })
+})
+
+/**
+ * #21 — O_NOFOLLOW write-through-fd hardening. Two write-escape gaps the #8
+ * confinement (realpath-then-write-by-path) leaves open, exercised against REAL
+ * temp dirs + real symlinks. Attack paths use RAW string concat — never
+ * path.join/resolve, which collapse `..` and HIDE the symlink (the #8 lesson).
+ */
+describe('handleFsWriteTextFile — #21 O_NOFOLLOW write hardening', () => {
+  it('refuses a write whose final component is a PRE-EXISTING dangling symlink out of the Workspace', async () => {
+    const ws = mkdtempSync(join(tmpdir(), 'vibe-ws-'))
+    const outside = mkdtempSync(join(tmpdir(), 'vibe-outside-'))
+    // Final component `ws/evil.txt` is a symlink to an as-yet-NONEXISTENT target
+    // outside the Workspace. realpath throws on a dangling link, so #8's
+    // resolveLikeKernel leaves it literal — an in-Workspace-LOOKING path that
+    // passes confinement — and a path-based writeFile then FOLLOWS the link and
+    // creates the file OUTSIDE the Workspace.
+    const outsideTarget = outside + '/evil.txt'
+    symlinkSync(outsideTarget, join(ws, 'evil.txt'))
+
+    const outcome = await handleFsWriteTextFile(
+      { path: ws + '/evil.txt', content: 'pwned' },
+      { workspaceDir: ws },
+    )
+
+    expect('error' in outcome).toBe(true)
+    expect(existsSync(outsideTarget)).toBe(false)
+
+    rmSync(ws, { recursive: true, force: true })
+    rmSync(outside, { recursive: true, force: true })
+  })
+})
+
+/**
+ * Direct unit tests of the through-fd writer. These simulate the TOCTOU outcome
+ * by PLANTING the symlink in place of a (would-be) validated component before
+ * the write, then asserting O_NOFOLLOW refuses it and nothing lands outside.
+ */
+describe('secureWriteWithinRoot (#21)', () => {
+  it('refuses when an INTERMEDIATE component is a symlink out of the root (ELOOP)', async () => {
+    const ws = mkdtempSync(join(tmpdir(), 'vibe-ws-'))
+    const outside = mkdtempSync(join(tmpdir(), 'vibe-outside-'))
+    // `ws/sub` is replaced (in place) by a symlink to `outside`. A path-based
+    // write to ws/sub/file.txt would follow it; the through-fd walk opens `sub`
+    // with O_NOFOLLOW|O_DIRECTORY and fails with ELOOP.
+    symlinkSync(outside, join(ws, 'sub'))
+
+    await expect(secureWriteWithinRoot(ws, ws + '/sub/file.txt', 'pwned')).rejects.toThrow()
+    expect(existsSync(outside + '/file.txt')).toBe(false)
+
+    rmSync(ws, { recursive: true, force: true })
+    rmSync(outside, { recursive: true, force: true })
+  })
+
+  it('refuses when the FINAL component is a symlink out of the root (ELOOP)', async () => {
+    const ws = mkdtempSync(join(tmpdir(), 'vibe-ws-'))
+    const outside = mkdtempSync(join(tmpdir(), 'vibe-outside-'))
+    symlinkSync(outside + '/file.txt', join(ws, 'file.txt'))
+
+    await expect(secureWriteWithinRoot(ws, ws + '/file.txt', 'pwned')).rejects.toThrow()
+    expect(existsSync(outside + '/file.txt')).toBe(false)
+
+    rmSync(ws, { recursive: true, force: true })
+    rmSync(outside, { recursive: true, force: true })
+  })
+
+  it('throws when the target is not within the root', async () => {
+    const ws = mkdtempSync(join(tmpdir(), 'vibe-ws-'))
+    const outside = mkdtempSync(join(tmpdir(), 'vibe-outside-'))
+
+    await expect(secureWriteWithinRoot(ws, outside + '/file.txt', 'x')).rejects.toThrow()
+    expect(existsSync(outside + '/file.txt')).toBe(false)
+
+    rmSync(ws, { recursive: true, force: true })
+    rmSync(outside, { recursive: true, force: true })
+  })
+
+  it('writes a new file in a nested in-Workspace subdir and overwrites an existing file', async () => {
+    const ws = mkdtempSync(join(tmpdir(), 'vibe-ws-'))
+    mkdirSync(join(ws, 'a'))
+    mkdirSync(join(ws, 'a', 'b'))
+
+    await secureWriteWithinRoot(ws, join(ws, 'a', 'b', 'new.txt'), 'first')
+    expect(readFileSync(join(ws, 'a', 'b', 'new.txt'), 'utf8')).toBe('first')
+
+    // Overwriting an existing regular file truncates + rewrites.
+    await secureWriteWithinRoot(ws, join(ws, 'a', 'b', 'new.txt'), 'second')
+    expect(readFileSync(join(ws, 'a', 'b', 'new.txt'), 'utf8')).toBe('second')
+
+    rmSync(ws, { recursive: true, force: true })
   })
 })
 

--- a/src/main/acp/fs-write.test.ts
+++ b/src/main/acp/fs-write.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterAll } from 'vitest'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync } from 'node:fs'
+import { open } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { handleFsWriteTextFile, isPathWithin, secureWriteWithinRoot, type WriteTextFn } from './fs-write'
@@ -278,6 +279,48 @@ describe('secureWriteWithinRoot (#21)', () => {
     expect(readFileSync(join(ws, 'a', 'b', 'new.txt'), 'utf8')).toBe('second')
 
     rmSync(ws, { recursive: true, force: true })
+  })
+
+  it('KNOWN RESIDUAL (accepted per ADR-0004): a live mid-walk swap of an intermediate dir to a symlink still escapes — needs openat to close', async () => {
+    // This test ENCODES the known limitation honestly. Opens are by absolute
+    // PATH (not openat relative to a held fd), so O_NOFOLLOW guards only each
+    // path's FINAL component; a verified intermediate is re-traversed as a
+    // non-final component on the next open, where the kernel silently follows it
+    // if it has since become a symlink. We drive the race deterministically via
+    // the SecureWriteDeps.open seam: right after `ws/a` is verified as a real dir
+    // (its check-open returns), a racing process swaps it for a symlink to
+    // `outside` (which already contains `b/`), so the write lands at
+    // outside/b/file.txt — OUTSIDE the Workspace.
+    //
+    // When openat-relative-to-parent-fd lands, flip this to expect NO escape
+    // (existsSync(...) === false and the call to reject).
+    const ws = mkdtempSync(join(tmpdir(), 'vibe-ws-'))
+    const outside = mkdtempSync(join(tmpdir(), 'vibe-outside-'))
+    mkdirSync(join(ws, 'a'))
+    mkdirSync(join(ws, 'a', 'b'))
+    mkdirSync(join(outside, 'b'))
+
+    let opens = 0
+    const racingOpen = (async (...args: Parameters<typeof open>) => {
+      const handle = await open(...args)
+      opens += 1
+      if (opens === 1) {
+        // `ws/a` has just been verified as a real dir; swap it for a symlink to
+        // `outside` before the next (deeper) open re-traverses it.
+        rmSync(join(ws, 'a'), { recursive: true, force: true })
+        symlinkSync(outside, join(ws, 'a'))
+      }
+      return handle
+    }) as typeof open
+
+    await secureWriteWithinRoot(ws, ws + '/a/b/file.txt', 'pwned', { open: racingOpen })
+
+    // CURRENT (residual) behavior: the write ESCAPED to outside/b/file.txt.
+    expect(existsSync(join(outside, 'b', 'file.txt'))).toBe(true)
+    expect(readFileSync(join(outside, 'b', 'file.txt'), 'utf8')).toBe('pwned')
+
+    rmSync(ws, { recursive: true, force: true })
+    rmSync(outside, { recursive: true, force: true })
   })
 })
 

--- a/src/main/acp/fs-write.ts
+++ b/src/main/acp/fs-write.ts
@@ -1,5 +1,6 @@
-import { realpath, writeFile } from 'node:fs/promises'
-import { dirname, isAbsolute, join, parse, relative, resolve } from 'node:path'
+import { constants as fsConstants } from 'node:fs'
+import { open, realpath, writeFile, type FileHandle } from 'node:fs/promises'
+import { dirname, isAbsolute, join, parse, relative, resolve, sep } from 'node:path'
 
 /**
  * Serve the agent's `fs/write_text_file` request (agent → client). Like reads,
@@ -57,10 +58,24 @@ export async function handleFsWriteTextFile(
     return { error: { code: -32602, message: 'fs/write_text_file: missing or invalid `content`' } }
   }
   // Confine to the Workspace. We resolve the target the way the KERNEL will at
-  // write time and write back that same canonical path, so the path we validated
-  // is the path we write (a residual realpath→write TOCTOU race remains — fully
-  // closing it needs openat/O_NOFOLLOW, out of scope here).
+  // write time, then write THROUGH file descriptors opened with O_NOFOLLOW
+  // (`secureWriteWithinRoot`) rather than by path. This closes two escapes the
+  // earlier resolve-then-writeFile-by-path left open:
+  //   • a PRE-EXISTING dangling symlink as the final component — realpath throws
+  //     on it so `resolveLikeKernel` leaves it literal (looks in-Workspace), and
+  //     a path-based writeFile would FOLLOW it outside. O_NOFOLLOW on the final
+  //     open refuses it. FULLY closed (open and write are the same fd — no
+  //     re-resolution between them).
+  //   • a planted INTERMEDIATE symlink swapped in for a validated real dir — each
+  //     intermediate is re-opened with O_NOFOLLOW|O_DIRECTORY, so a symlink there
+  //     fails with ELOOP. Closed for already-planted symlinks.
+  // ONE irreducible residual remains: a sub-microsecond swap of an intermediate
+  // directory for a symlink BETWEEN our O_NOFOLLOW open of that component and the
+  // open of the next one down. Truly closing it needs native openat() relative to
+  // the parent fd (no portable Node API); it is accepted under ADR-0004's desktop
+  // trust model ("you launched this agent against your account").
   let writeTarget = path
+  let secureRoot: string | undefined
   if (deps.workspaceDir) {
     const confined = await confinedWriteTarget(deps.workspaceDir, path)
     if (!confined) {
@@ -71,11 +86,19 @@ export async function handleFsWriteTextFile(
         },
       }
     }
-    writeTarget = confined
+    writeTarget = confined.realTarget
+    secureRoot = confined.realRoot
   }
 
   try {
-    await write(writeTarget, content)
+    // Secure (through-fd) writer only when confined AND no test writer is
+    // injected; injected writers (test fakes) keep the path-based seam, and an
+    // unconfined write (no workspaceDir) uses the plain default writer.
+    if (secureRoot !== undefined && deps.write === undefined) {
+      await secureWriteWithinRoot(secureRoot, writeTarget, content)
+    } else {
+      await write(writeTarget, content)
+    }
     return { result: {} }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
@@ -84,21 +107,82 @@ export async function handleFsWriteTextFile(
 }
 
 /**
- * The canonical real path of `target` IF it stays inside `workspaceDir`, else
- * `null` — symlink-resolved confinement (ADR-0004). Both sides are realpath-
- * resolved before the lexical containment check, so a symlink inside the
- * Workspace pointing out cannot escape and a symlinked Workspace root isn't
- * falsely rejected.
+ * The realpath'd Workspace root plus the canonical real path of `target` IF the
+ * latter stays inside the former, else `null` — symlink-resolved confinement
+ * (ADR-0004). Both sides are realpath-resolved before the lexical containment
+ * check, so a symlink inside the Workspace pointing out cannot escape and a
+ * symlinked Workspace root isn't falsely rejected. `realRoot` is handed to the
+ * secure writer so it knows where the through-fd walk must start.
  */
-async function confinedWriteTarget(workspaceDir: string, target: string): Promise<string | null> {
+async function confinedWriteTarget(
+  workspaceDir: string,
+  target: string,
+): Promise<{ realRoot: string; realTarget: string } | null> {
   const realRoot = await realpath(workspaceDir).catch(() => resolve(workspaceDir))
   const realTarget = await resolveLikeKernel(target)
-  return isPathWithin(realRoot, realTarget) ? realTarget : null
+  return isPathWithin(realRoot, realTarget) ? { realRoot, realTarget } : null
 }
 
 /** Boolean form of {@link confinedWriteTarget}. */
 export async function isWriteWithinWorkspace(workspaceDir: string, target: string): Promise<boolean> {
   return (await confinedWriteTarget(workspaceDir, target)) !== null
+}
+
+/** Inject `open` for testing {@link secureWriteWithinRoot} directly. */
+export interface SecureWriteDeps {
+  open?: typeof open
+}
+
+/**
+ * Write `content` to `target` — which MUST resolve within `realRoot` (the
+ * realpath'd Workspace root) — following NO symlinks on the way down, by opening
+ * file descriptors with `O_NOFOLLOW` and writing THROUGH the final fd.
+ *
+ * Walk `target`'s components relative to `realRoot`: each INTERMEDIATE component
+ * is opened `O_RDONLY | O_DIRECTORY | O_NOFOLLOW`, so a component that is (or was
+ * swapped to) a symlink fails with `ELOOP`; the FINAL component is opened
+ * `O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW` and written through that handle, so
+ * a symlink there (dangling or live) is refused and there is no path
+ * re-resolution between open and write. All handles close in `finally`.
+ *
+ * Portability: `O_NOFOLLOW` is POSIX. Where it is undefined (e.g. Windows) we
+ * fall back to a path-based `writeFile` — confinement was already validated and
+ * the primary target is macOS/darwin where `O_NOFOLLOW` is defined.
+ */
+export async function secureWriteWithinRoot(
+  realRoot: string,
+  target: string,
+  content: string,
+  deps: SecureWriteDeps = {},
+): Promise<void> {
+  const openFn = deps.open ?? open
+  const C = fsConstants
+
+  if (C.O_NOFOLLOW === undefined) {
+    await writeFile(target, content, 'utf8')
+    return
+  }
+
+  const rel = relative(realRoot, target)
+  if (rel === '' || rel.startsWith('..') || isAbsolute(rel)) {
+    throw new Error(`secureWriteWithinRoot: target escapes the root: ${target}`)
+  }
+  const parts = rel.split(sep).filter((p) => p.length > 0)
+
+  const handles: FileHandle[] = []
+  try {
+    let acc = realRoot
+    for (let i = 0; i < parts.length - 1; i++) {
+      acc = join(acc, parts[i])
+      handles.push(await openFn(acc, C.O_RDONLY | (C.O_DIRECTORY ?? 0) | C.O_NOFOLLOW))
+    }
+    acc = join(acc, parts[parts.length - 1])
+    const fileHandle = await openFn(acc, C.O_WRONLY | C.O_CREAT | C.O_TRUNC | C.O_NOFOLLOW, 0o666)
+    handles.push(fileHandle)
+    await fileHandle.writeFile(content, 'utf8')
+  } finally {
+    await Promise.allSettled(handles.map((h) => h.close()))
+  }
 }
 
 /**

--- a/src/main/acp/fs-write.ts
+++ b/src/main/acp/fs-write.ts
@@ -66,14 +66,21 @@ export async function handleFsWriteTextFile(
   //     a path-based writeFile would FOLLOW it outside. O_NOFOLLOW on the final
   //     open refuses it. FULLY closed (open and write are the same fd — no
   //     re-resolution between them).
-  //   • a planted INTERMEDIATE symlink swapped in for a validated real dir — each
-  //     intermediate is re-opened with O_NOFOLLOW|O_DIRECTORY, so a symlink there
-  //     fails with ELOOP. Closed for already-planted symlinks.
-  // ONE irreducible residual remains: a sub-microsecond swap of an intermediate
-  // directory for a symlink BETWEEN our O_NOFOLLOW open of that component and the
-  // open of the next one down. Truly closing it needs native openat() relative to
-  // the parent fd (no portable Node API); it is accepted under ADR-0004's desktop
-  // trust model ("you launched this agent against your account").
+  //   • a STATICALLY-PLANTED intermediate symlink (present BEFORE the walk reaches
+  //     it) — when we open that component as a path ending in it with
+  //     O_NOFOLLOW|O_DIRECTORY it fails with ELOOP. Caught.
+  // RESIDUAL (accepted under ADR-0004's desktop trust model — "you launched this
+  // agent against your account"): a LIVE mid-walk swap of an intermediate dir to a
+  // symlink by a separate racing local process still escapes. We open by ABSOLUTE
+  // PATH (not openat relative to a held fd), so O_NOFOLLOW guards ONLY the FINAL
+  // component of each path. Once a component is verified, it is re-traversed as a
+  // NON-final component on every deeper open, where the kernel SILENTLY follows it
+  // if it has since become a symlink. So the residual window for an intermediate
+  // component runs from its check-open ALL THE WAY to the final write-open, and the
+  // kept-open FileHandles anchor NOTHING (they are not load-bearing). Truly closing
+  // it needs native openat() relative to the parent fd (no portable Node API),
+  // which would ALSO make the held fds load-bearing. See the "KNOWN RESIDUAL"
+  // characterization test in fs-write.test.ts.
   let writeTarget = path
   let secureRoot: string | undefined
   if (deps.workspaceDir) {


### PR DESCRIPTION
## What

Hardens the `fs/write_text_file` write path so a confined write can no longer follow a symlink out of the Workspace. Two escapes the prior resolve-then-write-by-path left open are now closed:

1. **Static dangling final-component symlink** (no race needed): if the final path component is a PRE-EXISTING symlink whose target doesn't exist, `realpath` throws on it so `resolveLikeKernel` left it literal — an in-Workspace-looking path that passed confinement. A path-based `writeFile` then followed it and created the file OUTSIDE the Workspace.
2. **Statically-planted intermediate symlink**: a symlink present before the walk reaches it, in place of a real dir component.

## How

- `confinedWriteTarget` keeps #8 confinement exactly as-is and now also returns the realpath'd Workspace root.
- New exported `secureWriteWithinRoot(realRoot, target, content, deps?)`: walks the target's components relative to `realRoot`, opening each INTERMEDIATE `O_RDONLY | O_DIRECTORY | O_NOFOLLOW` and the FINAL `O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW`, writing the content THROUGH that handle (no path re-resolution between open and write). Handles close in `finally`. Where `O_NOFOLLOW` is undefined (Windows) it falls back to a path-based `writeFile`; primary target is macOS/darwin.
- The handler uses the secure writer when confined (`workspaceDir` set) AND no `deps.write` override is injected; injected writers (test fakes) and unconfined writes keep the path-based seam. Secure-write failures map to the existing `-32603` error path (never throws).

## Residual (NOT closed) — accepted under ADR-0004

A **live mid-walk swap** of an intermediate dir to a symlink by a separate racing local process still escapes. The opens are by **absolute path** (not `openat` relative to a held fd), so `O_NOFOLLOW` guards only the FINAL component of each path; once a component is verified it is re-traversed as a NON-final component on every deeper open, where the kernel silently follows it if it has since become a symlink. The residual window for an intermediate component therefore runs from its check-open all the way to the final write-open, and the kept-open `FileHandle`s are NOT load-bearing. Statically-planted symlinks ARE still caught; only the live mid-walk swap escapes. Truly closing it needs native `openat()` relative to the parent fd (no portable Node API), which would also make the held fds load-bearing. Accepted under ADR-0004's desktop trust model.

On platforms without `O_NOFOLLOW` (Windows), the path-fallback gets **none** of this hardening and remains vulnerable to the static dangling-final-symlink write; acceptable only because macOS/darwin is the primary target.

The limitation is encoded as an executable characterization test ("KNOWN RESIDUAL ... a live mid-walk swap of an intermediate dir to a symlink still escapes — needs openat to close"), which drives the swap via the `SecureWriteDeps.open` seam and asserts the current escape, with a note to flip it when `openat` lands.

## Tests

Added 6 tests (fs-write.test.ts 12→18; full suite 96 passed). Test #1 (static dangling-final-symlink) was confirmed RED against the old code first — it returned `{result:{}}` (success) and followed the dangling symlink. All existing #8 confinement tests pass unchanged. Updated in-code comment and `docs/adr/0004-fs-access-confinement.md`.

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)