### PR TITLE
TB3: reopen a Thread, render from JSONL (process-free replay) (#32)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,6 +6,7 @@ import {
   IPC,
   type ListMetadataResult,
   type OpenThreadArgs,
+  type ReadTranscriptResult,
   type RespondPermissionArgs,
   type SendPromptArgs,
   type SendPromptResult,
@@ -351,6 +352,14 @@ function registerIpc(): void {
     // metadata alone — no agent spawned, no transcript loaded.
     if (!metadataStore) return []
     return groupThreadsByWorkspace(metadataStore.snapshot())
+  })
+
+  ipcMain.handle(IPC.readTranscript, (_event, threadId: string): Promise<ReadTranscriptResult> => {
+    // The process-free reopen source (ADR-0005, TB3): hand the renderer the
+    // Thread's logged input stream so it can replay through the reducer with NO
+    // `vibe-acp` spawned. A missing/absent log reads back as [] (never throws).
+    if (!transcriptStore) return Promise.resolve([])
+    return transcriptStore.read(threadId)
   })
 }
 

--- a/src/main/persistence/transcript.ts
+++ b/src/main/persistence/transcript.ts
@@ -1,5 +1,6 @@
 import { appendFile, readFile } from 'node:fs/promises'
 import { join } from 'node:path'
+import type { TranscriptEntry } from '../../shared/ipc'
 
 /**
  * The per-Thread visible-conversation transcript we OWN (ADR-0005). The main
@@ -10,15 +11,11 @@ import { join } from 'node:path'
  * view with NO `vibe-acp` process. The renderer stays pure (ADR-0001) — it never
  * writes here.
  *
- * The entry union mirrors the reducer's INPUTS (`ConversationAction`), so a
- * replay is a near-mechanical map from entry -> dispatched action.
+ * `TranscriptEntry` (the entry union, mirroring the reducer's `ConversationAction`
+ * inputs) lives in `src/shared/ipc.ts` so the renderer replay can name it across
+ * the composite project boundary; re-exported here for the main-side writers.
  */
