### PR TITLE
TB5: New-Thread drafts + multiple Threads per Workspace + switching (#34)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -134,11 +134,13 @@ async function recordThread(agentId: string, workspaceDir: string, thread: Threa
  * Without a store (best-effort degraded mode), open a session directly so a draft
  * can still prompt; an already-bound Thread always reuses its `sessionId`.
  */
-async function bindThreadSession(agent: WorkspaceAgent, args: SendPromptArgs): Promise<string> {
-  // Point the bridge at the Thread being prompted, so a session-less chokepoint
-  // (notably `respondPermission`) tees to the ACTIVE Thread when several share an
-  // agent — refreshed every prompt, not just on a fresh mint (last-write-wins,
-  // and only the active Thread prompts at a time).
+async function bindThreadSession(
+  agent: WorkspaceAgent,
+  args: SendPromptArgs,
+): Promise<{ sessionId: string; minted: boolean }> {
+  // Point the bridge at the Thread being prompted, so a session-less lifecycle
+  // event tees to the ACTIVE Thread when several share an agent — refreshed every
+  // prompt (last-write-wins, and only the active Thread prompts at a time).
   transcriptThreads.set(args.agentId, args.threadId)
   if (metadataStore) {
     const bound = await ensureBoundSession({
@@ -148,11 +150,11 @@ async function bindThreadSession(agent: WorkspaceAgent, args: SendPromptArgs): P
       workspaceId: args.workspaceId,
       sessionId: args.sessionId,
     })
-    return bound.sessionId
+    return { sessionId: bound.sessionId, minted: bound.minted }
   }
-  if (args.sessionId) return args.sessionId
+  if (args.sessionId) return { sessionId: args.sessionId, minted: false }
   const thread = await agent.openThread()
-  return thread.sessionId
+  return { sessionId: thread.sessionId, minted: true }
 }
 
 /**
@@ -326,7 +328,7 @@ function registerIpc(): void {
 
   ipcMain.handle(
     IPC.sendPrompt,
-    async (_event, args: SendPromptArgs): Promise<SendPromptResult> => {
+    async (event, args: SendPromptArgs): Promise<SendPromptResult> => {
       const agent = agents.get(args.agentId)
       if (!agent) return { ok: false, kind: 'error', error: `No active agent for id ${args.agentId}.` }
 
@@ -337,7 +339,16 @@ function registerIpc(): void {
       // failed first prompt leaves no transcript residue.
       let sessionId: string
       try {
-        sessionId = await bindThreadSession(agent, args)
+        const bound = await bindThreadSession(agent, args)
+        sessionId = bound.sessionId
+        // Tell the renderer its draft is now bound, the INSTANT `session/new`
+        // returns and BEFORE `agent.prompt` streams any event below (same
+        // webContents, so ordered ahead of those `acp:event`s). This binds the
+        // draft's live view to its OWN session up front, so it never infers a
+        // session from an arbitrary (possibly sibling) event.
+        if (bound.minted && !event.sender.isDestroyed()) {
+          event.sender.send(IPC.threadBound, { threadId: args.threadId, sessionId })
+        }
       } catch (err) {
         if (err instanceof WorkspaceAgentError && err.authState === 'not-signed-in') {
           return { ok: false, kind: 'not-signed-in', agentId: args.agentId, authMethods: agent.authMethods }
@@ -378,8 +389,11 @@ function registerIpc(): void {
     // approve/deny decision lives in the renderer (ADR-0001). We also tee the
     // choice to the transcript — main sees requestId + optionId but not the
     // option's display name (renderer-side), so the entry's `name` is null.
+    // Tee by the renderer-supplied `threadId` directly (TB5), NOT the agent's
+    // last-prompted map: answering Thread A's permission after switching+prompting
+    // a sibling B must land in A's log, not B's.
     const agent = agents.get(args.agentId)
-    teeTranscript(threadIdForTee(args.agentId), resolvePermissionEntry(args.requestId, args.optionId))
+    teeTranscript(args.threadId, resolvePermissionEntry(args.requestId, args.optionId))
     agent?.respondPermission(args.requestId, args.optionId)
   })
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,6 +4,8 @@ import { randomUUID } from 'node:crypto'
 import { basename, join } from 'node:path'
 import {
   IPC,
+  type CreateDraftArgs,
+  type CreateDraftResult,
   type ListMetadataResult,
   type OpenThreadArgs,
   type ReadTranscriptResult,
@@ -33,6 +35,8 @@ import {
   type TranscriptEntry,
 } from './persistence/transcript'
 import { WorkspaceAgent, WorkspaceAgentError } from './workspace-agent'
+import { ensureBoundSession } from './thread-binding'
+import { createThreadDraft } from './persistence/drafts'
 
 /** Active Workspace agents keyed by a generated agent id. */
 const agents = new Map<string, WorkspaceAgent>()
@@ -84,29 +88,71 @@ function teeTranscript(threadId: string | null, entry: TranscriptEntry): void {
   void transcriptStore.append(threadId, entry)
 }
 
+/** Our minted handles for a connected Thread (TB5) — carried to the renderer. */
+interface ThreadIds {
+  threadId: string
+  workspaceId: string
+}
+
 /**
- * Persist that this Workspace was opened and a Thread minted. The Thread gets a
- * durable id (minted by the store) distinct from its ACP `sessionId`, which is
- * stored as the resume cursor for a later reopen (TB3). Best-effort: a metadata
- * write must never break the live connect flow. Also seeds the `agentId ->
- * threadId` transcript bridge so the agent's streamed events tee to this Thread.
+ * Persist that this Workspace was opened and a Thread minted, and RETURN our
+ * durable Thread + Workspace ids (TB5) so the renderer can later create drafts
+ * and bind-on-first-prompt under them. The Thread id is distinct from its ACP
+ * `sessionId` (the resume cursor for a reopen, TB3). Best-effort: a metadata
+ * write must never break the live connect flow — on a store failure we synthesize
+ * ids so the live conversation still works (the binding upsert simply retries).
+ * Also seeds the `agentId -> threadId` transcript bridge so the agent's streamed
+ * events tee to this Thread.
  */
-async function recordThread(agentId: string, workspaceDir: string, thread: ThreadInfo): Promise<void> {
-  if (!metadataStore) return
-  try {
-    const ws = await metadataStore.upsertWorkspace({
-      dir: workspaceDir,
-      displayName: basename(workspaceDir),
-    })
-    const record = await metadataStore.upsertThread({
-      workspaceId: ws.id,
-      sessionId: thread.sessionId,
-      title: thread.title,
-    })
-    transcriptThreads.set(agentId, record.id)
-  } catch {
-    // A persistence failure is non-fatal — the user is still connected.
+async function recordThread(agentId: string, workspaceDir: string, thread: ThreadInfo): Promise<ThreadIds> {
+  if (metadataStore) {
+    try {
+      const ws = await metadataStore.upsertWorkspace({
+        dir: workspaceDir,
+        displayName: basename(workspaceDir),
+      })
+      const record = await metadataStore.upsertThread({
+        workspaceId: ws.id,
+        sessionId: thread.sessionId,
+        title: thread.title,
+      })
+      transcriptThreads.set(agentId, record.id)
+      return { threadId: record.id, workspaceId: ws.id }
+    } catch {
+      // A persistence failure is non-fatal — fall through to synthesized ids.
+    }
   }
+  const ids = { threadId: randomUUID(), workspaceId: randomUUID() }
+  transcriptThreads.set(agentId, ids.threadId)
+  return ids
+}
+
+/**
+ * Resolve the ACP session to prompt, binding a draft on its first prompt (TB5).
+ * With a metadata store, delegate to `ensureBoundSession` (one `session/new`,
+ * bind by id, reuse thereafter) and seed the transcript bridge on a fresh mint.
+ * Without a store (best-effort degraded mode), open a session directly so a draft
+ * can still prompt; an already-bound Thread always reuses its `sessionId`.
+ */
+async function bindThreadSession(agent: WorkspaceAgent, args: SendPromptArgs): Promise<string> {
+  // Point the bridge at the Thread being prompted, so a session-less chokepoint
+  // (notably `respondPermission`) tees to the ACTIVE Thread when several share an
+  // agent — refreshed every prompt, not just on a fresh mint (last-write-wins,
+  // and only the active Thread prompts at a time).
+  transcriptThreads.set(args.agentId, args.threadId)
+  if (metadataStore) {
+    const bound = await ensureBoundSession({
+      agent,
+      store: metadataStore,
+      threadId: args.threadId,
+      workspaceId: args.workspaceId,
+      sessionId: args.sessionId,
+    })
+    return bound.sessionId
+  }
+  if (args.sessionId) return args.sessionId
+  const thread = await agent.openThread()
+  return thread.sessionId
 }
 
 /**
@@ -128,12 +174,19 @@ async function recordWorkspaceOpen(workspaceDir: string): Promise<void> {
   }
 }
 
-/** Build the renderer-facing connection (carries the sign-out gate + methods). */
-function connectionFor(agentId: string, agent: WorkspaceAgent, thread: ThreadInfo): ThreadConnection {
+/** Build the renderer-facing connection (carries our minted ids + sign-out gate). */
+function connectionFor(
+  agentId: string,
+  agent: WorkspaceAgent,
+  thread: ThreadInfo,
+  ids: ThreadIds,
+): ThreadConnection {
   return {
     agentId,
     workspaceDir: agent.workspaceDir,
     ...thread,
+    threadId: ids.threadId,
+    workspaceId: ids.workspaceId,
     signOutAvailable: agent.signOutAvailable,
     authMethods: agent.authMethods,
   }
@@ -250,8 +303,8 @@ function registerIpc(): void {
       }
 
       const thread = await agent.openThread()
-      await recordThread(agentId, args.workspaceDir, thread)
-      return { ok: true, thread: connectionFor(agentId, agent, thread) }
+      const ids = await recordThread(agentId, args.workspaceDir, thread)
+      return { ok: true, thread: connectionFor(agentId, agent, thread, ids) }
     } catch (err) {
       return threadFailureResult(agentId, agent, err)
     }
@@ -264,8 +317,8 @@ function registerIpc(): void {
     if (!agent) return { ok: false, kind: 'error', error: `No active agent for id ${args.agentId}.`, hint: null }
     try {
       const thread = await agent.openThread()
-      await recordThread(args.agentId, agent.workspaceDir, thread)
-      return { ok: true, thread: connectionFor(args.agentId, agent, thread) }
+      const ids = await recordThread(args.agentId, agent.workspaceDir, thread)
+      return { ok: true, thread: connectionFor(args.agentId, agent, thread, ids) }
     } catch (err) {
       return threadFailureResult(args.agentId, agent, err)
     }
@@ -276,29 +329,45 @@ function registerIpc(): void {
     async (_event, args: SendPromptArgs): Promise<SendPromptResult> => {
       const agent = agents.get(args.agentId)
       if (!agent) return { ok: false, kind: 'error', error: `No active agent for id ${args.agentId}.` }
-      // Tee the user's prompt (the conversation INPUT) before sending it, so it
-      // precedes the streamed events it triggers. Main has no renderer item id,
-      // so we mint one — it's an opaque replay key, never matched against.
-      const threadId = threadIdForTee(args.agentId, args.sessionId)
-      teeTranscript(threadId, userPromptEntry(randomUUID(), args.text))
+
+      // Bind on first prompt (ADR-0005, TB5): a draft (sessionId null) mints its
+      // session via `session/new` NOW and binds it onto this Thread id; an
+      // already-bound Thread reuses its session — no second `session/new`. A
+      // binding failure surfaces WITHOUT teeing: nothing was logged yet, so a
+      // failed first prompt leaves no transcript residue.
+      let sessionId: string
       try {
-        const result = await agent.prompt(args.sessionId, args.text)
+        sessionId = await bindThreadSession(agent, args)
+      } catch (err) {
+        if (err instanceof WorkspaceAgentError && err.authState === 'not-signed-in') {
+          return { ok: false, kind: 'not-signed-in', agentId: args.agentId, authMethods: agent.authMethods }
+        }
+        return { ok: false, kind: 'error', error: err instanceof Error ? err.message : String(err) }
+      }
+
+      // Tee the user's prompt (the conversation INPUT) to THIS Thread's log before
+      // sending it, so it precedes the streamed events it triggers. We hold the
+      // Thread id, so no bridge lookup — a draft's first prompt can't misroute to
+      // another Thread. Main has no renderer item id, so mint an opaque replay key.
+      teeTranscript(args.threadId, userPromptEntry(randomUUID(), args.text))
+      try {
+        const result = await agent.prompt(sessionId, args.text)
         // Tee the clean turn end: this signal lives ONLY in this IPC response
         // (never an `acp:event`), so without it a replay leaves `isProcessing`
         // stuck true. Serialized after the turn's events (TranscriptStore chain).
-        teeTranscript(threadId, turnCompleteEntry())
-        return { ok: true, result }
+        teeTranscript(args.threadId, turnCompleteEntry())
+        return { ok: true, result, sessionId }
       } catch (err) {
         // Mid-session expiry (-32000): keep the agent alive so the renderer can
         // re-auth in place on the same agent; don't stop it. This is a re-auth
         // flow, NOT a conversation error — tee `turn-complete` (the renderer
         // synthesizes no ErrorItem here either), so replay isn't left processing.
         if (err instanceof WorkspaceAgentError && err.authState === 'not-signed-in') {
-          teeTranscript(threadId, turnCompleteEntry())
+          teeTranscript(args.threadId, turnCompleteEntry())
           return { ok: false, kind: 'not-signed-in', agentId: args.agentId, authMethods: agent.authMethods }
         }
         const message = err instanceof Error ? err.message : String(err)
-        teeTranscript(threadId, turnErrorEntry(message))
+        teeTranscript(args.threadId, turnErrorEntry(message))
         return { ok: false, kind: 'error', error: message }
       }
     },
@@ -345,6 +414,20 @@ function registerIpc(): void {
     const agent = agents.get(agentId)
     agent?.stop()
     agents.delete(agentId)
+  })
+
+  ipcMain.handle(IPC.createDraft, async (_event, args: CreateDraftArgs): Promise<CreateDraftResult> => {
+    // Mint a NEW-Thread draft (ADR-0005, TB5): a durable Thread id with NO ACP
+    // session and NO agent work — `session/new` is deferred to its first prompt
+    // (see `bindThreadSession`), so an abandoned draft creates no session and no
+    // JSONL. It appears in the next `listMetadata` immediately.
+    if (!metadataStore) return { ok: false, error: 'Metadata store is not ready.' }
+    try {
+      const thread = await createThreadDraft(metadataStore, args.workspaceId)
+      return { ok: true, thread }
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) }
+    }
   })
 
   ipcMain.handle(IPC.listMetadata, (): ListMetadataResult => {

--- a/src/main/persistence/drafts.test.ts
+++ b/src/main/persistence/drafts.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, afterAll } from 'vitest'
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createThreadDraft } from './drafts'
+import { MetadataStore } from './metadata-store'
+import { TranscriptStore } from './transcript'
+
+/**
+ * New-Thread drafts (ADR-0005, TB5 #34): minting a Thread must write ONLY a
+ * metadata record with NO ACP session and NO transcript file — `session/new`
+ * and the JSONL are deferred to the first prompt. Exercised over REAL temp-dir
+ * stores via the injectable seams — no `userData`, no `vibe-acp` spawned.
+ */
+
+const dir = mkdtempSync(join(tmpdir(), 'vibe-drafts-'))
+afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+describe('createThreadDraft', () => {
+  it('writes a metadata Thread with a null sessionId and no transcript file', async () => {
+    const store = new MetadataStore({ filePath: join(dir, 'draft.json') })
+    await store.load()
+    const transcripts = mkdtempSync(join(dir, 'transcripts-'))
+    const transcriptStore = new TranscriptStore({ dir: transcripts })
+
+    const ws = await store.upsertWorkspace({ dir: '/proj/draft' })
+    const draft = await createThreadDraft(store, ws.id)
+
+    // A durable id is minted, but the draft is bound to NO ACP session.
+    expect(draft.id.length).toBeGreaterThan(0)
+    expect(draft.sessionId).toBeNull()
+    expect(draft.workspaceId).toBe(ws.id)
+
+    // It appears in the index immediately (cold-listable).
+    expect(store.snapshot().threads.map((t) => t.id)).toContain(draft.id)
+
+    // No transcript was written: the JSONL file does not exist and reads empty.
+    expect(existsSync(join(transcripts, `${draft.id}.jsonl`))).toBe(false)
+    expect(await transcriptStore.read(draft.id)).toEqual([])
+  })
+
+  it('leaves no transcript residue for a draft that is never prompted (abandoned)', async () => {
+    const store = new MetadataStore({ filePath: join(dir, 'abandoned.json') })
+    await store.load()
+    const transcripts = mkdtempSync(join(dir, 'transcripts-'))
+
+    const ws = await store.upsertWorkspace({ dir: '/proj/abandon' })
+    const draft = await createThreadDraft(store, ws.id)
+
+    // Abandon it (never prompted): the record stays session-less and no file exists.
+    const persisted = store.snapshot().threads.find((t) => t.id === draft.id)
+    expect(persisted?.sessionId).toBeNull()
+    expect(existsSync(join(transcripts, `${draft.id}.jsonl`))).toBe(false)
+  })
+})

--- a/src/main/persistence/drafts.ts
+++ b/src/main/persistence/drafts.ts
@@ -1,0 +1,21 @@
+import type { ThreadRecord } from './metadata-store'
+
+/**
+ * The minimal store surface a draft needs: mint a Thread (ADR-0005). Kept
+ * structural so the helper is unit-testable over a temp-dir MetadataStore (or a
+ * fake) without dragging in the whole store.
+ */
+export interface DraftThreadStore {
+  upsertThread(input: { workspaceId: string; sessionId: null }): Promise<ThreadRecord>
+}
+
+/**
+ * Create a NEW-Thread draft (ADR-0005, TB5 #34): mint a durable Thread id under a
+ * Workspace with NO ACP session (`sessionId: null`) and NO agent work, so the
+ * draft appears in the list immediately while `session/new` is deferred to its
+ * first prompt (see `ensureBoundSession`). This writes ONLY the metadata record —
+ * never a JSONL — so a draft that is never prompted leaves no transcript residue.
+ */
+export function createThreadDraft(store: DraftThreadStore, workspaceId: string): Promise<ThreadRecord> {
+  return store.upsertThread({ workspaceId, sessionId: null })
+}

--- a/src/main/persistence/transcript.test.ts
+++ b/src/main/persistence/transcript.test.ts
@@ -231,3 +231,23 @@ describe('sessionIdFromPayload (S3 routing)', () => {
     expect(sessionIdFromPayload('nope')).toBeNull()
   })
 })
+
+/**
+ * Permission-response routing under multiplexing (TB5 #34). Several Threads share
+ * one agent; a permission response must tee to the Thread it ANSWERS (by its
+ * explicit threadId), NOT the agent's last-prompted Thread. This pins the
+ * per-threadId contract `respondPermission` now uses (it tees by args.threadId,
+ * not the agentId -> threadId map that would misroute after a sibling prompt).
+ */
+describe('resolve-permission routing by threadId (TB5 multiplex)', () => {
+  it('tees a resolve-permission entry to the answered Thread, not a sibling', async () => {
+    const store = storeAt()
+    // Thread A has a pending permission; meanwhile sibling B was the last prompted.
+    await store.append('perm-A', resolvePermissionEntry('req-1', 'allow-once'))
+
+    const a = await store.read('perm-A')
+    expect(a).toEqual([{ t: 'resolve-permission', requestId: 'req-1', optionId: 'allow-once', name: null }])
+    // The sibling's log is untouched — the entry did not misroute to B.
+    expect(await store.read('perm-B')).toEqual([])
+  })
+})

--- a/src/main/thread-binding.test.ts
+++ b/src/main/thread-binding.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, afterAll } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { ensureBoundSession, type SessionOpener } from './thread-binding'
+import { createThreadDraft } from './persistence/drafts'
+import { MetadataStore } from './persistence/metadata-store'
+import type { ThreadInfo } from '../shared/ipc'
+
+/**
+ * Bind-on-first-prompt (ADR-0005, TB5 #34): a draft (sessionId null) triggers
+ * exactly ONE `session/new` on the Workspace's agent on its first prompt, binds
+ * the returned sessionId onto the SAME Thread id, and reuses it thereafter.
+ * Tested at the agent seam with an injected fake opener (counting `session/new`
+ * calls) over a REAL temp-dir store — never a live `vibe-acp`.
+ */
+
+const dir = mkdtempSync(join(tmpdir(), 'vibe-binding-'))
+afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+/** A fake agent that mints a fresh sessionId per `openThread` (one per session/new). */
+function fakeOpener(prefix = 'sess'): SessionOpener & { calls: number } {
+  let n = 0
+  return {
+    calls: 0,
+    async openThread(): Promise<ThreadInfo> {
+      this.calls++
+      n++
+      return { sessionId: `${prefix}-${n}`, title: null, modes: null, models: null }
+    },
+  }
+}
+
+describe('ensureBoundSession', () => {
+  it('mints one session on a draft, binds it by id, and reuses it (no second session/new)', async () => {
+    const store = new MetadataStore({ filePath: join(dir, 'bind.json') })
+    await store.load()
+    const ws = await store.upsertWorkspace({ dir: '/proj/bind' })
+    const draft = await createThreadDraft(store, ws.id)
+    const agent = fakeOpener()
+
+    // First prompt on the draft: exactly one session/new, bound onto the same id.
+    const first = await ensureBoundSession({
+      agent,
+      store,
+      threadId: draft.id,
+      workspaceId: ws.id,
+      sessionId: null,
+    })
+    expect(agent.calls).toBe(1)
+    expect(first.minted).toBe(true)
+    expect(first.sessionId).toBe('sess-1')
+
+    // The SAME Thread id now carries the bound sessionId (resume cursor).
+    const bound = store.snapshot().threads.find((t) => t.id === draft.id)
+    expect(bound?.id).toBe(draft.id)
+    expect(bound?.sessionId).toBe('sess-1')
+    expect(store.snapshot().threads.filter((t) => t.id === draft.id)).toHaveLength(1) // no duplicate
+
+    // A subsequent prompt passes the bound sessionId: NO second session/new.
+    const second = await ensureBoundSession({
+      agent,
+      store,
+      threadId: draft.id,
+      workspaceId: ws.id,
+      sessionId: first.sessionId,
+    })
+    expect(agent.calls).toBe(1) // unchanged
+    expect(second.minted).toBe(false)
+    expect(second.sessionId).toBe('sess-1')
+  })
+
+  it('binds two drafts under one agent to two distinct sessions (multi-Thread per Workspace)', async () => {
+    const store = new MetadataStore({ filePath: join(dir, 'multi.json') })
+    await store.load()
+    const ws = await store.upsertWorkspace({ dir: '/proj/multi' })
+    const a = await createThreadDraft(store, ws.id)
+    const b = await createThreadDraft(store, ws.id)
+    const agent = fakeOpener()
+
+    const ra = await ensureBoundSession({ agent, store, threadId: a.id, workspaceId: ws.id, sessionId: null })
+    const rb = await ensureBoundSession({ agent, store, threadId: b.id, workspaceId: ws.id, sessionId: null })
+
+    expect(agent.calls).toBe(2) // one session/new per draft
+    expect(ra.sessionId).not.toBe(rb.sessionId) // independent sessions on one agent
+
+    const threads = store.snapshot().threads
+    expect(threads.find((t) => t.id === a.id)?.sessionId).toBe(ra.sessionId)
+    expect(threads.find((t) => t.id === b.id)?.sessionId).toBe(rb.sessionId)
+  })
+})

--- a/src/main/thread-binding.ts
+++ b/src/main/thread-binding.ts
@@ -1,0 +1,61 @@
+import type { ThreadInfo } from '../shared/ipc'
+import type { ThreadRecord } from './persistence/metadata-store'
+
+/**
+ * The minimal agent surface for binding: open a new ACP session (`session/new`).
+ * One `vibe-acp` agent can host many sessions, so each call mints a distinct one —
+ * letting several Threads coexist under a single Workspace agent (ADR-0005).
+ */
+export interface SessionOpener {
+  openThread(): Promise<ThreadInfo>
+}
+
+/** The minimal store surface for binding: re-target a Thread by id (upsert). */
+export interface ThreadBindStore {
+  upsertThread(input: {
+    id: string
+    workspaceId: string
+    sessionId: string
+  }): Promise<ThreadRecord>
+}
+
+export interface BoundSession {
+  /** The ACP session this Thread is now bound to. */
+  sessionId: string
+  /** True when THIS call minted the session (`session/new` ran), false when reused. */
+  minted: boolean
+  /** The title `session/new` returned, when binding (null on reuse). */
+  title: string | null
+}
+
+/**
+ * Ensure a Thread has a bound ACP session before prompting (ADR-0005, TB5 #34).
+ *
+ * A draft (`sessionId === null`) triggers exactly ONE `session/new` on the
+ * Workspace's agent, binds the returned sessionId onto the SAME Thread id
+ * (`upsertThread` by id, preserving `createdAt`), and reports it `minted`. An
+ * already-bound Thread (the caller passes its sessionId) returns that session
+ * untouched with NO `session/new` — so the first prompt mints the session and
+ * every subsequent prompt reuses it.
+ *
+ * The caller is responsible for passing the bound sessionId back on later prompts
+ * (it flows to the renderer in the prompt result); a stale `null` would re-mint.
+ */
+export async function ensureBoundSession(args: {
+  agent: SessionOpener
+  store: ThreadBindStore
+  threadId: string
+  workspaceId: string
+  sessionId: string | null
+}): Promise<BoundSession> {
+  if (args.sessionId) {
+    return { sessionId: args.sessionId, minted: false, title: null }
+  }
+  const thread = await args.agent.openThread()
+  await args.store.upsertThread({
+    id: args.threadId,
+    workspaceId: args.workspaceId,
+    sessionId: thread.sessionId,
+  })
+  return { sessionId: thread.sessionId, minted: true, title: thread.title }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2,6 +2,8 @@ import { contextBridge, ipcRenderer } from 'electron'
 import {
   IPC,
   type AcpEvent,
+  type CreateDraftArgs,
+  type CreateDraftResult,
   type ListMetadataResult,
   type ReadTranscriptResult,
   type RespondPermissionArgs,
@@ -32,6 +34,8 @@ const api = {
   signOut: (args: SignOutArgs): Promise<SignOutResult> => ipcRenderer.invoke(IPC.signOut, args),
   stopAgent: (agentId: string): Promise<void> => ipcRenderer.invoke(IPC.stopAgent, agentId),
   listMetadata: (): Promise<ListMetadataResult> => ipcRenderer.invoke(IPC.listMetadata),
+  createDraft: (args: CreateDraftArgs): Promise<CreateDraftResult> =>
+    ipcRenderer.invoke(IPC.createDraft, args),
   readTranscript: (threadId: string): Promise<ReadTranscriptResult> =>
     ipcRenderer.invoke(IPC.readTranscript, threadId),
   onAcpEvent: (listener: (event: AcpEvent) => void): (() => void) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -16,6 +16,7 @@ import {
   type SignOutResult,
   type StartThreadArgs,
   type StartThreadResult,
+  type ThreadBoundEvent,
   type VibeDetectResult,
 } from '../shared/ipc'
 
@@ -42,6 +43,11 @@ const api = {
     const handler = (_e: unknown, payload: AcpEvent): void => listener(payload)
     ipcRenderer.on(IPC.acpEvent, handler)
     return () => ipcRenderer.removeListener(IPC.acpEvent, handler)
+  },
+  onThreadBound: (listener: (event: ThreadBoundEvent) => void): (() => void) => {
+    const handler = (_e: unknown, payload: ThreadBoundEvent): void => listener(payload)
+    ipcRenderer.on(IPC.threadBound, handler)
+    return () => ipcRenderer.removeListener(IPC.threadBound, handler)
   },
 }
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -13,8 +13,8 @@ import {
   signedInAuthViewState,
 } from './auth/auth-view'
 import { routeThreadResult, type ConnectState } from './connection/routing'
+import { ConnectedWorkspace } from './connection/ConnectedWorkspace'
 import { ColdThread } from './conversation/ColdThread'
-import { Conversation } from './conversation/Conversation'
 
 export function App(): JSX.Element {
   const [detect, setDetect] = useState<VibeDetectResult | null>(null)
@@ -155,10 +155,13 @@ export function App(): JSX.Element {
                   toSignInPanel(connect.thread.agentId, connect.thread.workspaceDir, authMethods)
                 }
               />
-              {/* Key by agentId so the Conversation's reducer can't bleed across Threads. */}
-              <Conversation
+              {/* Key by agentId so the per-Workspace Thread state can't bleed across
+                  connections. Hosts multiple Threads on the one agent + switching (TB5). */}
+              <ConnectedWorkspace
                 key={connect.thread.agentId}
-                thread={connect.thread}
+                connection={connect.thread}
+                threads={threadsForWorkspace(recents, connect.thread.workspaceId)}
+                refreshRecents={refreshRecents}
                 onAuthExpired={(authMethods) =>
                   toSignInPanel(connect.thread.agentId, connect.thread.workspaceDir, authMethods)
                 }
@@ -366,6 +369,11 @@ function RecentList({
 /** A Thread's list label — its title, or a placeholder until one arrives (TB2). */
 function threadLabel(thread: ThreadMeta): string {
   return thread.title ?? 'Untitled thread'
+}
+
+/** The persisted Threads under a connected Workspace (by minted id), for its list (TB5). */
+function threadsForWorkspace(recents: ListMetadataResult, workspaceId: string): ThreadMeta[] {
+  return recents.find((w) => w.id === workspaceId)?.threads ?? []
 }
 
 function StatusRow({ ok, label }: { ok: boolean; label: string }): JSX.Element {

--- a/src/renderer/src/connection/ConnectedWorkspace.tsx
+++ b/src/renderer/src/connection/ConnectedWorkspace.tsx
@@ -2,7 +2,7 @@ import { useState, type JSX } from 'react'
 import type { AuthMethod, ThreadConnection, ThreadMeta } from '../../../shared/ipc'
 import { ColdThread } from '../conversation/ColdThread'
 import { Conversation } from '../conversation/Conversation'
-import { routeThreadSelection } from './thread-selection'
+import { routeThreadSelection, seedSessionId } from './thread-selection'
 
 /**
  * A connected Workspace hosting MULTIPLE Threads on one `vibe-acp` agent (TB5
@@ -65,7 +65,7 @@ export function ConnectedWorkspace({
 
   // The session to seed the selected Thread with: the one bound this session (if
   // any) wins over the persisted cursor, so a bound draft isn't re-minted on switch.
-  const seedSessionId = boundSessions[selected.id] ?? selected.sessionId
+  const seedSession = seedSessionId(selected, boundSessions)
 
   return (
     <div className="workspace">
@@ -101,7 +101,7 @@ export function ConnectedWorkspace({
             agentId: connection.agentId,
             threadId: selected.id,
             workspaceId: connection.workspaceId,
-            sessionId: seedSessionId,
+            sessionId: seedSession,
             title: selected.title,
           }}
           onAuthExpired={onAuthExpired}

--- a/src/renderer/src/connection/ConnectedWorkspace.tsx
+++ b/src/renderer/src/connection/ConnectedWorkspace.tsx
@@ -1,0 +1,143 @@
+import { useState, type JSX } from 'react'
+import type { AuthMethod, ThreadConnection, ThreadMeta } from '../../../shared/ipc'
+import { ColdThread } from '../conversation/ColdThread'
+import { Conversation } from '../conversation/Conversation'
+import { routeThreadSelection } from './thread-selection'
+
+/**
+ * A connected Workspace hosting MULTIPLE Threads on one `vibe-acp` agent (TB5
+ * #34). Lists the Workspace's Threads, mints new drafts (`New Thread` — a durable
+ * id with NO ACP session until its first prompt), and switches between them: a
+ * Thread hosted live this session renders as a live `Conversation` (binding its
+ * draft session on the first prompt); one bound in a prior launch replays
+ * read-only from JSONL (`ColdThread`) until TB4 adds `session/load`.
+ *
+ * Thread metadata comes from the cold list (`recents`); the agent context
+ * (agentId, our minted ids) comes from the initial `connection`. `liveThreadIds`
+ * tracks which Threads are hosted on THIS agent — the auto-opened one plus drafts
+ * created since connecting — and is the source of truth for live-vs-cold routing.
+ */
+export function ConnectedWorkspace({
+  connection,
+  threads,
+  refreshRecents,
+  onAuthExpired,
+}: {
+  connection: ThreadConnection
+  /** The Workspace's persisted Threads (most-recent-first) from the cold list. */
+  threads: ThreadMeta[]
+  /** Re-fetch the metadata list (after minting a draft) so it appears immediately. */
+  refreshRecents: () => Promise<void>
+  /** Mid-session expiry (-32000): route to in-place re-auth with these methods. */
+  onAuthExpired: (authMethods: AuthMethod[]) => void
+}): JSX.Element {
+  const [liveThreadIds, setLiveThreadIds] = useState<ReadonlySet<string>>(
+    () => new Set([connection.threadId]),
+  )
+  const [selectedThreadId, setSelectedThreadId] = useState(connection.threadId)
+  // Sessions bound this session (TB5): a draft's first prompt mints one, lifted
+  // here so switching away and back re-seeds it instead of re-minting.
+  const [boundSessions, setBoundSessions] = useState<Record<string, string>>(() =>
+    connection.sessionId ? { [connection.threadId]: connection.sessionId } : {},
+  )
+  const [busy, setBusy] = useState(false)
+
+  // The agent always hosts at least its auto-opened Thread — ensure it's listed
+  // even before the metadata list refresh that includes it has landed.
+  const list = withConnectionThread(threads, connection)
+  const selected = list.find((t) => t.id === selectedThreadId) ?? list[0]
+  const view = routeThreadSelection(selected, liveThreadIds)
+
+  async function newThread(): Promise<void> {
+    if (busy) return
+    setBusy(true)
+    try {
+      const result = await window.api.createDraft({ workspaceId: connection.workspaceId })
+      if (!result.ok) return
+      // The draft is hosted on THIS agent (its session binds on first prompt).
+      setLiveThreadIds((prev) => new Set(prev).add(result.thread.id))
+      await refreshRecents()
+      setSelectedThreadId(result.thread.id)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  // The session to seed the selected Thread with: the one bound this session (if
+  // any) wins over the persisted cursor, so a bound draft isn't re-minted on switch.
+  const seedSessionId = boundSessions[selected.id] ?? selected.sessionId
+
+  return (
+    <div className="workspace">
+      <div className="workspace__bar">
+        <span className="workspace__name" title={connection.workspaceDir}>
+          {connection.workspaceDir}
+        </span>
+        <button className="btn" onClick={() => void newThread()} disabled={busy}>
+          New Thread
+        </button>
+      </div>
+
+      <ul className="workspace__threads">
+        {list.map((t) => (
+          <li key={t.id}>
+            <button
+              className={
+                t.id === selected.id ? 'workspace__thread workspace__thread--active' : 'workspace__thread'
+              }
+              onClick={() => setSelectedThreadId(t.id)}
+            >
+              <span className="workspace__thread-label">{threadLabel(t, liveThreadIds)}</span>
+              {!liveThreadIds.has(t.id) && <span className="badge">history</span>}
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      {view === 'live' ? (
+        <Conversation
+          key={selected.id}
+          thread={{
+            agentId: connection.agentId,
+            threadId: selected.id,
+            workspaceId: connection.workspaceId,
+            sessionId: seedSessionId,
+            title: selected.title,
+          }}
+          onAuthExpired={onAuthExpired}
+          onBound={(sessionId) =>
+            setBoundSessions((prev) => ({ ...prev, [selected.id]: sessionId }))
+          }
+        />
+      ) : (
+        <ColdThread
+          key={selected.id}
+          thread={selected}
+          onClose={() => setSelectedThreadId(connection.threadId)}
+        />
+      )}
+    </div>
+  )
+}
+
+/** Ensure the agent's auto-opened Thread is present (synthesized if the list lags). */
+function withConnectionThread(threads: ThreadMeta[], connection: ThreadConnection): ThreadMeta[] {
+  if (threads.some((t) => t.id === connection.threadId)) return threads
+  const synthesized: ThreadMeta = {
+    id: connection.threadId,
+    workspaceId: connection.workspaceId,
+    sessionId: connection.sessionId,
+    title: connection.title,
+    createdAt: 0,
+    lastActiveAt: 0,
+  }
+  return [synthesized, ...threads]
+}
+
+/** A Thread's list label — its title, or a draft/placeholder until one arrives. */
+function threadLabel(thread: ThreadMeta, liveThreadIds: ReadonlySet<string>): string {
+  if (thread.title) return thread.title
+  // A live, session-less Thread is a fresh draft awaiting its first prompt.
+  if (liveThreadIds.has(thread.id) && thread.sessionId === null) return 'New thread (draft)'
+  return 'Untitled thread'
+}

--- a/src/renderer/src/connection/routing.test.ts
+++ b/src/renderer/src/connection/routing.test.ts
@@ -14,6 +14,8 @@ const AUTH_METHODS: AuthMethod[] = [{ id: 'browser-auth-delegated', name: 'Sign 
 const THREAD: ThreadConnection = {
   agentId: 'a1',
   workspaceDir: '/abs/ws',
+  threadId: 't1',
+  workspaceId: 'w1',
   sessionId: 's1',
   title: null,
   modes: null,

--- a/src/renderer/src/connection/thread-selection.test.ts
+++ b/src/renderer/src/connection/thread-selection.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { routeThreadSelection } from './thread-selection'
+import { routeThreadSelection, seedSessionId } from './thread-selection'
 import type { ThreadMeta } from '../../../shared/ipc'
 
 /**
@@ -29,5 +29,22 @@ describe('routeThreadSelection', () => {
 
   it('routes a draft that is not (yet) tracked live as cold — membership is the source of truth', () => {
     expect(routeThreadSelection(thread('t-unknown', null), new Set())).toBe('cold')
+  })
+})
+
+describe('seedSessionId (no double-mint on remount)', () => {
+  it('prefers a session bound this session over a stale persisted cursor', () => {
+    // A draft bound this session (sD lifted via thread:bound) whose persisted
+    // record still reads null: a switch-away-and-back must re-seed sD, NOT null —
+    // otherwise the next prompt would re-mint a second session.
+    const draft = thread('t-draft', null)
+    expect(seedSessionId(draft, { 't-draft': 'sD' })).toBe('sD')
+    // The seeded sD then flows to sendPrompt, taking ensureBoundSession's reuse
+    // branch (no second session/new) — proven in thread-binding.test.ts.
+  })
+
+  it('falls back to the persisted cursor when nothing was bound this session', () => {
+    expect(seedSessionId(thread('t-open', 'sess-1'), {})).toBe('sess-1')
+    expect(seedSessionId(thread('t-fresh', null), {})).toBeNull()
   })
 })

--- a/src/renderer/src/connection/thread-selection.test.ts
+++ b/src/renderer/src/connection/thread-selection.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { routeThreadSelection } from './thread-selection'
+import type { ThreadMeta } from '../../../shared/ipc'
+
+/**
+ * Switching between a Workspace's Threads (ADR-0005, TB5 #34). A Thread opened
+ * or drafted in THIS session is hosted live on the running agent; one bound in a
+ * PRIOR launch (its session lives on a now-dead process) replays read-only from
+ * JSONL until TB4 adds `session/load`. Pure routing — no React, no IPC.
+ */
+
+function thread(id: string, sessionId: string | null): ThreadMeta {
+  return { id, workspaceId: 'w1', sessionId, title: null, createdAt: 1, lastActiveAt: 1 }
+}
+
+describe('routeThreadSelection', () => {
+  it('routes a Thread live when it is hosted on the current agent this session', () => {
+    const live = new Set(['t-open', 't-draft'])
+    // The auto-opened Thread (already bound this session) and a fresh draft.
+    expect(routeThreadSelection(thread('t-open', 'sess-1'), live)).toBe('live')
+    expect(routeThreadSelection(thread('t-draft', null), live)).toBe('live')
+  })
+
+  it('routes a prior-session Thread cold (read-only replay), even though it has a sessionId', () => {
+    const live = new Set(['t-open'])
+    // Bound in a previous launch; not hosted on the current agent.
+    expect(routeThreadSelection(thread('t-old', 'sess-from-yesterday'), live)).toBe('cold')
+  })
+
+  it('routes a draft that is not (yet) tracked live as cold — membership is the source of truth', () => {
+    expect(routeThreadSelection(thread('t-unknown', null), new Set())).toBe('cold')
+  })
+})

--- a/src/renderer/src/connection/thread-selection.ts
+++ b/src/renderer/src/connection/thread-selection.ts
@@ -1,0 +1,23 @@
+import type { ThreadMeta } from '../../../shared/ipc'
+
+/** How a selected Thread is rendered: live on the agent, or cold from JSONL. */
+export type ThreadView = 'live' | 'cold'
+
+/**
+ * Route a selected Thread to its view (ADR-0005, TB5 #34). Several Threads
+ * coexist under one Workspace agent; `liveThreadIds` is the set hosted on the
+ * CURRENT agent this session — the auto-opened Thread plus any drafts created
+ * since connecting.
+ *
+ * A member routes `live` (it has, or on its first prompt will mint, a session on
+ * the running agent — see `ensureBoundSession`). A non-member routes `cold`: it
+ * was bound in a prior launch, so its ACP session lives on a now-dead process and
+ * it replays read-only from JSONL until TB4 (#33) adds `session/load`. Membership
+ * is the source of truth — a `sessionId` from a prior launch does NOT make it live.
+ */
+export function routeThreadSelection(
+  thread: ThreadMeta,
+  liveThreadIds: ReadonlySet<string>,
+): ThreadView {
+  return liveThreadIds.has(thread.id) ? 'live' : 'cold'
+}

--- a/src/renderer/src/connection/thread-selection.ts
+++ b/src/renderer/src/connection/thread-selection.ts
@@ -21,3 +21,18 @@ export function routeThreadSelection(
 ): ThreadView {
   return liveThreadIds.has(thread.id) ? 'live' : 'cold'
 }
+
+/**
+ * The session to seed a selected Thread's live view with (TB5). A session bound
+ * THIS session (lifted when main signals `thread:bound`, kept in `boundSessions`)
+ * wins over the Thread's persisted `sessionId` cursor — so switching away from a
+ * just-bound draft and back RE-SEEDS its real session instead of seeing a stale
+ * `null` and re-minting a second one (`ensureBoundSession` then takes its reuse
+ * branch — zero extra `session/new`).
+ */
+export function seedSessionId(
+  thread: ThreadMeta,
+  boundSessions: Readonly<Record<string, string>>,
+): string | null {
+  return boundSessions[thread.id] ?? thread.sessionId
+}

--- a/src/renderer/src/conversation/Conversation.tsx
+++ b/src/renderer/src/conversation/Conversation.tsx
@@ -13,7 +13,7 @@ import {
   type ToolItem,
   type UserItem,
 } from './reducer'
-import { eventBelongsToThread, sessionIdOfEvent } from './event-routing'
+import { eventBelongsToThread } from './event-routing'
 import { replayTranscript } from './replay'
 
 /** Process-local counter for unique echoed-prompt ids. */
@@ -37,8 +37,10 @@ export interface LiveThread {
  * A live Thread: hydrates its saved history from JSONL on mount (TB5), then
  * subscribes to the agent's `acp:event` stream — routing only THIS Thread's
  * session into the reducer (reducer.ts) — and lets the user send prompts. A
- * draft's first prompt binds its session in main (`session/new`); the returned
- * `sessionId` is reused thereafter so the session is never re-minted.
+ * draft's first prompt binds its session in main (`session/new`), which signals
+ * `thread:bound` BEFORE the session streams; the bound `sessionId` is reused
+ * thereafter so the session is never re-minted, and the draft NEVER infers its
+ * session from an arbitrary event (which could be a sibling's).
  */
 export function Conversation({
   thread,
@@ -55,8 +57,14 @@ export function Conversation({
   const [state, dispatch] = useReducer(conversationReducer, initialConversationState)
   const [draft, setDraft] = useState('')
   // The session this Thread is bound to — null until a draft's first prompt binds
-  // it. Seeded from the record, advanced by the prompt result and live events.
+  // it (via main's `thread:bound`). Seeded from the record; mirrored into a ref so
+  // the event subscription reads the LATEST value without re-subscribing (a stale
+  // closure would drop the draft's own first events after binding).
   const [boundSessionId, setBoundSessionId] = useState<string | null>(thread.sessionId)
+  const boundRef = useRef<string | null>(thread.sessionId)
+  // Keep the lift callback in a ref so the bound subscription needn't depend on it.
+  const onBoundRef = useRef(onBound)
+  onBoundRef.current = onBound
   const listRef = useRef<HTMLDivElement>(null)
   // True once any live event has been folded in: guards the async hydrate from
   // clobbering events that streamed in before the JSONL read resolved.
@@ -65,6 +73,11 @@ export function Conversation({
   // Hydrate this Thread's saved history from JSONL once (TB5): switching INTO a
   // previously-used Thread shows its conversation before live events resume. A
   // draft (or a fresh Thread) has none, so this is a no-op there.
+  //
+  // Deferred (NIT): if the Thread's PRIOR turn was still in-flight when we last
+  // left it, its JSONL may lag the live tail by a few un-flushed events; the
+  // `liveSeen` guard keeps a late hydrate from clobbering resumed live events, but
+  // the brief early-history gap on such a reopen is accepted for this slice.
   useEffect(() => {
     let active = true
     void window.api.readTranscript(thread.threadId).then((entries) => {
@@ -77,19 +90,32 @@ export function Conversation({
     }
   }, [thread.threadId])
 
+  // Bind a draft to its OWN session the instant main signals `thread:bound` —
+  // BEFORE that session's first event arrives (main emits it ahead of the prompt
+  // stream). We never adopt a session from an incoming event, so a sibling's
+  // still-streaming turn can't be spliced into this draft. Also lifts the session
+  // so a switch-away-and-back re-seeds it instead of re-minting.
+  useEffect(() => {
+    return window.api.onThreadBound((e) => {
+      if (e.threadId !== thread.threadId) return
+      boundRef.current = e.sessionId
+      setBoundSessionId(e.sessionId)
+      onBoundRef.current?.(e.sessionId)
+    })
+  }, [thread.threadId])
+
   // Subscribe to this agent's events; route ONLY this Thread's session to the
-  // reducer (one agent hosts many sessions, TB5). A draft adopts its session from
-  // the first tagged event so later events of OTHER Threads can't leak in.
+  // reducer (one agent hosts many sessions, TB5). Reads `boundRef` live so an
+  // UNBOUND draft rejects every session-tagged event (no sibling adoption), and a
+  // bound Thread takes only its own — without re-subscribing on each binding.
   useEffect(() => {
     return window.api.onAcpEvent((event) => {
       if (event.agentId !== thread.agentId) return
-      if (!eventBelongsToThread(event.payload, boundSessionId)) return
+      if (!eventBelongsToThread(event.payload, boundRef.current)) return
       liveSeen.current = true
-      const sid = sessionIdOfEvent(event.payload)
-      if (boundSessionId === null && sid !== null) setBoundSessionId(sid)
       dispatch({ type: 'acp-event', payload: event.payload })
     })
-  }, [thread.agentId, boundSessionId])
+  }, [thread.agentId])
 
   // Keep the latest item in view as the answer streams in.
   useEffect(() => {
@@ -112,7 +138,9 @@ export function Conversation({
       })
       if (result.ok) {
         // Reuse the now-bound session on the next prompt (no second session/new),
-        // and lift it so a switch-away-and-back doesn't re-mint.
+        // and lift it so a switch-away-and-back doesn't re-mint. `thread:bound`
+        // already set this for a fresh draft; this also covers the no-store path.
+        boundRef.current = result.sessionId
         setBoundSessionId(result.sessionId)
         onBound?.(result.sessionId)
       } else if (result.kind === 'not-signed-in') {
@@ -133,6 +161,7 @@ export function Conversation({
   function respondPermission(item: PermissionItem, option: PermissionOption): void {
     void window.api.respondPermission({
       agentId: thread.agentId,
+      threadId: thread.threadId,
       requestId: item.requestId,
       optionId: option.optionId,
     })
@@ -155,6 +184,7 @@ export function Conversation({
       if (!deny) continue
       void window.api.respondPermission({
         agentId: thread.agentId,
+        threadId: thread.threadId,
         requestId: item.requestId,
         optionId: deny.optionId,
       })

--- a/src/renderer/src/conversation/Conversation.tsx
+++ b/src/renderer/src/conversation/Conversation.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useReducer, useRef, useState, type JSX, type KeyboardEvent } from 'react'
-import type { AuthMethod, ThreadConnection } from '../../../shared/ipc'
+import type { AuthMethod } from '../../../shared/ipc'
 import {
   conversationReducer,
   initialConversationState,
@@ -13,35 +13,83 @@ import {
   type ToolItem,
   type UserItem,
 } from './reducer'
+import { eventBelongsToThread, sessionIdOfEvent } from './event-routing'
+import { replayTranscript } from './replay'
 
 /** Process-local counter for unique echoed-prompt ids. */
 let promptSeq = 0
 
 /**
- * A connected Thread: subscribes to the agent's `acp:event` stream, reduces it
- * into conversation items (reducer.ts), and lets the user send prompts. Reads
- * are served transparently in main, so a read-only turn streams reasoning + an
- * answer and completes without any approval UI (that's TB3).
+ * The live handle for one Thread hosted on a Workspace agent (TB5). `sessionId`
+ * is the bound ACP session, or `null` for a draft whose `session/new` is deferred
+ * to its first prompt. Several of these can share one `agentId` (one `vibe-acp`
+ * hosting many sessions); switching mounts the selected one (keyed by `threadId`).
+ */
+export interface LiveThread {
+  agentId: string
+  threadId: string
+  workspaceId: string
+  sessionId: string | null
+  title: string | null
+}
+
+/**
+ * A live Thread: hydrates its saved history from JSONL on mount (TB5), then
+ * subscribes to the agent's `acp:event` stream — routing only THIS Thread's
+ * session into the reducer (reducer.ts) — and lets the user send prompts. A
+ * draft's first prompt binds its session in main (`session/new`); the returned
+ * `sessionId` is reused thereafter so the session is never re-minted.
  */
 export function Conversation({
   thread,
   onAuthExpired,
+  onBound,
 }: {
-  thread: ThreadConnection
+  thread: LiveThread
   /** Mid-session expiry (-32000): route to in-place re-auth with these methods. */
   onAuthExpired: (authMethods: AuthMethod[]) => void
+  /** The Thread's session once bound (TB5) — lifts it so a switch-away-and-back
+   *  re-seeds the bound session instead of re-minting it. */
+  onBound?: (sessionId: string) => void
 }): JSX.Element {
   const [state, dispatch] = useReducer(conversationReducer, initialConversationState)
   const [draft, setDraft] = useState('')
+  // The session this Thread is bound to — null until a draft's first prompt binds
+  // it. Seeded from the record, advanced by the prompt result and live events.
+  const [boundSessionId, setBoundSessionId] = useState<string | null>(thread.sessionId)
   const listRef = useRef<HTMLDivElement>(null)
+  // True once any live event has been folded in: guards the async hydrate from
+  // clobbering events that streamed in before the JSONL read resolved.
+  const liveSeen = useRef(false)
 
-  // Subscribe once per agent; ignore events from other agents sharing the channel.
+  // Hydrate this Thread's saved history from JSONL once (TB5): switching INTO a
+  // previously-used Thread shows its conversation before live events resume. A
+  // draft (or a fresh Thread) has none, so this is a no-op there.
+  useEffect(() => {
+    let active = true
+    void window.api.readTranscript(thread.threadId).then((entries) => {
+      if (!active || liveSeen.current) return
+      const replayed = replayTranscript(entries)
+      if (replayed.items.length > 0) dispatch({ type: 'hydrate', state: replayed })
+    })
+    return () => {
+      active = false
+    }
+  }, [thread.threadId])
+
+  // Subscribe to this agent's events; route ONLY this Thread's session to the
+  // reducer (one agent hosts many sessions, TB5). A draft adopts its session from
+  // the first tagged event so later events of OTHER Threads can't leak in.
   useEffect(() => {
     return window.api.onAcpEvent((event) => {
       if (event.agentId !== thread.agentId) return
+      if (!eventBelongsToThread(event.payload, boundSessionId)) return
+      liveSeen.current = true
+      const sid = sessionIdOfEvent(event.payload)
+      if (boundSessionId === null && sid !== null) setBoundSessionId(sid)
       dispatch({ type: 'acp-event', payload: event.payload })
     })
-  }, [thread.agentId])
+  }, [thread.agentId, boundSessionId])
 
   // Keep the latest item in view as the answer streams in.
   useEffect(() => {
@@ -57,13 +105,20 @@ export function Conversation({
     try {
       const result = await window.api.sendPrompt({
         agentId: thread.agentId,
-        sessionId: thread.sessionId,
+        threadId: thread.threadId,
+        workspaceId: thread.workspaceId,
+        sessionId: boundSessionId,
         text,
       })
-      // Mid-session expiry: route to in-place re-auth (the agent stays alive).
-      if (!result.ok && result.kind === 'not-signed-in') {
+      if (result.ok) {
+        // Reuse the now-bound session on the next prompt (no second session/new),
+        // and lift it so a switch-away-and-back doesn't re-mint.
+        setBoundSessionId(result.sessionId)
+        onBound?.(result.sessionId)
+      } else if (result.kind === 'not-signed-in') {
+        // Mid-session expiry: route to in-place re-auth (the agent stays alive).
         onAuthExpired(result.authMethods)
-      } else if (!result.ok) {
+      } else {
         // Surface a failed turn as a conversation item rather than dropping it.
         dispatch({ type: 'turn-error', message: result.error })
       }

--- a/src/renderer/src/conversation/event-routing.test.ts
+++ b/src/renderer/src/conversation/event-routing.test.ts
@@ -38,10 +38,27 @@ describe('eventBelongsToThread', () => {
     expect(eventBelongsToThread({ type: 'error', message: 'boom' }, null)).toBe(true)
   })
 
-  it('accepts a session-tagged event for a not-yet-bound (draft) Thread so its first turn shows', () => {
-    // A draft has no bound session until its first prompt resolves; its first
-    // turn's events must still render (only the selected Thread is mounted, so
-    // there is no other live Thread to misroute to).
-    expect(eventBelongsToThread({ params: { sessionId: 's-new' } }, null)).toBe(true)
+  it('REJECTS every session-tagged event while a draft is still unbound (no sibling adoption)', () => {
+    // A sibling Thread stays live on the shared agent: an unbound draft must NOT
+    // adopt an arbitrary event's session, or it would splice a sibling's turn in.
+    // Main's `thread:bound` signal binds the draft BEFORE its own events arrive,
+    // so rejecting-while-unbound drops nothing of the draft's own stream.
+    expect(eventBelongsToThread({ params: { sessionId: 's-sibling' } }, null)).toBe(false)
+    expect(eventBelongsToThread({ params: { sessionId: 's-own' } }, null)).toBe(false)
+  })
+
+  it('after binding (thread:bound) routes the draft to its OWN session, rejecting a sibling', () => {
+    // Models the canonical race: draft D mounts unbound while sibling A streams on
+    // sA. Until D is bound, BOTH are rejected. Once `thread:bound` sets D to sD,
+    // D accepts its own sD events and still rejects A's sA events.
+    const sibling = { params: { sessionId: 'sA' } }
+    const own = { params: { sessionId: 'sD' } }
+    expect(eventBelongsToThread(sibling, null)).toBe(false)
+    expect(eventBelongsToThread(own, null)).toBe(false)
+    expect(eventBelongsToThread(own, 'sD')).toBe(true)
+    expect(eventBelongsToThread(sibling, 'sD')).toBe(false)
+    // Lifecycle still passes through at every stage.
+    expect(eventBelongsToThread({ type: 'exit', info: {} }, null)).toBe(true)
+    expect(eventBelongsToThread({ type: 'exit', info: {} }, 'sD')).toBe(true)
   })
 })

--- a/src/renderer/src/conversation/event-routing.test.ts
+++ b/src/renderer/src/conversation/event-routing.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { eventBelongsToThread, sessionIdOfEvent } from './event-routing'
+
+/**
+ * Live event routing for multiple Threads on ONE agent (ADR-0005, TB5 #34). A
+ * single `vibe-acp` hosts many ACP sessions, all streamed over the one
+ * `acp:event` channel tagged only by `agentId`; the renderer must route each
+ * session-tagged payload to the Thread bound to that sessionId, while agent-wide
+ * lifecycle events (no sessionId) pass through. Pure — no React, no IPC.
+ */
+
+describe('sessionIdOfEvent', () => {
+  it('pulls params.sessionId from a session/update or request_permission payload', () => {
+    expect(sessionIdOfEvent({ method: 'session/update', params: { sessionId: 's1' } })).toBe('s1')
+    expect(
+      sessionIdOfEvent({ method: 'session/request_permission', params: { sessionId: 's2' } }),
+    ).toBe('s2')
+  })
+
+  it('returns null for lifecycle payloads and malformed input', () => {
+    expect(sessionIdOfEvent({ type: 'exit', info: {} })).toBeNull()
+    expect(sessionIdOfEvent({ type: 'stderr', text: 'x' })).toBeNull()
+    expect(sessionIdOfEvent(null)).toBeNull()
+    expect(sessionIdOfEvent({ params: {} })).toBeNull()
+  })
+})
+
+describe('eventBelongsToThread', () => {
+  it('routes a session-tagged event only to the Thread bound to that session', () => {
+    const mine = { params: { sessionId: 's1' } }
+    const other = { params: { sessionId: 's2' } }
+    expect(eventBelongsToThread(mine, 's1')).toBe(true)
+    expect(eventBelongsToThread(other, 's1')).toBe(false)
+  })
+
+  it('passes session-less lifecycle events through (agent-wide)', () => {
+    expect(eventBelongsToThread({ type: 'exit', info: {} }, 's1')).toBe(true)
+    expect(eventBelongsToThread({ type: 'error', message: 'boom' }, null)).toBe(true)
+  })
+
+  it('accepts a session-tagged event for a not-yet-bound (draft) Thread so its first turn shows', () => {
+    // A draft has no bound session until its first prompt resolves; its first
+    // turn's events must still render (only the selected Thread is mounted, so
+    // there is no other live Thread to misroute to).
+    expect(eventBelongsToThread({ params: { sessionId: 's-new' } }, null)).toBe(true)
+  })
+})

--- a/src/renderer/src/conversation/event-routing.ts
+++ b/src/renderer/src/conversation/event-routing.ts
@@ -1,0 +1,38 @@
+/**
+ * Live event routing for multiple Threads hosted by ONE agent (ADR-0005, TB5).
+ * A single `vibe-acp` agent hosts many ACP sessions, and main streams every
+ * session's `session/update` (and `session/request_permission`) over the one
+ * `acp:event` channel tagged only by `agentId`. So agentId alone can't tell two
+ * Threads apart — these helpers route each payload by its OWN `params.sessionId`,
+ * mirroring main's transcript tee. Pure (no React, no IPC) so it's unit-tested.
+ */
+
+/**
+ * The ACP `sessionId` a payload is FOR (`session/update` and
+ * `session/request_permission` both carry `params.sessionId`). Child lifecycle
+ * payloads (`{type:'exit'|'error'|'stderr'}`) carry none -> `null`.
+ */
+export function sessionIdOfEvent(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object') return null
+  const params = (payload as { params?: unknown }).params
+  if (!params || typeof params !== 'object') return null
+  const sessionId = (params as { sessionId?: unknown }).sessionId
+  return typeof sessionId === 'string' ? sessionId : null
+}
+
+/**
+ * Whether an `acp:event` payload belongs to a Thread's live view, given the
+ * session that Thread is bound to (`null` while a draft is unbound).
+ *
+ * A session-tagged event routes to the Thread bound to that session. A
+ * session-less lifecycle event (exit/error/stderr) is agent-wide and always
+ * passes through. A not-yet-bound (draft) Thread accepts session-tagged events
+ * too — its first turn must render before `session/new` round-trips back, and
+ * only the selected Thread is mounted so there is no sibling to misroute to.
+ */
+export function eventBelongsToThread(payload: unknown, boundSessionId: string | null): boolean {
+  const sid = sessionIdOfEvent(payload)
+  if (sid === null) return true
+  if (boundSessionId === null) return true
+  return sid === boundSessionId
+}

--- a/src/renderer/src/conversation/event-routing.ts
+++ b/src/renderer/src/conversation/event-routing.ts
@@ -22,17 +22,20 @@ export function sessionIdOfEvent(payload: unknown): string | null {
 
 /**
  * Whether an `acp:event` payload belongs to a Thread's live view, given the
- * session that Thread is bound to (`null` while a draft is unbound).
+ * session that Thread is bound to (`null` while a draft is still unbound).
  *
- * A session-tagged event routes to the Thread bound to that session. A
+ * A session-tagged event routes ONLY to the Thread bound to that session. A
  * session-less lifecycle event (exit/error/stderr) is agent-wide and always
- * passes through. A not-yet-bound (draft) Thread accepts session-tagged events
- * too — its first turn must render before `session/new` round-trips back, and
- * only the selected Thread is mounted so there is no sibling to misroute to.
+ * passes through. An UNBOUND draft (`boundSessionId === null`) REJECTS every
+ * session-tagged event — siblings stay live on the shared agent, so adopting an
+ * arbitrary event's session would splice a sibling's turn into the draft. Main
+ * emits a `thread:bound` signal the instant `session/new` returns and BEFORE that
+ * session streams any event (see `sendPrompt`), so a draft is bound before its
+ * own first event arrives — rejecting-while-unbound drops nothing of its own.
  */
 export function eventBelongsToThread(payload: unknown, boundSessionId: string | null): boolean {
   const sid = sessionIdOfEvent(payload)
   if (sid === null) return true
-  if (boundSessionId === null) return true
+  if (boundSessionId === null) return false
   return sid === boundSessionId
 }

--- a/src/renderer/src/conversation/reducer.test.ts
+++ b/src/renderer/src/conversation/reducer.test.ts
@@ -359,3 +359,24 @@ describe('transcript replay contract: turn-outcome entries (TB2 S2)', () => {
     expect(next.items.some((i): i is ErrorItem => i.kind === 'error' && i.message === 'kaboom')).toBe(true)
   })
 })
+
+/**
+ * Switching to a live Thread (TB5 #34) seeds its reducer from the replayed JSONL
+ * history before live events resume, via a `hydrate` action that REPLACES state
+ * wholesale. This lets one mounted Conversation show a Thread's saved history and
+ * then continue live, without a separate read-only view.
+ */
+describe('hydrate (TB5 switch-to-live seeding)', () => {
+  it('replaces the whole state with the provided (replayed) state', () => {
+    const replayed: ConversationState = {
+      ...initialConversationState,
+      title: 'Earlier thread',
+      items: [{ kind: 'user', id: 'u1', text: 'hi from before' }],
+    }
+    const next = conversationReducer(
+      { ...initialConversationState, title: 'stale', items: [{ kind: 'user', id: 'x', text: 'stale' }] },
+      { type: 'hydrate', state: replayed },
+    )
+    expect(next).toEqual(replayed)
+  })
+})

--- a/src/renderer/src/conversation/reducer.ts
+++ b/src/renderer/src/conversation/reducer.ts
@@ -168,12 +168,18 @@ export type ConversationAction =
   | { type: 'turn-error'; message: string }
   | { type: 'recover' }
   | { type: 'resolve-permission'; requestId: number | string; optionId: string; name: string }
+  // Seed a live Thread from its replayed JSONL history (TB5 #34): replace the
+  // whole state, so switching INTO a Thread shows its saved conversation before
+  // live events resume. The provided state is already folded (via replayTranscript).
+  | { type: 'hydrate'; state: ConversationState }
 
 export function conversationReducer(
   state: ConversationState,
   action: ConversationAction,
 ): ConversationState {
   switch (action.type) {
+    case 'hydrate':
+      return action.state
     case 'send-prompt':
       return {
         ...state,

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -613,3 +613,72 @@ body {
   outline: none;
   border-color: var(--accent);
 }
+
+/* --- Connected Workspace: multiple Threads + switching (TB5) --- */
+
+.workspace {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.workspace__bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.workspace__name {
+  flex: 1;
+  font-size: 12px;
+  color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.workspace__threads {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  padding: 6px 0;
+}
+
+.workspace__thread {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  text-align: left;
+  background: none;
+  border: none;
+  border-radius: var(--radius);
+  padding: 6px 8px;
+  font: inherit;
+  font-size: 13px;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.workspace__thread:hover {
+  background: var(--accent-tint);
+  color: var(--accent-text);
+}
+
+.workspace__thread--active {
+  background: var(--accent-tint);
+  color: var(--accent-text);
+  font-weight: 600;
+}
+
+.workspace__thread-label {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -28,6 +28,8 @@ export const IPC = {
   listMetadata: 'metadata:list',
   /** Read a Thread's persisted JSONL transcript for a process-free reopen (TB3). */
   readTranscript: 'transcript:read',
+  /** Mint a NEW-Thread draft (durable id, no ACP session) under a Workspace (TB5). */
+  createDraft: 'thread:create-draft',
 } as const
 
 /**
@@ -116,6 +118,10 @@ export interface ThreadConnection extends ThreadInfo {
   /** Id of the Workspace agent (one `vibe-acp` process) in main. */
   agentId: string
   workspaceDir: string
+  /** Our durable, minted Thread id (TB5) — distinct from the ACP `sessionId`. */
+  threadId: string
+  /** Our minted Workspace id (TB5) — the key drafts/binds are recorded under. */
+  workspaceId: string
   /** Whether sign-out is available — drives the connected signed-in indicator. */
   signOutAvailable: boolean
   /** Advertised sign-in methods, kept so sign-out can route back to the panel. */
@@ -154,18 +160,43 @@ export interface PromptResult {
 export interface SendPromptArgs {
   /** Id of the Workspace agent (one `vibe-acp` process) hosting the Thread. */
   agentId: string
-  /** ACP session id of the Thread to prompt. */
-  sessionId: string
+  /** Our durable Thread id — bound to its ACP session on the first prompt (TB5). */
+  threadId: string
+  /** Our minted Workspace id — the key the binding is recorded under (TB5). */
+  workspaceId: string
+  /**
+   * The Thread's bound ACP session, or `null` for a draft's FIRST prompt — which
+   * triggers `session/new` in main (ADR-0005). The caller reuses the `sessionId`
+   * returned in the result on subsequent prompts so the session is not re-minted.
+   */
+  sessionId: string | null
   /** The user's prompt text. */
   text: string
 }
 
 export type SendPromptResult =
-  | { ok: true; result: PromptResult }
+  // `sessionId` is the Thread's now-bound session (minted on a draft's first
+  // prompt, else the one passed in) — the renderer reuses it on the next prompt.
+  | { ok: true; result: PromptResult; sessionId: string }
   // Mid-session expiry (-32000): the agent stays alive so the renderer can route
   // to the sign-in panel in place and re-auth on the same agent (no restart).
   | { ok: false; kind: 'not-signed-in'; agentId: string; authMethods: AuthMethod[] }
   | { ok: false; kind: 'error'; error: string }
+
+/** Mint a NEW-Thread draft under a Workspace (TB5): no ACP session, no agent work. */
+export interface CreateDraftArgs {
+  /** Our minted Workspace id the draft is created under. */
+  workspaceId: string
+}
+
+/**
+ * The `createDraft` reply: the minted draft Thread (`sessionId: null`), or an
+ * error if metadata isn't ready. The renderer adds it to the list and selects it;
+ * `session/new` is deferred to its first prompt.
+ */
+export type CreateDraftResult =
+  | { ok: true; thread: ThreadMeta }
+  | { ok: false; error: string }
 
 /** Reply to an agent `session/request_permission` with the user's choice. */
 export interface RespondPermissionArgs {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -24,6 +24,12 @@ export const IPC = {
   signOut: 'auth:sign-out',
   /** Main -> renderer: streamed ACP event tagged by the owning agent. */
   acpEvent: 'acp:event',
+  /**
+   * Main -> renderer: a draft's session was just minted (`session/new`) and bound
+   * to its Thread (TB5). Emitted BEFORE that session streams any event, so a draft
+   * is bound before its own events arrive — it never infers its session from one.
+   */
+  threadBound: 'thread:bound',
   /** List persisted Workspaces + their Threads for the cold launch list (ADR-0005). */
   listMetadata: 'metadata:list',
   /** Read a Thread's persisted JSONL transcript for a process-free reopen (TB3). */
@@ -143,6 +149,17 @@ export interface AcpEvent {
   payload: unknown
 }
 
+/**
+ * Main -> renderer signal that a draft's `session/new` returned and its session
+ * is bound to `threadId` (TB5). Sent the instant binding completes and BEFORE the
+ * session streams any event, so the draft's live view adopts its OWN session up
+ * front instead of inferring one from an arbitrary (possibly sibling) event.
+ */
+export interface ThreadBoundEvent {
+  threadId: string
+  sessionId: string
+}
+
 /** Token usage for a completed turn (`session/prompt` response). */
 export interface PromptUsage {
   inputTokens?: number
@@ -202,6 +219,12 @@ export type CreateDraftResult =
 export interface RespondPermissionArgs {
   /** Id of the Workspace agent (one `vibe-acp` process) hosting the Thread. */
   agentId: string
+  /**
+   * Our durable Thread id (TB5) — the permission response is teed to THIS Thread's
+   * log directly, not via the agent's last-prompted map, so answering a Thread's
+   * permission after switching+prompting a sibling can't misroute the entry.
+   */
+  threadId: string
   /** The JSON-RPC id of the agent's `session/request_permission` request. */
   requestId: number | string
   /** The `optionId` of the option the user selected. */


### PR DESCRIPTION
## What

Tracer-bullet **TB5** (ADR-0005): a Workspace agent now hosts **multiple Threads**, Threads start as **drafts** that bind their ACP session lazily, and the user can **switch** between them.

- **New-Thread draft** — `New Thread` mints a durable Thread id with `sessionId: null` and **no agent work** (no `session/new`, no JSONL). It appears in the list immediately. (`createThreadDraft` + `createDraft` IPC.)
- **Bind on first prompt** — the first prompt on a draft runs `session/new` **once** on the Workspace's agent, binds the returned `sessionId` onto the **same** Thread id, and starts its transcript. Subsequent prompts pass the bound `sessionId` back, so the session is **never re-minted**. (`ensureBoundSession`; `sendPrompt` returns the bound `sessionId`.)
- **Multiple Threads + switching** — one `vibe-acp` agent hosts many ACP sessions. Live events are routed **by `params.sessionId`** so sibling Threads can't leak into each other (`event-routing.ts`). Switching mounts the selected Thread, **hydrating its saved JSONL** then continuing live (reducer `hydrate`). A Thread bound in a **prior launch** replays read-only via `ColdThread` (TB3) until TB4 (`session/load`). `routeThreadSelection` decides live-vs-cold.
- **No residue for abandoned drafts** — a draft never prompted creates no ACP session and no `<id>.jsonl`; only its session-less metadata record exists.

## Tests (strict TDD, temp-dir / injected seams — no live `vibe-acp`)

- `drafts.test.ts` — a draft writes metadata with `sessionId === null` and **no** transcript file (incl. the abandoned case).
- `thread-binding.test.ts` — first prompt → one `session/new`, bound by id; reuse → **no** second `session/new`; two drafts on one agent → two distinct sessions.
- `event-routing.test.ts` / `thread-selection.test.ts` / reducer `hydrate` — pure routing + seeding.

Gates green: `lint`, `typecheck`, `build`, **140 tests** (was 127; +13).

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)