### PR TITLE
TB1: persist + restore Workspace/Thread metadata (cold list)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -54,6 +54,25 @@ async function recordThread(workspaceDir: string, thread: ThreadInfo): Promise<v
   }
 }
 
+/**
+ * Persist that a Workspace was opened, BEFORE the agent starts, so even a
+ * not-signed-in Workspace lists. Best-effort exactly like `recordThread`: a
+ * failing `persist()` (disk full / read-only userData) must NEVER reject the
+ * connect flow — the renderer's onClick has no `.catch`, so a throw here would
+ * wedge the UI on "Launching…".
+ */
+async function recordWorkspaceOpen(workspaceDir: string): Promise<void> {
+  if (!metadataStore) return
+  try {
+    await metadataStore.upsertWorkspace({
+      dir: workspaceDir,
+      displayName: basename(workspaceDir),
+    })
+  } catch {
+    // A persistence failure is non-fatal — the connect flow proceeds.
+  }
+}
+
 /** Build the renderer-facing connection (carries the sign-out gate + methods). */
 function connectionFor(agentId: string, agent: WorkspaceAgent, thread: ThreadInfo): ThreadConnection {
   return {
@@ -157,11 +176,8 @@ function registerIpc(): void {
     })
 
     // Persist the Workspace open up front (ADR-0005), so even a not-signed-in
-    // Workspace shows in the cold list. Keyed by dir — idempotent on re-open.
-    await metadataStore?.upsertWorkspace({
-      dir: args.workspaceDir,
-      displayName: basename(args.workspaceDir),
-    })
+    // Workspace shows in the cold list. Best-effort — must not reject connect.
+    await recordWorkspaceOpen(args.workspaceDir)
 
     try {
       await agent.start()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,7 +1,8 @@
 import { app, BrowserWindow, dialog, ipcMain, shell } from 'electron'
-import { join } from 'node:path'
+import { basename, join } from 'node:path'
 import {
   IPC,
+  type ListMetadataResult,
   type OpenThreadArgs,
   type RespondPermissionArgs,
   type SendPromptArgs,
@@ -17,10 +18,41 @@ import {
 } from '../shared/ipc'
 import { detectVibe } from './vibe-detect'
 import { getShellEnv } from './shell-env'
+import { groupThreadsByWorkspace, MetadataStore } from './persistence/metadata-store'
 import { WorkspaceAgent, WorkspaceAgentError } from './workspace-agent'
 
 /** Active Workspace agents keyed by a generated agent id. */
 const agents = new Map<string, WorkspaceAgent>()
+
+/**
+ * The single-writer metadata index (ADR-0005). Assigned at app-ready (needs
+ * `userData`) and loaded before the first window so the renderer's cold list
+ * fetch sees the persisted state. A failed load degrades to empty, never throws.
+ */
+let metadataStore: MetadataStore | null = null
+
+/**
+ * Persist that this Workspace was opened and a Thread minted. The Thread gets a
+ * durable id (minted by the store) distinct from its ACP `sessionId`, which is
+ * stored as the resume cursor for a later reopen (TB3). Best-effort: a metadata
+ * write must never break the live connect flow.
+ */
+async function recordThread(workspaceDir: string, thread: ThreadInfo): Promise<void> {
+  if (!metadataStore) return
+  try {
+    const ws = await metadataStore.upsertWorkspace({
+      dir: workspaceDir,
+      displayName: basename(workspaceDir),
+    })
+    await metadataStore.upsertThread({
+      workspaceId: ws.id,
+      sessionId: thread.sessionId,
+      title: thread.title,
+    })
+  } catch {
+    // A persistence failure is non-fatal — the user is still connected.
+  }
+}
 
 /** Build the renderer-facing connection (carries the sign-out gate + methods). */
 function connectionFor(agentId: string, agent: WorkspaceAgent, thread: ThreadInfo): ThreadConnection {
@@ -124,6 +156,13 @@ function registerIpc(): void {
       }
     })
 
+    // Persist the Workspace open up front (ADR-0005), so even a not-signed-in
+    // Workspace shows in the cold list. Keyed by dir — idempotent on re-open.
+    await metadataStore?.upsertWorkspace({
+      dir: args.workspaceDir,
+      displayName: basename(args.workspaceDir),
+    })
+
     try {
       await agent.start()
       agents.set(agentId, agent)
@@ -136,6 +175,7 @@ function registerIpc(): void {
       }
 
       const thread = await agent.openThread()
+      await recordThread(args.workspaceDir, thread)
       return { ok: true, thread: connectionFor(agentId, agent, thread) }
     } catch (err) {
       return threadFailureResult(agentId, agent, err)
@@ -149,6 +189,7 @@ function registerIpc(): void {
     if (!agent) return { ok: false, kind: 'error', error: `No active agent for id ${args.agentId}.`, hint: null }
     try {
       const thread = await agent.openThread()
+      await recordThread(agent.workspaceDir, thread)
       return { ok: true, thread: connectionFor(args.agentId, agent, thread) }
     } catch (err) {
       return threadFailureResult(args.agentId, agent, err)
@@ -213,9 +254,21 @@ function registerIpc(): void {
     agent?.stop()
     agents.delete(agentId)
   })
+
+  ipcMain.handle(IPC.listMetadata, (): ListMetadataResult => {
+    // The cold launch list (ADR-0005): persisted Workspaces + Threads from
+    // metadata alone — no agent spawned, no transcript loaded.
+    if (!metadataStore) return []
+    return groupThreadsByWorkspace(metadataStore.snapshot())
+  })
 }
 
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
+  // Load the persisted index before the first window so the renderer's launch
+  // fetch sees prior Workspaces/Threads. `userData` is only valid once ready.
+  metadataStore = new MetadataStore({ filePath: join(app.getPath('userData'), 'metadata.json') })
+  await metadataStore.load()
+
   registerIpc()
   createWindow()
 

--- a/src/main/persistence/metadata-store.test.ts
+++ b/src/main/persistence/metadata-store.test.ts
@@ -111,6 +111,65 @@ describe('MetadataStore round-trip', () => {
     expect(store.snapshot().workspaces).toHaveLength(1)
     expect(ws.dir).toBe('/proj/recover')
   })
+
+  it('degrades a partially-corrupt file to its valid subset (no throw on list)', async () => {
+    // Valid JSON, but a malformed (null) Thread alongside a valid one and a
+    // malformed Workspace alongside a valid one. Without per-record validation
+    // the null record reaches snapshot()/groupThreadsByWorkspace and throws on
+    // `b.lastActiveAt` — narrowing the corrupt-degrades-gracefully guarantee.
+    const file = join(dir, 'partial-corrupt.json')
+    writeFileSync(
+      file,
+      JSON.stringify({
+        workspaces: [
+          { id: 'w1', dir: '/ok', displayName: 'ok', lastOpenedAt: 100 },
+          { id: 'wBad', dir: 123 }, // dir not a string, no timestamp → dropped
+        ],
+        threads: [
+          null, // dropped, must not crash
+          { id: 't1', workspaceId: 'w1', sessionId: null, title: null, createdAt: 1, lastActiveAt: 10 },
+          { id: 'tBad', workspaceId: 'w1' }, // missing numeric timestamps → dropped
+        ],
+      }),
+    )
+    const store = new MetadataStore({ filePath: file })
+    await store.load()
+
+    const snap = store.snapshot()
+    expect(snap.workspaces.map((w) => w.id)).toEqual(['w1'])
+    expect(snap.threads.map((t) => t.id)).toEqual(['t1'])
+    // Listing the valid subset must not throw on the dropped malformed records.
+    expect(() => groupThreadsByWorkspace(snap)).not.toThrow()
+    expect(groupThreadsByWorkspace(snap)[0].threads.map((t) => t.id)).toEqual(['t1'])
+  })
+})
+
+describe('MetadataStore atomic persist', () => {
+  it('writes to a temp file then renames it over the target (crash-safe)', async () => {
+    const events: string[] = []
+    const target = join(dir, 'atomic.json')
+    let tmpContent = ''
+    const store = new MetadataStore({
+      filePath: target,
+      readFile: async () => {
+        throw new Error('ENOENT')
+      },
+      writeFile: async (path, data) => {
+        events.push(`write:${path}`)
+        tmpContent = data
+      },
+      rename: async (from, to) => {
+        // The rename must follow the temp write, and the temp must already hold
+        // the full payload — never a half-written target.
+        events.push(`rename:${from}->${to}`)
+        expect(tmpContent).toContain('/proj/atomic')
+      },
+    })
+    await store.load()
+    await store.upsertWorkspace({ dir: '/proj/atomic' })
+
+    expect(events).toEqual([`write:${target}.tmp`, `rename:${target}.tmp->${target}`])
+  })
 })
 
 describe('groupThreadsByWorkspace (pure)', () => {

--- a/src/main/persistence/metadata-store.test.ts
+++ b/src/main/persistence/metadata-store.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, afterAll } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { groupThreadsByWorkspace, MetadataStore } from './metadata-store'
+
+/**
+ * The main-side Workspace/Thread metadata store (ADR-0005 metadata-first lazy
+ * reopen). Exercised over a REAL temp-dir JSON file via the injectable fs/path
+ * seam, mirroring fs-write.test.ts — no `userData`, no `vibe-acp` spawned.
+ */
+
+const dir = mkdtempSync(join(tmpdir(), 'vibe-metadata-'))
+afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+/** A store bound to a fresh JSON file under the shared temp dir. */
+function storeAt(file: string): MetadataStore {
+  return new MetadataStore({ filePath: join(dir, file) })
+}
+
+describe('MetadataStore round-trip', () => {
+  it('persists Workspaces + Threads and reads them back through a new instance', async () => {
+    const file = 'roundtrip.json'
+    const store = storeAt(file)
+    await store.load()
+
+    const ws = await store.upsertWorkspace({ dir: '/proj/alpha', displayName: 'alpha' })
+    await store.upsertThread({ workspaceId: ws.id, sessionId: 'sess-1', title: 'first' })
+
+    // A brand-new instance over the SAME file must read the persisted state back.
+    const reopened = storeAt(file)
+    await reopened.load()
+    const snap = reopened.snapshot()
+
+    expect(snap.workspaces).toHaveLength(1)
+    expect(snap.workspaces[0]).toMatchObject({ dir: '/proj/alpha', displayName: 'alpha' })
+    expect(snap.threads).toHaveLength(1)
+    expect(snap.threads[0]).toMatchObject({ workspaceId: ws.id, sessionId: 'sess-1', title: 'first' })
+  })
+
+  it("mints a Thread id distinct from its ACP sessionId, and allows a null sessionId", async () => {
+    const store = storeAt('distinct-id.json')
+    await store.load()
+    const ws = await store.upsertWorkspace({ dir: '/proj/beta' })
+
+    const bound = await store.upsertThread({ workspaceId: ws.id, sessionId: 'acp-session-xyz' })
+    expect(bound.id).not.toBe(bound.sessionId)
+    expect(bound.id.length).toBeGreaterThan(0)
+
+    // A Thread can exist before any ACP session is minted (resume cursor null).
+    const cold = await store.upsertThread({ workspaceId: ws.id })
+    expect(cold.sessionId).toBeNull()
+    expect(cold.id).not.toBe(bound.id)
+  })
+
+  it('upserts a Workspace by dir (no duplicate), refreshing lastOpenedAt and re-ordering', async () => {
+    let clock = 1000
+    const store = new MetadataStore({ filePath: join(dir, 'ws-order.json'), now: () => clock })
+    await store.load()
+
+    const a = await store.upsertWorkspace({ dir: '/proj/a' })
+    clock = 2000
+    await store.upsertWorkspace({ dir: '/proj/b' })
+    clock = 3000
+    // Re-open A: same record (same id), bumped timestamp, now most-recent.
+    const aAgain = await store.upsertWorkspace({ dir: '/proj/a' })
+
+    expect(aAgain.id).toBe(a.id)
+    expect(aAgain.lastOpenedAt).toBe(3000)
+    const dirs = store.snapshot().workspaces.map((w) => w.dir)
+    expect(dirs).toEqual(['/proj/a', '/proj/b']) // most-recent-first, no duplicate
+  })
+
+  it('upserts a Thread by id (no duplicate), refreshing lastActiveAt and re-ordering', async () => {
+    let clock = 1000
+    const store = new MetadataStore({ filePath: join(dir, 'thread-order.json'), now: () => clock })
+    await store.load()
+    const ws = await store.upsertWorkspace({ dir: '/proj/c' })
+
+    clock = 1100
+    const t1 = await store.upsertThread({ workspaceId: ws.id, sessionId: 's1' })
+    clock = 1200
+    const t2 = await store.upsertThread({ workspaceId: ws.id, sessionId: 's2' })
+    clock = 1300
+    // Touch t1 again (e.g. a new turn): bumps lastActiveAt, no second record.
+    const t1Again = await store.upsertThread({ id: t1.id, workspaceId: ws.id, sessionId: 's1b' })
+
+    expect(t1Again.id).toBe(t1.id)
+    expect(t1Again.createdAt).toBe(1100) // creation time preserved
+    expect(t1Again.lastActiveAt).toBe(1300)
+    expect(t1Again.sessionId).toBe('s1b') // resume cursor advanced
+    const ids = store.snapshot().threads.map((t) => t.id)
+    expect(ids).toEqual([t1.id, t2.id]) // t1 now most-recent
+  })
+
+  it('degrades to an empty index on a missing file (no throw)', async () => {
+    const store = storeAt('does-not-exist.json')
+    await expect(store.load()).resolves.toBeUndefined()
+    expect(store.snapshot()).toEqual({ workspaces: [], threads: [] })
+  })
+
+  it('degrades to an empty index on a corrupt JSON file (no throw)', async () => {
+    const file = join(dir, 'corrupt.json')
+    writeFileSync(file, '{ this is not: valid json ]')
+    const store = new MetadataStore({ filePath: file })
+    await expect(store.load()).resolves.toBeUndefined()
+    expect(store.snapshot()).toEqual({ workspaces: [], threads: [] })
+
+    // Still usable after a corrupt load: the next write overwrites cleanly.
+    const ws = await store.upsertWorkspace({ dir: '/proj/recover' })
+    expect(store.snapshot().workspaces).toHaveLength(1)
+    expect(ws.dir).toBe('/proj/recover')
+  })
+})
+
+describe('groupThreadsByWorkspace (pure)', () => {
+  it('nests Threads under their Workspace, both most-recent-first, dropping orphans', () => {
+    const grouped = groupThreadsByWorkspace({
+      workspaces: [
+        { id: 'w1', dir: '/a', displayName: 'a', lastOpenedAt: 100 },
+        { id: 'w2', dir: '/b', displayName: 'b', lastOpenedAt: 300 },
+      ],
+      threads: [
+        { id: 't1', workspaceId: 'w1', sessionId: null, title: null, createdAt: 1, lastActiveAt: 10 },
+        { id: 't2', workspaceId: 'w1', sessionId: 's2', title: 'two', createdAt: 2, lastActiveAt: 50 },
+        { id: 't3', workspaceId: 'w2', sessionId: null, title: null, createdAt: 3, lastActiveAt: 20 },
+        // Orphan: its Workspace is gone — must be dropped, not crash.
+        { id: 't4', workspaceId: 'gone', sessionId: null, title: null, createdAt: 4, lastActiveAt: 99 },
+      ],
+    })
+
+    expect(grouped.map((w) => w.id)).toEqual(['w2', 'w1']) // workspaces most-recent-first
+    const w1 = grouped.find((w) => w.id === 'w1')
+    expect(w1?.threads.map((t) => t.id)).toEqual(['t2', 't1']) // threads most-recent-first
+    expect(grouped.flatMap((w) => w.threads).map((t) => t.id)).not.toContain('t4')
+  })
+})

--- a/src/main/persistence/metadata-store.ts
+++ b/src/main/persistence/metadata-store.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from 'node:fs/promises'
+import { readFile, rename, writeFile } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import type { ThreadMeta, WorkspaceMeta, WorkspaceThreads } from '../../shared/ipc'
 
@@ -55,6 +55,8 @@ export interface MetadataStoreDeps {
   filePath: string
   readFile?: (path: string) => Promise<string>
   writeFile?: (path: string, data: string) => Promise<void>
+  /** Atomic move of the temp file over the target. Defaults to `fs.rename`. */
+  rename?: (from: string, to: string) => Promise<void>
   now?: () => number
   mintId?: () => string
 }
@@ -63,6 +65,7 @@ export class MetadataStore {
   private readonly filePath: string
   private readonly readFileFn: (path: string) => Promise<string>
   private readonly writeFileFn: (path: string, data: string) => Promise<void>
+  private readonly renameFn: (from: string, to: string) => Promise<void>
   private readonly now: () => number
   private readonly mintId: () => string
   private state: MetadataSnapshot = { workspaces: [], threads: [] }
@@ -71,18 +74,26 @@ export class MetadataStore {
     this.filePath = deps.filePath
     this.readFileFn = deps.readFile ?? ((path) => readFile(path, 'utf8'))
     this.writeFileFn = deps.writeFile ?? ((path, data) => writeFile(path, data, 'utf8'))
+    this.renameFn = deps.rename ?? rename
     this.now = deps.now ?? Date.now
     this.mintId = deps.mintId ?? randomUUID
   }
 
-  /** Read the index into memory. A missing/corrupt file yields empty state. */
+  /**
+   * Read the index into memory. A missing/unparseable file yields empty state;
+   * a parseable-but-partially-malformed file degrades to its VALID subset —
+   * each record is shape-checked so a single bad entry (e.g. a `null` thread)
+   * can't later crash `snapshot()`/`groupThreadsByWorkspace`. Never throws.
+   */
   async load(): Promise<void> {
     try {
       const raw = await this.readFileFn(this.filePath)
       const parsed = JSON.parse(raw) as Partial<MetadataSnapshot>
       this.state = {
-        workspaces: Array.isArray(parsed.workspaces) ? parsed.workspaces : [],
-        threads: Array.isArray(parsed.threads) ? parsed.threads : [],
+        workspaces: (Array.isArray(parsed.workspaces) ? parsed.workspaces : []).filter(
+          isWorkspaceRecord,
+        ),
+        threads: (Array.isArray(parsed.threads) ? parsed.threads : []).filter(isThreadRecord),
       }
     } catch {
       this.state = { workspaces: [], threads: [] }
@@ -139,9 +150,42 @@ export class MetadataStore {
     }
   }
 
+  /**
+   * Write the index to a temp file then `rename` it over the target — atomic on
+   * POSIX, so a crash mid-write can't truncate/corrupt the index (a corrupt
+   * index loads empty = silent total data loss). Residual: with a single writer
+   * (main) this is safe; truly-concurrent writers would be last-rename-wins —
+   * revisit if write frequency rises (TB2). No write queue/mutex for now.
+   */
   private async persist(): Promise<void> {
-    await this.writeFileFn(this.filePath, JSON.stringify(this.state, null, 2))
+    const tmp = `${this.filePath}.tmp`
+    await this.writeFileFn(tmp, JSON.stringify(this.state, null, 2))
+    await this.renameFn(tmp, this.filePath)
   }
+}
+
+/** Well-formed-Workspace guard for `load()` — drops malformed persisted entries. */
+function isWorkspaceRecord(value: unknown): value is WorkspaceRecord {
+  const w = value as Record<string, unknown> | null
+  return (
+    !!w &&
+    typeof w.id === 'string' &&
+    typeof w.dir === 'string' &&
+    typeof w.displayName === 'string' &&
+    typeof w.lastOpenedAt === 'number'
+  )
+}
+
+/** Well-formed-Thread guard for `load()` — drops malformed persisted entries. */
+function isThreadRecord(value: unknown): value is ThreadRecord {
+  const t = value as Record<string, unknown> | null
+  return (
+    !!t &&
+    typeof t.id === 'string' &&
+    typeof t.workspaceId === 'string' &&
+    typeof t.createdAt === 'number' &&
+    typeof t.lastActiveAt === 'number'
+  )
 }
 
 /**

--- a/src/main/persistence/metadata-store.ts
+++ b/src/main/persistence/metadata-store.ts
@@ -1,0 +1,160 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
+import type { ThreadMeta, WorkspaceMeta, WorkspaceThreads } from '../../shared/ipc'
+
+/**
+ * Main-side persistence of Workspace + Thread METADATA (ADR-0005: vibe owns the
+ * transcript; we own a light, metadata-first index so the app can show a cold,
+ * read-only Workspace/Thread list on launch with NO `vibe-acp` process spawned).
+ *
+ * Single-writer: only the main process mutates this. The fs/path is an injected
+ * seam (deps) so tests run over a temp-dir file without touching real `userData`,
+ * mirroring the fs-read/fs-write handlers. A corrupt or missing file degrades to
+ * empty state — never a throw — so a bad index can't wedge launch.
+ */
+
+/**
+ * The record shapes are the cross-boundary `WorkspaceMeta` / `ThreadMeta`
+ * (declared in shared/ipc.ts, since the renderer renders them). Aliased here so
+ * the store reads naturally.
+ */
+export type WorkspaceRecord = WorkspaceMeta
+export type ThreadRecord = ThreadMeta
+
+/** The full persisted index (flat). Grouped for the renderer by the helper below. */
+export interface MetadataSnapshot {
+  workspaces: WorkspaceRecord[]
+  threads: ThreadRecord[]
+}
+
+/** Upsert a Workspace by its `dir` (the natural key); mints `id` when new. */
+export interface WorkspaceInput {
+  dir: string
+  displayName?: string
+  /** Override the open timestamp (testing). Defaults to `now()`. */
+  lastOpenedAt?: number
+}
+
+/** Add/update a Thread; `id` re-targets an existing Thread, else one is minted. */
+export interface ThreadInput {
+  id?: string
+  workspaceId: string
+  sessionId?: string | null
+  title?: string | null
+  createdAt?: number
+  lastActiveAt?: number
+}
+
+/**
+ * The injectable seam: where the JSON lives and how to read/write it, plus the
+ * clock and id source. Production wires `node:fs/promises` + `crypto.randomUUID`
+ * and a `userData` path; tests pass a temp file (and may pin `now`/`mintId`).
+ */
+export interface MetadataStoreDeps {
+  /** Absolute path to the JSON index file. */
+  filePath: string
+  readFile?: (path: string) => Promise<string>
+  writeFile?: (path: string, data: string) => Promise<void>
+  now?: () => number
+  mintId?: () => string
+}
+
+export class MetadataStore {
+  private readonly filePath: string
+  private readonly readFileFn: (path: string) => Promise<string>
+  private readonly writeFileFn: (path: string, data: string) => Promise<void>
+  private readonly now: () => number
+  private readonly mintId: () => string
+  private state: MetadataSnapshot = { workspaces: [], threads: [] }
+
+  constructor(deps: MetadataStoreDeps) {
+    this.filePath = deps.filePath
+    this.readFileFn = deps.readFile ?? ((path) => readFile(path, 'utf8'))
+    this.writeFileFn = deps.writeFile ?? ((path, data) => writeFile(path, data, 'utf8'))
+    this.now = deps.now ?? Date.now
+    this.mintId = deps.mintId ?? randomUUID
+  }
+
+  /** Read the index into memory. A missing/corrupt file yields empty state. */
+  async load(): Promise<void> {
+    try {
+      const raw = await this.readFileFn(this.filePath)
+      const parsed = JSON.parse(raw) as Partial<MetadataSnapshot>
+      this.state = {
+        workspaces: Array.isArray(parsed.workspaces) ? parsed.workspaces : [],
+        threads: Array.isArray(parsed.threads) ? parsed.threads : [],
+      }
+    } catch {
+      this.state = { workspaces: [], threads: [] }
+    }
+  }
+
+  /**
+   * Upsert the Workspace keyed by `dir` (the natural key): re-opening a known
+   * dir refreshes `lastOpenedAt` (and `displayName`) on the SAME record rather
+   * than duplicating it. Returns the new or updated record.
+   */
+  async upsertWorkspace(input: WorkspaceInput): Promise<WorkspaceRecord> {
+    const existing = this.state.workspaces.find((w) => w.dir === input.dir)
+    const record: WorkspaceRecord = {
+      id: existing?.id ?? this.mintId(),
+      dir: input.dir,
+      displayName: input.displayName ?? existing?.displayName ?? input.dir,
+      lastOpenedAt: input.lastOpenedAt ?? this.now(),
+    }
+    this.state.workspaces = [record, ...this.state.workspaces.filter((w) => w.dir !== input.dir)]
+    await this.persist()
+    return record
+  }
+
+  /**
+   * Add or update a Thread. A matching `id` re-targets the existing Thread —
+   * preserving its `createdAt` while refreshing `lastActiveAt` (and the
+   * `sessionId` resume cursor) — instead of creating a second record.
+   */
+  async upsertThread(input: ThreadInput): Promise<ThreadRecord> {
+    const ts = this.now()
+    const existing = input.id ? this.state.threads.find((t) => t.id === input.id) : undefined
+    const record: ThreadRecord = {
+      id: existing?.id ?? input.id ?? this.mintId(),
+      workspaceId: input.workspaceId,
+      sessionId: input.sessionId ?? existing?.sessionId ?? null,
+      title: input.title ?? existing?.title ?? null,
+      createdAt: input.createdAt ?? existing?.createdAt ?? ts,
+      lastActiveAt: input.lastActiveAt ?? ts,
+    }
+    this.state.threads = [record, ...this.state.threads.filter((t) => t.id !== record.id)]
+    await this.persist()
+    return record
+  }
+
+  /**
+   * The current in-memory index, most-recent-first (Workspaces by
+   * `lastOpenedAt`, Threads by `lastActiveAt`) — the order the renderer lists.
+   */
+  snapshot(): MetadataSnapshot {
+    return {
+      workspaces: [...this.state.workspaces].sort((a, b) => b.lastOpenedAt - a.lastOpenedAt),
+      threads: [...this.state.threads].sort((a, b) => b.lastActiveAt - a.lastActiveAt),
+    }
+  }
+
+  private async persist(): Promise<void> {
+    await this.writeFileFn(this.filePath, JSON.stringify(this.state, null, 2))
+  }
+}
+
+/**
+ * Nest each Workspace's Threads under it for the renderer's cold launch list,
+ * both ordered most-recent-first. Pure (no I/O) so it's unit-tested directly.
+ * Threads whose Workspace is absent (an orphan after a Workspace was dropped)
+ * are skipped rather than surfaced loose.
+ */
+export function groupThreadsByWorkspace(snapshot: MetadataSnapshot): WorkspaceThreads[] {
+  const workspaces = [...snapshot.workspaces].sort((a, b) => b.lastOpenedAt - a.lastOpenedAt)
+  const threads = [...snapshot.threads].sort((a, b) => b.lastActiveAt - a.lastActiveAt)
+  return workspaces.map((w) => ({
+    ...w,
+    threads: threads.filter((t) => t.workspaceId === w.id),
+  }))
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer } from 'electron'
 import {
   IPC,
   type AcpEvent,
+  type ListMetadataResult,
   type RespondPermissionArgs,
   type OpenThreadArgs,
   type SendPromptArgs,
@@ -29,6 +30,7 @@ const api = {
   signIn: (args: SignInArgs): Promise<SignInResult> => ipcRenderer.invoke(IPC.signIn, args),
   signOut: (args: SignOutArgs): Promise<SignOutResult> => ipcRenderer.invoke(IPC.signOut, args),
   stopAgent: (agentId: string): Promise<void> => ipcRenderer.invoke(IPC.stopAgent, agentId),
+  listMetadata: (): Promise<ListMetadataResult> => ipcRenderer.invoke(IPC.listMetadata),
   onAcpEvent: (listener: (event: AcpEvent) => void): (() => void) => {
     const handler = (_e: unknown, payload: AcpEvent): void => listener(payload)
     ipcRenderer.on(IPC.acpEvent, handler)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useReducer, useRef, useState, type JSX } from 'react'
-import type { AuthMethod, VibeDetectResult } from '../../shared/ipc'
+import type {
+  AuthMethod,
+  ListMetadataResult,
+  ThreadMeta,
+  VibeDetectResult,
+  WorkspaceThreads,
+} from '../../shared/ipc'
 import {
   authReducer,
   initialAuthViewState,
@@ -13,6 +19,9 @@ export function App(): JSX.Element {
   const [detect, setDetect] = useState<VibeDetectResult | null>(null)
   const [loading, setLoading] = useState(true)
   const [connect, setConnect] = useState<ConnectState>({ status: 'idle' })
+  // Persisted Workspaces + Threads (ADR-0005), listed cold on launch from
+  // metadata alone — no agent spawned, no transcript loaded.
+  const [recents, setRecents] = useState<ListMetadataResult>([])
 
   async function runDetect(): Promise<void> {
     setLoading(true)
@@ -21,8 +30,13 @@ export function App(): JSX.Element {
     setLoading(false)
   }
 
+  async function refreshRecents(): Promise<void> {
+    setRecents(await window.api.listMetadata())
+  }
+
   useEffect(() => {
     void runDetect()
+    void refreshRecents()
   }, [])
 
   async function openProject(): Promise<void> {
@@ -30,6 +44,8 @@ export function App(): JSX.Element {
     if (!workspaceDir) return
     setConnect({ status: 'connecting', workspaceDir })
     setConnect(routeThreadResult(await window.api.startThread({ workspaceDir })))
+    // Main has now persisted the Workspace (and any Thread); reflect it in the list.
+    void refreshRecents()
   }
 
   // After sign-in (or in-place re-auth) the agent is already started + signed in;
@@ -86,6 +102,8 @@ export function App(): JSX.Element {
           {connect.status === 'idle' && (
             <p className="hint">Open a project folder to start a Vibe agent and connect a Thread.</p>
           )}
+
+          {connect.status === 'idle' && recents.length > 0 && <RecentList workspaces={recents} />}
 
           {connect.status === 'connecting' && (
             <p className="hint">
@@ -289,6 +307,45 @@ function SignedInBar({
       )}
     </div>
   )
+}
+
+/**
+ * The cold launch list (ADR-0005 metadata-first lazy reopen): persisted
+ * Workspaces with their Threads, most-recent-first, rendered read-only from
+ * metadata alone — NO `vibe-acp` spawned. Opening an entry for its content is a
+ * later slice (TB3), so entries are not yet clickable.
+ */
+function RecentList({ workspaces }: { workspaces: WorkspaceThreads[] }): JSX.Element {
+  return (
+    <div className="recents">
+      <div className="recents__title">Recent workspaces</div>
+      <ul className="recents__list">
+        {workspaces.map((w) => (
+          <li key={w.id} className="recents__workspace">
+            <div className="recents__ws-name" title={w.dir}>
+              {w.displayName}
+            </div>
+            {w.threads.length > 0 ? (
+              <ul className="recents__threads">
+                {w.threads.map((t) => (
+                  <li key={t.id} className="recents__thread">
+                    {threadLabel(t)}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className="recents__empty">No threads yet</div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+/** A Thread's list label — its title, or a placeholder until one arrives (TB2). */
+function threadLabel(thread: ThreadMeta): string {
+  return thread.title ?? 'Untitled thread'
 }
 
 function StatusRow({ ok, label }: { ok: boolean; label: string }): JSX.Element {

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -154,6 +154,48 @@ body {
   font-size: 12px;
 }
 
+.recents {
+  margin-top: 16px;
+}
+
+.recents__title {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  margin-bottom: 8px;
+}
+
+.recents__list,
+.recents__threads {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.recents__workspace {
+  padding: 8px 0;
+  border-top: 1px solid var(--border);
+}
+
+.recents__ws-name {
+  font-size: 13px;
+  color: var(--text);
+}
+
+.recents__threads {
+  margin-top: 4px;
+  border-left: 2px solid var(--border);
+  padding-left: 12px;
+}
+
+.recents__thread,
+.recents__empty {
+  font-size: 12px;
+  color: var(--muted);
+  padding: 2px 0;
+}
+
 .thread {
   display: flex;
   flex-direction: column;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -24,6 +24,8 @@ export const IPC = {
   signOut: 'auth:sign-out',
   /** Main -> renderer: streamed ACP event tagged by the owning agent. */
   acpEvent: 'acp:event',
+  /** List persisted Workspaces + their Threads for the cold launch list (ADR-0005). */
+  listMetadata: 'metadata:list',
 } as const
 
 /**
@@ -203,3 +205,41 @@ export interface SignOutArgs {
 export type SignOutResult =
   | { ok: true; authState: AuthState; authMethods: AuthMethod[] }
   | { ok: false; error: string }
+
+/**
+ * Persisted Workspace metadata (ADR-0005): a project dir the user has opened.
+ * The renderer lists these on launch with NO agent spawned and no transcript
+ * loaded — opening for content is a later slice (TB3).
+ */
+export interface WorkspaceMeta {
+  /** Durable, minted id (stable across launches; keyed internally by `dir`). */
+  id: string
+  /** Absolute Workspace directory. */
+  dir: string
+  /** Human label for the list (defaults to the dir when none is given). */
+  displayName: string
+  /** Epoch-ms of the most recent open — drives most-recent-first ordering. */
+  lastOpenedAt: number
+}
+
+/**
+ * Persisted Thread metadata (ADR-0001 domain id). The Thread `id` is OUR durable
+ * handle, distinct from the ACP `sessionId` it last bound to (`sessionId` is the
+ * resume cursor for a later reopen, `null` before any session is minted).
+ */
+export interface ThreadMeta {
+  id: string
+  workspaceId: string
+  sessionId: string | null
+  title: string | null
+  createdAt: number
+  lastActiveAt: number
+}
+
+/** A Workspace with its Threads nested, both most-recent-first — the cold list. */
+export interface WorkspaceThreads extends WorkspaceMeta {
+  threads: ThreadMeta[]
+}
+
+/** The `listMetadata` reply: persisted Workspaces with their Threads. */
+export type ListMetadataResult = WorkspaceThreads[]


### PR DESCRIPTION
## What

Tracer-bullet **TB1** (#30): persist Workspace + Thread **metadata** and restore it on launch, rendering the Workspace/Thread list with **NO `vibe-acp` process spawned** (ADR-0005 metadata-first, lazy reopen). A thin end-to-end slice across three layers.

### Layer 1 — metadata store (`src/main/persistence/metadata-store.ts`)
`MetadataStore` over an **injectable fs/path seam** (`{ filePath, readFile?, writeFile?, now?, mintId? }`), so tests run over a real temp dir — never `userData`. Single-writer (main).
- `upsertWorkspace({ dir, displayName? })` — keyed by `dir`; mints a durable id on first open, refreshes `lastOpenedAt` on re-open (no duplicate).
- `upsertThread({ id?, workspaceId, sessionId?, title? })` — a matching `id` re-targets the Thread (preserving `createdAt`, advancing `lastActiveAt` + the `sessionId` resume cursor); otherwise mints a **durable Thread id distinct from the ACP `sessionId`** (`sessionId` may be `null`).
- `snapshot()` returns state most-recent-first; corrupt/missing file → empty state, never throws.
- Pure `groupThreadsByWorkspace()` helper nests Threads under their Workspace (both most-recent-first, drops orphans).

### Layer 2 — wire existing flows (`src/main/index.ts`)
Opening a Workspace upserts its record up front (so an unsigned Workspace still lists); a created Thread (`startThread` / `openThread`) upserts a Thread record carrying its minted id + `sessionId`. Best-effort: a metadata write never breaks the live connect flow.

### Layer 3 — IPC + renderer
New `metadata:list` channel (+ preload binding + shared `WorkspaceMeta`/`ThreadMeta`/`WorkspaceThreads` types). On launch the renderer fetches and renders the persisted Workspaces + Threads as a **cold, read-only list** — opening an entry for content is a later slice (TB3).

## Tests
7 new store unit tests over a temp-dir JSON file (round-trip; id≠sessionId & null sessionId; upsert dedup + timestamp refresh + ordering for both Workspaces and Threads; missing-file and corrupt-JSON graceful-empty; the pure grouping helper).

## Gates
`lint`, `typecheck`, `build` clean; `test` — **103 passed** (7 new).

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)