### PR TITLE
TB4 (#33): continue a reopened Thread — session/load resume + re-bind on failure

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -26,6 +26,7 @@ import { getShellEnv } from './shell-env'
 import { groupThreadsByWorkspace, MetadataStore } from './persistence/metadata-store'
 import {
   acpEventEntry,
+  agentReboundEntry,
   resolvePermissionEntry,
   sessionIdFromPayload,
   TranscriptStore,
@@ -145,16 +146,22 @@ async function recordThread(agentId: string, workspaceDir: string, thread: Threa
 }
 
 /**
- * Resolve the ACP session to prompt, binding a draft on its first prompt (TB5).
- * With a metadata store, delegate to `ensureBoundSession` (one `session/new`,
- * bind by id, reuse thereafter) and seed the transcript bridge on a fresh mint.
+ * Resolve the ACP session to prompt, binding a draft on its first prompt (TB5) and
+ * RESUMING a reopened Thread on its first prompt (TB4 #33). With a metadata store,
+ * delegate to `ensureBoundSession`, which distinguishes the three cases: draft ->
+ * `session/new`; reopened (stored session not hosted by this fresh agent) ->
+ * `session/load`, re-binding fresh on a resume failure; already-hosted -> reuse.
+ * `minted` is true for a draft mint OR a re-bind; `rebound` flags the re-bind so
+ * the caller tees the "context reset" notice and re-emits `thread:bound`.
+ *
  * Without a store (best-effort degraded mode), open a session directly so a draft
- * can still prompt; an already-bound Thread always reuses its `sessionId`.
+ * can still prompt; reuse a session the agent already hosts, else open a fresh one
+ * (never the bug's `No open Thread` throw — degraded mode has no cursor to resume).
  */
 async function bindThreadSession(
   agent: WorkspaceAgent,
   args: SendPromptArgs,
-): Promise<{ sessionId: string; minted: boolean }> {
+): Promise<{ sessionId: string; minted: boolean; rebound: boolean }> {
   // Point the bridge at the Thread being prompted, so a session-less lifecycle
   // event tees to the ACTIVE Thread when several share an agent — refreshed every
   // prompt (last-write-wins, and only the active Thread prompts at a time).
@@ -167,11 +174,13 @@ async function bindThreadSession(
       workspaceId: args.workspaceId,
       sessionId: args.sessionId,
     })
-    return { sessionId: bound.sessionId, minted: bound.minted }
+    return { sessionId: bound.sessionId, minted: bound.minted, rebound: bound.rebound }
   }
-  if (args.sessionId) return { sessionId: args.sessionId, minted: false }
+  if (args.sessionId && agent.hasSession(args.sessionId)) {
+    return { sessionId: args.sessionId, minted: false, rebound: false }
+  }
   const thread = await agent.openThread()
-  return { sessionId: thread.sessionId, minted: true }
+  return { sessionId: thread.sessionId, minted: true, rebound: false }
 }
 
 /**
@@ -355,16 +364,20 @@ function registerIpc(): void {
       // binding failure surfaces WITHOUT teeing: nothing was logged yet, so a
       // failed first prompt leaves no transcript residue.
       let sessionId: string
+      let rebound: boolean
       try {
         const bound = await bindThreadSession(agent, args)
         sessionId = bound.sessionId
+        rebound = bound.rebound
         // Tell the renderer its draft is now bound, the INSTANT `session/new`
         // returns and BEFORE `agent.prompt` streams any event below (same
         // webContents, so ordered ahead of those `acp:event`s). This binds the
         // draft's live view to its OWN session up front, so it never infers a
-        // session from an arbitrary (possibly sibling) event.
+        // session from an arbitrary (possibly sibling) event. `rebound` (TB4 #33)
+        // carries a NEW session for a reopened Thread whose resume failed — the
+        // renderer rebinds its live view to it AND renders the "context reset" notice.
         if (bound.minted && !event.sender.isDestroyed()) {
-          event.sender.send(IPC.threadBound, { threadId: args.threadId, sessionId })
+          event.sender.send(IPC.threadBound, { threadId: args.threadId, sessionId, rebound })
         }
       } catch (err) {
         if (err instanceof WorkspaceAgentError && err.authState === 'not-signed-in') {
@@ -378,6 +391,10 @@ function registerIpc(): void {
       // Thread id, so no bridge lookup — a draft's first prompt can't misroute to
       // another Thread. Main has no renderer item id, so mint an opaque replay key.
       teeTranscript(args.threadId, userPromptEntry(randomUUID(), args.text))
+      // On a re-bind (TB4 #33), persist the "context reset" notice right AFTER the
+      // user's prompt and BEFORE the turn's events — so a later reopen replays it
+      // in the same position the live view rendered it (`thread:bound` -> notice).
+      if (rebound) teeTranscript(args.threadId, agentReboundEntry())
       try {
         const result = await agent.prompt(sessionId, args.text)
         // Tee the clean turn end: this signal lives ONLY in this IPC response

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -36,7 +36,7 @@ import {
   type TranscriptEntry,
 } from './persistence/transcript'
 import { WorkspaceAgent, WorkspaceAgentError } from './workspace-agent'
-import { ensureBoundSession } from './thread-binding'
+import { ensureBoundSession, resolveContinueTarget } from './thread-binding'
 import { createThreadDraft } from './persistence/drafts'
 import { deleteThread } from './persistence/delete-thread'
 
@@ -221,6 +221,37 @@ function connectionFor(
 }
 
 /**
+ * Build a connection that CONTINUES an existing persisted Thread (TB4 #33) WITHOUT
+ * opening a new one: look its record up in the metadata store and seed the
+ * connection with its ids + stored `sessionId` cursor (modes/models stay null until
+ * the lazy `session/load` on first prompt). Also seeds the transcript bridge so a
+ * session-less lifecycle event tees to this Thread. Returns `null` when there's no
+ * store or no matching record, so the caller falls back to opening a fresh Thread.
+ */
+function continueConnection(
+  agentId: string,
+  agent: WorkspaceAgent,
+  threadId: string,
+): ThreadConnection | null {
+  if (!metadataStore) return null
+  const target = resolveContinueTarget(metadataStore, threadId)
+  if (!target) return null
+  transcriptThreads.set(agentId, target.threadId)
+  return {
+    agentId,
+    workspaceDir: agent.workspaceDir,
+    sessionId: target.sessionId,
+    title: target.title,
+    modes: null,
+    models: null,
+    threadId: target.threadId,
+    workspaceId: target.workspaceId,
+    signOutAvailable: agent.signOutAvailable,
+    authMethods: agent.authMethods,
+  }
+}
+
+/**
  * Map a thread-open failure to a result. An auth-classified error (a -32000
  * mid-session/expiry) keeps the agent ALIVE and routes to the sign-in panel;
  * any other failure stops + disposes the agent.
@@ -328,6 +359,15 @@ function registerIpc(): void {
       // shows the sign-in panel and re-tries openThread after sign-in.
       if (agent.authState === 'not-signed-in') {
         return { ok: false, kind: 'not-signed-in', agentId, workspaceDir: args.workspaceDir, authMethods: agent.authMethods }
+      }
+
+      // Continue from the cold launch list (TB4 #33): connect to the EXISTING
+      // Thread (its first prompt drives the lazy `session/load` resume) without
+      // opening — and persisting — a throwaway empty Thread. Falls through to the
+      // normal open when the record can't be resolved (degraded / no store).
+      if (args.continueThreadId) {
+        const continued = continueConnection(agentId, agent, args.continueThreadId)
+        if (continued) return { ok: true, thread: continued }
       }
 
       const thread = await agent.openThread()

--- a/src/main/persistence/transcript.test.ts
+++ b/src/main/persistence/transcript.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   acpEventEntry,
+  agentReboundEntry,
   parseTranscript,
   resolvePermissionEntry,
   sessionIdFromPayload,
@@ -179,6 +180,10 @@ describe('entry constructors mirror the reducer inputs', () => {
       optionId: 'deny',
       name: null,
     })
+    // The agent-rebound notice (TB4 #33) carries no payload — the copy is a
+    // renderer-side constant — and round-trips through parseTranscript.
+    expect(agentReboundEntry()).toEqual({ t: 'agent-rebound' })
+    expect(parseTranscript('{"t":"agent-rebound"}\n')).toEqual([{ t: 'agent-rebound' }])
   })
 })
 

--- a/src/main/persistence/transcript.ts
+++ b/src/main/persistence/transcript.ts
@@ -43,6 +43,16 @@ export function turnErrorEntry(message: string): TranscriptEntry {
 }
 
 /**
+ * The agent's context was reset on a reopen (TB4 #33), teed at `sendPrompt` when a
+ * `session/load` resume failed and main re-bound a fresh `session/new` — mirrors
+ * the `agent-rebound` reducer action. Persisted so the notice survives a later
+ * reopen; the user-facing copy is a renderer-side constant, so it carries none.
+ */
+export function agentReboundEntry(): TranscriptEntry {
+  return { t: 'agent-rebound' }
+}
+
+/**
  * A permission response, teed at `respondPermission` — mirrors `resolve-permission`.
  * Main observes `requestId` + `optionId` at the chokepoint but not the option's
  * display `name` (that lives in the renderer's permission item), so `name`
@@ -203,6 +213,7 @@ function isTranscriptEntry(value: unknown): value is TranscriptEntry {
     t === 'acp-event' ||
     t === 'turn-complete' ||
     t === 'turn-error' ||
-    t === 'resolve-permission'
+    t === 'resolve-permission' ||
+    t === 'agent-rebound'
   )
 }

--- a/src/main/thread-binding.test.ts
+++ b/src/main/thread-binding.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterAll } from 'vitest'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { ensureBoundSession, type SessionBinder } from './thread-binding'
+import { ensureBoundSession, resolveContinueTarget, type SessionBinder } from './thread-binding'
 import { createThreadDraft } from './persistence/drafts'
 import { MetadataStore } from './persistence/metadata-store'
 import { SessionLoadError, WorkspaceAgentError } from './workspace-agent'
@@ -217,6 +217,54 @@ describe('ensureBoundSession — reopened Thread (TB4 #33)', () => {
 
     expect(agent.loadCalls).toBe(1)
     expect(agent.newCalls).toBe(0) // an auth expiry is NOT a resume failure — no re-bind
+  })
+})
+
+/**
+ * Cold-launch "Continue" (TB4 #33 review FIX 1): continuing a reopened Thread must
+ * spawn the agent but open NO new Thread — `resolveContinueTarget` READS the
+ * existing record (adds NO record, mints NO session), and the first prompt resumes
+ * THAT session. Pinned at the store + binding seam (the IPC handler that calls these
+ * is electron-coupled).
+ */
+describe('resolveContinueTarget — continue without opening a Thread (TB4 #33)', () => {
+  it('seeds from the existing record without persisting a new Thread, then resumes on first prompt', async () => {
+    const store = new MetadataStore({ filePath: join(dir, `continue-${randomName()}.json`) })
+    await store.load()
+    const ws = await store.upsertWorkspace({ dir: '/proj/continue' })
+    const existing = await store.upsertThread({ workspaceId: ws.id, sessionId: 'cursor-1', title: 'Earlier' })
+    const before = store.snapshot().threads.length
+
+    // Resolving the continue target reads the record — it persists nothing.
+    const target = resolveContinueTarget(store, existing.id)
+    expect(target).toEqual({
+      threadId: existing.id,
+      workspaceId: ws.id,
+      sessionId: 'cursor-1',
+      title: 'Earlier',
+    })
+    expect(store.snapshot().threads.length).toBe(before) // NO extra Thread persisted
+
+    // The first prompt on the continued Thread resumes its stored session — no
+    // session/new, no new record.
+    const agent = fakeBinder({ loadOutcome: 'resume' })
+    const bound = await ensureBoundSession({
+      agent,
+      store,
+      threadId: target!.threadId,
+      workspaceId: target!.workspaceId,
+      sessionId: target!.sessionId,
+    })
+    expect(agent.loadCalls).toBe(1)
+    expect(agent.newCalls).toBe(0)
+    expect(bound).toMatchObject({ sessionId: 'cursor-1', resumed: true, minted: false, rebound: false })
+    expect(store.snapshot().threads.length).toBe(before) // still no extra record
+  })
+
+  it('returns null for an unknown Thread id (caller falls back to opening fresh)', async () => {
+    const store = new MetadataStore({ filePath: join(dir, `continue-miss-${randomName()}.json`) })
+    await store.load()
+    expect(resolveContinueTarget(store, 'no-such-thread')).toBeNull()
   })
 })
 

