### PR TITLE
TB1 (#46): persistent two-pane app shell + pure nav reducer

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,10 +1,9 @@
-import { useEffect, useReducer, useRef, useState, type JSX } from 'react'
+import { useEffect, useReducer, useRef, useState, type JSX, type ReactNode } from 'react'
 import type {
   AuthMethod,
   ListMetadataResult,
   ThreadMeta,
   VibeDetectResult,
-  WorkspaceThreads,
 } from '../../shared/ipc'
 import {
   authReducer,
@@ -14,8 +13,19 @@ import {
 } from './auth/auth-view'
 import { routeThreadResult, type ConnectState } from './connection/routing'
 import { ConnectedWorkspace } from './connection/ConnectedWorkspace'
-import { ColdThread } from './conversation/ColdThread'
+import { Shell } from './shell/Shell'
 
+/**
+ * Thin glue (ADR-0006): App owns IPC/data wiring — detection, the persisted
+ * Workspace/Thread metadata, and the connect flow — and renders the persistent
+ * `<Shell>`. The shell owns navigation (its pure nav reducer) and the two-pane
+ * layout; App feeds it the cold list, the sidebar's top controls, and the
+ * connection-active outlet, plus the connect-flow callbacks.
+ *
+ * Connection/auth states (connecting / not-signed-in / error / connected) still
+ * route as before, but now INTO the outlet (`connectionOutlet`) rather than
+ * swapping the whole view — the sidebar stays put. TB4 (#49) moves these inline.
+ */
 export function App(): JSX.Element {
   const [detect, setDetect] = useState<VibeDetectResult | null>(null)
   const [loading, setLoading] = useState(true)
@@ -23,9 +33,6 @@ export function App(): JSX.Element {
   // Persisted Workspaces + Threads (ADR-0005), listed cold on launch from
   // metadata alone — no agent spawned, no transcript loaded.
   const [recents, setRecents] = useState<ListMetadataResult>([])
-  // A persisted Thread the user clicked to REOPEN read-only from its JSONL (TB3,
-  // #32) — rendered with no agent spawned. null = showing the cold launch list.
-  const [coldThread, setColdThread] = useState<ThreadMeta | null>(null)
 
   async function runDetect(): Promise<void> {
     setLoading(true)
@@ -41,12 +48,11 @@ export function App(): JSX.Element {
   /**
    * Delete a persisted Thread (TB6): main removes its metadata + JSONL and
    * best-effort closes any live session; we then re-fetch so it disappears from
-   * the list. If the deleted Thread is the one open read-only, drop back to the
-   * list so we don't render a now-gone transcript.
+   * the list. The shell derives its selected (cold) Thread from `recents`, so a
+   * deleted-and-selected Thread collapses to the placeholder on its own.
    */
   async function deleteThread(thread: ThreadMeta): Promise<void> {
     await window.api.deleteThread(thread.id)
-    setColdThread((open) => (open?.id === thread.id ? null : open))
     await refreshRecents()
   }
 
@@ -72,19 +78,17 @@ export function App(): JSX.Element {
   }
 
   /**
-   * Continue a reopened Thread from the cold launch list (TB4 #33). No agent runs
-   * for a cold-list Thread, so we spawn its Workspace agent via `startThread`,
+   * Continue a reopened Thread from the sidebar's cold list (TB4 #33). No agent
+   * runs for a cold-list Thread, so we spawn its Workspace agent via `startThread`,
    * passing `continueThreadId` so main opens NO extra Thread and instead seeds the
-   * connection with THIS Thread (its first prompt drives the `session/load` resume).
-   * The connection thread IS the continued one, so it lands selected + live with no
-   * separate plumbing. The Workspace dir comes from the cold list (a `ThreadMeta`
-   * carries only `workspaceId`). If the agent comes up not-signed-in, no Thread is
-   * opened (the standard not-signed-in result) and the continue can be re-driven.
+   * connection with THIS Thread (its first prompt drives the `session/load`
+   * resume). The connection thread IS the continued one, so it lands selected +
+   * live with no separate plumbing. The Workspace dir comes from the cold list (a
+   * `ThreadMeta` carries only `workspaceId`).
    */
   async function continueColdThread(thread: ThreadMeta): Promise<void> {
     const workspace = recents.find((w) => w.id === thread.workspaceId)
     if (!workspace) return
-    setColdThread(null)
     setConnect({ status: 'connecting', workspaceDir: workspace.dir })
     setConnect(
       routeThreadResult(
@@ -101,6 +105,16 @@ export function App(): JSX.Element {
 
   const connecting = connect.status === 'connecting'
 
+  // The sidebar's pinned top: the environment check + the Open-project control.
+  const sidebarTop = (
+    <div className="shell__top">
+      <Environment detect={detect} loading={loading} onRecheck={() => void runDetect()} />
+      <button className="btn shell__open" onClick={() => void openProject()} disabled={connecting}>
+        {connecting ? 'Connecting…' : 'Open project'}
+      </button>
+    </div>
+  )
+
   return (
     <div className="app">
       <header className="app__header">
@@ -108,111 +122,124 @@ export function App(): JSX.Element {
         <span className="app__subtitle">Orchestrator for Mistral Vibe agents · ACP backend</span>
       </header>
 
-      <main className="app__main">
-        <section className="card">
-          <div className="card__title">
-            <span>Environment</span>
-            <button className="btn" onClick={() => void runDetect()} disabled={loading}>
-              {loading ? 'Checking…' : 'Re-check'}
-            </button>
-          </div>
+      <Shell
+        workspaces={recents}
+        sidebarTop={sidebarTop}
+        connectionOutlet={renderConnectionOutlet(connect, {
+          continueToThread,
+          toSignInPanel,
+          refreshRecents,
+          threads: connect.status === 'connected' ? threadsForWorkspace(recents, connect.thread.workspaceId) : [],
+        })}
+        onContinueColdThread={(thread) => void continueColdThread(thread)}
+        onDeleteThread={deleteThread}
+      />
+    </div>
+  )
+}
 
-          {detect && (
-            <ul className="status">
-              <StatusRow ok={detect.vibeFound} label="vibe CLI" />
-              <StatusRow ok={detect.vibeAcpFound} label="vibe-acp (ACP server)" />
-              <li className="status__row">
-                <span className="status__label">version</span>
-                <span className="status__value">{detect.vibeVersion ?? '—'}</span>
-              </li>
-              {detect.error && <li className="status__error">{detect.error}</li>}
-            </ul>
-          )}
-        </section>
+/**
+ * The connection-active outlet (everything but `idle`). Routed exactly as before,
+ * now rendered INTO the shell outlet rather than swapping the whole view — the
+ * sidebar persists across it. `null` on `idle` hands the outlet back to the shell's
+ * nav-selected cold Thread (or placeholder). TB4 (#49) folds these inline.
+ */
+function renderConnectionOutlet(
+  connect: ConnectState,
+  handlers: {
+    continueToThread: (agentId: string, workspaceDir: string) => void
+    toSignInPanel: (agentId: string, workspaceDir: string, authMethods: AuthMethod[]) => void
+    refreshRecents: () => Promise<void>
+    threads: ThreadMeta[]
+  },
+): ReactNode | null {
+  switch (connect.status) {
+    case 'idle':
+      return null
+    case 'connecting':
+      return (
+        <p className="hint">
+          Launching <code>vibe-acp</code> in <code>{connect.workspaceDir}</code> and running the ACP
+          handshake…
+        </p>
+      )
+    case 'not-signed-in':
+      return (
+        <SignInPanel
+          key={connect.agentId}
+          agentId={connect.agentId}
+          authMethods={connect.authMethods}
+          onSignedIn={() => handlers.continueToThread(connect.agentId, connect.workspaceDir)}
+        />
+      )
+    case 'error':
+      return (
+        <div className="alert">
+          <div className="alert__title">Couldn’t connect</div>
+          <div className="alert__message">{connect.message}</div>
+          {connect.hint && <div className="alert__hint">{connect.hint}</div>}
+        </div>
+      )
+    case 'connected':
+      return (
+        <>
+          {/* Key by agentId (like Conversation) so its useReducer seed resets
+              across connections — a new agent can't inherit the prior session's
+              sign-out gate. */}
+          <SignedInBar
+            key={connect.thread.agentId}
+            agentId={connect.thread.agentId}
+            authMethods={connect.thread.authMethods}
+            signOutAvailable={connect.thread.signOutAvailable}
+            onSignedOut={(authMethods) =>
+              handlers.toSignInPanel(connect.thread.agentId, connect.thread.workspaceDir, authMethods)
+            }
+          />
+          {/* Key by agentId so the per-Workspace Thread state can't bleed across
+              connections. Hosts multiple Threads on the one agent + switching (TB5). */}
+          <ConnectedWorkspace
+            key={connect.thread.agentId}
+            connection={connect.thread}
+            threads={handlers.threads}
+            refreshRecents={handlers.refreshRecents}
+            onAuthExpired={(authMethods) =>
+              handlers.toSignInPanel(connect.thread.agentId, connect.thread.workspaceDir, authMethods)
+            }
+          />
+        </>
+      )
+  }
+}
 
-        <section className="card">
-          <div className="card__title">
-            <span>Workspace</span>
-            <button className="btn" onClick={() => void openProject()} disabled={connecting}>
-              {connecting ? 'Connecting…' : 'Open project'}
-            </button>
-          </div>
-
-          {/* Reopened Thread: render its saved conversation from JSONL, read-only,
-              with NO agent spawned (TB3). Takes over the idle view until closed. */}
-          {connect.status === 'idle' && coldThread && (
-            <ColdThread
-              thread={coldThread}
-              onClose={() => setColdThread(null)}
-              onContinue={() => void continueColdThread(coldThread)}
-            />
-          )}
-
-          {connect.status === 'idle' && !coldThread && (
-            <p className="hint">Open a project folder to start a Vibe agent and connect a Thread.</p>
-          )}
-
-          {connect.status === 'idle' && !coldThread && recents.length > 0 && (
-            <RecentList
-              workspaces={recents}
-              onOpenThread={setColdThread}
-              onDeleteThread={deleteThread}
-            />
-          )}
-
-          {connect.status === 'connecting' && (
-            <p className="hint">
-              Launching <code>vibe-acp</code> in <code>{connect.workspaceDir}</code> and running the
-              ACP handshake…
-            </p>
-          )}
-
-          {connect.status === 'not-signed-in' && (
-            <SignInPanel
-              key={connect.agentId}
-              agentId={connect.agentId}
-              authMethods={connect.authMethods}
-              onSignedIn={() => void continueToThread(connect.agentId, connect.workspaceDir)}
-            />
-          )}
-
-          {connect.status === 'error' && (
-            <div className="alert">
-              <div className="alert__title">Couldn’t connect</div>
-              <div className="alert__message">{connect.message}</div>
-              {connect.hint && <div className="alert__hint">{connect.hint}</div>}
-            </div>
-          )}
-
-          {connect.status === 'connected' && (
-            <>
-              {/* Key by agentId (like Conversation) so its useReducer seed resets
-                  across connections — a new agent can't inherit the prior
-                  session's sign-out gate. */}
-              <SignedInBar
-                key={connect.thread.agentId}
-                agentId={connect.thread.agentId}
-                authMethods={connect.thread.authMethods}
-                signOutAvailable={connect.thread.signOutAvailable}
-                onSignedOut={(authMethods) =>
-                  toSignInPanel(connect.thread.agentId, connect.thread.workspaceDir, authMethods)
-                }
-              />
-              {/* Key by agentId so the per-Workspace Thread state can't bleed across
-                  connections. Hosts multiple Threads on the one agent + switching (TB5). */}
-              <ConnectedWorkspace
-                key={connect.thread.agentId}
-                connection={connect.thread}
-                threads={threadsForWorkspace(recents, connect.thread.workspaceId)}
-                refreshRecents={refreshRecents}
-                onAuthExpired={(authMethods) =>
-                  toSignInPanel(connect.thread.agentId, connect.thread.workspaceDir, authMethods)
-                }
-              />
-            </>
-          )}
-        </section>
-      </main>
+/** The environment check: whether `vibe` / `vibe-acp` are installed + reachable. */
+function Environment({
+  detect,
+  loading,
+  onRecheck,
+}: {
+  detect: VibeDetectResult | null
+  loading: boolean
+  onRecheck: () => void
+}): JSX.Element {
+  return (
+    <div className="env">
+      <div className="env__title">
+        <span>Environment</span>
+        <button className="btn btn--ghost" onClick={onRecheck} disabled={loading}>
+          {loading ? 'Checking…' : 'Re-check'}
+        </button>
+      </div>
+      {detect && (
+        <ul className="status">
+          <StatusRow ok={detect.vibeFound} label="vibe CLI" />
+          <StatusRow ok={detect.vibeAcpFound} label="vibe-acp (ACP server)" />
+          <li className="status__row">
+            <span className="status__label">version</span>
+            <span className="status__value">{detect.vibeVersion ?? '—'}</span>
+          </li>
+          {detect.error && <li className="status__error">{detect.error}</li>}
+        </ul>
+      )}
     </div>
   )
 }
@@ -365,107 +392,6 @@ function SignedInBar({
       )}
     </div>
   )
-}
-
-/**
- * The cold launch list (ADR-0005 metadata-first lazy reopen): persisted
- * Workspaces with their Threads, most-recent-first, rendered from metadata alone —
- * NO `vibe-acp` spawned. Clicking a Thread reopens it read-only from its JSONL
- * (`onOpenThread`, TB3) — still no agent; that replays the transcript locally.
- */
-function RecentList({
-  workspaces,
-  onOpenThread,
-  onDeleteThread,
-}: {
-  workspaces: WorkspaceThreads[]
-  onOpenThread: (thread: ThreadMeta) => void
-  /** Delete a Thread (TB6) — removes its metadata + JSONL, then refreshes the list. */
-  onDeleteThread: (thread: ThreadMeta) => Promise<void>
-}): JSX.Element {
-  return (
-    <div className="recents">
-      <div className="recents__title">Recent workspaces</div>
-      <ul className="recents__list">
-        {workspaces.map((w) => (
-          <li key={w.id} className="recents__workspace">
-            <div className="recents__ws-name" title={w.dir}>
-              {w.displayName}
-            </div>
-            {w.threads.length > 0 ? (
-              <ul className="recents__threads">
-                {w.threads.map((t) => (
-                  <RecentThread
-                    key={t.id}
-                    thread={t}
-                    onOpen={onOpenThread}
-                    onDelete={onDeleteThread}
-                  />
-                ))}
-              </ul>
-            ) : (
-              <div className="recents__empty">No threads yet</div>
-            )}
-          </li>
-        ))}
-      </ul>
-    </div>
-  )
-}
-
-/**
- * One Thread row in the cold list: opens read-only on click (TB3), with a delete
- * control (TB6). Delete is two-step — a first click arms an INLINE confirm (Delete
- * / Cancel) rather than a native `confirm()` (which would block the renderer), so
- * a single misclick can't nuke a Thread's history.
- */
-function RecentThread({
-  thread,
-  onOpen,
-  onDelete,
-}: {
-  thread: ThreadMeta
-  onOpen: (thread: ThreadMeta) => void
-  onDelete: (thread: ThreadMeta) => Promise<void>
-}): JSX.Element {
-  const [confirming, setConfirming] = useState(false)
-  return (
-    <li className="recents__thread">
-      <button className="recents__thread-btn" onClick={() => onOpen(thread)}>
-        {threadLabel(thread)}
-      </button>
-      {confirming ? (
-        <span className="recents__thread-confirm">
-          <button
-            className="btn btn--ghost btn--danger"
-            onClick={() => {
-              setConfirming(false)
-              void onDelete(thread)
-            }}
-          >
-            Delete
-          </button>
-          <button className="btn btn--ghost" onClick={() => setConfirming(false)}>
-            Cancel
-          </button>
-        </span>
-      ) : (
-        <button
-          className="recents__thread-delete"
-          aria-label="Delete thread"
-          title="Delete thread"
-          onClick={() => setConfirming(true)}
-        >
-          ✕
-        </button>
-      )}
-    </li>
-  )
-}
-
-/** A Thread's list label — its title, or a placeholder until one arrives (TB2). */
-function threadLabel(thread: ThreadMeta): string {
-  return thread.title ?? 'Untitled thread'
 }
 
 /** The persisted Threads under a connected Workspace (by minted id), for its list (TB5). */

--- a/src/renderer/src/shell/Shell.tsx
+++ b/src/renderer/src/shell/Shell.tsx
@@ -40,6 +40,14 @@ export function Shell({
 }): JSX.Element {
   const [nav, dispatch] = useReducer(navReducer, initialNavState)
   const selectedThread = findSelectedThread(workspaces, nav)
+  // Offer delete only while NO connection is active (`connectionOutlet` null). The
+  // always-mounted sidebar would otherwise expose delete DURING a live connection,
+  // letting a user remove the Thread the agent is hosting out from under it —
+  // orphaning the live conversation, whose next prompt would write a deleted/
+  // recreated JSONL. On `origin/main` delete lived in the idle-gated cold list and
+  // was structurally impossible while connected; we preserve that invariant. Safe
+  // live-list delete (with teardown) is TB2/TB3 (#47/#48).
+  const deletable = connectionOutlet === null
 
   return (
     <div className="shell">
@@ -48,6 +56,7 @@ export function Shell({
         <WorkspaceNav
           workspaces={workspaces}
           nav={nav}
+          deletable={deletable}
           onSelectWorkspace={(workspaceId) => dispatch({ type: 'select-workspace', workspaceId })}
           onSelectThread={(workspaceId, threadId) =>
             dispatch({ type: 'select-thread', workspaceId, threadId })
@@ -88,12 +97,15 @@ export function Shell({
 function WorkspaceNav({
   workspaces,
   nav,
+  deletable,
   onSelectWorkspace,
   onSelectThread,
   onDeleteThread,
 }: {
   workspaces: ListMetadataResult
   nav: NavState
+  /** Whether per-row delete is offered (false while a connection is active). */
+  deletable: boolean
   onSelectWorkspace: (workspaceId: string) => void
   onSelectThread: (workspaceId: string, threadId: string) => void
   onDeleteThread: (thread: ThreadMeta) => Promise<void>
@@ -125,6 +137,7 @@ function WorkspaceNav({
                     key={t.id}
                     thread={t}
                     selected={t.id === nav.selectedThreadId}
+                    deletable={deletable}
                     onOpen={() => onSelectThread(w.id, t.id)}
                     onDelete={onDeleteThread}
                   />
@@ -142,19 +155,22 @@ function WorkspaceNav({
 
 /**
  * One Thread row in the sidebar: selecting it on click (the outlet reopens it
- * read-only — TB3), highlighted when selected, with a delete control (TB6). Delete
- * is two-step — a first click arms an INLINE confirm (Delete / Cancel) rather than
- * a native `confirm()` (which would block the renderer), so a single misclick can't
- * nuke a Thread's history.
+ * read-only — TB3), highlighted when selected, with a delete control (TB6) shown
+ * only when `deletable` (i.e. no live connection — see Shell). Delete is two-step —
+ * a first click arms an INLINE confirm (Delete / Cancel) rather than a native
+ * `confirm()` (which would block the renderer), so a single misclick can't nuke a
+ * Thread's history.
  */
 function NavThread({
   thread,
   selected,
+  deletable,
   onOpen,
   onDelete,
 }: {
   thread: ThreadMeta
   selected: boolean
+  deletable: boolean
   onOpen: () => void
   onDelete: (thread: ThreadMeta) => Promise<void>
 }): JSX.Element {
@@ -167,7 +183,7 @@ function NavThread({
       >
         {threadLabel(thread)}
       </button>
-      {confirming ? (
+      {!deletable ? null : confirming ? (
         <span className="recents__thread-confirm">
           <button
             className="btn btn--ghost btn--danger"

--- a/src/renderer/src/shell/Shell.tsx
+++ b/src/renderer/src/shell/Shell.tsx
@@ -1,0 +1,202 @@
+import { useReducer, useState, type JSX, type ReactNode } from 'react'
+import type { ListMetadataResult, ThreadMeta } from '../../../shared/ipc'
+import { ColdThread } from '../conversation/ColdThread'
+import { findSelectedThread, initialNavState, navReducer, type NavState } from './nav-reducer'
+
+/**
+ * The persistent two-pane app shell (ADR-0006 decision 1): a left sidebar that
+ * stays mounted and a right conversation OUTLET whose content swaps. Selection is
+ * a pure nav reducer at this root (decision 2) — no router, no UI store.
+ *
+ * The sidebar lists the persisted Workspaces + Threads (cold metadata) and is the
+ * always-there navigation surface. The outlet shows EITHER the connection-active
+ * view App routes in (`connectionOutlet` — connecting / sign-in / error / the live
+ * `ConnectedWorkspace`; TB4 #49 moves these inline), OR, on the idle path, the
+ * nav-selected cold Thread replayed read-only (`ColdThread`). Both render INTO the
+ * same outlet element while the sidebar element is fixed, so navigating never
+ * unmounts the sidebar — that's the whole point of the shell.
+ *
+ * The warm-agent pool (decision 3) and a unified live/cold Thread list are TB2
+ * (#47); here the sidebar is the cold list and live Threads surface only inside
+ * the `connectionOutlet`.
+ */
+export function Shell({
+  workspaces,
+  sidebarTop,
+  connectionOutlet,
+  onContinueColdThread,
+  onDeleteThread,
+}: {
+  /** Persisted Workspaces + Threads for the sidebar list (cold metadata). */
+  workspaces: ListMetadataResult
+  /** App-owned controls pinned above the list (Open project + environment status). */
+  sidebarTop: ReactNode
+  /** The connection-active outlet (non-idle connect states), or null on the idle path. */
+  connectionOutlet: ReactNode | null
+  /** Continue a selected cold Thread live (TB4 #33) — App drives the connect flow. */
+  onContinueColdThread: (thread: ThreadMeta) => void
+  /** Delete a Thread (TB6) — removes its metadata + JSONL, then refreshes the list. */
+  onDeleteThread: (thread: ThreadMeta) => Promise<void>
+}): JSX.Element {
+  const [nav, dispatch] = useReducer(navReducer, initialNavState)
+  const selectedThread = findSelectedThread(workspaces, nav)
+
+  return (
+    <div className="shell">
+      <aside className="shell__sidebar">
+        {sidebarTop}
+        <WorkspaceNav
+          workspaces={workspaces}
+          nav={nav}
+          onSelectWorkspace={(workspaceId) => dispatch({ type: 'select-workspace', workspaceId })}
+          onSelectThread={(workspaceId, threadId) =>
+            dispatch({ type: 'select-thread', workspaceId, threadId })
+          }
+          onDeleteThread={onDeleteThread}
+        />
+      </aside>
+
+      <main className="shell__outlet">
+        {connectionOutlet ??
+          (selectedThread ? (
+            // Idle path: reopen the selected Thread read-only from its JSONL (TB3),
+            // with a Continue affordance that hands back to App's connect flow (TB4).
+            <ColdThread
+              key={selectedThread.id}
+              thread={selectedThread}
+              onClose={() => dispatch({ type: 'clear' })}
+              onContinue={() => onContinueColdThread(selectedThread)}
+            />
+          ) : (
+            <div className="shell__empty">
+              <p className="hint">
+                Select a thread from the sidebar to view it, or open a project to start a live agent.
+              </p>
+            </div>
+          ))}
+      </main>
+    </div>
+  )
+}
+
+/**
+ * The sidebar's navigation list: persisted Workspaces with their Threads, most-
+ * recent-first, rendered from cold metadata alone — NO `vibe-acp` spawned. The
+ * selected Workspace / Thread are highlighted; clicking a Thread selects it (the
+ * outlet then reopens it read-only). Delete (TB6) is preserved per row.
+ */
+function WorkspaceNav({
+  workspaces,
+  nav,
+  onSelectWorkspace,
+  onSelectThread,
+  onDeleteThread,
+}: {
+  workspaces: ListMetadataResult
+  nav: NavState
+  onSelectWorkspace: (workspaceId: string) => void
+  onSelectThread: (workspaceId: string, threadId: string) => void
+  onDeleteThread: (thread: ThreadMeta) => Promise<void>
+}): JSX.Element {
+  if (workspaces.length === 0) {
+    return <p className="hint">No workspaces yet. Open a project to begin.</p>
+  }
+  return (
+    <nav className="recents">
+      <div className="recents__title">Workspaces</div>
+      <ul className="recents__list">
+        {workspaces.map((w) => (
+          <li key={w.id} className="recents__workspace">
+            <button
+              className={
+                w.id === nav.selectedWorkspaceId
+                  ? 'recents__ws-name recents__ws-name--active'
+                  : 'recents__ws-name'
+              }
+              title={w.dir}
+              onClick={() => onSelectWorkspace(w.id)}
+            >
+              {w.displayName}
+            </button>
+            {w.threads.length > 0 ? (
+              <ul className="recents__threads">
+                {w.threads.map((t) => (
+                  <NavThread
+                    key={t.id}
+                    thread={t}
+                    selected={t.id === nav.selectedThreadId}
+                    onOpen={() => onSelectThread(w.id, t.id)}
+                    onDelete={onDeleteThread}
+                  />
+                ))}
+              </ul>
+            ) : (
+              <div className="recents__empty">No threads yet</div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}
+
+/**
+ * One Thread row in the sidebar: selecting it on click (the outlet reopens it
+ * read-only — TB3), highlighted when selected, with a delete control (TB6). Delete
+ * is two-step — a first click arms an INLINE confirm (Delete / Cancel) rather than
+ * a native `confirm()` (which would block the renderer), so a single misclick can't
+ * nuke a Thread's history.
+ */
+function NavThread({
+  thread,
+  selected,
+  onOpen,
+  onDelete,
+}: {
+  thread: ThreadMeta
+  selected: boolean
+  onOpen: () => void
+  onDelete: (thread: ThreadMeta) => Promise<void>
+}): JSX.Element {
+  const [confirming, setConfirming] = useState(false)
+  return (
+    <li className="recents__thread">
+      <button
+        className={selected ? 'recents__thread-btn recents__thread-btn--active' : 'recents__thread-btn'}
+        onClick={onOpen}
+      >
+        {threadLabel(thread)}
+      </button>
+      {confirming ? (
+        <span className="recents__thread-confirm">
+          <button
+            className="btn btn--ghost btn--danger"
+            onClick={() => {
+              setConfirming(false)
+              void onDelete(thread)
+            }}
+          >
+            Delete
+          </button>
+          <button className="btn btn--ghost" onClick={() => setConfirming(false)}>
+            Cancel
+          </button>
+        </span>
+      ) : (
+        <button
+          className="recents__thread-delete"
+          aria-label="Delete thread"
+          title="Delete thread"
+          onClick={() => setConfirming(true)}
+        >
+          ✕
+        </button>
+      )}
+    </li>
+  )
+}
+
+/** A Thread's list label — its title, or a placeholder until one arrives. */
+function threadLabel(thread: ThreadMeta): string {
+  return thread.title ?? 'Untitled thread'
+}

--- a/src/renderer/src/shell/nav-reducer.test.ts
+++ b/src/renderer/src/shell/nav-reducer.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { findSelectedThread, initialNavState, navReducer, type NavState } from './nav-reducer'
+import type { ListMetadataResult, ThreadMeta } from '../../../shared/ipc'
+
+/**
+ * Shell navigation (ADR-0006 decision 2). A pure reducer holding WHICH Workspace
+ * and Thread the user is looking at — decoupled from connection lifecycle and
+ * mirroring conversation/reducer.ts (no React, no IPC, no router). The invariant
+ * under test: a selected Thread always belongs to the selected Workspace.
+ */
+
+function thread(id: string, workspaceId: string): ThreadMeta {
+  return { id, workspaceId, sessionId: null, title: null, createdAt: 1, lastActiveAt: 1 }
+}
+
+describe('navReducer', () => {
+  it('starts with nothing selected', () => {
+    expect(initialNavState).toEqual({ selectedWorkspaceId: null, selectedThreadId: null })
+  })
+
+  it('select-thread pins both the Thread and its Workspace', () => {
+    const next = navReducer(initialNavState, { type: 'select-thread', workspaceId: 'w1', threadId: 't1' })
+    expect(next).toEqual({ selectedWorkspaceId: 'w1', selectedThreadId: 't1' })
+  })
+
+  it('switching to a different Workspace drops the now-foreign Thread selection', () => {
+    const start: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 't1' }
+    const next = navReducer(start, { type: 'select-workspace', workspaceId: 'w2' })
+    expect(next).toEqual({ selectedWorkspaceId: 'w2', selectedThreadId: null })
+  })
+
+  it('re-selecting the same Workspace is a no-op (keeps the Thread selection)', () => {
+    const start: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 't1' }
+    const next = navReducer(start, { type: 'select-workspace', workspaceId: 'w1' })
+    expect(next).toBe(start) // same reference: no spurious re-render or cleared Thread
+  })
+
+  it('clear resets to nothing selected', () => {
+    const start: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 't1' }
+    expect(navReducer(start, { type: 'clear' })).toEqual(initialNavState)
+  })
+})
+
+describe('findSelectedThread (cold-outlet derivation)', () => {
+  const workspaces: ListMetadataResult = [
+    { id: 'w1', dir: '/a', displayName: 'A', lastOpenedAt: 2, threads: [thread('t1', 'w1'), thread('t2', 'w1')] },
+    { id: 'w2', dir: '/b', displayName: 'B', lastOpenedAt: 1, threads: [thread('t3', 'w2')] },
+  ]
+
+  it('resolves the selected Thread to its cold metadata', () => {
+    const state: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 't2' }
+    expect(findSelectedThread(workspaces, state)?.id).toBe('t2')
+  })
+
+  it('returns null when no Thread is selected', () => {
+    expect(findSelectedThread(workspaces, { selectedWorkspaceId: 'w1', selectedThreadId: null })).toBeNull()
+  })
+
+  it('returns null when the selected Thread no longer exists (e.g. after a delete refreshed the list)', () => {
+    const state: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 'gone' }
+    expect(findSelectedThread(workspaces, state)).toBeNull()
+  })
+
+  it('scopes the lookup to the selected Workspace (a Thread id under another Workspace is not matched)', () => {
+    const state: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 't3' }
+    expect(findSelectedThread(workspaces, state)).toBeNull()
+  })
+})

--- a/src/renderer/src/shell/nav-reducer.ts
+++ b/src/renderer/src/shell/nav-reducer.ts
@@ -1,0 +1,58 @@
+import type { ListMetadataResult, ThreadMeta } from '../../../shared/ipc'
+
+/**
+ * Shell navigation state (ADR-0006 decision 2): WHICH Workspace and Thread the
+ * user is looking at — decoupled from connection lifecycle (whether that
+ * Workspace's agent is spawned / signed in). A pure reducer at the shell root,
+ * mirroring conversation/reducer.ts (ADR-0001): no router, no UI-store library.
+ *
+ * Invariant: a selected Thread always belongs to the selected Workspace — every
+ * `select-thread` carries its `workspaceId`, and switching Workspace drops a
+ * Thread selection that no longer belongs.
+ */
+export interface NavState {
+  selectedWorkspaceId: string | null
+  selectedThreadId: string | null
+}
+
+export type NavAction =
+  | { type: 'select-workspace'; workspaceId: string }
+  | { type: 'select-thread'; workspaceId: string; threadId: string }
+  | { type: 'clear' }
+
+export const initialNavState: NavState = {
+  selectedWorkspaceId: null,
+  selectedThreadId: null,
+}
+
+export function navReducer(state: NavState, action: NavAction): NavState {
+  switch (action.type) {
+    case 'select-workspace':
+      // Re-selecting the SAME Workspace is a no-op (keeps any Thread selection);
+      // switching to a different one drops the now-foreign Thread selection so the
+      // two can never disagree.
+      if (state.selectedWorkspaceId === action.workspaceId) return state
+      return { selectedWorkspaceId: action.workspaceId, selectedThreadId: null }
+    case 'select-thread':
+      // Selecting a Thread pins its Workspace too, so the two never disagree.
+      return { selectedWorkspaceId: action.workspaceId, selectedThreadId: action.threadId }
+    case 'clear':
+      return initialNavState
+  }
+}
+
+/**
+ * The selected Thread's cold metadata, or null when nothing is selected or the
+ * selection no longer exists (e.g. after a delete refreshed the list). The idle
+ * outlet reopens this Thread read-only (ColdThread); a null collapses to the
+ * placeholder, so a deleted/absent selection never renders a gone transcript. The
+ * lookup is scoped to the selected Workspace, upholding the reducer's invariant.
+ */
+export function findSelectedThread(
+  workspaces: ListMetadataResult,
+  state: NavState,
+): ThreadMeta | null {
+  if (state.selectedThreadId === null) return null
+  const workspace = workspaces.find((w) => w.id === state.selectedWorkspaceId)
+  return workspace?.threads.find((t) => t.id === state.selectedThreadId) ?? null
+}

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -70,6 +70,95 @@ body {
   max-width: 640px;
 }
 
+/* --- App shell: persistent two-pane layout (TB1, ADR-0006) --- */
+
+.shell {
+  flex: 1;
+  display: flex;
+  min-height: 0; /* let both panes own their own scroll */
+}
+
+.shell__sidebar {
+  width: 300px;
+  flex: none;
+  border-right: 1px solid var(--border);
+  padding: 16px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* The outlet swaps content while the sidebar stays mounted (criterion 1). */
+.shell__outlet {
+  flex: 1;
+  min-width: 0;
+  padding: 24px;
+  overflow-y: auto;
+}
+
+.shell__empty {
+  max-width: 420px;
+}
+
+.shell__top {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.shell__open {
+  align-self: flex-start;
+}
+
+.env {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.env__title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 600;
+  font-size: 13px;
+}
+
+/* Workspace name as a selectable button (sidebar nav). */
+.recents__ws-name {
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  border-radius: var(--radius);
+  padding: 2px 4px;
+  margin: 0 -4px;
+  font: inherit;
+  font-size: 13px;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.recents__ws-name:hover {
+  background: var(--accent-tint);
+}
+
+.recents__ws-name--active {
+  color: var(--accent-text);
+  font-weight: 600;
+}
+
+/* The selected Thread row in the sidebar nav. */
+.recents__thread-btn--active {
+  color: var(--accent-text);
+  background: var(--accent-tint);
+  font-weight: 600;
+}
+
 .card {
   background: var(--panel);
   border: 1px solid var(--border);


### PR DESCRIPTION
## What this is

TB1 (closes #46) — first slice of the **UI/layout-shell epic** (PRD #45, ADR-0006). Replaces the stacked-card `connect.status` view-swap with a **persistent two-pane `<Shell>`**: a sidebar that stays mounted ‖ a conversation outlet that swaps. Implements ADR-0006 decisions **1** (shell shape) and **2** (pure nav reducer). Deliberately does NOT implement the warm-agent pool (decision 3 → TB2 #47).

## Behavior

- A top-level `<Shell>` renders `<aside>` (sidebar) + `<main>` (outlet); the sidebar element is fixed, so navigation never unmounts it.
- **Navigation is a pure reducer** (`shell/nav-reducer.ts`): `select-workspace` / `select-thread` / `clear`, with the invariant that a selected Thread always belongs to the selected Workspace. No router, no state-lib (ADR-0006).
- Selecting a cold Thread renders `ColdThread` (read-only JSONL replay, no agent) in the outlet; a live connection renders `ConnectedWorkspace` there. `App.tsx` is thinned to IPC/data glue + the connection-outlet routing (unchanged behavior, now rendered into the outlet — TB4 #49 moves auth states fully inline).

## Review

Implemented via the team loop: independent gate verification + an adversarial review. The thinning was verified **regression-free** (every `connect.status` branch, agentId keying, auth generation guard, continue/refresh wiring preserved) and the nav reducer's invariant **correct** (no stale/foreign selection, graceful on delete). **No MUST-FIX.** Folded one review fix: gate sidebar delete to the non-connected state (the always-mounted sidebar newly exposed delete-while-connected, which could orphan a live conversation; restores origin/main's idle-only-delete invariant). Two desync findings are genuinely TB2/TB3-shaped and tracked on #47/#48.

## Gates

`lint` ✓ · `typecheck` ✓ · `build` ✓ · `test` ✓ — **183 tests** (174 baseline + 9 nav-reducer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)