### PR TITLE
spike(#29): live probe for vibe-acp session/load behaviour

### DIFF
--- a/docs/acp-capture.md
+++ b/docs/acp-capture.md
@@ -277,3 +277,58 @@ Vibe also exposes these ACP extension methods (all `_`-prefixed on the wire): `t
   `signInUrl` via the system opener → `authenticate(complete, attemptId)`. (Fallback: blocking
   `browser-auth`.)
 - **#13 Sign out / status:** `_auth/signOut`, gated on `signOutAvailable`; show `authState`.
+
+## 9. `session/load` — resume behaviour (captured 2026-06-29 via the #29 spike, vibe-acp 2.18.0)
+
+Captured live by `scripts/spike-session-load.ts` against the real binary (signed-in user,
+`authState: os_keyring`). The probe created a session (`session/new` + a trivial prompt),
+then resumed it from a **fresh process**. This is the protocol truth TB4 (#33) builds on.
+
+### `agentCapabilities.loadSession: true`
+`initialize` advertises `loadSession: true` — so we may call `session/load`. Gate the resume
+path on this flag (fall straight to (b) re-bind if a future build drops it).
+
+### Resume SUCCEEDS — `session/load` (client → agent)
+Request params mirror `session/new` but carry the prior `sessionId`:
+
+```json
+{ "sessionId": "4d8e9017-925b-e223-27d0-5b2107d5dbdd", "cwd": "/tmp/vibe-spike", "mcpServers": [] }
+```
+
+Two things happen, in this order:
+
+1. **History is replayed OVER THE WIRE as `session/update` notifications, BEFORE the result
+   resolves.** Observed replay for a one-turn session (5 notifications):
+   `user_message_chunk` → `agent_thought_chunk` → `agent_message_chunk` → `usage_update`
+   → `available_commands_update`. Each carries the original `messageId`s. Note the replayed
+   `usage_update` reports `used: 0` / `cost: 0` (replay, not a re-charge).
+2. **The `session/load` result resolves** with the SAME shape as `session/new`
+   (`configOptions`, `models`, `modes`, `_meta.workspace_trust`) **except there is NO
+   `sessionId` field** in the result — the caller already knows the id it loaded.
+
+> **Design consequence for TB4:** because WE own the JSONL transcript and replay it through
+> our reducer on reopen, the wire-replayed `session/update` notifications during `session/load`
+> are DUPLICATES of history we already have. TB4 must **suppress/ignore** the notifications
+> that arrive between the `session/load` request and its result (don't tee them, don't render
+> them) — otherwise the conversation doubles. The result resolving is the "resume complete"
+> signal; live streaming resumes only on the NEXT user prompt.
+
+### Resume FAILS — unknown/expired session id
+`session/load` with a `sessionId` the agent doesn't know rejects with a JSON-RPC error:
+
+```json
+{ "code": -32602, "message": "Session not found: <id>", "data": { "session_id": "<id>" } }
+```
+
+> **This `-32602` ("Session not found") is the exact signal the (b) re-bind branch keys on.**
+> On it (or any `session/load` rejection), TB4 falls back to binding a FRESH session
+> (`session/new`) under the SAME Thread id, keeping our JSONL history visible — Vibe loses its
+> agent-side context, we don't lose the user's visible transcript. Match on `code === -32602`
+> AND/OR a `Session not found` message; treat any other load error as re-bind too (fail safe).
+
+### Infra gotcha — the spike runs under `node`, NOT `bun`
+Bun 1.3.8's `node:child_process` does **not** deliver `stdin.write()` to a piped child, so
+vibe-acp never receives `initialize` and the handshake times out at 30s with no stderr/exit.
+The same `AcpClient` code works instantly under `node` (initialize replies in ~0.9s) and under
+Electron (which is why the app itself was unaffected). To re-run the probe:
+`bun build scripts/spike-session-load.ts --target=node --outfile=/tmp/spike.mjs && node /tmp/spike.mjs --phase=all --cwd=/tmp/vibe-spike`.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,6 +35,16 @@ export default tseslint.config(
     },
   },
 
+  // One-off Node CLI probes (e.g. the issue #29 session/load spike). Run via
+  // `bun scripts/*.ts`; not part of the app/build graph, so they live outside
+  // tsconfig — this block keeps `eslint .` covering them with Node globals.
+  {
+    files: ['scripts/**/*.{ts,mts,mjs}'],
+    languageOptions: {
+      globals: { ...globals.node },
+    },
+  },
+
   // Renderer runs in the browser; React 19 (no react-in-jsx-scope needed).
   //
   // We register eslint-plugin-react-hooks manually and enable just the two