--- a/src/main/thread-binding.test.ts
+++ b/src/main/thread-binding.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect, afterAll } from 'vitest'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { ensureBoundSession, type SessionOpener } from './thread-binding'
+import { ensureBoundSession, type SessionBinder } from './thread-binding'
 import { createThreadDraft } from './persistence/drafts'
 import { MetadataStore } from './persistence/metadata-store'
+import { SessionLoadError, WorkspaceAgentError } from './workspace-agent'
 import type { ThreadInfo } from '../shared/ipc'
 
 /**
@@ -18,15 +19,59 @@ import type { ThreadInfo } from '../shared/ipc'
 const dir = mkdtempSync(join(tmpdir(), 'vibe-binding-'))
 afterAll(() => rmSync(dir, { recursive: true, force: true }))
 
-/** A fake agent that mints a fresh sessionId per `openThread` (one per session/new). */
-function fakeOpener(prefix = 'sess'): SessionOpener & { calls: number } {
+/**
+ * A fake binder that mints a fresh sessionId per `openThread` (one per session/new)
+ * and HOSTS each minted session thereafter — so `hasSession` mirrors a real agent,
+ * letting a subsequent prompt take the reuse branch instead of re-minting.
+ */
+function fakeOpener(prefix = 'sess'): SessionBinder & { calls: number } {
   let n = 0
+  const hosted = new Set<string>()
   return {
     calls: 0,
+    loadSessionAvailable: true,
+    hasSession: (id) => hosted.has(id),
+    loadThread() {
+      throw new Error('loadThread should not be called for a draft mint')
+    },
     async openThread(): Promise<ThreadInfo> {
       this.calls++
       n++
-      return { sessionId: `${prefix}-${n}`, title: null, modes: null, models: null }
+      const sessionId = `${prefix}-${n}`
+      hosted.add(sessionId)
+      return { sessionId, title: null, modes: null, models: null }
+    },
+  }
+}
+
+/**
+ * A fake binder for the REOPENED-Thread cases (TB4 #33): `hosts` is the set of
+ * sessions it already holds, `loadSessionAvailable` gates resume, and `loadThread`
+ * resolves (resume) or rejects (re-bind) per the injected outcome. `loadCalls` /
+ * `newCalls` let a test assert which path ran.
+ */
+function fakeBinder(opts: {
+  hosts?: Set<string>
+  loadSessionAvailable?: boolean
+  loadOutcome?: 'resume' | SessionLoadError | WorkspaceAgentError
+}): SessionBinder & { loadCalls: number; newCalls: number } {
+  let n = 0
+  return {
+    loadCalls: 0,
+    newCalls: 0,
+    loadSessionAvailable: opts.loadSessionAvailable ?? true,
+    hasSession: (id) => (opts.hosts ?? new Set()).has(id),
+    async loadThread(sessionId): Promise<ThreadInfo> {
+      this.loadCalls++
+      const outcome = opts.loadOutcome ?? 'resume'
+      if (outcome !== 'resume') throw outcome
+      // Resume keeps the SAME id (the session/load result carries none, §9).
+      return { sessionId, title: null, modes: null, models: null }
+    },
+    async openThread(): Promise<ThreadInfo> {
+      this.newCalls++
+      n++
+      return { sessionId: `fresh-${n}`, title: 'Fresh', modes: null, models: null }
     },
   }
 }
@@ -89,3 +134,93 @@ describe('ensureBoundSession', () => {
     expect(threads.find((t) => t.id === b.id)?.sessionId).toBe(rb.sessionId)
   })
 })
+
+/**
+ * Reopened-Thread binding (TB4 #33): the first prompt in a reopened cold Thread
+ * (stored sessionId, NOT yet hosted by the freshly-spawned agent) must resume via
+ * `session/load`, re-binding a fresh `session/new` on a resume failure — all keyed
+ * off the agent's `hasSession` / `loadSessionAvailable` / `loadThread` seam.
+ */
+describe('ensureBoundSession — reopened Thread (TB4 #33)', () => {
+  async function reopenedStore(sessionId: string): Promise<{
+    store: MetadataStore
+    workspaceId: string
+    threadId: string
+  }> {
+    const store = new MetadataStore({ filePath: join(dir, `reopen-${randomName()}.json`) })
+    await store.load()
+    const ws = await store.upsertWorkspace({ dir: `/proj/${randomName()}` })
+    const thread = await store.upsertThread({ workspaceId: ws.id, sessionId })
+    return { store, workspaceId: ws.id, threadId: thread.id }
+  }
+
+  it('(ii) resumes via session/load when the agent does not yet host the stored session', async () => {
+    const { store, workspaceId, threadId } = await reopenedStore('old-sess')
+    const agent = fakeBinder({ loadOutcome: 'resume' })
+
+    const bound = await ensureBoundSession({ agent, store, threadId, workspaceId, sessionId: 'old-sess' })
+
+    expect(agent.loadCalls).toBe(1) // session/load ran
+    expect(agent.newCalls).toBe(0) // NO session/new
+    expect(bound).toMatchObject({ sessionId: 'old-sess', minted: false, resumed: true, rebound: false })
+    // The stored cursor is unchanged — same session resumed.
+    expect(store.snapshot().threads.find((t) => t.id === threadId)?.sessionId).toBe('old-sess')
+  })
+
+  it('(ii->fail) re-binds a fresh session/new and updates the stored cursor on a resume failure', async () => {
+    const { store, workspaceId, threadId } = await reopenedStore('dead-sess')
+    const agent = fakeBinder({ loadOutcome: new SessionLoadError('Session not found: dead-sess') })
+
+    const bound = await ensureBoundSession({ agent, store, threadId, workspaceId, sessionId: 'dead-sess' })
+
+    expect(agent.loadCalls).toBe(1) // tried to resume…
+    expect(agent.newCalls).toBe(1) // …failed, so re-bound fresh
+    expect(bound).toMatchObject({ minted: true, rebound: true, resumed: false })
+    expect(bound.sessionId).toBe('fresh-1')
+    // SAME Thread id, NEW cursor: history stays attached, agent context restarts.
+    const record = store.snapshot().threads.find((t) => t.id === threadId)
+    expect(record?.id).toBe(threadId)
+    expect(record?.sessionId).toBe('fresh-1')
+    expect(store.snapshot().threads.filter((t) => t.id === threadId)).toHaveLength(1)
+  })
+
+  it('(ii) skips session/load and re-binds straight away when resume is NOT advertised', async () => {
+    const { store, workspaceId, threadId } = await reopenedStore('old-sess')
+    const agent = fakeBinder({ loadSessionAvailable: false })
+
+    const bound = await ensureBoundSession({ agent, store, threadId, workspaceId, sessionId: 'old-sess' })
+
+    expect(agent.loadCalls).toBe(0) // never sends a doomed session/load
+    expect(agent.newCalls).toBe(1)
+    expect(bound).toMatchObject({ minted: true, rebound: true })
+  })
+
+  it('(iii) reuses a session the agent already hosts — no session/load, no session/new', async () => {
+    const { store, workspaceId, threadId } = await reopenedStore('live-sess')
+    const agent = fakeBinder({ hosts: new Set(['live-sess']) })
+
+    const bound = await ensureBoundSession({ agent, store, threadId, workspaceId, sessionId: 'live-sess' })
+
+    expect(agent.loadCalls).toBe(0)
+    expect(agent.newCalls).toBe(0)
+    expect(bound).toMatchObject({ sessionId: 'live-sess', minted: false, resumed: false, rebound: false })
+  })
+
+  it('propagates a -32000 auth expiry from session/load WITHOUT re-binding (routes to sign-in)', async () => {
+    const { store, workspaceId, threadId } = await reopenedStore('old-sess')
+    const authErr = new WorkspaceAgentError('Not signed in', null, 'not-signed-in')
+    const agent = fakeBinder({ loadOutcome: authErr })
+
+    await expect(
+      ensureBoundSession({ agent, store, threadId, workspaceId, sessionId: 'old-sess' }),
+    ).rejects.toBe(authErr)
+
+    expect(agent.loadCalls).toBe(1)
+    expect(agent.newCalls).toBe(0) // an auth expiry is NOT a resume failure — no re-bind
+  })
+})
+
+/** A short unique suffix so each reopened-Thread test gets its own store file. */
+function randomName(): string {
+  return Math.random().toString(36).slice(2, 10)
+}

