### PR TITLE
feat(brand): Mistral light-mode tokens, orange gradient, zero radius

### DIFF
--- a/docs/design/brand.md
+++ b/docs/design/brand.md
@@ -1,0 +1,60 @@
+# Mistral brand — design tokens
+
+Light mode, Mistral orange accents, sharp edges. All UI color/radius flows
+through the token layer in `src/renderer/src/styles.css` (`:root`). Components
+reference tokens only — no raw hex/rgba and no non-zero radius in component rules.
+
+## The rule
+
+- **Orange = fills, borders, gradients.** Use `--accent` / `--accent-grad`.
+- **Orange text = `--accent-text`** (a darker burnt orange). The vivid fill
+  orange (`--accent`) fails WCAG AA as text on the light background, so any
+  orange _text_ must use `--accent-text`.
+- **Body text = `--text`** (warm near-black). Secondary text = `--muted`.
+- **Radius = `--radius` (0).** Every corner is square — cards, buttons, inputs,
+  chips, badges, alerts, and the status dot.
+
+## Palette
+
+| Token                   | Value                                          | Use                                  |
+| ----------------------- | ---------------------------------------------- | ------------------------------------ |
+| `--bg`                  | `#fafaf8`                                       | App background (warm off-white)      |
+| `--surface`             | `#ffffff`                                       | Surface alias                        |
+| `--panel`               | `#ffffff`                                       | Cards / raised surfaces              |
+| `--border`              | `#e7e3dd`                                       | Borders / dividers (warm light gray) |
+| `--text`                | `#1e1a17`                                       | Body text (warm near-black)          |
+| `--muted`               | `#6b6a66`                                       | Secondary / muted text               |
+| `--accent`              | `#fa500f`                                       | Orange fills, borders, dot           |
+| `--accent-text`         | `#c2410c`                                       | Orange **text** (AA-safe)            |
+| `--accent-grad`         | `linear-gradient(135deg, #ff8a00, #f23005)`     | Primary buttons / active states      |
+| `--on-accent`           | `#1a1100`                                       | Label color on the orange gradient   |
+| `--ok`                  | `#1a7f37`                                       | Success text / status                |
+| `--bad`                 | `#b42318`                                       | Error text / status                  |
+| `--radius`              | `0`                                             | All corners                          |
+
+### Semantic tints (token-layer rgba; never raw rgba in component rules)
+
+| Token                  | Value                       | Use                          |
+| ---------------------- | --------------------------- | ---------------------------- |
+| `--accent-tint`        | `rgba(250, 80, 15, 0.08)`   | Sign-in / permission bg      |
+| `--accent-tint-border` | `rgba(250, 80, 15, 0.35)`   | Sign-in / permission border  |
+| `--ok-tint`            | `rgba(26, 127, 55, 0.10)`   | Badge / signed-in bg         |
+| `--ok-tint-border`     | `rgba(26, 127, 55, 0.35)`   | Badge border                 |
+| `--bad-tint`           | `rgba(180, 35, 24, 0.08)`   | Alert bg                     |
+| `--bad-tint-border`    | `rgba(180, 35, 24, 0.35)`   | Alert border                 |
+
+## Contrast (WCAG, computed on `--bg` `#fafaf8` unless noted)
+
+| Pair                                       | Ratio   | AA (normal ≥4.5) |
+| ------------------------------------------ | ------- | ---------------- |
+| `--text` `#1e1a17`                         | 16.53:1 | pass             |
+| `--muted` `#6b6a66`                        | 5.18:1  | pass             |
+| `--accent-text` `#c2410c`                  | 4.96:1  | pass             |
+| `--ok` `#1a7f37`                           | 4.86:1  | pass             |
+| `--bad` `#b42318`                          | 6.29:1  | pass             |
+| `--accent` `#fa500f` (fill only, not text) | 3.23:1  | n/a — fills only |
+| `--on-accent` `#1a1100` on gradient        | 7.91 → 4.63:1 | pass (whole gradient range) |
+
+The button label (`--on-accent`, dark) is verified across the full gradient:
+7.91:1 at the amber stop (`#ff8a00`) down to 4.63:1 at the red-orange stop
+(`#f23005`) — AA across the entire fill.

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1,12 +1,31 @@
 :root {
-  --bg: #0e0f13;
-  --panel: #16181f;
-  --border: #262a35;
-  --text: #e6e8ee;
-  --muted: #8b90a0;
-  --accent: #ff7a1a;
-  --ok: #3fb950;
-  --bad: #f85149;
+  /* Mistral light-mode brand tokens.
+     Orange = fills / borders / gradients. --accent-text = orange TEXT (AA-safe). */
+  --bg: #fafaf8;
+  --surface: #ffffff;
+  --panel: #ffffff;
+  --border: #e7e3dd;
+  --text: #1e1a17;
+  --muted: #6b6a66;
+
+  --accent: #fa500f;
+  --accent-text: #c2410c;
+  --accent-grad: linear-gradient(135deg, #ff8a00 0%, #f23005 100%);
+  --on-accent: #1a1100;
+
+  --ok: #1a7f37;
+  --bad: #b42318;
+
+  /* Semantic tints (token-layer rgba; never raw rgba in component rules). */
+  --accent-tint: rgba(250, 80, 15, 0.08);
+  --accent-tint-border: rgba(250, 80, 15, 0.35);
+  --ok-tint: rgba(26, 127, 55, 0.1);
+  --ok-tint-border: rgba(26, 127, 55, 0.35);
+  --bad-tint: rgba(180, 35, 24, 0.08);
+  --bad-tint-border: rgba(180, 35, 24, 0.35);
+
+  --radius: 0;
+
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
 
@@ -54,7 +73,7 @@ body {
 .card {
   background: var(--panel);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius);
   padding: 16px;
 }
 
@@ -67,10 +86,10 @@ body {
 }
 
 .btn {
-  background: var(--accent);
-  color: #1a1100;
+  background: var(--accent-grad);
+  color: var(--on-accent);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 6px 12px;
   font-weight: 600;
   cursor: pointer;
@@ -115,7 +134,7 @@ body {
 .dot {
   width: 9px;
   height: 9px;
-  border-radius: 50%;
+  border-radius: var(--radius);
   display: inline-block;
 }
 
@@ -172,10 +191,10 @@ body {
 }
 
 .badge {
-  background: rgba(63, 185, 80, 0.15);
+  background: var(--ok-tint);
   color: var(--ok);
-  border: 1px solid rgba(63, 185, 80, 0.4);
-  border-radius: 999px;
+  border: 1px solid var(--ok-tint-border);
+  border-radius: var(--radius);
   padding: 2px 10px;
   font-size: 11px;
   font-weight: 600;
@@ -202,7 +221,7 @@ body {
 
 .chip {
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 2px 8px;
   font-size: 12px;
   color: var(--muted);
@@ -210,13 +229,13 @@ body {
 
 .chip--active {
   border-color: var(--accent);
-  color: var(--accent);
+  color: var(--accent-text);
 }
 
 .alert {
-  border: 1px solid rgba(248, 81, 73, 0.4);
-  background: rgba(248, 81, 73, 0.08);
-  border-radius: 8px;
+  border: 1px solid var(--bad-tint-border);
+  background: var(--bad-tint);
+  border-radius: var(--radius);
   padding: 12px;
   display: flex;
   flex-direction: column;
@@ -241,9 +260,9 @@ body {
 }
 
 .signin {
-  border: 1px solid rgba(255, 122, 26, 0.4);
-  background: rgba(255, 122, 26, 0.08);
-  border-radius: 8px;
+  border: 1px solid var(--accent-tint-border);
+  background: var(--accent-tint);
+  border-radius: var(--radius);
   padding: 12px;
   display: flex;
   flex-direction: column;
@@ -252,7 +271,7 @@ body {
 }
 
 .signin__title {
-  color: var(--accent);
+  color: var(--accent-text);
   font-weight: 600;
   font-size: 13px;
 }
@@ -270,8 +289,8 @@ body {
 }
 
 .signin--done {
-  border-color: rgba(63, 185, 80, 0.4);
-  background: rgba(63, 185, 80, 0.08);
+  border-color: var(--ok-tint-border);
+  background: var(--ok-tint);
 }
 
 .signin--done .signin__title {
@@ -289,8 +308,8 @@ body {
   padding: 8px 12px;
   margin-bottom: 10px;
   border: 1px solid var(--border);
-  border-radius: 8px;
-  background: rgba(63, 185, 80, 0.06);
+  border-radius: var(--radius);
+  background: var(--ok-tint);
   font-size: 13px;
 }
 
@@ -375,13 +394,13 @@ body {
 .msg--user .msg__body {
   background: var(--panel);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius);
   padding: 8px 12px;
   align-self: flex-start;
 }
 
 .msg--assistant .msg__role {
-  color: var(--accent);
+  color: var(--accent-text);
 }
 
 .reasoning {
@@ -408,7 +427,7 @@ body {
 
 .fallback {
   border: 1px dashed var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 6px 10px;
 }
 
@@ -424,7 +443,7 @@ body {
 
 .tool {
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius);
   padding: 8px 12px;
   background: var(--panel);
 }
@@ -455,9 +474,9 @@ body {
 }
 
 .permission {
-  border: 1px solid rgba(255, 122, 26, 0.4);
-  background: rgba(255, 122, 26, 0.08);
-  border-radius: 8px;
+  border: 1px solid var(--accent-tint-border);
+  background: var(--accent-tint);
+  border-radius: var(--radius);
   padding: 12px;
   display: flex;
   flex-direction: column;
@@ -467,7 +486,7 @@ body {
 .permission__title {
   font-size: 13px;
   font-weight: 600;
-  color: var(--accent);
+  color: var(--accent-text);
 }
 
 .permission__chosen {
@@ -492,7 +511,7 @@ body {
   background: transparent;
   color: var(--muted);
   border: 1px dashed var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 4px 10px;
   font-size: 12px;
   cursor: pointer;
@@ -515,7 +534,7 @@ body {
   background: var(--bg);
   color: var(--text);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius);
   padding: 8px 10px;
   font-family: inherit;
   font-size: 14px;


### PR DESCRIPTION
## Summary

Establishes the Mistral visual identity entirely through the design-token layer in the single global stylesheet (`src/renderer/src/styles.css`). Token/visual slice only — no layout, component, or `.tsx` changes.

- **Light mode** throughout: warm off-white bg (`#fafaf8`), white surfaces, warm near-black text. No dark-theme remnants.
- **Mistral orange** accent (`--accent: #fa500f`) for fills/borders/dot; **amber→red-orange gradient** (`--accent-grad`) for primary buttons + active states.
- **Zero radius** everywhere via a single `--radius: 0` token (all 14 `border-radius` rules — cards, buttons, inputs, chips, badges, alerts, status dot → square).
- **AA-safe orange text** via a darker `--accent-text: #c2410c`; the vivid fill orange is used for fills/borders only.
- **Semantic tint tokens** (`--accent/ok/bad-tint[-border]`) replace every former rgba/hex literal in component rules — no raw hex/rgba left outside `:root`.
- New `docs/design/brand.md`: palette, token names, the orange-fill-vs-`--accent-text` rule, and computed contrast ratios.

## Contrast (WCAG, on `--bg` unless noted)

| Pair | Ratio | AA |
| --- | --- | --- |
| `--text` body | 16.53:1 | pass |
| `--muted` | 5.18:1 | pass |
| `--accent-text` | 4.96:1 | pass |
| `--ok` | 4.86:1 | pass |
| `--bad` | 6.29:1 | pass |
| `--on-accent` on gradient | 7.91 → 4.63:1 | pass (full range) |

`--accent` (3.23:1) is used for fills/borders only, never as text.

## Gates

`lint`, `typecheck`, `build`, `test` — all green (96 tests passed across 8 files).

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)