-export type TranscriptEntry =
-  | { t: 'user-prompt'; id: string; text: string }
-  | { t: 'acp-event'; payload: unknown }
-  | { t: 'turn-complete' }
-  | { t: 'turn-error'; message: string }
-  | { t: 'resolve-permission'; requestId: number | string; optionId: string; name: string | null }
+export type { TranscriptEntry }
 
 /** The user's prompt, teed at `sendPrompt` — mirrors the `send-prompt` action. */
 export function userPromptEntry(id: string, text: string): TranscriptEntry {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3,6 +3,7 @@ import {
   IPC,
   type AcpEvent,
   type ListMetadataResult,
+  type ReadTranscriptResult,
   type RespondPermissionArgs,
   type OpenThreadArgs,
   type SendPromptArgs,
@@ -31,6 +32,8 @@ const api = {
   signOut: (args: SignOutArgs): Promise<SignOutResult> => ipcRenderer.invoke(IPC.signOut, args),
   stopAgent: (agentId: string): Promise<void> => ipcRenderer.invoke(IPC.stopAgent, agentId),
   listMetadata: (): Promise<ListMetadataResult> => ipcRenderer.invoke(IPC.listMetadata),
+  readTranscript: (threadId: string): Promise<ReadTranscriptResult> =>
+    ipcRenderer.invoke(IPC.readTranscript, threadId),
   onAcpEvent: (listener: (event: AcpEvent) => void): (() => void) => {
     const handler = (_e: unknown, payload: AcpEvent): void => listener(payload)
     ipcRenderer.on(IPC.acpEvent, handler)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -13,6 +13,7 @@ import {
   signedInAuthViewState,
 } from './auth/auth-view'
 import { routeThreadResult, type ConnectState } from './connection/routing'
+import { ColdThread } from './conversation/ColdThread'
 import { Conversation } from './conversation/Conversation'
 
 export function App(): JSX.Element {
@@ -22,6 +23,9 @@ export function App(): JSX.Element {
   // Persisted Workspaces + Threads (ADR-0005), listed cold on launch from
   // metadata alone — no agent spawned, no transcript loaded.
   const [recents, setRecents] = useState<ListMetadataResult>([])
+  // A persisted Thread the user clicked to REOPEN read-only from its JSONL (TB3,
+  // #32) — rendered with no agent spawned. null = showing the cold launch list.
+  const [coldThread, setColdThread] = useState<ThreadMeta | null>(null)
 
   async function runDetect(): Promise<void> {
     setLoading(true)
@@ -99,11 +103,19 @@ export function App(): JSX.Element {
             </button>
           </div>
 
-          {connect.status === 'idle' && (
+          {/* Reopened Thread: render its saved conversation from JSONL, read-only,
+              with NO agent spawned (TB3). Takes over the idle view until closed. */}
+          {connect.status === 'idle' && coldThread && (
+            <ColdThread thread={coldThread} onClose={() => setColdThread(null)} />
+          )}
+
+          {connect.status === 'idle' && !coldThread && (
             <p className="hint">Open a project folder to start a Vibe agent and connect a Thread.</p>
           )}
 
-          {connect.status === 'idle' && recents.length > 0 && <RecentList workspaces={recents} />}
+          {connect.status === 'idle' && !coldThread && recents.length > 0 && (
+            <RecentList workspaces={recents} onOpenThread={setColdThread} />
+          )}
 
           {connect.status === 'connecting' && (
             <p className="hint">
@@ -311,11 +323,17 @@ function SignedInBar({
 
 /**
  * The cold launch list (ADR-0005 metadata-first lazy reopen): persisted
- * Workspaces with their Threads, most-recent-first, rendered read-only from
- * metadata alone — NO `vibe-acp` spawned. Opening an entry for its content is a
- * later slice (TB3), so entries are not yet clickable.
+ * Workspaces with their Threads, most-recent-first, rendered from metadata alone —
+ * NO `vibe-acp` spawned. Clicking a Thread reopens it read-only from its JSONL
+ * (`onOpenThread`, TB3) — still no agent; that replays the transcript locally.
  */
-function RecentList({ workspaces }: { workspaces: WorkspaceThreads[] }): JSX.Element {
+function RecentList({
+  workspaces,
+  onOpenThread,
+}: {
+  workspaces: WorkspaceThreads[]
+  onOpenThread: (thread: ThreadMeta) => void
+}): JSX.Element {
   return (
     <div className="recents">
       <div className="recents__title">Recent workspaces</div>
@@ -329,7 +347,9 @@ function RecentList({ workspaces }: { workspaces: WorkspaceThreads[] }): JSX.Ele
               <ul className="recents__threads">
                 {w.threads.map((t) => (
                   <li key={t.id} className="recents__thread">
-                    {threadLabel(t)}
+                    <button className="recents__thread-btn" onClick={() => onOpenThread(t)}>
+                      {threadLabel(t)}
+                    </button>
                   </li>
                 ))}
               </ul>

--- a/src/renderer/src/conversation/ColdThread.tsx
+++ b/src/renderer/src/conversation/ColdThread.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState, type JSX } from 'react'
+import type { ThreadMeta } from '../../../shared/ipc'
+import { Item, UsageBar } from './Conversation'
+import { initialConversationState, type ConversationState } from './reducer'
+import { replayTranscript } from './replay'
+
+/**
+ * A reopened Thread rendered READ-ONLY from its persisted JSONL (ADR-0005, TB3
+ * #32) — NO `vibe-acp` spawned. On mount we fetch the Thread's logged input
+ * stream over IPC (`readTranscript`) and replay it through the SAME reducer the
+ * live turn used (`replayTranscript`) to rebuild exactly what the user saw.
+ *
+ * The composer stays disabled: actually CONTINUING the conversation (spawn +
+ * `session/load`) is a later slice (TB4, #33), so this view only displays the
+ * history and points there.
+ */
+export function ColdThread({
+  thread,
+  onClose,
+}: {
+  thread: ThreadMeta
+  onClose: () => void
+}): JSX.Element {
+  // null = still loading; a ConversationState once the transcript has replayed.
+  const [state, setState] = useState<ConversationState | null>(null)
+
+  // Fetch + replay once per Thread. Reads only — no agent is started here.
+  useEffect(() => {
+    let active = true
+    void window.api.readTranscript(thread.id).then((entries) => {
+      if (active) setState(replayTranscript(entries))
+    })
+    return () => {
+      active = false
+    }
+  }, [thread.id])
+
+  const view = state ?? initialConversationState
+  const title = view.title ?? thread.title ?? 'Untitled thread'
+
+  return (
+    <div className="conv conv--cold">
+      <div className="conv__head">
+        <button className="btn btn--ghost" onClick={onClose}>
+          ← Back
+        </button>
+        <span className="conv__title">{title}</span>
+        <span className="badge">history</span>
+      </div>
+
+      <UsageBar state={view} />
+
+      <div className="messages">
+        {state === null ? (
+          <p className="hint">Loading conversation…</p>
+        ) : view.items.length === 0 ? (
+          <p className="hint">This thread has no saved conversation yet.</p>
+        ) : (
+          view.items.map((item) => <Item key={item.id} item={item} onPermission={noPermission} />)
+        )}
+      </div>
+
+      <p className="hint">
+        Viewing saved history — replayed from disk with no agent running. Continuing this conversation
+        is coming soon.
+      </p>
+    </div>
+  )
+}
+
+/** Read-only view: permissions already replayed as resolved, so this never fires. */
+const noPermission = (): void => {}

--- a/src/renderer/src/conversation/Conversation.tsx
+++ b/src/renderer/src/conversation/Conversation.tsx
@@ -171,7 +171,7 @@ export function Conversation({
   )
 }
 
-function UsageBar({ state }: { state: { usage: { used: number; size: number } | null; cost: { amount: number; currency: string } | null } }): JSX.Element | null {
+export function UsageBar({ state }: { state: { usage: { used: number; size: number } | null; cost: { amount: number; currency: string } | null } }): JSX.Element | null {
   if (!state.usage && !state.cost) return null
   return (
     <div className="usage">
@@ -190,7 +190,7 @@ function UsageBar({ state }: { state: { usage: { used: number; size: number } | 
   )
 }
 
-function Item({
+export function Item({
   item,
   onPermission,
 }: {

--- a/src/renderer/src/conversation/replay.test.ts
+++ b/src/renderer/src/conversation/replay.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest'
+import type { TranscriptEntry } from '../../../shared/ipc'
+import {
+  conversationReducer,
+  initialConversationState,
+  type AssistantItem,
+  type ConversationState,
+  type PermissionItem,
+  type ReasoningItem,
+  type ToolItem,
+} from './reducer'
+import { replayTranscript } from './replay'
+
+/**
+ * TB3 (#32): a reopened Thread renders FROM its JSONL, no `vibe-acp` spawned.
+ * `replayTranscript` folds the logged `TranscriptEntry[]` through the SAME
+ * `conversationReducer` the live turn used (ADR-0001) — so a recorded turn
+ * replays to the very state it originally produced. These tests pin that.
+ */
+
+const SESSION_ID = '8b7044cf-19d1-7a23-8da1-929c81b23170'
+
+/** Wrap an `update` object in the `session/update` notification frame. */
+function update(u: Record<string, unknown>): unknown {
+  return { jsonrpc: '2.0', method: 'session/update', params: { sessionId: SESSION_ID, update: u } }
+}
+
+/** The recorded read-turn transcript: prompt, streamed events, clean turn end. */
+const READ_TRANSCRIPT: TranscriptEntry[] = [
+  { t: 'user-prompt', id: 'user:0', text: 'read the readme' },
+  { t: 'acp-event', payload: update({ sessionUpdate: 'session_info_update', title: 'Read the README' }) },
+  { t: 'acp-event', payload: update({ sessionUpdate: 'agent_thought_chunk', content: { type: 'text', text: 'Let me ' }, messageId: 'r1' }) },
+  { t: 'acp-event', payload: update({ sessionUpdate: 'agent_thought_chunk', content: { type: 'text', text: 'check the file.' }, messageId: 'r1' }) },
+  { t: 'acp-event', payload: update({ sessionUpdate: 'tool_call', toolCallId: 'EcjzekVw0', kind: 'read', status: 'pending', title: 'Read README.md' }) },
+  { t: 'acp-event', payload: update({ sessionUpdate: 'tool_call_update', toolCallId: 'EcjzekVw0', status: 'completed', rawOutput: { ok: true } }) },
+  { t: 'acp-event', payload: update({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'The README ' }, messageId: 'a1' }) },
+  { t: 'acp-event', payload: update({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'describes vibe-mistro.' }, messageId: 'a1' }) },
+  { t: 'acp-event', payload: update({ sessionUpdate: 'usage_update', used: 21047, size: 128000, cost: { amount: 0.0123, currency: 'USD' } }) },
+  { t: 'turn-complete' },
+]
+
+describe('replayTranscript (TB3 #32)', () => {
+  it('folds a recorded turn to the same ConversationState the live turn produced', () => {
+    const replayed = replayTranscript(READ_TRANSCRIPT)
+
+    // Equivalent to driving the live reducer with the same input stream.
+    const live: ConversationState = [
+      { type: 'send-prompt', id: 'user:0', text: 'read the readme' } as const,
+      ...READ_TRANSCRIPT.slice(1, -1).map(
+        (e) => ({ type: 'acp-event', payload: (e as { payload: unknown }).payload }) as const,
+      ),
+      { type: 'turn-complete' } as const,
+    ].reduce(conversationReducer, initialConversationState)
+
+    expect(replayed).toEqual(live)
+
+    // And the rebuilt view is exactly what the user saw: ordered items, text, title.
+    expect(replayed.title).toBe('Read the README')
+    expect(replayed.usage).toEqual({ used: 21047, size: 128000 })
+    expect(replayed.cost).toEqual({ amount: 0.0123, currency: 'USD' })
+    expect(replayed.items.map((i) => i.kind)).toEqual(['user', 'reasoning', 'tool', 'assistant'])
+    expect((replayed.items[1] as ReasoningItem).text).toBe('Let me check the file.')
+    expect((replayed.items[2] as ToolItem).status).toBe('completed')
+    expect((replayed.items[3] as AssistantItem).text).toBe('The README describes vibe-mistro.')
+    expect(replayed.isProcessing).toBe(false)
+  })
+
+  it('renders a replayed resolved permission as resolved, recovering the chosen name from the request', () => {
+    // A write+permission turn: the request_permission event carries the option
+    // names; the resolve-permission entry (teed by main) has name:null (TB2).
+    const TOOL_CALL_ID = 'EcjzekVw0'
+    const transcript: TranscriptEntry[] = [
+      { t: 'user-prompt', id: 'user:0', text: 'write a file' },
+      { t: 'acp-event', payload: update({ sessionUpdate: 'tool_call', toolCallId: TOOL_CALL_ID, kind: 'edit', status: 'pending', title: 'Write note.txt' }) },
+      {
+        t: 'acp-event',
+        payload: {
+          jsonrpc: '2.0',
+          id: 4,
+          method: 'session/request_permission',
+          params: {
+            sessionId: SESSION_ID,
+            toolCall: { toolCallId: TOOL_CALL_ID },
+            options: [
+              { kind: 'allow_once', name: 'Allow once', optionId: 'allow_once' },
+              { kind: 'reject_once', name: 'Deny', optionId: 'reject_once' },
+            ],
+          },
+        },
+      },
+      // Main observed only requestId + optionId at the chokepoint -> name is null.
+      { t: 'resolve-permission', requestId: 4, optionId: 'allow_once', name: null },
+      { t: 'acp-event', payload: update({ sessionUpdate: 'tool_call_update', toolCallId: TOOL_CALL_ID, status: 'completed', rawOutput: { bytes_written: 19 } }) },
+      { t: 'turn-complete' },
+    ]
+
+    const replayed = replayTranscript(transcript)
+    const perm = replayed.items.find((i): i is PermissionItem => i.kind === 'permission')!
+    // Resolved (renders "You chose: …", no re-prompt) with the name recovered
+    // from the matching request event's options by optionId.
+    expect(perm.chosenOptionId).toBe('allow_once')
+    expect(perm.chosenName).toBe('Allow once')
+  })
+
+  it('forces isProcessing false even when the final turn was cut off (no terminal entry)', () => {
+    // App closed mid-turn: a prompt + a streamed chunk, but NO turn-complete /
+    // turn-error. Live this would leave isProcessing true; a cold reopen is never
+    // mid-turn, so replay must clear it (no phantom spinner).
+    const cutOff: TranscriptEntry[] = [
+      { t: 'user-prompt', id: 'user:0', text: 'do a long thing' },
+      { t: 'acp-event', payload: update({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'working' }, messageId: 'a1' }) },
+    ]
+    expect(replayTranscript(cutOff).isProcessing).toBe(false)
+  })
+
+  it('replays an empty transcript to the initial (empty) conversation, never throwing', () => {
+    // A cold/never-prompted Thread reads back [] (IPC) — the view is just empty.
+    const replayed = replayTranscript([])
+    expect(replayed).toEqual(initialConversationState)
+    expect(replayed.items).toHaveLength(0)
+    expect(replayed.isProcessing).toBe(false)
+  })
+})

--- a/src/renderer/src/conversation/replay.ts
+++ b/src/renderer/src/conversation/replay.ts
@@ -1,0 +1,71 @@
+import type { TranscriptEntry } from '../../../shared/ipc'
+import {
+  conversationReducer,
+  initialConversationState,
+  type ConversationAction,
+  type ConversationState,
+} from './reducer'
+
+/**
+ * Rebuild a Thread's conversation view from its persisted JSONL transcript
+ * (ADR-0005, TB3 #32) with NO `vibe-acp` process. Each `TranscriptEntry` maps
+ * near-mechanically to the `ConversationAction` it was teed from, and we fold the
+ * lot through the EXISTING `conversationReducer` (ADR-0001) — the same code path
+ * the live turn used — so a recorded turn replays to the state it produced.
+ *
+ * Two reopen-only corrections beyond the 1:1 map:
+ *  - a `resolve-permission` entry carries `optionId` but `name:null` (main can't
+ *    see the renderer-side display name at the chokepoint), so we recover the
+ *    chosen option's name from the permission item already folded into state —
+ *    making a resolved permission render RESOLVED with the right name, not re-prompt;
+ *  - `isProcessing` is forced false at the end: a cold reopen is never mid-turn,
+ *    and a log whose final turn was cut off (app closed before its terminal entry)
+ *    would otherwise leave a phantom in-flight spinner.
+ */
+export function replayTranscript(entries: TranscriptEntry[]): ConversationState {
+  let state = initialConversationState
+  for (const entry of entries) {
+    state = conversationReducer(state, toAction(entry, state))
+  }
+  return state.isProcessing ? { ...state, isProcessing: false } : state
+}
+
+/** Map one logged entry to its reducer action (using `state` to recover names). */
+function toAction(entry: TranscriptEntry, state: ConversationState): ConversationAction {
+  switch (entry.t) {
+    case 'user-prompt':
+      return { type: 'send-prompt', id: entry.id, text: entry.text }
+    case 'acp-event':
+      return { type: 'acp-event', payload: entry.payload }
+    case 'turn-complete':
+      return { type: 'turn-complete' }
+    case 'turn-error':
+      return { type: 'turn-error', message: entry.message }
+    case 'resolve-permission':
+      return {
+        type: 'resolve-permission',
+        requestId: entry.requestId,
+        optionId: entry.optionId,
+        // The entry's `name` is null (TB2): recover the chosen option's display
+        // name from the request event already folded into the permission item.
+        name: entry.name ?? recoverOptionName(state, entry.requestId, entry.optionId),
+      }
+  }
+}
+
+/**
+ * Recover a chosen permission option's display name from the permission item the
+ * earlier `session/request_permission` event folded into state. Falls back to the
+ * raw `optionId` if the option can't be matched (defensive — replay never throws).
+ */
+function recoverOptionName(
+  state: ConversationState,
+  requestId: number | string,
+  optionId: string,
+): string {
+  const permission = state.items.find(
+    (item) => item.kind === 'permission' && item.requestId === requestId,
+  )
+  if (permission?.kind !== 'permission') return optionId
+  return permission.options.find((o) => o.optionId === optionId)?.name ?? optionId
+}

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -215,6 +215,32 @@ body {
   padding: 2px 0;
 }
 
+/* Clickable Thread in the cold list — reopens its saved conversation (TB3). */
+.recents__thread-btn {
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  border-radius: var(--radius);
+  padding: 2px 4px;
+  margin: 0 -4px;
+  font: inherit;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.recents__thread-btn:hover {
+  color: var(--accent-text);
+  background: var(--accent-tint);
+}
+
+/* The read-only reopened-Thread view (TB3): a muted variant of the live conv. */
+.conv--cold .badge {
+  background: var(--accent-tint);
+  color: var(--accent-text);
+  border-color: var(--accent-tint-border);
+}
+
 .thread {
   display: flex;
   flex-direction: column;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -26,6 +26,8 @@ export const IPC = {
   acpEvent: 'acp:event',
   /** List persisted Workspaces + their Threads for the cold launch list (ADR-0005). */
   listMetadata: 'metadata:list',
+  /** Read a Thread's persisted JSONL transcript for a process-free reopen (TB3). */
+  readTranscript: 'transcript:read',
 } as const
 
 /**
@@ -243,3 +245,24 @@ export interface WorkspaceThreads extends WorkspaceMeta {
 
 /** The `listMetadata` reply: persisted Workspaces with their Threads. */
 export type ListMetadataResult = WorkspaceThreads[]
+
+/**
+ * One line of a Thread's append-only JSONL transcript (ADR-0005). The main
+ * process tees these conversation INPUTS as they cross the IPC chokepoints; on
+ * reopen (TB3) the renderer replays them through the existing `conversationReducer`
+ * to rebuild the view with NO `vibe-acp` process. The union mirrors the reducer's
+ * `ConversationAction` inputs, so the replay is a near-mechanical entry -> action map.
+ *
+ * Declared here (not in the main-only transcript store) so BOTH the renderer
+ * replay and the preload bridge can name it across the composite project boundary
+ * — the renderer cannot import the main process. `transcript.ts` re-exports it.
+ */
+export type TranscriptEntry =
+  | { t: 'user-prompt'; id: string; text: string }
+  | { t: 'acp-event'; payload: unknown }
+  | { t: 'turn-complete' }
+  | { t: 'turn-error'; message: string }
+  | { t: 'resolve-permission'; requestId: number | string; optionId: string; name: string | null }
+
+/** The `readTranscript` reply: a Thread's transcript entries (empty when none). */
+export type ReadTranscriptResult = TranscriptEntry[]


### PR DESCRIPTION
## What

Reopen a persisted Thread and render its full conversation **from the JSONL transcript, with no `vibe-acp` process spawned** (ADR-0005). On click, main hands the renderer the Thread's logged input stream; the renderer replays it through the **existing** `conversationReducer` from `initialConversationState` to rebuild exactly what the user saw.

## How

**Read path (main → renderer).** New `transcript:read` IPC channel (`shared/ipc` + preload + main handler) returning a Thread's `TranscriptEntry[]` via `transcriptStore.read(id)`. A missing/cold log reads back `[]` (never throws). The `TranscriptEntry` union moves to `src/shared/ipc.ts` (re-exported from `transcript.ts`) so the renderer replay + preload can name it across the composite project boundary.

**Replay (renderer, pure).** `replayTranscript(entries: TranscriptEntry[]): ConversationState` maps each entry 1:1 to its `ConversationAction` (`user-prompt`→`send-prompt`, `acp-event`→`acp-event`, `turn-complete`/`turn-error`, `resolve-permission`) and folds through the **existing** reducer. Two reopen-only corrections:
- **Permission name recovery:** the `resolve-permission` entry has `optionId` but `name:null` (TB2). While folding, the chosen option's display name is recovered from the permission item already in state (matched by `requestId` then `optionId`) — so a resolved permission renders **resolved** (not re-prompting) with the right name. No reducer change; live behavior untouched.
- **`isProcessing` forced false:** a cold reopen is never mid-turn, so a log whose final turn was cut off (app closed before its terminal entry) never shows a phantom in-flight spinner.

**Renderer.** Clicking a Thread in the cold "Recent" list reopens it read-only in a new `ColdThread` view, reusing the existing item rendering (`Item`/`UsageBar` exported from `Conversation.tsx`) — **still no agent spawned**. The composer is a disabled hint; actually continuing (spawn + `session/load`) is TB4 (#33).

## Tests (strict TDD, one at a time)

4 new tests in `replay.test.ts`:
1. a recorded turn folds to the same `ConversationState` the live reducer produces (ordered items, accumulated text, title, usage/cost).
2. a replayed resolved permission is resolved with the chosen name recovered from the request event.
3. `isProcessing` is false after replay, including a cut-off final turn (no terminal entry).
4. an empty transcript replays to the initial empty state, never throwing.

## Gates

`bun run lint && bun run typecheck && bun run build && bun run test` — all green. **127 tests pass** (123 baseline + 4 new).

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)