--- a/src/main/thread-binding.ts
+++ b/src/main/thread-binding.ts
@@ -36,6 +36,41 @@ export interface ThreadBindStore {
   }): Promise<ThreadRecord>
 }
 
+/** The seed needed to connect to a CONTINUED (already-persisted) Thread (TB4 #33). */
+export interface ContinueTarget {
+  threadId: string
+  workspaceId: string
+  /** The stored ACP session cursor to resume on first prompt (null = a fresh draft). */
+  sessionId: string | null
+  title: string | null
+}
+
+/** The minimal store surface for resolving a continue target: read the index. */
+export interface ContinueLookupStore {
+  snapshot(): { threads: ThreadRecord[] }
+}
+
+/**
+ * Resolve the persisted Thread to seed a continue-start connection (TB4 #33) — the
+ * cold-launch "Continue" path spawns the agent but opens NO new Thread, so it
+ * READS (never writes) the existing record's ids + stored session cursor. Returns
+ * `null` when the record can't be found, so the caller falls back to opening a
+ * fresh Thread (degraded / no store) and connect never wedges.
+ */
+export function resolveContinueTarget(
+  store: ContinueLookupStore,
+  threadId: string,
+): ContinueTarget | null {
+  const record = store.snapshot().threads.find((t) => t.id === threadId)
+  if (!record) return null
+  return {
+    threadId: record.id,
+    workspaceId: record.workspaceId,
+    sessionId: record.sessionId,
+    title: record.title,
+  }
+}
+
 export interface BoundSession {
   /** The ACP session this Thread is now bound to. */
   sessionId: string

--- a/src/main/thread-binding.ts
+++ b/src/main/thread-binding.ts
@@ -1,4 +1,5 @@
 import type { ThreadInfo } from '../shared/ipc'
+import { WorkspaceAgentError } from './workspace-agent'
 import type { ThreadRecord } from './persistence/metadata-store'
 
 /**
@@ -8,6 +9,22 @@ import type { ThreadRecord } from './persistence/metadata-store'
  */
 export interface SessionOpener {
   openThread(): Promise<ThreadInfo>
+}
+
+/**
+ * The fuller agent surface needed to bind a REOPENED Thread (TB4 #33): besides
+ * minting a fresh session, the binder must report whether it already hosts a given
+ * session (`hasSession`), resume one it doesn't (`loadThread` -> `session/load`),
+ * and expose whether resume is even advertised (`loadSessionAvailable`). `WorkspaceAgent`
+ * satisfies this; tests inject a fake.
+ */
+export interface SessionBinder extends SessionOpener {
+  /** Whether this agent currently hosts (opened or loaded) the given session. */
+  hasSession(sessionId: string): boolean
+  /** Resume a prior session via `session/load`; rejects (typed) on a load failure. */
+  loadThread(sessionId: string): Promise<ThreadInfo>
+  /** Whether the agent advertised `loadSession` (gates the resume path). */
+  readonly loadSessionAvailable: boolean
 }
 
 /** The minimal store surface for binding: re-target a Thread by id (upsert). */
@@ -22,40 +39,83 @@ export interface ThreadBindStore {
 export interface BoundSession {
   /** The ACP session this Thread is now bound to. */
   sessionId: string
-  /** True when THIS call minted the session (`session/new` ran), false when reused. */
+  /** True when THIS call minted a session (`session/new` ran) — a draft OR a re-bind. */
   minted: boolean
-  /** The title `session/new` returned, when binding (null on reuse). */
+  /** The title `session/new` returned, when binding (null on reuse/resume). */
   title: string | null
+  /** True when a prior session was resumed via `session/load` (case ii success). */
+  resumed: boolean
+  /**
+   * True when a resume FAILED and we re-bound the SAME Thread to a fresh
+   * `session/new` (case ii -> fail). The caller tees the "context reset" notice
+   * and re-emits `thread:bound` with the NEW sessionId; `minted` is also true.
+   */
+  rebound: boolean
 }
 
 /**
- * Ensure a Thread has a bound ACP session before prompting (ADR-0005, TB5 #34).
+ * Ensure a Thread has a usable ACP session before prompting (ADR-0005; TB5 #34,
+ * TB4 #33). Three cases, distinguished here:
  *
- * A draft (`sessionId === null`) triggers exactly ONE `session/new` on the
- * Workspace's agent, binds the returned sessionId onto the SAME Thread id
- * (`upsertThread` by id, preserving `createdAt`), and reports it `minted`. An
- * already-bound Thread (the caller passes its sessionId) returns that session
- * untouched with NO `session/new` — so the first prompt mints the session and
- * every subsequent prompt reuses it.
+ *  (i)   DRAFT (`sessionId === null`): exactly ONE `session/new`, bound onto the
+ *        SAME Thread id (`upsertThread` by id, preserving `createdAt`) — `minted`.
+ *  (ii)  REOPENED (stored `sessionId`, NOT hosted by this freshly-spawned agent):
+ *        `session/load` to resume the agent's context (gated on `loadSessionAvailable`).
+ *        On success the turn proceeds on the SAME session (`resumed`). On a resume
+ *        FAILURE (or when resume isn't advertised) we RE-BIND a fresh `session/new`
+ *        under the same Thread id and update the stored cursor (`rebound` + `minted`),
+ *        keeping the visible JSONL history attached. A `-32000` auth expiry is NOT a
+ *        resume failure — it propagates so the caller routes to sign-in.
+ *  (iii) ALREADY HOSTED (the agent already opened/loaded this session this run):
+ *        reuse it, NO `session/load` and NO `session/new`.
  *
- * The caller is responsible for passing the bound sessionId back on later prompts
- * (it flows to the renderer in the prompt result); a stale `null` would re-mint.
+ * This is the fix for the reopened-Thread bug: before TB4, case (ii) returned the
+ * stored sessionId untouched, so `agent.prompt` threw `No open Thread` because the
+ * fresh agent's session map was empty (it never resumed the session).
  */
 export async function ensureBoundSession(args: {
-  agent: SessionOpener
+  agent: SessionBinder
   store: ThreadBindStore
   threadId: string
   workspaceId: string
   sessionId: string | null
 }): Promise<BoundSession> {
-  if (args.sessionId) {
-    return { sessionId: args.sessionId, minted: false, title: null }
+  // (i) draft: mint a fresh session and bind it.
+  if (!args.sessionId) return mintAndBind(args)
+
+  // (iii) already hosted this run: reuse with no load/new.
+  if (args.agent.hasSession(args.sessionId)) {
+    return { sessionId: args.sessionId, minted: false, title: null, resumed: false, rebound: false }
   }
+
+  // (ii) reopened: resume via session/load if advertised, else re-bind.
+  if (args.agent.loadSessionAvailable) {
+    try {
+      const resumed = await args.agent.loadThread(args.sessionId)
+      return { sessionId: resumed.sessionId, minted: false, title: null, resumed: true, rebound: false }
+    } catch (err) {
+      // A mid-session auth expiry (-32000) isn't a resume failure — let the caller
+      // route to sign-in rather than re-binding (which would just fail the same way).
+      if (err instanceof WorkspaceAgentError && err.authState === 'not-signed-in') throw err
+      // Any other load rejection (the captured -32602, or anything — fail-safe):
+      // fall through to a fresh re-bind, keeping the JSONL history attached.
+    }
+  }
+  return { ...(await mintAndBind(args)), rebound: true }
+}
+
+/** Mint a fresh `session/new` and bind it onto the Thread id (draft or re-bind). */
+async function mintAndBind(args: {
+  agent: SessionBinder
+  store: ThreadBindStore
+  threadId: string
+  workspaceId: string
+}): Promise<BoundSession> {
   const thread = await args.agent.openThread()
   await args.store.upsertThread({
     id: args.threadId,
     workspaceId: args.workspaceId,
     sessionId: thread.sessionId,
   })
-  return { sessionId: thread.sessionId, minted: true, title: thread.title }
+  return { sessionId: thread.sessionId, minted: true, title: thread.title, resumed: false, rebound: false }
 }

--- a/src/main/workspace-agent.test.ts
+++ b/src/main/workspace-agent.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { AUTH_HINT, SPAWN_HINT, WorkspaceAgent, WorkspaceAgentError } from './workspace-agent'
+import {
+  AUTH_HINT,
+  SessionLoadError,
+  SPAWN_HINT,
+  WorkspaceAgent,
+  WorkspaceAgentError,
+} from './workspace-agent'
 import type { ChildProcessLike, SpawnFn } from './acp/client'
 
 /**
@@ -893,5 +899,172 @@ describe('WorkspaceAgent — write + permission (TB3)', () => {
 
     const reply = sent(fake).find((m) => m.id === 0 && m.result !== undefined)
     expect(reply?.result).toEqual({ outcome: { outcome: 'selected', optionId: 'allow_once' } })
+  })
+})
+
+// --- TB4: session/load resume + replay suppression (#33) ---------------------
+
+/** A session id NOT opened by `connect` — the agent must `session/load` to host it. */
+const LOAD_SESSION_ID = 'aaaa1111-bbbb-2222-cccc-333344445555'
+
+/** A `session/update` notification for a session (a replayed-history chunk). */
+function sessionUpdate(sessionId: string): string {
+  return (
+    JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'session/update',
+      params: {
+        sessionId,
+        update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'replay' }, messageId: 'a1' },
+      },
+    }) + '\n'
+  )
+}
+
+/** Whether an emitted `event` payload is a `session/update` notification. */
+function isSessionUpdate(e: unknown): boolean {
+  return (e as { method?: string } | null)?.method === 'session/update'
+}
+
+/** The `session/load` request the agent sent, parsed loosely (cwd/mcpServers). */
+function loadRequest(fake: CapturingFake): { id?: number; params?: { sessionId?: string; cwd?: string; mcpServers?: unknown[] } } | undefined {
+  return fake.writes
+    .map((w) => JSON.parse(w) as { id?: number; method?: string; params?: { sessionId?: string; cwd?: string; mcpServers?: unknown[] } })
+    .find((m) => m.method === 'session/load')
+}
+
+/** Drive a ready agent whose initialize advertises (or omits) `loadSession`. */
+async function connectWithLoadSession(fake: CapturingFake, advertise: boolean): Promise<WorkspaceAgent> {
+  const agent = new WorkspaceAgent({ workspaceDir: '/abs/workspace', spawn: () => fake.child })
+  const started = agent.start()
+  fake.feed(
+    JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      result: { protocolVersion: 1, agentCapabilities: advertise ? { loadSession: true } : {} },
+    }) + '\n',
+  )
+  await new Promise((r) => setTimeout(r, 0))
+  fake.feed(
+    JSON.stringify({ jsonrpc: '2.0', id: 2, result: { authenticated: true, authState: 'os_keyring' } }) + '\n',
+  )
+  await started
+  return agent
+}
+
+describe('WorkspaceAgent.loadThread() — resume (TB4 #33)', () => {
+  it('sends session/load {sessionId,cwd,mcpServers:[]}, registers the session, and resolves to its info', async () => {
+    const fake = makeCapturingFake()
+    const agent = await connect(fake)
+    expect(agent.hasSession(LOAD_SESSION_ID)).toBe(false)
+
+    const loading = agent.loadThread(LOAD_SESSION_ID)
+    await new Promise((r) => setTimeout(r, 0))
+    const req = loadRequest(fake)
+    expect(req?.params).toEqual({ sessionId: LOAD_SESSION_ID, cwd: '/abs/workspace', mcpServers: [] })
+
+    // The result mirrors session/new but carries NO sessionId (acp-capture §9).
+    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: req?.id, result: { modes: null, models: null } }) + '\n')
+    const info = await loading
+    expect(info.sessionId).toBe(LOAD_SESSION_ID) // kept the id we loaded
+    expect(agent.hasSession(LOAD_SESSION_ID)).toBe(true) // now hosted -> next prompt reuses it
+  })
+
+  it('SUPPRESSES the wire-replayed session/update during load, then forwards live ones (no double history)', async () => {
+    const fake = makeCapturingFake()
+    const agent = await connect(fake)
+    const events: unknown[] = []
+    agent.on('event', (e) => events.push(e))
+
+    const loading = agent.loadThread(LOAD_SESSION_ID)
+    await new Promise((r) => setTimeout(r, 0))
+    const req = loadRequest(fake)
+
+    // A replayed-history notification arrives BETWEEN the request and its result —
+    // we already own this history in our JSONL, so it must NOT be emitted outward.
+    fake.feed(sessionUpdate(LOAD_SESSION_ID))
+    expect(events.filter(isSessionUpdate)).toHaveLength(0)
+
+    // The result resolves (the "resume complete" signal) — the gate clears.
+    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: req?.id, result: {} }) + '\n')
+    await loading
+
+    // A notification AFTER resume forwards normally (live streaming resumes).
+    fake.feed(sessionUpdate(LOAD_SESSION_ID))
+    expect(events.filter(isSessionUpdate)).toHaveLength(1)
+  })
+
+  it('does NOT suppress notifications for a DIFFERENT session while one is loading', async () => {
+    const fake = makeCapturingFake()
+    const agent = await connect(fake)
+    const events: unknown[] = []
+    agent.on('event', (e) => events.push(e))
+
+    const loading = agent.loadThread(LOAD_SESSION_ID)
+    await new Promise((r) => setTimeout(r, 0))
+    const req = loadRequest(fake)
+
+    // The gate is per-session: a sibling session's live event still flows through.
+    fake.feed(sessionUpdate(SESSION_ID))
+    expect(events.filter(isSessionUpdate)).toHaveLength(1)
+
+    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: req?.id, result: {} }) + '\n')
+    await loading
+  })
+
+  it('rejects with SessionLoadError on -32602 "Session not found", leaves the session unhosted, and clears the gate', async () => {
+    const fake = makeCapturingFake()
+    const agent = await connect(fake)
+
+    const settled = agent.loadThread(LOAD_SESSION_ID).catch((e: unknown) => e)
+    await new Promise((r) => setTimeout(r, 0))
+    const req = loadRequest(fake)
+    fake.feed(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: req?.id,
+        error: { code: -32602, message: 'Session not found: x', data: { session_id: 'x' } },
+      }) + '\n',
+    )
+
+    const err = await settled
+    expect(err).toBeInstanceOf(SessionLoadError)
+    expect(agent.hasSession(LOAD_SESSION_ID)).toBe(false) // a failed resume hosts nothing
+
+    // The suppression gate cleared on failure too — later notifications forward.
+    const events: unknown[] = []
+    agent.on('event', (e) => events.push(e))
+    fake.feed(sessionUpdate(LOAD_SESSION_ID))
+    expect(events.filter(isSessionUpdate)).toHaveLength(1)
+  })
+
+  it('maps a -32000 load failure to a not-signed-in WorkspaceAgentError (NOT a SessionLoadError)', async () => {
+    const fake = makeCapturingFake()
+    const agent = await connect(fake)
+
+    const settled = agent.loadThread(LOAD_SESSION_ID).catch((e: unknown) => e)
+    await new Promise((r) => setTimeout(r, 0))
+    const req = loadRequest(fake)
+    fake.feed(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: req?.id,
+        error: { code: -32000, message: 'Missing API key for mistral provider.' },
+      }) + '\n',
+    )
+
+    const err = await settled
+    expect(err).toBeInstanceOf(WorkspaceAgentError)
+    expect(err).not.toBeInstanceOf(SessionLoadError)
+    expect((err as WorkspaceAgentError).authState).toBe('not-signed-in')
+    expect(agent.authState).toBe('not-signed-in') // flips so the caller routes to sign-in
+  })
+
+  it('reflects agentCapabilities.loadSession from initialize (gates the resume path)', async () => {
+    const withCap = await connectWithLoadSession(makeCapturingFake(), true)
+    expect(withCap.loadSessionAvailable).toBe(true)
+
+    const withoutCap = await connectWithLoadSession(makeCapturingFake(), false)
+    expect(withoutCap.loadSessionAvailable).toBe(false)
   })
 })