--- a/scripts/README-spike-29.md
+++ b/scripts/README-spike-29.md
@@ -1,0 +1,96 @@
+# Spike #29 — verify `vibe-acp` `session/load` replay behaviour (LIVE / HITL)
+
+`scripts/spike-session-load.ts` is a throwaway, heavily-logged probe that drives
+`vibe-acp` directly to answer issue **#29**: when you `session/load` a `sessionId`
+created in an *earlier* process, does the agent resume and replay the conversation
+(as `session/update` notifications), return it some other way, or not at all — and
+what error comes back for an unknown id (the signal **TB4 #33** re-binds on)?
+
+It **reuses the app's own transport** (`src/main/acp/client.ts::AcpClient`), so the
+newline-delimited JSON-RPC framing is byte-identical to production, and sends the
+same `initialize` params as `src/main/workspace-agent.ts`.
+
+## ⚠️ This is LIVE — run it yourself, signed in
+
+- It uses your **real Mistral account**: it calls `session/new` + `session/prompt`,
+  so it **consumes credits** and writes to the **real session store**.
+- It does **not** call `authenticate` or `_auth/signOut` — it never changes your
+  sign-in state. It only *reads* it via `_auth/status` to fail fast if signed out.
+- **Prerequisite:** you must be **SIGNED IN**. If you aren't, run `vibe` once to
+  sign in. The probe exits with code `2` and a clear message if `_auth/status`
+  reports `authenticated:false` or any call returns `-32000`.
+
+## Run it
+
+From the spike worktree (where this branch is checked out):
+
+```
+cd /Users/abdullahatrash/mistral/vibe-mistro-wt29 && bun scripts/spike-session-load.ts --phase=all
+```
+
+`bun` runs the TypeScript directly (no build/compile step). `vibe-acp` must be on
+your `PATH` (it is if `vibe` works in your shell).
+
+### Flags
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--phase=a\|b\|c\|all` | `all` | Which phase(s) to run. `all` = A→B→C in sequence. |
+| `--cwd=<dir>` | a stable temp dir | Session working dir. **B must use the same cwd as A.** |
+| `--session=<id>` | — | Run B/C against a known sessionId (else read from a prior A run). |
+| `--command=<bin>` | `vibe-acp` | Launch command. |
+| `--state-file=<path>` | temp file | Where A persists `{sessionId,cwd}` for a later B/C. |
+| `--idle-ms=<n>` | `5000` | Replay idle-gap in B: "replay done" after this much silence. |
+
+Standalone resume (e.g. after a real prior session):
+`bun scripts/spike-session-load.ts --phase=b --session=<uuid> --cwd=<same cwd as A>`
+
+## What each phase prints (and how to read it)
+
+- **PHASE A** — `initialize` result, `_auth/status`, `session/new` result, the
+  `>>> sessionId = …` line, every `session/update` during the trivial turn, and the
+  `session/prompt` turn-end result. Ends by persisting `{sessionId,cwd}`.
+- **PHASE B** — spawns a **fresh** `vibe-acp`, then `session/load{sessionId,cwd,
+  mcpServers:[]}`. Logs the **raw** `session/load` result **and every replayed
+  `session/update`** as it arrives, waits out the idle-gap, then prints
+  **PHASE B SUMMARY**: did load succeed? how many notifications replayed, grouped by
+  `sessionUpdate` type? → tells us if history replays over the wire or must come
+  from our JSONL.
+- **PHASE C** — `session/load` with a random bogus UUID. Prints
+  **PHASE C SUMMARY** with the exact `error.code` / `error.message` / `error.data`
+  (or flags an unexpected success). **This is the resume-failure signal TB4 keys on.**
+
+## Paste results back into `docs/acp-capture.md`
+
+Add a new section using this template, filling in the verbatim JSON from the run:
+
+```markdown
+## 9. `session/load` (resume) — captured <date>, vibe-acp <version>
+
+### Request (Phase B)
+\`\`\`json
+{"id":N,"method":"session/load","params":{"sessionId":"<uuid>","cwd":"<abs>","mcpServers":[]}}
+\`\`\`
+
+### Response (result)
+\`\`\`json
+<paste the "session/load result" JSON from PHASE B>
+\`\`\`
+
+### Replay
+- Replayed `session/update` notifications: <count> (or "none").
+- By `sessionUpdate` type: <paste the PHASE B SUMMARY breakdown>.
+- Replay-done signal: idle-gap of ~<idle-ms>ms (no terminal marker observed / marker = …).
+- Shape: <paste one representative replayed notification, verbatim>.
+
+### Unknown session (Phase C)
+\`\`\`
+error.code    = <code>
+error.message = "<message>"
+error.data    = <data>
+\`\`\`
+
+### Conclusion
+- Does reopen-for-continue need anything beyond our JSONL replay? <yes/no + why>.
+- How TB4 should detect resume failure: key on `error.code == <code>` from `session/load`.
+```

--- a/scripts/spike-session-load.ts
+++ b/scripts/spike-session-load.ts
@@ -1,0 +1,561 @@
+/**
+ * Spike probe for GitHub issue #29 — verify `vibe-acp`'s `session/load` behaviour.
+ *
+ * HITL / LIVE: this drives the user's REAL Mistral account (consumes credits,
+ * touches the real session store). It is NOT part of the test suite and must be
+ * run by a signed-in user, by hand:
+ *
+ *     bun scripts/spike-session-load.ts --phase=all
+ *
+ * It reuses the app's own transport (`src/main/acp/client.ts::AcpClient`) so the
+ * newline-delimited JSON-RPC framing is byte-identical to production. The
+ * `initialize` params mirror `src/main/workspace-agent.ts` so the handshake the
+ * agent sees is the same one the app sends.
+ *
+ * Phases (see issue #29):
+ *   A — create a session in one process: initialize → session/new → a trivial
+ *       session/prompt → print + persist the resulting sessionId, then exit.
+ *   B — resume in a FRESH process: initialize → session/load{sessionId,cwd,
+ *       mcpServers:[]}; log the response AND every replayed session/update, using
+ *       an idle-gap to decide "replay done". Summarise what (if anything) replayed.
+ *   C — unknown session: session/load with a random bogus UUID; print the exact
+ *       error code + message (the signal TB4 #33 re-binds on).
+ *
+ * Flags:
+ *   --phase=a|b|c|all   (default: all)
+ *   --cwd=<dir>         working dir for the session (default: a STABLE temp dir
+ *                       so a later standalone --phase=b reuses the same cwd as A)
+ *   --session=<id>      run B/C against a known sessionId (else B/C read the id
+ *                       persisted by a prior A run)
+ *   --command=<bin>     launch command (default: vibe-acp)
+ *   --state-file=<path> where A persists {sessionId,cwd} (default below)
+ *   --idle-ms=<n>       replay idle-gap in B (default 5000)
+ *   --help
+ */
+
+import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { AcpClient } from '../src/main/acp/client'
+
+// ---------------------------------------------------------------------------
+// Config / args
+// ---------------------------------------------------------------------------
+
+const PROTOCOL_VERSION = 1
+const CLIENT_INFO = { name: 'vibe-mistro', version: '0.0.1' } as const
+const DEFAULT_STATE_FILE = join(tmpdir(), 'vibe-spike-session.txt')
+const DEFAULT_CWD = join(tmpdir(), 'vibe-spike-cwd')
+const DEFAULT_IDLE_MS = 5000
+
+// Per-phase request timeouts. A real prompt turn can take a while; loads are quick.
+const TIMEOUT = {
+  initialize: 30_000,
+  authStatus: 15_000,
+  sessionNew: 30_000,
+  prompt: 120_000,
+  load: 30_000,
+} as const
+
+interface Args {
+  phase: 'a' | 'b' | 'c' | 'all'
+  cwd: string
+  session: string | null
+  command: string
+  stateFile: string
+  idleMs: number
+  help: boolean
+}
+
+function parseArgs(argv: string[]): Args {
+  const out: Args = {
+    phase: 'all',
+    cwd: DEFAULT_CWD,
+    session: null,
+    command: 'vibe-acp',
+    stateFile: DEFAULT_STATE_FILE,
+    idleMs: DEFAULT_IDLE_MS,
+    help: false,
+  }
+  for (const arg of argv) {
+    if (arg === '--help' || arg === '-h') out.help = true
+    else if (arg.startsWith('--phase=')) {
+      const v = arg.slice('--phase='.length)
+      if (v !== 'a' && v !== 'b' && v !== 'c' && v !== 'all') {
+        throw new Error(`--phase must be one of a|b|c|all (got "${v}")`)
+      }
+      out.phase = v
+    } else if (arg.startsWith('--cwd=')) out.cwd = arg.slice('--cwd='.length)
+    else if (arg.startsWith('--session=')) out.session = arg.slice('--session='.length)
+    else if (arg.startsWith('--command=')) out.command = arg.slice('--command='.length)
+    else if (arg.startsWith('--state-file=')) out.stateFile = arg.slice('--state-file='.length)
+    else if (arg.startsWith('--idle-ms=')) out.idleMs = Number(arg.slice('--idle-ms='.length))
+    else throw new Error(`Unknown argument: ${arg}`)
+  }
+  return out
+}
+
+const HELP = `spike-session-load — live probe for vibe-acp session/load (issue #29)
+
+USAGE
+  bun scripts/spike-session-load.ts [--phase=a|b|c|all] [--cwd=<dir>] [--session=<id>]
+                                    [--command=<bin>] [--state-file=<path>] [--idle-ms=<n>]
+
+REQUIRES: you must be SIGNED IN to Mistral Vibe (run \`vibe\` once to sign in).
+This is LIVE and consumes credits. Default --phase=all runs A -> B -> C.
+
+  --phase=all   create a session (A), resume it in a fresh process (B), probe a
+                bogus id (C). Default.
+  --phase=a     only create + persist a session id.
+  --phase=b     only resume; uses --session, else the id persisted by a prior A.
+  --phase=c     only probe a bogus id.
+  --cwd=<dir>   session working dir (default: ${DEFAULT_CWD}).
+                B must use the SAME cwd as A.
+  --session=<id> known sessionId for B/C.
+  --idle-ms=<n>  replay idle-gap in B (default ${DEFAULT_IDLE_MS}).
+`
+
+// ---------------------------------------------------------------------------
+// Logging helpers
+// ---------------------------------------------------------------------------
+
+function banner(text: string): void {
+  console.log(`\n=== ${text} ===`)
+}
+
+function log(text: string): void {
+  console.log(text)
+}
+
+/** Print a JSON value verbatim, indented, prefixed for copy-paste. */
+function dumpJson(label: string, value: unknown): void {
+  console.log(`${label}:`)
+  console.log(JSON.stringify(value, null, 2))
+}
+
+function isRpcError(err: unknown): err is { code: number; message: string; data?: unknown } {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    typeof (err as { code: unknown }).code === 'number'
+  )
+}
+
+/** The -32000 "not signed in" guard — Vibe reserves it for UnauthenticatedError. */
+function isUnauthenticated(err: unknown): boolean {
+  return isRpcError(err) && err.code === -32000
+}
+
+function failNotSignedIn(where: string): never {
+  banner('NOT SIGNED IN')
+  log(
+    `vibe-acp returned -32000 (UnauthenticatedError) at ${where}.\n` +
+      `You must be SIGNED IN to run this probe. Run \`vibe\` to sign in, then retry.`,
+  )
+  process.exit(2)
+}
+
+// ---------------------------------------------------------------------------
+// Connection wrapper (reuses the app's AcpClient transport)
+// ---------------------------------------------------------------------------
+
+interface NotificationRecord {
+  sessionUpdate: string
+  raw: unknown
+}
+
+class Probe {
+  readonly client: AcpClient
+  /** Every session/update notification seen, in order. */
+  readonly notifications: NotificationRecord[] = []
+  /** Timestamp (ms) of the last inbound traffic — drives the replay idle-gap. */
+  lastActivity = Date.now()
+  private exited: { code: number | null; signal: string | null } | null = null
+
+  constructor(command: string, cwd: string) {
+    this.client = new AcpClient({ command, cwd, env: process.env })
+
+    this.client.on('notification', (msg: unknown) => {
+      this.lastActivity = Date.now()
+      const m = msg as { method?: string; params?: { update?: { sessionUpdate?: string } } }
+      const sessionUpdate = m.params?.update?.sessionUpdate ?? `(non-update: ${m.method ?? '?'})`
+      this.notifications.push({ sessionUpdate, raw: msg })
+      log(`  [notification] ${m.method} :: ${sessionUpdate}`)
+      dumpJson('  raw', msg)
+    })
+
+    // Server-initiated requests. For the trivial prompt in phase A these are
+    // unlikely, but serve them defensively so a turn never stalls, and LOG them.
+    this.client.on('serverRequest', (msg: unknown) => {
+      this.lastActivity = Date.now()
+      this.onServerRequest(msg)
+    })
+
+    this.client.on('stderr', (text: string) => {
+      const trimmed = text.trimEnd()
+      if (trimmed) log(`  [stderr] ${trimmed}`)
+    })
+    this.client.on('error', (err: Error) => log(`  [client error] ${err.message}`))
+    this.client.on('exit', (info: unknown) => {
+      const i = info as { code: number | null; signal: string | null }
+      this.exited = i
+      log(`  [exit] code=${i.code} signal=${i.signal}`)
+    })
+  }
+
+  private onServerRequest(msg: unknown): void {
+    const req = msg as { id?: number | string; method?: string; params?: unknown }
+    log(`  [serverRequest] ${req.method} (id=${String(req.id)})`)
+    dumpJson('  raw', msg)
+    if (req.id === undefined) return
+
+    if (req.method === 'fs/read_text_file') {
+      const path = (req.params as { path?: string })?.path
+      let content = ''
+      try {
+        if (path && existsSync(path)) content = readFileSync(path, 'utf8')
+      } catch {
+        /* respond with empty content rather than wedge the turn */
+      }
+      this.client.respond(req.id, { content })
+    } else if (req.method === 'fs/write_text_file') {
+      const p = req.params as { path?: string; content?: string }
+      try {
+        if (p?.path) writeFileSync(p.path, p.content ?? '')
+      } catch {
+        /* ignore — best-effort for a probe */
+      }
+      this.client.respond(req.id, {})
+    } else if (req.method === 'session/request_permission') {
+      // Auto-allow once so the (trivial) turn can finish unattended.
+      this.client.respond(req.id, { outcome: { outcome: 'selected', optionId: 'allow_once' } })
+    } else {
+      // Unknown server request — answer with method-not-found so we never hang.
+      this.client.respondError(req.id, { code: -32601, message: 'method not found (probe)' })
+    }
+  }
+
+  start(): void {
+    this.client.start()
+  }
+
+  stop(): void {
+    this.client.stop()
+  }
+
+  hasExited(): boolean {
+    return this.exited !== null
+  }
+
+  /** initialize + _auth/status, with the same params the app sends. */
+  async initialize(): Promise<void> {
+    banner('initialize')
+    const init = await withTimeout(
+      this.client.request('initialize', {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {
+          fs: { readTextFile: true, writeTextFile: true },
+          _meta: { 'browser-auth-delegated': true },
+        },
+        clientInfo: CLIENT_INFO,
+      }),
+      TIMEOUT.initialize,
+      'initialize',
+    )
+    dumpJson('initialize result', init)
+
+    banner('_auth/status')
+    let status: unknown
+    try {
+      status = await withTimeout(this.client.request('_auth/status'), TIMEOUT.authStatus, '_auth/status')
+      dumpJson('_auth/status result', status)
+    } catch (err) {
+      log(`_auth/status failed (non-fatal): ${describeError(err)}`)
+      return
+    }
+    const authed = (status as { authenticated?: boolean })?.authenticated
+    if (authed === false) {
+      banner('NOT SIGNED IN')
+      log(
+        `_auth/status reports authenticated=false. You must be SIGNED IN to run this probe.\n` +
+          `Run \`vibe\` to sign in, then retry.`,
+      )
+      process.exit(2)
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Async helpers
+// ---------------------------------------------------------------------------
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(`Timed out after ${ms}ms waiting for ${label}`)), ms)
+  })
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer)) as Promise<T>
+}
+
+function describeError(err: unknown): string {
+  if (isRpcError(err)) {
+    return `JSON-RPC error code=${err.code} message=${JSON.stringify(err.message)} data=${JSON.stringify(err.data ?? null)}`
+  }
+  if (err instanceof Error) return err.message
+  return String(err)
+}
+
+/** Block until traffic has been idle for `idleMs`, or `maxMs` elapses overall. */
+async function waitForIdle(probe: Probe, idleMs: number, maxMs: number): Promise<'idle' | 'timeout'> {
+  const start = Date.now()
+  for (;;) {
+    const sinceActivity = Date.now() - probe.lastActivity
+    if (sinceActivity >= idleMs) return 'idle'
+    if (Date.now() - start >= maxMs) return 'timeout'
+    if (probe.hasExited()) return 'idle'
+    await sleep(250)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// State persistence (Phase A -> later B/C)
+// ---------------------------------------------------------------------------
+
+interface PersistedState {
+  sessionId: string
+  cwd: string
+  createdAt: string
+}
+
+function persistState(file: string, state: PersistedState): void {
+  writeFileSync(file, JSON.stringify(state, null, 2))
+}
+
+function loadState(file: string): PersistedState | null {
+  if (!existsSync(file)) return null
+  try {
+    return JSON.parse(readFileSync(file, 'utf8')) as PersistedState
+  } catch {
+    return null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Phases
+// ---------------------------------------------------------------------------
+
+/** Phase A: create and remember a session in this process, then exit. */
+async function phaseA(args: Args): Promise<PersistedState> {
+  banner('PHASE A — create & remember a session')
+  mkdirSync(args.cwd, { recursive: true })
+  log(`cwd: ${args.cwd}`)
+
+  const probe = new Probe(args.command, args.cwd)
+  try {
+    probe.start()
+    await probe.initialize()
+
+    banner('session/new')
+    let session: { sessionId: string }
+    try {
+      session = await withTimeout(
+        probe.client.request('session/new', { cwd: args.cwd, mcpServers: [] }),
+        TIMEOUT.sessionNew,
+        'session/new',
+      )
+    } catch (err) {
+      if (isUnauthenticated(err)) failNotSignedIn('session/new')
+      throw err
+    }
+    dumpJson('session/new result', session)
+    const sessionId = session.sessionId
+    log(`\n>>> sessionId = ${sessionId}`)
+
+    banner('session/prompt (trivial)')
+    log('prompt text: "Reply with the word: ok"')
+    try {
+      const result = await withTimeout(
+        probe.client.request('session/prompt', {
+          sessionId,
+          prompt: [{ type: 'text', text: 'Reply with the word: ok' }],
+        }),
+        TIMEOUT.prompt,
+        'session/prompt',
+      )
+      dumpJson('session/prompt result (turn end)', result)
+    } catch (err) {
+      if (isUnauthenticated(err)) failNotSignedIn('session/prompt')
+      throw err
+    }
+
+    const state: PersistedState = { sessionId, cwd: args.cwd, createdAt: new Date().toISOString() }
+    persistState(args.stateFile, state)
+    banner('PHASE A DONE')
+    log(`sessionId : ${sessionId}`)
+    log(`cwd       : ${args.cwd}`)
+    log(`persisted : ${args.stateFile}`)
+    return state
+  } finally {
+    // Clean exit of THIS process's agent — Phase B uses a brand-new one.
+    probe.stop()
+  }
+}
+
+/** Phase B: resume the saved session in a FRESH process and log any replay. */
+async function phaseB(args: Args, sessionId: string, cwd: string): Promise<void> {
+  banner('PHASE B — resume in a FRESH process')
+  log(`sessionId: ${sessionId}`)
+  log(`cwd      : ${cwd}`)
+  mkdirSync(cwd, { recursive: true })
+
+  const probe = new Probe(args.command, cwd)
+  try {
+    probe.start()
+    await probe.initialize()
+
+    banner('session/load')
+    log(`request params: {"sessionId":"${sessionId}","cwd":"${cwd}","mcpServers":[]}`)
+    log('(any replayed session/update notifications are logged below as they arrive)')
+    let loadResult: unknown
+    let loadError: unknown = null
+    try {
+      loadResult = await withTimeout(
+        probe.client.request('session/load', { sessionId, cwd, mcpServers: [] }),
+        TIMEOUT.load,
+        'session/load',
+      )
+      dumpJson('session/load result', loadResult)
+    } catch (err) {
+      loadError = err
+      if (isUnauthenticated(err)) failNotSignedIn('session/load')
+      banner('session/load FAILED')
+      log(describeError(err))
+    }
+
+    // Whether the response resolved or rejected, wait out the replay idle-gap:
+    // some agents stream history as notifications that arrive after the result.
+    banner(`waiting for replay idle-gap (${args.idleMs}ms idle, ${TIMEOUT.load}ms max)`)
+    const outcome = await waitForIdle(probe, args.idleMs, TIMEOUT.load)
+    log(`replay wait ended: ${outcome}`)
+
+    // ---- Summary ----
+    banner('PHASE B SUMMARY')
+    const succeeded = loadError === null
+    log(`session/load succeeded?   ${succeeded ? 'YES' : 'NO'}`)
+    if (!succeeded) log(`  error: ${describeError(loadError)}`)
+    log(`replayed notifications:   ${probe.notifications.length}`)
+    if (probe.notifications.length > 0) {
+      const byType = new Map<string, number>()
+      for (const n of probe.notifications) byType.set(n.sessionUpdate, (byType.get(n.sessionUpdate) ?? 0) + 1)
+      log('  by sessionUpdate type:')
+      for (const [type, count] of byType) log(`    ${type}: ${count}`)
+      log('  => session/load REPLAYS prior history as session/update notifications (shape above).')
+    } else {
+      log('  => session/load did NOT replay any session/update notifications.')
+      log('     (History likely must be rendered from our own JSONL — confirm against the result shape above.)')
+    }
+  } finally {
+    probe.stop()
+  }
+}
+
+/** Phase C: load an unknown/bogus session id; capture the exact error. */
+async function phaseC(args: Args, cwd: string): Promise<void> {
+  banner('PHASE C — unknown session id')
+  const bogus = randomUUID()
+  log(`bogus sessionId: ${bogus}`)
+  log(`cwd            : ${cwd}`)
+  mkdirSync(cwd, { recursive: true })
+
+  const probe = new Probe(args.command, cwd)
+  try {
+    probe.start()
+    await probe.initialize()
+
+    banner('session/load (bogus id)')
+    try {
+      const result = await withTimeout(
+        probe.client.request('session/load', { sessionId: bogus, cwd, mcpServers: [] }),
+        TIMEOUT.load,
+        'session/load',
+      )
+      banner('PHASE C SUMMARY — UNEXPECTED SUCCESS')
+      log('session/load with a bogus id did NOT error. Result:')
+      dumpJson('result', result)
+      log('NOTE: this is surprising — TB4 cannot key resume-failure on an error code here.')
+    } catch (err) {
+      if (isUnauthenticated(err)) failNotSignedIn('session/load')
+      banner('PHASE C SUMMARY — error captured (the signal TB4 re-binds on)')
+      if (isRpcError(err)) {
+        log(`error.code    = ${err.code}`)
+        log(`error.message = ${JSON.stringify(err.message)}`)
+        log(`error.data    = ${JSON.stringify(err.data ?? null)}`)
+      } else {
+        log(`non-RPC error: ${describeError(err)}`)
+      }
+    }
+  } finally {
+    probe.stop()
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2))
+  if (args.help) {
+    log(HELP)
+    return
+  }
+
+  log('vibe-acp session/load spike (issue #29) — LIVE, requires a signed-in user.')
+  log(`command=${args.command} phase=${args.phase} cwd=${args.cwd}`)
+
+  if (args.phase === 'a') {
+    await phaseA(args)
+    return
+  }
+
+  if (args.phase === 'all') {
+    const state = await phaseA(args)
+    await phaseB(args, state.sessionId, state.cwd)
+    await phaseC(args, state.cwd)
+    banner('ALL PHASES COMPLETE')
+    return
+  }
+
+  // Standalone B or C: resolve sessionId/cwd from --session or persisted state.
+  const persisted = loadState(args.stateFile)
+  const sessionId = args.session ?? persisted?.sessionId ?? null
+  const cwd = args.cwd !== DEFAULT_CWD ? args.cwd : (persisted?.cwd ?? args.cwd)
+
+  if (args.phase === 'b') {
+    if (!sessionId) {
+      throw new Error(
+        `--phase=b needs a sessionId: pass --session=<id> or run --phase=a first ` +
+          `(persisted state: ${args.stateFile}).`,
+      )
+    }
+    await phaseB(args, sessionId, cwd)
+    return
+  }
+
+  if (args.phase === 'c') {
+    await phaseC(args, cwd)
+    return
+  }
+}
+
+main().catch((err) => {
+  banner('PROBE FAILED')
+  console.error(describeError(err))
+  process.exit(1)
+})


### PR DESCRIPTION
## What

A throwaway, heavily-logged **HITL** probe for issue #29 — the user runs it **signed in** to capture how `vibe-acp`'s `session/load` actually behaves. It does **not** auto-run in CI/tests.

`scripts/spike-session-load.ts`:
- **Phase A** — `initialize` → `session/new` → a trivial `session/prompt` ("Reply with the word: ok") → print + persist the `sessionId`.
- **Phase B** — a **FRESH** process: `session/load{sessionId,cwd,mcpServers:[]}`; logs the raw response **and every replayed `session/update`**, using a ~5s **idle-gap** to decide "replay done", then summarises whether/how history replays.
- **Phase C** — `session/load` with a bogus UUID; captures the exact `error.code`/`message`/`data` — the resume-failure signal **TB4 #33** re-binds on.

Flags: `--phase=a|b|c|all` (default `all`), `--cwd`, `--session`, `--command`, `--state-file`, `--idle-ms`.

## How it's built
- **Reuses the app's `AcpClient`** (`src/main/acp/client.ts`) so the newline-delimited JSON-RPC framing is byte-identical to production; sends the **same `initialize` params** as `workspace-agent.ts`.
- **Safety:** never calls `authenticate`/`_auth/signOut` — only reads `_auth/status`, and fails fast (exit 2) on `authenticated:false` or a `-32000` from any call. Run via `bun scripts/spike-session-load.ts`.
- `eslint.config.mjs`: a `scripts/**` block (Node globals) so `eslint .` covers the probe, which lives outside the app tsconfig by design.
- `scripts/README-spike-29.md`: exact command, signed-in prerequisite, and a `docs/acp-capture.md` paste template.

## Run it (by the user, signed in — LIVE, consumes credits)
```
cd /Users/abdullahatrash/mistral/vibe-mistro-wt29 && bun scripts/spike-session-load.ts --phase=all
```

## Verification (no live run performed)
`lint` ✅ · `typecheck` ✅ · `build` ✅ · standalone `tsc` on the script ✅ · `--help`/bad-arg dry parse ✅. The live `session/new`/`prompt`/`load` path was **not** executed here.

Refs #29 — this stays open until the user's live run is captured into `docs/acp-capture.md` (does **not** Close it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)