--- a/src/main/workspace-agent.test.ts
+++ b/src/main/workspace-agent.test.ts
@@ -1012,6 +1012,34 @@ describe('WorkspaceAgent.loadThread() — resume (TB4 #33)', () => {
     await loading
   })
 
+  it('DROPS a session/update with no usable sessionId DURING a load (fail-safe), then forwards it after', async () => {
+    const fake = makeCapturingFake()
+    const agent = await connect(fake)
+    const events: unknown[] = []
+    agent.on('event', (e) => events.push(e))
+
+    // A malformed replay with no sessionId can't be attributed — drop it during the
+    // load window rather than risk teeing it (which would double history).
+    const noSessionUpdate =
+      JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: { update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'x' }, messageId: 'a1' } },
+      }) + '\n'
+
+    const loading = agent.loadThread(LOAD_SESSION_ID)
+    await new Promise((r) => setTimeout(r, 0))
+    const req = loadRequest(fake)
+    fake.feed(noSessionUpdate)
+    expect(events.filter(isSessionUpdate)).toHaveLength(0) // dropped during the load
+
+    // Once the load settles (no load in flight), such a notification forwards again.
+    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: req?.id, result: {} }) + '\n')
+    await loading
+    fake.feed(noSessionUpdate)
+    expect(events.filter(isSessionUpdate)).toHaveLength(1)
+  })
+
   it('rejects with SessionLoadError on -32602 "Session not found", leaves the session unhosted, and clears the gate', async () => {
     const fake = makeCapturingFake()
     const agent = await connect(fake)

--- a/src/main/workspace-agent.ts
+++ b/src/main/workspace-agent.ts
@@ -570,13 +570,19 @@ export class WorkspaceAgent extends EventEmitter {
    * Whether a notification is a `session/update` replayed for a session whose
    * `session/load` is still in flight (TB4 #33) — if so we drop it (don't emit).
    * Only `session/update` replays are gated; any other notification flows through.
+   *
+   * Fail-safe: while ANY load is in flight we ALSO drop a `session/update` that
+   * lacks a usable string `sessionId`. We can't attribute it to a session, and a
+   * malformed replay leaking into the tee during a load window would double history;
+   * dropping an unattributable update for the duration of a load is the safer call.
    */
   private isSuppressedReplay(msg: unknown): boolean {
     if (this.loadingSessions.size === 0) return false
     const m = msg as { method?: unknown; params?: { sessionId?: unknown } } | null
     if (!m || m.method !== 'session/update') return false
     const sessionId = m.params?.sessionId
-    return typeof sessionId === 'string' && this.loadingSessions.has(sessionId)
+    if (typeof sessionId !== 'string') return true // unattributable during a load -> drop
+    return this.loadingSessions.has(sessionId)
   }
 
   /**

--- a/src/main/workspace-agent.ts
+++ b/src/main/workspace-agent.ts
@@ -49,6 +49,20 @@ export class WorkspaceAgentError extends Error {
   }
 }
 
+/**
+ * A `session/load` resume failed for a reason that should fall back to a fresh
+ * re-bind (TB4 #33): the captured `-32602` "Session not found" (acp-capture §9),
+ * or — fail-safe — ANY other non-auth load rejection. Distinct from a plain
+ * `WorkspaceAgentError` so the binding logic can tell "resume failed, re-bind"
+ * apart from "mid-session auth expiry" (which routes to sign-in instead).
+ */
+export class SessionLoadError extends WorkspaceAgentError {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SessionLoadError'
+  }
+}
+
 interface InitializeResult {
   protocolVersion?: number
   agentInfo?: { name?: string; title?: string; version?: string }
@@ -101,6 +115,20 @@ export class WorkspaceAgent extends EventEmitter {
    * (TB6 #35) so we never send a doomed -32601 to an agent that can't service it.
    */
   private sessionCloseAvailableValue = false
+  /**
+   * Whether `initialize` advertised `agentCapabilities.loadSession` (acp-capture
+   * §1/§9) — gates the `session/load` resume path (TB4 #33). When false, callers
+   * go straight to a fresh re-bind instead of sending a doomed `session/load`.
+   */
+  private loadSessionAvailableValue = false
+  /**
+   * Sessions with a `session/load` in flight (TB4 #33). While a session id is in
+   * this set we DROP its `session/update` notifications instead of emitting them:
+   * on resume the agent replays prior history over the wire (acp-capture §9), but
+   * WE already own that history in our JSONL and rendered it on reopen — forwarding
+   * the replay would DOUBLE the conversation. Cleared when the load settles.
+   */
+  private readonly loadingSessions = new Set<string>()
 
   constructor(options: WorkspaceAgentOptions) {
     super()
@@ -116,7 +144,12 @@ export class WorkspaceAgent extends EventEmitter {
     })
 
     // Forward raw protocol + lifecycle events; we do not interpret them here.
-    this.client.on('notification', (msg: unknown) => this.emit('event', msg))
+    // EXCEPT: while a `session/load` is in flight for a session, drop its replayed
+    // `session/update` notifications (TB4 #33) — see `loadingSessions`.
+    this.client.on('notification', (msg: unknown) => {
+      if (this.isSuppressedReplay(msg)) return
+      this.emit('event', msg)
+    })
     this.client.on('serverRequest', (msg: unknown) => this.onServerRequest(msg))
     this.client.on('stderr', (text: string) => this.emit('event', { type: 'stderr', text }))
     this.client.on('exit', (info: unknown) => this.emit('event', { type: 'exit', info }))
@@ -173,6 +206,7 @@ export class WorkspaceAgent extends EventEmitter {
       ])
       this.authMethodsValue = extractAuthMethods(init)
       this.sessionCloseAvailableValue = extractSessionCloseCapability(init)
+      this.loadSessionAvailableValue = extractLoadSessionCapability(init)
       // `initialize` can't reveal auth state (its authMethods is always
       // present), so query the `_auth/status` extension method (acp-capture §8).
       await this.detectAuthState(earlyFailure)
@@ -197,6 +231,11 @@ export class WorkspaceAgent extends EventEmitter {
   /** Whether sign-out is currently available (from the last `_auth/status`). */
   get signOutAvailable(): boolean {
     return this.signOutAvailableValue
+  }
+
+  /** Whether the agent advertised `loadSession` — gates the resume path (TB4 #33). */
+  get loadSessionAvailable(): boolean {
+    return this.loadSessionAvailableValue
   }
 
   /** The absolute Workspace directory this agent operates in (for dedup). */
@@ -373,6 +412,54 @@ export class WorkspaceAgent extends EventEmitter {
     return thread
   }
 
+  /** Whether this agent currently hosts (has opened or loaded) a given session. */
+  hasSession(sessionId: string): boolean {
+    return this.threads.has(sessionId)
+  }
+
+  /**
+   * Resume a prior Thread's ACP session via `session/load` (TB4 #33, acp-capture
+   * §9). Params mirror `session/new` but carry the stored `sessionId`; the success
+   * result has NO `sessionId` (the caller already knows the id it loaded), so we
+   * keep the one we passed and register it so the next prompt reuses it. While the
+   * load is in flight we SUPPRESS the session's replayed `session/update`
+   * notifications (`loadingSessions`) — we already own that history in our JSONL,
+   * so forwarding the replay would double the conversation.
+   *
+   * On failure, throws a `SessionLoadError` for the captured `-32602` "Session not
+   * found" (and — fail-safe — any other non-auth load rejection) so the caller can
+   * re-bind a fresh session; a `-32000` rejection is mapped to a not-signed-in
+   * `WorkspaceAgentError` instead, routing to sign-in rather than a re-bind.
+   */
+  async loadThread(sessionId: string): Promise<ThreadInfo> {
+    if (!this.initialized) {
+      throw new WorkspaceAgentError('Agent is not initialized; call start() first.')
+    }
+    this.loadingSessions.add(sessionId)
+    try {
+      const result = await this.client.request<SessionNewResult>('session/load', {
+        sessionId,
+        cwd: this.workspaceDirValue,
+        mcpServers: [],
+      })
+      const thread: ThreadInfo = {
+        // The `session/load` result omits `sessionId` (acp-capture §9) — keep ours.
+        sessionId,
+        title: result.title ?? null,
+        modes: result.modes ?? null,
+        models: result.models ?? null,
+      }
+      this.threads.set(sessionId, thread)
+      return thread
+    } catch (err) {
+      throw this.mapLoadError(err)
+    } finally {
+      // Clear the suppression gate the instant the load settles (success OR
+      // failure): from here on, live streaming for this session forwards normally.
+      this.loadingSessions.delete(sessionId)
+    }
+  }
+
   /**
    * Send a prompt to a Thread (`session/prompt`) and resolve when the turn
    * ends. The streamed `session/update` notifications flow out on the `event`
@@ -479,6 +566,31 @@ export class WorkspaceAgent extends EventEmitter {
     this.client.removeListener('exit', onExit)
   }
 
+  /**
+   * Whether a notification is a `session/update` replayed for a session whose
+   * `session/load` is still in flight (TB4 #33) — if so we drop it (don't emit).
+   * Only `session/update` replays are gated; any other notification flows through.
+   */
+  private isSuppressedReplay(msg: unknown): boolean {
+    if (this.loadingSessions.size === 0) return false
+    const m = msg as { method?: unknown; params?: { sessionId?: unknown } } | null
+    if (!m || m.method !== 'session/update') return false
+    const sessionId = m.params?.sessionId
+    return typeof sessionId === 'string' && this.loadingSessions.has(sessionId)
+  }
+
+  /**
+   * Map a `session/load` rejection (TB4 #33). A `-32000` is a mid-session auth
+   * expiry — map (and cache) it as not-signed-in so the caller routes to sign-in.
+   * Everything else (the captured `-32602` "Session not found", or any other
+   * failure — fail-safe) becomes a `SessionLoadError` so the caller re-binds fresh.
+   */
+  private mapLoadError(err: unknown): WorkspaceAgentError {
+    const mapped = this.mapErrorAndCacheAuth(err)
+    if (mapped.authState === 'not-signed-in') return mapped
+    return new SessionLoadError(mapped.message)
+  }
+
   /** Spawn-time failures (ENOENT, etc.). */
   private mapSpawnError(err: unknown): WorkspaceAgentError {
     const code = (err as { code?: string })?.code
@@ -549,6 +661,16 @@ function extractSessionCloseCapability(init: InitializeResult): boolean {
   const caps = (init.agentCapabilities as { sessionCapabilities?: { close?: unknown } } | null)
     ?.sessionCapabilities
   return !!caps && caps.close !== undefined
+}
+
+/**
+ * Whether `initialize` advertised `agentCapabilities.loadSession: true`
+ * (acp-capture §1/§9). Defaults to false on any absent/malformed shape — so we
+ * only attempt `session/load` against an agent that genuinely announces resume
+ * support (TB4 #33), and fall straight to a re-bind otherwise.
+ */
+function extractLoadSessionCapability(init: InitializeResult): boolean {
+  return (init.agentCapabilities as { loadSession?: unknown } | null)?.loadSession === true
 }
 
 /** Pull the well-formed `authMethods` out of an `initialize` result. */

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -26,6 +26,10 @@ export function App(): JSX.Element {
   // A persisted Thread the user clicked to REOPEN read-only from its JSONL (TB3,
   // #32) — rendered with no agent spawned. null = showing the cold launch list.
   const [coldThread, setColdThread] = useState<ThreadMeta | null>(null)
+  // A reopened Thread the user chose to CONTINUE from the cold launch list (TB4,
+  // #33): set while we spawn that Workspace's agent, then handed to
+  // `ConnectedWorkspace` so it lands selected + live and resumes on first prompt.
+  const [continueThreadId, setContinueThreadId] = useState<string | null>(null)
 
   async function runDetect(): Promise<void> {
     setLoading(true)
@@ -58,6 +62,9 @@ export function App(): JSX.Element {
   async function openProject(): Promise<void> {
     const workspaceDir = await window.api.openWorkspaceDialog()
     if (!workspaceDir) return
+    // A normal Open-project connect opens a fresh Thread — clear any pending
+    // cold-list continue so its id can't leak into this different connection (TB4).
+    setContinueThreadId(null)
     setConnect({ status: 'connecting', workspaceDir })
     setConnect(routeThreadResult(await window.api.startThread({ workspaceDir })))
     // Main has now persisted the Workspace (and any Thread); reflect it in the list.
@@ -69,6 +76,24 @@ export function App(): JSX.Element {
   async function continueToThread(agentId: string, workspaceDir: string): Promise<void> {
     setConnect({ status: 'connecting', workspaceDir })
     setConnect(routeThreadResult(await window.api.openThread({ agentId })))
+  }
+
+  /**
+   * Continue a reopened Thread from the cold launch list (TB4 #33). No agent runs
+   * for a cold-list Thread, so we spawn its Workspace agent (reusing the same
+   * `startThread` connect flow as Open project), then hand the Thread id to
+   * `ConnectedWorkspace` via `continueThreadId` so it lands selected + live and its
+   * first prompt drives the resume (`session/load`). The Workspace dir comes from
+   * the cold list (a `ThreadMeta` carries only `workspaceId`).
+   */
+  async function continueColdThread(thread: ThreadMeta): Promise<void> {
+    const workspace = recents.find((w) => w.id === thread.workspaceId)
+    if (!workspace) return
+    setColdThread(null)
+    setContinueThreadId(thread.id)
+    setConnect({ status: 'connecting', workspaceDir: workspace.dir })
+    setConnect(routeThreadResult(await window.api.startThread({ workspaceDir: workspace.dir })))
+    void refreshRecents()
   }
 
   /** Sign-out / mid-session expiry: drop back to the sign-in panel (same agent). */
@@ -118,7 +143,11 @@ export function App(): JSX.Element {
           {/* Reopened Thread: render its saved conversation from JSONL, read-only,
               with NO agent spawned (TB3). Takes over the idle view until closed. */}
           {connect.status === 'idle' && coldThread && (
-            <ColdThread thread={coldThread} onClose={() => setColdThread(null)} />
+            <ColdThread
+              thread={coldThread}
+              onClose={() => setColdThread(null)}
+              onContinue={() => void continueColdThread(coldThread)}
+            />
           )}
 
           {connect.status === 'idle' && !coldThread && (
@@ -181,6 +210,7 @@ export function App(): JSX.Element {
                 onAuthExpired={(authMethods) =>
                   toSignInPanel(connect.thread.agentId, connect.thread.workspaceDir, authMethods)
                 }
+                continueThreadId={continueThreadId ?? undefined}
               />
             </>
           )}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -26,10 +26,6 @@ export function App(): JSX.Element {
   // A persisted Thread the user clicked to REOPEN read-only from its JSONL (TB3,
   // #32) — rendered with no agent spawned. null = showing the cold launch list.
   const [coldThread, setColdThread] = useState<ThreadMeta | null>(null)
-  // A reopened Thread the user chose to CONTINUE from the cold launch list (TB4,
-  // #33): set while we spawn that Workspace's agent, then handed to
-  // `ConnectedWorkspace` so it lands selected + live and resumes on first prompt.
-  const [continueThreadId, setContinueThreadId] = useState<string | null>(null)
 
   async function runDetect(): Promise<void> {
     setLoading(true)
@@ -62,9 +58,6 @@ export function App(): JSX.Element {
   async function openProject(): Promise<void> {
     const workspaceDir = await window.api.openWorkspaceDialog()
     if (!workspaceDir) return
-    // A normal Open-project connect opens a fresh Thread — clear any pending
-    // cold-list continue so its id can't leak into this different connection (TB4).
-    setContinueThreadId(null)
     setConnect({ status: 'connecting', workspaceDir })
     setConnect(routeThreadResult(await window.api.startThread({ workspaceDir })))
     // Main has now persisted the Workspace (and any Thread); reflect it in the list.
@@ -80,19 +73,24 @@ export function App(): JSX.Element {
 
   /**
    * Continue a reopened Thread from the cold launch list (TB4 #33). No agent runs
-   * for a cold-list Thread, so we spawn its Workspace agent (reusing the same
-   * `startThread` connect flow as Open project), then hand the Thread id to
-   * `ConnectedWorkspace` via `continueThreadId` so it lands selected + live and its
-   * first prompt drives the resume (`session/load`). The Workspace dir comes from
-   * the cold list (a `ThreadMeta` carries only `workspaceId`).
+   * for a cold-list Thread, so we spawn its Workspace agent via `startThread`,
+   * passing `continueThreadId` so main opens NO extra Thread and instead seeds the
+   * connection with THIS Thread (its first prompt drives the `session/load` resume).
+   * The connection thread IS the continued one, so it lands selected + live with no
+   * separate plumbing. The Workspace dir comes from the cold list (a `ThreadMeta`
+   * carries only `workspaceId`). If the agent comes up not-signed-in, no Thread is
+   * opened (the standard not-signed-in result) and the continue can be re-driven.
    */
   async function continueColdThread(thread: ThreadMeta): Promise<void> {
     const workspace = recents.find((w) => w.id === thread.workspaceId)
     if (!workspace) return
     setColdThread(null)
-    setContinueThreadId(thread.id)
     setConnect({ status: 'connecting', workspaceDir: workspace.dir })
-    setConnect(routeThreadResult(await window.api.startThread({ workspaceDir: workspace.dir })))
+    setConnect(
+      routeThreadResult(
+        await window.api.startThread({ workspaceDir: workspace.dir, continueThreadId: thread.id }),
+      ),
+    )
     void refreshRecents()
   }
 
@@ -210,7 +208,6 @@ export function App(): JSX.Element {
                 onAuthExpired={(authMethods) =>
                   toSignInPanel(connect.thread.agentId, connect.thread.workspaceDir, authMethods)
                 }
-                continueThreadId={continueThreadId ?? undefined}
               />
             </>
           )}

--- a/src/renderer/src/connection/ConnectedWorkspace.tsx
+++ b/src/renderer/src/connection/ConnectedWorkspace.tsx
@@ -22,6 +22,7 @@ export function ConnectedWorkspace({
   threads,
   refreshRecents,
   onAuthExpired,
+  continueThreadId,
 }: {
   connection: ThreadConnection
   /** The Workspace's persisted Threads (most-recent-first) from the cold list. */
@@ -30,11 +31,17 @@ export function ConnectedWorkspace({
   refreshRecents: () => Promise<void>
   /** Mid-session expiry (-32000): route to in-place re-auth with these methods. */
   onAuthExpired: (authMethods: AuthMethod[]) => void
+  /**
+   * A reopened Thread to CONTINUE on connect (TB4 #33): land selected + live so its
+   * first prompt resumes it (`session/load`). Set when the user continued from the
+   * cold launch list (which had to spawn this agent first).
+   */
+  continueThreadId?: string
 }): JSX.Element {
   const [liveThreadIds, setLiveThreadIds] = useState<ReadonlySet<string>>(
-    () => new Set([connection.threadId]),
+    () => new Set(continueThreadId ? [connection.threadId, continueThreadId] : [connection.threadId]),
   )
-  const [selectedThreadId, setSelectedThreadId] = useState(connection.threadId)
+  const [selectedThreadId, setSelectedThreadId] = useState(continueThreadId ?? connection.threadId)
   // Sessions bound this session (TB5): a draft's first prompt mints one, lifted
   // here so switching away and back re-seeds it instead of re-minting.
   const [boundSessions, setBoundSessions] = useState<Record<string, string>>(() =>
@@ -66,6 +73,14 @@ export function ConnectedWorkspace({
   // The session to seed the selected Thread with: the one bound this session (if
   // any) wins over the persisted cursor, so a bound draft isn't re-minted on switch.
   const seedSession = seedSessionId(selected, boundSessions)
+
+  // Continue a reopened (cold) Thread (TB4 #33): promote it to live + select it.
+  // Its persisted `sessionId` cursor seeds the live view, so the FIRST prompt drives
+  // `ensureBoundSession`'s resume path (`session/load`, re-binding fresh on failure).
+  function continueThread(threadId: string): void {
+    setLiveThreadIds((prev) => new Set(prev).add(threadId))
+    setSelectedThreadId(threadId)
+  }
 
   return (
     <div className="workspace">
@@ -114,6 +129,7 @@ export function ConnectedWorkspace({
           key={selected.id}
           thread={selected}
           onClose={() => setSelectedThreadId(connection.threadId)}
+          onContinue={() => continueThread(selected.id)}
         />
       )}
     </div>

--- a/src/renderer/src/connection/ConnectedWorkspace.tsx
+++ b/src/renderer/src/connection/ConnectedWorkspace.tsx
@@ -22,7 +22,6 @@ export function ConnectedWorkspace({
   threads,
   refreshRecents,
   onAuthExpired,
-  continueThreadId,
 }: {
   connection: ThreadConnection
   /** The Workspace's persisted Threads (most-recent-first) from the cold list. */
@@ -31,17 +30,14 @@ export function ConnectedWorkspace({
   refreshRecents: () => Promise<void>
   /** Mid-session expiry (-32000): route to in-place re-auth with these methods. */
   onAuthExpired: (authMethods: AuthMethod[]) => void
-  /**
-   * A reopened Thread to CONTINUE on connect (TB4 #33): land selected + live so its
-   * first prompt resumes it (`session/load`). Set when the user continued from the
-   * cold launch list (which had to spawn this agent first).
-   */
-  continueThreadId?: string
 }): JSX.Element {
+  // A continue-from-cold-launch lands here with the CONTINUED Thread already AS the
+  // connection thread (main opened no extra Thread, TB4 #33) — so it's live +
+  // selected by default, with no separate continue plumbing.
   const [liveThreadIds, setLiveThreadIds] = useState<ReadonlySet<string>>(
-    () => new Set(continueThreadId ? [connection.threadId, continueThreadId] : [connection.threadId]),
+    () => new Set([connection.threadId]),
   )
-  const [selectedThreadId, setSelectedThreadId] = useState(continueThreadId ?? connection.threadId)
+  const [selectedThreadId, setSelectedThreadId] = useState(connection.threadId)
   // Sessions bound this session (TB5): a draft's first prompt mints one, lifted
   // here so switching away and back re-seeds it instead of re-minting.
   const [boundSessions, setBoundSessions] = useState<Record<string, string>>(() =>

--- a/src/renderer/src/conversation/ColdThread.tsx
+++ b/src/renderer/src/conversation/ColdThread.tsx
@@ -10,16 +10,20 @@ import { replayTranscript } from './replay'
  * stream over IPC (`readTranscript`) and replay it through the SAME reducer the
  * live turn used (`replayTranscript`) to rebuild exactly what the user saw.
  *
- * The composer stays disabled: actually CONTINUING the conversation (spawn +
- * `session/load`) is a later slice (TB4, #33), so this view only displays the
- * history and points there.
+ * When `onContinue` is provided (TB4 #33), a "Continue" affordance spawns/uses the
+ * Workspace agent and resumes this Thread via `session/load` (re-binding fresh if
+ * the agent can't resume) — the first prompt then runs on the resumed session. The
+ * caller owns that transition (it has the Workspace context); here we only invite it.
  */
 export function ColdThread({
   thread,
   onClose,
+  onContinue,
 }: {
   thread: ThreadMeta
   onClose: () => void
+  /** Continue this reopened Thread live (TB4 #33). Absent = view-only. */
+  onContinue?: () => void
 }): JSX.Element {
   // null = still loading; a ConversationState once the transcript has replayed.
   const [state, setState] = useState<ConversationState | null>(null)
@@ -46,6 +50,11 @@ export function ColdThread({
         </button>
         <span className="conv__title">{title}</span>
         <span className="badge">history</span>
+        {onContinue && (
+          <button className="btn" onClick={onContinue}>
+            Continue
+          </button>
+        )}
       </div>
 
       <UsageBar state={view} />
@@ -61,8 +70,9 @@ export function ColdThread({
       </div>
 
       <p className="hint">
-        Viewing saved history — replayed from disk with no agent running. Continuing this conversation
-        is coming soon.
+        {onContinue
+          ? 'Viewing saved history — replayed from disk. Continue to resume this conversation with the agent.'
+          : 'Viewing saved history — replayed from disk with no agent running.'}
       </p>
     </div>
   )

--- a/src/renderer/src/conversation/Conversation.tsx
+++ b/src/renderer/src/conversation/Conversation.tsx
@@ -7,6 +7,7 @@ import {
   type ConversationItem,
   type ErrorItem,
   type FallbackItem,
+  type NoticeItem,
   type PermissionItem,
   type PermissionOption,
   type ReasoningItem,
@@ -101,6 +102,11 @@ export function Conversation({
       boundRef.current = e.sessionId
       setBoundSessionId(e.sessionId)
       onBoundRef.current?.(e.sessionId)
+      // A re-bind (TB4 #33): the agent couldn't resume this reopened Thread, so
+      // main minted a fresh session. Weave the honest "context reset" notice in
+      // NOW — main emits `thread:bound` before the prompt streams, so it lands
+      // after the user's prompt and before the agent's response (matching replay).
+      if (e.rebound) dispatch({ type: 'agent-rebound' })
     })
   }, [thread.threadId])
 
@@ -297,6 +303,8 @@ export function Item({
       return <ErrorRow item={item} />
     case 'fallback':
       return <FallbackRow item={item} />
+    case 'notice':
+      return <NoticeRow item={item} />
   }
 }
 
@@ -379,6 +387,17 @@ function ErrorRow({ item }: { item: ErrorItem }): JSX.Element {
     <div className="alert">
       <div className="alert__title">Turn ended</div>
       <div className="alert__message">{item.message}</div>
+    </div>
+  )
+}
+
+function NoticeRow({ item }: { item: NoticeItem }): JSX.Element {
+  return (
+    <div className="notice">
+      <span className="notice__icon" aria-hidden>
+        ↻
+      </span>
+      <span className="notice__message">{item.message}</span>
     </div>
   )
 }

--- a/src/renderer/src/conversation/reducer.test.ts
+++ b/src/renderer/src/conversation/reducer.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect } from 'vitest'
 import {
   conversationReducer,
   initialConversationState,
+  REBOUND_NOTICE,
   type AssistantItem,
   type ConversationState,
   type ErrorItem,
   type FallbackItem,
+  type NoticeItem,
   type PermissionItem,
   type ReasoningItem,
   type ToolItem,
@@ -378,5 +380,27 @@ describe('hydrate (TB5 switch-to-live seeding)', () => {
       { type: 'hydrate', state: replayed },
     )
     expect(next).toEqual(replayed)
+  })
+})
+
+/**
+ * Agent context-reset notice (TB4 #33): a failed `session/load` resume re-binds a
+ * fresh session, and the reducer weaves an honest "context reset" notice into the
+ * conversation — NOT a turn error, so the composer stays usable.
+ */
+describe('agent-rebound (TB4 context reset notice)', () => {
+  it('appends a notice item with the reset copy without disabling input', () => {
+    const start: ConversationState = {
+      ...initialConversationState,
+      items: [{ kind: 'user', id: 'u1', text: 'continue please' }],
+    }
+    const next = conversationReducer(start, { type: 'agent-rebound' })
+
+    const notice = next.items.find((i): i is NoticeItem => i.kind === 'notice')
+    expect(notice?.message).toBe(REBOUND_NOTICE)
+    // The notice follows the user's prompt and is NOT an error item.
+    expect(next.items.map((i) => i.kind)).toEqual(['user', 'notice'])
+    expect(next.isProcessing).toBe(false)
+    expect(next.items.some((i) => i.kind === 'error')).toBe(false)
   })
 })

--- a/src/renderer/src/conversation/reducer.ts
+++ b/src/renderer/src/conversation/reducer.ts
@@ -110,6 +110,17 @@ export interface FallbackItem {
   raw: unknown
 }
 
+/**
+ * A system notice woven into the conversation (TB4 #33) — currently the honest
+ * "agent context was reset" line shown after a `session/load` resume failed and
+ * main re-bound a fresh session. Not a turn error; the composer stays usable.
+ */
+export interface NoticeItem {
+  kind: 'notice'
+  id: string
+  message: string
+}
+
 export type ConversationItem =
   | UserItem
   | ReasoningItem
@@ -118,6 +129,7 @@ export type ConversationItem =
   | PermissionItem
   | ErrorItem
   | FallbackItem
+  | NoticeItem
 
 export interface ContextUsage {
   used: number
@@ -148,7 +160,17 @@ export interface ConversationState {
   fallbackSeq: number
   /** Monotonic counter for stable error item ids. */
   errorSeq: number
+  /** Monotonic counter for stable notice item ids (TB4 #33). */
+  noticeSeq: number
 }
+
+/**
+ * The user-facing "agent context reset" copy (TB4 #33). Honest per ADR-0005: the
+ * visible history above is OURS (read from JSONL) and stays; only the agent's own
+ * memory restarted, so it won't recall the earlier turns.
+ */
+export const REBOUND_NOTICE =
+  "Agent context was reset — the agent couldn't resume this thread, so it starts fresh and won't recall earlier turns. Your conversation history above is preserved."
 
 export const initialConversationState: ConversationState = {
   items: [],
@@ -159,6 +181,7 @@ export const initialConversationState: ConversationState = {
   isProcessing: false,
   fallbackSeq: 0,
   errorSeq: 0,
+  noticeSeq: 0,
 }
 
 export type ConversationAction =
@@ -168,6 +191,9 @@ export type ConversationAction =
   | { type: 'turn-error'; message: string }
   | { type: 'recover' }
   | { type: 'resolve-permission'; requestId: number | string; optionId: string; name: string }
+  // The agent's context was reset after a failed `session/load` resume (TB4 #33):
+  // append the honest "context reset" notice. Not a turn error — input stays usable.
+  | { type: 'agent-rebound' }
   // Seed a live Thread from its replayed JSONL history (TB5 #34): replace the
   // whole state, so switching INTO a Thread shows its saved conversation before
   // live events resume. The provided state is already folded (via replayTranscript).
@@ -196,6 +222,8 @@ export function conversationReducer(
       return { ...appendError(state, 'Turn ended manually — input re-enabled.'), isProcessing: false }
     case 'resolve-permission':
       return resolvePermission(state, action.requestId, action.optionId, action.name)
+    case 'agent-rebound':
+      return appendNotice(state, REBOUND_NOTICE)
     case 'acp-event':
       return reduceAcpEvent(state, action.payload)
   }
@@ -436,6 +464,11 @@ function appendFallback(state: ConversationState, update: SessionUpdate): Conver
 function appendError(state: ConversationState, message: string): ConversationState {
   const item: ErrorItem = { kind: 'error', id: `error:${state.errorSeq}`, message }
   return { ...state, items: [...state.items, item], errorSeq: state.errorSeq + 1 }
+}
+
+function appendNotice(state: ConversationState, message: string): ConversationState {
+  const item: NoticeItem = { kind: 'notice', id: `notice:${state.noticeSeq}`, message }
+  return { ...state, items: [...state.items, item], noticeSeq: state.noticeSeq + 1 }
 }
 
 function extractCommands(update: SessionUpdate): AcpCommand[] {

--- a/src/renderer/src/conversation/replay.test.ts
+++ b/src/renderer/src/conversation/replay.test.ts
@@ -3,8 +3,10 @@ import type { TranscriptEntry } from '../../../shared/ipc'
 import {
   conversationReducer,
   initialConversationState,
+  REBOUND_NOTICE,
   type AssistantItem,
   type ConversationState,
+  type NoticeItem,
   type PermissionItem,
   type ReasoningItem,
   type ToolItem,
@@ -111,6 +113,23 @@ describe('replayTranscript (TB3 #32)', () => {
       { t: 'acp-event', payload: update({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'working' }, messageId: 'a1' }) },
     ]
     expect(replayTranscript(cutOff).isProcessing).toBe(false)
+  })
+
+  it('replays an agent-rebound entry as a persisted context-reset notice (TB4 #33)', () => {
+    // A reopened Thread whose resume failed: main teed the notice right after the
+    // user prompt, before the re-bound turn's events. Reopening must show it again.
+    const transcript: TranscriptEntry[] = [
+      { t: 'user-prompt', id: 'user:0', text: 'continue please' },
+      { t: 'agent-rebound' },
+      { t: 'acp-event', payload: update({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'Fresh start.' }, messageId: 'a1' }) },
+      { t: 'turn-complete' },
+    ]
+
+    const replayed = replayTranscript(transcript)
+    expect(replayed.items.map((i) => i.kind)).toEqual(['user', 'notice', 'assistant'])
+    const notice = replayed.items.find((i): i is NoticeItem => i.kind === 'notice')
+    expect(notice?.message).toBe(REBOUND_NOTICE)
+    expect(replayed.isProcessing).toBe(false)
   })
 
   it('replays an empty transcript to the initial (empty) conversation, never throwing', () => {

--- a/src/renderer/src/conversation/replay.ts
+++ b/src/renderer/src/conversation/replay.ts
@@ -41,6 +41,8 @@ function toAction(entry: TranscriptEntry, state: ConversationState): Conversatio
       return { type: 'turn-complete' }
     case 'turn-error':
       return { type: 'turn-error', message: entry.message }
+    case 'agent-rebound':
+      return { type: 'agent-rebound' }
     case 'resolve-permission':
       return {
         type: 'resolve-permission',

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -468,6 +468,29 @@ body {
   font-weight: 600;
 }
 
+/* Agent context-reset notice (TB4 #33): woven into the conversation, not an error. */
+.notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--accent-tint);
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--muted);
+}
+
+.notice__icon {
+  color: var(--accent-text);
+  font-weight: 600;
+}
+
+.notice__message {
+  flex: 1;
+}
+
 .usage {
   display: flex;
   gap: 16px;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -117,6 +117,15 @@ export interface ThreadInfo {
 export interface StartThreadArgs {
   /** Absolute path to the Workspace the agent should operate in. */
   workspaceDir: string
+  /**
+   * Continue an existing persisted Thread from the cold launch list (TB4 #33).
+   * When set, `startThread` spawns + starts the agent and records the Workspace as
+   * usual, but opens NO new Thread (no `session/new`, no extra record) — it seeds
+   * the connection with THIS Thread's stored `sessionId` cursor instead, so the
+   * first prompt drives the lazy `session/load` resume. Falls back to opening a
+   * fresh Thread when the record can't be found (degraded / no store).
+   */
+  continueThreadId?: string
 }
 
 /** Open a Thread on an agent already started + signed in (after sign-in / re-auth). */
@@ -126,7 +135,13 @@ export interface OpenThreadArgs {
 }
 
 /** A Thread plus the Workspace agent that hosts it. */
-export interface ThreadConnection extends ThreadInfo {
+export interface ThreadConnection extends Omit<ThreadInfo, 'sessionId'> {
+  /**
+   * The bound ACP session, or `null` for a continued/draft Thread whose session
+   * binds lazily on first prompt (TB4 #33): a continue-start seeds this from the
+   * stored cursor (which may be null for a never-prompted draft).
+   */
+  sessionId: string | null
   /** Id of the Workspace agent (one `vibe-acp` process) in main. */
   agentId: string
   workspaceDir: string

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -164,6 +164,12 @@ export interface AcpEvent {
 export interface ThreadBoundEvent {
   threadId: string
   sessionId: string
+  /**
+   * True when this binding RE-bound a reopened Thread to a fresh `session/new`
+   * after a `session/load` resume failed (TB4 #33). The renderer renders a
+   * one-time "agent context reset" notice; absent/false on a normal draft mint.
+   */
+  rebound?: boolean
 }
 
 /** Token usage for a completed turn (`session/prompt` response). */
@@ -323,6 +329,11 @@ export type TranscriptEntry =
   | { t: 'turn-complete' }
   | { t: 'turn-error'; message: string }
   | { t: 'resolve-permission'; requestId: number | string; optionId: string; name: string | null }
+  // The agent's context was reset on a reopen (TB4 #33): a `session/load` resume
+  // failed, so main re-bound the SAME Thread to a fresh `session/new`. Teed so the
+  // "context reset" notice persists in history across a later reopen. The copy is
+  // a renderer-side constant, so the entry carries no payload.
+  | { t: 'agent-rebound' }
 
 /** The `readTranscript` reply: a Thread's transcript entries (empty when none). */
 export type ReadTranscriptResult = TranscriptEntry[]


### PR DESCRIPTION
## What this is

TB4 (closes #33) — the LAST slice of the persistence epic (PRD #27, ADR-0005). A reopened cold Thread carries a stored ACP `sessionId` and already renders its history from our own JSONL (TB3). This makes its **first prompt resume Vibe's agent context** via `session/load`, and **re-bind to a fresh session on resume failure** (keeping the visible history). Built on the live protocol truth captured by the #29 spike (`docs/acp-capture.md §9`).

## Behavior

- **Resume:** first prompt in a reopened Thread `session/load`s the stored `sessionId` (gated on advertised `agentCapabilities.loadSession`), then prompts on the resumed session.
- **Re-bind (ADR-0005 (b)):** on a `session/load` failure (the captured `-32602` "Session not found", and any non-auth failure — fail-safe), mint a fresh `session/new` under the SAME Thread id, update the stored cursor, and persist a user-visible **"agent context reset"** notice — history and composer preserved. A `-32000` auth expiry routes to sign-in instead.
- **No double history:** the `session/update` notifications Vibe replays *during* `session/load` are SUPPRESSED (we already own that history in our JSONL) — dropped before teeing/forwarding, per-session, cleared the instant the load settles.
- **Three binding cases** in `ensureBoundSession`: (i) draft → `session/new`; (ii) reopened, not hosted → `session/load`/re-bind; (iii) already hosted → reuse. TB5 draft behavior preserved.
- **Cold launch list "Continue"** spawns the agent but opens NO throwaway Thread — the connection lands directly on the continued Thread (read-only `resolveContinueTarget`, no new session/record).
- `ColdThread`'s "coming soon" hint is now a real **Continue** button.

## Review

Implemented via the team loop: independent verification + an adversarial review (no MUST-FIX; suppression / resumed-event routing / rebind-cursor persistence all verified correct). Folded 3 review fixes: the stray-empty-Thread wart (FIX 1), a reconnect-path id leak (FIX 2, moot after FIX 1), and a defensive suppression hardening (FIX 3).

## Gates

`lint` ✓ · `typecheck` ✓ · `build` ✓ · `test` ✓ — **174 tests** (16 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)