### PR TITLE
TB2 (#47): Workspace switcher + warm-agent pool (one warm agent per open Workspace)

### DIFF
--- a/src/main/agent-pool.test.ts
+++ b/src/main/agent-pool.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest'
+import { AgentPool, type PoolAgent } from './agent-pool'
+
+/**
+ * The warm-agent pool (ADR-0006 decision 3, TB2 #47): one `vibe-acp` agent per
+ * OPEN Workspace, lazily spawned on first select and kept warm thereafter — so
+ * reselecting a Workspace REUSES the same agent (no second spawn/handshake) and
+ * switching away never tears it down. Exercised at the injected-factory seam with
+ * a fake agent (counting spawns + stops) — NEVER a live vibe-acp, like the
+ * `thread-binding` / `workspace-agent` tests.
+ */
+
+interface FakeAgent extends PoolAgent {
+  readonly workspaceDir: string
+  stops: number
+}
+
+/** A counting fake-agent factory: one fresh agent per `vibe-acp` spawn. */
+function fakeFactory(): { create: (workspaceDir: string) => FakeAgent; spawns: number } {
+  const tracker = {
+    spawns: 0,
+    create(workspaceDir: string): FakeAgent {
+      tracker.spawns++
+      return {
+        workspaceDir,
+        stops: 0,
+        stop() {
+          this.stops++
+        },
+      }
+    },
+  }
+  return tracker
+}
+
+/** A pool over the fake factory, with a deterministic id sequence for assertions. */
+function makePool(): { pool: AgentPool<FakeAgent>; factory: ReturnType<typeof fakeFactory> } {
+  const factory = fakeFactory()
+  let n = 0
+  const pool = new AgentPool<FakeAgent>({ createAgent: factory.create, mintId: () => `a${++n}` })
+  return { pool, factory }
+}
+
+describe('AgentPool — lazy-spawn-once + reuse-by-Workspace', () => {
+  it('spawns an agent on first acquire and returns a minted id (created=true)', () => {
+    const { pool, factory } = makePool()
+
+    const first = pool.acquire('/proj/a')
+
+    expect(factory.spawns).toBe(1)
+    expect(first.created).toBe(true)
+    expect(first.agentId).toBe('a1')
+    expect(first.agent.workspaceDir).toBe('/proj/a')
+  })
+
+  it('REUSES the warm agent on a second acquire of the same Workspace (no second spawn/handshake)', () => {
+    const { pool, factory } = makePool()
+
+    const first = pool.acquire('/proj/a')
+    const second = pool.acquire('/proj/a')
+
+    expect(factory.spawns).toBe(1) // spawned once, reused
+    expect(second.created).toBe(false)
+    expect(second.agentId).toBe(first.agentId) // same renderer-facing handle
+    expect(second.agent).toBe(first.agent) // same warm process
+  })
+
+  it('spawns a DISTINCT agent per Workspace (both stay warm at once)', () => {
+    const { pool, factory } = makePool()
+
+    const a = pool.acquire('/proj/a')
+    const b = pool.acquire('/proj/b')
+
+    expect(factory.spawns).toBe(2)
+    expect(b.agentId).not.toBe(a.agentId)
+    expect(b.agent).not.toBe(a.agent)
+    // Acquiring A again after B was spawned still reuses A — B's spawn didn't evict it.
+    expect(pool.acquire('/proj/a').agent).toBe(a.agent)
+  })
+})
+
+describe('AgentPool — lookups', () => {
+  it('resolves an agent by its renderer agentId handle, null for an unknown id', () => {
+    const { pool } = makePool()
+    const { agentId, agent } = pool.acquire('/proj/a')
+
+    expect(pool.get(agentId)).toBe(agent)
+    expect(pool.get('nope')).toBeNull()
+  })
+
+  it('resolves the warm agent + id for a Workspace, null when none is warm', () => {
+    const { pool } = makePool()
+    const acquired = pool.acquire('/proj/a')
+
+    expect(pool.getByWorkspace('/proj/a')).toEqual({ agentId: acquired.agentId, agent: acquired.agent })
+    expect(pool.getByWorkspace('/proj/unknown')).toBeNull()
+  })
+
+  it('lists every warm agent (for fan-out like best-effort session close)', () => {
+    const { pool } = makePool()
+    const a = pool.acquire('/proj/a').agent
+    const b = pool.acquire('/proj/b').agent
+
+    expect(pool.agents()).toEqual(expect.arrayContaining([a, b]))
+    expect(pool.agents()).toHaveLength(2)
+  })
+})
+
+describe('AgentPool — explicit dispose (the TB5 eviction seam)', () => {
+  it('dispose stops the agent, drops it from both lookups, and re-warms fresh on next acquire', () => {
+    const { pool, factory } = makePool()
+    const { agentId, agent } = pool.acquire('/proj/a')
+
+    pool.dispose(agentId)
+
+    expect(agent.stops).toBe(1) // the child was stopped
+    expect(pool.get(agentId)).toBeNull()
+    expect(pool.getByWorkspace('/proj/a')).toBeNull()
+
+    // A subsequent select re-warms transparently with a brand-new agent.
+    const rewarmed = pool.acquire('/proj/a')
+    expect(factory.spawns).toBe(2)
+    expect(rewarmed.created).toBe(true)
+    expect(rewarmed.agent).not.toBe(agent)
+  })
+
+  it('dispose of one Workspace leaves the others warm', () => {
+    const { pool } = makePool()
+    const a = pool.acquire('/proj/a')
+    const b = pool.acquire('/proj/b')
+
+    pool.dispose(a.agentId)
+
+    expect(pool.getByWorkspace('/proj/a')).toBeNull()
+    expect(pool.getByWorkspace('/proj/b')).toEqual({ agentId: b.agentId, agent: b.agent })
+    expect(b.agent.stops).toBe(0)
+  })
+
+  it('dispose of an unknown id is a no-op (never throws)', () => {
+    const { pool } = makePool()
+    expect(() => pool.dispose('nope')).not.toThrow()
+  })
+
+  it('disposeAll stops every warm agent and empties the pool (app quit)', () => {
+    const { pool } = makePool()
+    const a = pool.acquire('/proj/a').agent
+    const b = pool.acquire('/proj/b').agent
+
+    pool.disposeAll()
+
+    expect(a.stops).toBe(1)
+    expect(b.stops).toBe(1)
+    expect(pool.agents()).toHaveLength(0)
+  })
+})

--- a/src/main/agent-pool.ts
+++ b/src/main/agent-pool.ts
@@ -1,0 +1,131 @@
+import { randomUUID } from 'node:crypto'
+import type { WorkspaceAgent } from './workspace-agent'
+
+/**
+ * The warm-agent pool (ADR-0006 decision 3): one `vibe-acp` agent per OPEN
+ * Workspace, keyed by Workspace directory. Selecting a Workspace lazily spawns its
+ * agent on first need and then keeps it warm, so reselecting REUSES the same agent
+ * (no second spawn, no re-handshake) and switching away never tears it down — a
+ * Workspace's Threads keep streaming while the user looks elsewhere.
+ *
+ * This replaces the dispose-then-respawn model: the old `disposeAgentsForWorkspace`
+ * dedup folds into the pool's reuse semantics (`acquire` returns the warm agent
+ * rather than spawning a second). The pool is the single LIFECYCLE OWNER — it mints
+ * the renderer-facing `agentId` handle, holds the agent, and is the only place an
+ * agent is stopped (`dispose`/`disposeAll`).
+ *
+ * Bounded only by spawn-once-and-reuse-per-Workspace here (unbounded warm count is
+ * fine for this slice). Idle-eviction and a warm-count cap are TB5 (#50): they hook
+ * in HERE — the pool owning lifecycle is the seam, so eviction will just call this
+ * pool's own `dispose` on an LRU/idle policy without scattering teardown elsewhere.
+ *
+ * The agent factory is injected (Seam B) so tests pool a fake — never a live
+ * `vibe-acp`. Generic over the agent type for that reason; production wires
+ * `WorkspaceAgent`.
+ */
+
+/** The minimal agent surface the pool owns: it only ever stops a warm agent. */
+export interface PoolAgent {
+  stop(): void
+}
+
+/** A warm agent plus its renderer-facing handle (the id the renderer prompts by). */
+export interface PooledAgent<A extends PoolAgent> {
+  agentId: string
+  agent: A
+}
+
+/** The outcome of an `acquire`: the warm agent, plus whether THIS call spawned it. */
+export interface AcquireResult<A extends PoolAgent> extends PooledAgent<A> {
+  /**
+   * True when this acquire SPAWNED the agent (first select of the Workspace) — the
+   * caller must `start()` it and wire its `event` tee. False on a reuse (already
+   * warm): start() is a no-op early-return and the tee is already wired.
+   */
+  created: boolean
+}
+
+interface PoolEntry<A extends PoolAgent> {
+  agentId: string
+  workspaceDir: string
+  agent: A
+}
+
+export interface AgentPoolOptions<A extends PoolAgent> {
+  /** Spawn a fresh agent for a Workspace dir (injected; tests pass a fake). */
+  createAgent: (workspaceDir: string) => A
+  /** Mint the renderer-facing agent id (testing). Defaults to a random uuid. */
+  mintId?: () => string
+}
+
+export class AgentPool<A extends PoolAgent = WorkspaceAgent> {
+  private readonly createAgent: (workspaceDir: string) => A
+  private readonly mintId: () => string
+  /** Warm agents keyed by the minted `agentId` (the renderer's handle). */
+  private readonly byId = new Map<string, PoolEntry<A>>()
+  /** Reverse index: Workspace dir -> `agentId`, for reuse + dir-scoped lookup. */
+  private readonly byWorkspace = new Map<string, string>()
+
+  constructor(options: AgentPoolOptions<A>) {
+    this.createAgent = options.createAgent
+    this.mintId = options.mintId ?? randomUUID
+  }
+
+  /**
+   * Lazily spawn-or-reuse the warm agent for a Workspace dir. Returns the warm
+   * agent + its handle and `created` (true only when this call spawned it). A
+   * second acquire of the same dir takes the reuse branch — same id, same process,
+   * `created: false` — so the caller never re-handshakes a warm Workspace.
+   */
+  acquire(workspaceDir: string): AcquireResult<A> {
+    const existingId = this.byWorkspace.get(workspaceDir)
+    if (existingId) {
+      const entry = this.byId.get(existingId)
+      if (entry) return { agentId: entry.agentId, agent: entry.agent, created: false }
+    }
+    const agentId = this.mintId()
+    const agent = this.createAgent(workspaceDir)
+    this.byId.set(agentId, { agentId, workspaceDir, agent })
+    this.byWorkspace.set(workspaceDir, agentId)
+    return { agentId, agent, created: true }
+  }
+
+  /** The warm agent for a renderer `agentId` handle, or null when none. */
+  get(agentId: string): A | null {
+    return this.byId.get(agentId)?.agent ?? null
+  }
+
+  /** The warm agent + id for a Workspace dir, or null when none is warm. */
+  getByWorkspace(workspaceDir: string): PooledAgent<A> | null {
+    const agentId = this.byWorkspace.get(workspaceDir)
+    if (!agentId) return null
+    const entry = this.byId.get(agentId)
+    return entry ? { agentId: entry.agentId, agent: entry.agent } : null
+  }
+
+  /** Every warm agent (for fan-out like best-effort session close on delete). */
+  agents(): A[] {
+    return [...this.byId.values()].map((e) => e.agent)
+  }
+
+  /**
+   * Stop + drop one warm agent by id (explicit close — `stopAgent`, or the TB5
+   * evictor). Idempotent: an unknown id is a no-op. After this the Workspace
+   * re-warms transparently on its next select (nothing user-visible is lost — the
+   * metadata + JSONL survive, ADR-0005).
+   */
+  dispose(agentId: string): void {
+    const entry = this.byId.get(agentId)
+    if (!entry) return
+    entry.agent.stop()
+    this.byId.delete(agentId)
+    this.byWorkspace.delete(entry.workspaceDir)
+  }
+
+  /** Stop + drop every warm agent (app quit). */
+  disposeAll(): void {
+    for (const entry of this.byId.values()) entry.agent.stop()
+    this.byId.clear()
+    this.byWorkspace.clear()
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, dialog, ipcMain, shell } from 'electron'
+import { app, BrowserWindow, dialog, ipcMain, shell, type WebContents } from 'electron'
 import { mkdir } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import { basename, join } from 'node:path'
@@ -36,12 +36,27 @@ import {
   type TranscriptEntry,
 } from './persistence/transcript'
 import { WorkspaceAgent, WorkspaceAgentError } from './workspace-agent'
+import { AgentPool } from './agent-pool'
 import { ensureBoundSession, resolveContinueTarget } from './thread-binding'
 import { createThreadDraft } from './persistence/drafts'
 import { deleteThread } from './persistence/delete-thread'
 
-/** Active Workspace agents keyed by a generated agent id. */
-const agents = new Map<string, WorkspaceAgent>()
+/**
+ * The warm-agent pool (ADR-0006 decision 3, TB2 #47): one `vibe-acp` agent per
+ * OPEN Workspace, lazily spawned on first select and kept warm thereafter — the
+ * lifecycle owner that replaces the old dispose-then-respawn `agents` map. The
+ * renderer still addresses an agent by the pool-minted `agentId` handle (one
+ * handle per Workspace), so `signIn`/`prompt`/etc resolve via `pool.get(agentId)`.
+ */
+const pool = new AgentPool({
+  createAgent: (workspaceDir) =>
+    new WorkspaceAgent({
+      workspaceDir,
+      env: getShellEnv(),
+      // Delegated sign-in (#12): open the returned signInUrl in the system browser.
+      openUrl: (url) => void shell.openExternal(url),
+    }),
+})
 
 /**
  * The single-writer metadata index (ADR-0005). Assigned at app-ready (needs
@@ -102,7 +117,7 @@ function bestEffortCloseFor(threadId: string): (() => Promise<void>) | undefined
   const sessionId = metadataStore?.snapshot().threads.find((t) => t.id === threadId)?.sessionId
   if (!sessionId) return undefined
   return async () => {
-    for (const agent of agents.values()) await agent.closeSession(sessionId)
+    for (const agent of pool.agents()) await agent.closeSession(sessionId)
   }
 }
 
@@ -258,28 +273,33 @@ function continueConnection(
  */
 function threadFailureResult(agentId: string, agent: WorkspaceAgent, err: unknown): StartThreadResult {
   if (err instanceof WorkspaceAgentError && err.authState === 'not-signed-in') {
-    // Keep the agent alive AND registered so the renderer's follow-up
-    // signIn({agentId}) finds it. Idempotent: startThread already registers on a
-    // successful start(), but a -32000 thrown from start() itself reaches here
-    // before that, so without this the child would leak + the button would dead-end.
-    agents.set(agentId, agent)
+    // Keep the agent WARM in the pool so the renderer's follow-up signIn({agentId})
+    // reuses it (it's already registered by `pool.acquire`) — a warm-but-unauthed
+    // Workspace is driven to sign-in, never respawned.
     return { ok: false, kind: 'not-signed-in', agentId, workspaceDir: agent.workspaceDir, authMethods: agent.authMethods }
   }
-  agent.stop()
-  agents.delete(agentId)
+  // A non-auth failure: dispose the agent so the next select re-warms fresh.
+  pool.dispose(agentId)
   if (err instanceof WorkspaceAgentError) return { ok: false, kind: 'error', error: err.message, hint: err.hint }
   return { ok: false, kind: 'error', error: err instanceof Error ? err.message : String(err), hint: null }
 }
 
-/** Stop + drop any live agent bound to this workspace (dedup before re-spawn). */
-function disposeAgentsForWorkspace(workspaceDir: string): void {
-  for (const [id, agent] of agents) {
-    if (agent.workspaceDir !== workspaceDir) continue
-    agent.stop()
-    agents.delete(id)
-  }
+/**
+ * Wire a freshly-spawned pool agent's `event` tee — called exactly ONCE per spawn
+ * (a reused warm agent already has its listener). Each streamed payload is teed to
+ * ITS Thread's JSONL, routed by the event's OWN sessionId so that with several
+ * warm agents an event always lands in the right Thread regardless of which
+ * Workspace is focused, then forwarded to the renderer tagged by `agentId`.
+ * Best-effort: the tee never gates the live forward.
+ */
+function wireAgentEvents(agentId: string, agent: WorkspaceAgent, sender: WebContents): void {
+  agent.on('event', (payload: unknown) => {
+    teeTranscript(threadIdForTee(agentId, sessionIdFromPayload(payload)), acpEventEntry(payload))
+    if (!sender.isDestroyed()) {
+      sender.send(IPC.acpEvent, { agentId, payload })
+    }
+  })
 }
-let agentCounterSeed = 0
 
 function createWindow(): void {
   const win = new BrowserWindow({
@@ -324,38 +344,24 @@ function registerIpc(): void {
   })
 
   ipcMain.handle(IPC.startThread, async (event, args: StartThreadArgs): Promise<StartThreadResult> => {
-    // Dedup: dispose any existing agent for this workspace before spawning, so a
-    // re-Connect (e.g. after a not-signed-in panel) can't orphan the previous child.
-    disposeAgentsForWorkspace(args.workspaceDir)
-
-    const agentId = `a${++agentCounterSeed}`
-    const agent = new WorkspaceAgent({
-      workspaceDir: args.workspaceDir,
-      env: getShellEnv(),
-      // Delegated sign-in (#12): open the returned signInUrl in the system browser.
-      openUrl: (url) => void shell.openExternal(url),
-    })
-
-    agent.on('event', (payload: unknown) => {
-      // Tee each streamed payload to its Thread's transcript (ADR-0005), routed
-      // by the event's OWN sessionId, before forwarding it — best-effort, never
-      // gating the live forward.
-      teeTranscript(threadIdForTee(agentId, sessionIdFromPayload(payload)), acpEventEntry(payload))
-      if (!event.sender.isDestroyed()) {
-        event.sender.send(IPC.acpEvent, { agentId, payload })
-      }
-    })
+    // Warm pool (ADR-0006 decision 3): lazily spawn this Workspace's agent on its
+    // first select and REUSE it thereafter — no dispose-then-respawn. A reused warm
+    // agent skips the handshake (start() early-returns below) and its event tee is
+    // already wired, so a re-select / continue never re-handshakes.
+    const { agentId, agent, created } = pool.acquire(args.workspaceDir)
+    if (created) wireAgentEvents(agentId, agent, event.sender)
 
     // Persist the Workspace open up front (ADR-0005), so even a not-signed-in
     // Workspace shows in the cold list. Best-effort — must not reject connect.
     await recordWorkspaceOpen(args.workspaceDir)
 
     try {
+      // Idempotent: spawns + handshakes a fresh agent, no-ops a warm one (already
+      // initialized) — so reuse never re-spawns the child or re-runs the handshake.
       await agent.start()
-      agents.set(agentId, agent)
 
-      // Detected not-signed-in: keep the agent (the sign-in flow drives it) but
-      // don't open a Thread — session/new would fail with -32000. The renderer
+      // Detected not-signed-in: keep the agent warm (the sign-in flow drives it)
+      // but don't open a Thread — session/new would fail with -32000. The renderer
       // shows the sign-in panel and re-tries openThread after sign-in.
       if (agent.authState === 'not-signed-in') {
         return { ok: false, kind: 'not-signed-in', agentId, workspaceDir: args.workspaceDir, authMethods: agent.authMethods }
@@ -381,7 +387,7 @@ function registerIpc(): void {
   ipcMain.handle(IPC.openThread, async (_event, args: OpenThreadArgs): Promise<StartThreadResult> => {
     // Open a Thread on an agent already started + signed in (after sign-in or an
     // in-place re-auth). Reuses the retained agent — no re-spawn.
-    const agent = agents.get(args.agentId)
+    const agent = pool.get(args.agentId)
     if (!agent) return { ok: false, kind: 'error', error: `No active agent for id ${args.agentId}.`, hint: null }
     try {
       const thread = await agent.openThread()
@@ -395,7 +401,7 @@ function registerIpc(): void {
   ipcMain.handle(
     IPC.sendPrompt,
     async (event, args: SendPromptArgs): Promise<SendPromptResult> => {
-      const agent = agents.get(args.agentId)
+      const agent = pool.get(args.agentId)
       if (!agent) return { ok: false, kind: 'error', error: `No active agent for id ${args.agentId}.` }
 
       // Bind on first prompt (ADR-0005, TB5): a draft (sessionId null) mints its
@@ -466,7 +472,7 @@ function registerIpc(): void {
     // Tee by the renderer-supplied `threadId` directly (TB5), NOT the agent's
     // last-prompted map: answering Thread A's permission after switching+prompting
     // a sibling B must land in A's log, not B's.
-    const agent = agents.get(args.agentId)
+    const agent = pool.get(args.agentId)
     teeTranscript(args.threadId, resolvePermissionEntry(args.requestId, args.optionId))
     agent?.respondPermission(args.requestId, args.optionId)
   })
@@ -475,7 +481,7 @@ function registerIpc(): void {
     // Drive Vibe's browser sign-in on the agent retained from startThread; main
     // orchestrates + relays the resulting AuthState, the renderer owns the view
     // state (ADR-0001). Credentials never touch us — Vibe owns the keyring (ADR-0003).
-    const agent = agents.get(args.agentId)
+    const agent = pool.get(args.agentId)
     if (!agent) return { ok: false, error: `No active agent for id ${args.agentId}.` }
     try {
       const authState = await agent.signIn(args.methodId)
@@ -488,7 +494,7 @@ function registerIpc(): void {
   ipcMain.handle(IPC.signOut, async (_event, args: SignOutArgs): Promise<SignOutResult> => {
     // Sign out via Vibe's keyring removal and relay the new state; the agent
     // stays alive so the user can sign a different account back in (ADR-0003).
-    const agent = agents.get(args.agentId)
+    const agent = pool.get(args.agentId)
     if (!agent) return { ok: false, error: `No active agent for id ${args.agentId}.` }
     try {
       const authState = await agent.signOut()
@@ -499,9 +505,9 @@ function registerIpc(): void {
   })
 
   ipcMain.handle(IPC.stopAgent, (_event, agentId: string) => {
-    const agent = agents.get(agentId)
-    agent?.stop()
-    agents.delete(agentId)
+    // Explicit close: the pool stops the child and drops it; the Workspace
+    // re-warms transparently on its next select (metadata + JSONL survive).
+    pool.dispose(agentId)
   })
 
   ipcMain.handle(IPC.createDraft, async (_event, args: CreateDraftArgs): Promise<CreateDraftResult> => {
@@ -587,9 +593,8 @@ app.whenReady().then(async () => {
 })
 
 app.on('window-all-closed', () => {
-  // The agents Map is process-global, which is fine for single-window TB1.
-  // A future multi-window slice should track + dispose agents per window.
-  for (const agent of agents.values()) agent.stop()
-  agents.clear()
+  // The pool is process-global, which is fine for single-window TB1/TB2.
+  // A future multi-window slice should scope the pool per window.
+  pool.disposeAll()
   if (process.platform !== 'darwin') app.quit()
 })

--- a/src/main/workspace-agent.test.ts
+++ b/src/main/workspace-agent.test.ts
@@ -1096,3 +1096,42 @@ describe('WorkspaceAgent.loadThread() — resume (TB4 #33)', () => {
     expect(withoutCap.loadSessionAvailable).toBe(false)
   })
 })
+
+// --- TB2: concurrent + idempotent start() (#47) -----------------------------
+
+describe('WorkspaceAgent.start() — concurrent + idempotent (TB2 #47)', () => {
+  it('shares ONE handshake across concurrent start() calls (child spawned once, no double-start throw)', async () => {
+    const fake = makeCapturingFake()
+    let spawns = 0
+    const agent = new WorkspaceAgent({
+      workspaceDir: '/abs/workspace',
+      spawn: () => {
+        spawns++
+        return fake.child
+      },
+    })
+
+    // Two starts race BEFORE the handshake completes — the bug: the warm pool
+    // dedups the agent object, but without a shared in-flight start the second
+    // hits `AcpClient.start()`'s "already started" throw and stops the child the
+    // first is still handshaking on.
+    const a = agent.start()
+    const b = agent.start()
+
+    // Drive the SINGLE handshake: initialize (id 1) then _auth/status (id 2).
+    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: 1, result: { protocolVersion: 1 } }) + '\n')
+    await new Promise((r) => setTimeout(r, 0))
+    fake.feed(
+      JSON.stringify({ jsonrpc: '2.0', id: 2, result: { authenticated: true, authState: 'os_keyring' } }) + '\n',
+    )
+
+    await expect(Promise.all([a, b])).resolves.toEqual([undefined, undefined])
+    expect(spawns).toBe(1) // one child, not two
+    expect(sent(fake).filter((m) => m.method === 'initialize')).toHaveLength(1) // one handshake
+
+    // A post-success start() is a no-op: no second spawn, no second initialize.
+    await agent.start()
+    expect(spawns).toBe(1)
+    expect(sent(fake).filter((m) => m.method === 'initialize')).toHaveLength(1)
+  })
+})

--- a/src/main/workspace-agent.ts
+++ b/src/main/workspace-agent.ts
@@ -129,6 +129,16 @@ export class WorkspaceAgent extends EventEmitter {
    * the replay would DOUBLE the conversation. Cleared when the load settles.
    */
   private readonly loadingSessions = new Set<string>()
+  /**
+   * The in-flight `start()` handshake, memoized so concurrent callers share ONE
+   * (TB2 #47): the warm pool dedups the agent OBJECT, but two `startThread`s for
+   * the same Workspace before the first handshake completes would otherwise both
+   * run start() — and the second would hit `AcpClient.start()`'s "already started"
+   * throw, disposing the child the first is still handshaking on. Null until a
+   * start begins and again once it settles; on success `initialized` makes later
+   * calls no-op, on failure clearing it lets a retry re-attempt from scratch.
+   */
+  private startPromise: Promise<void> | null = null
 
   constructor(options: WorkspaceAgentOptions) {
     super()
@@ -160,10 +170,25 @@ export class WorkspaceAgent extends EventEmitter {
    * Spawn vibe-acp and complete `initialize`. The `initialize` response is the
    * readiness signal; start is raced against an early process error/exit so a
    * failed spawn rejects instead of hanging.
+   *
+   * Concurrency-safe (TB2 #47): an already-initialized agent no-ops, and
+   * overlapping callers SHARE one in-flight handshake (`startPromise`) so the
+   * child is spawned exactly once — never a second `AcpClient.start()` racing the
+   * first. The memo clears when the handshake settles (success keeps the agent
+   * initialized; a failure lets a later call retry).
    */
-  async start(): Promise<void> {
-    if (this.initialized) return
+  start(): Promise<void> {
+    if (this.initialized) return Promise.resolve()
+    if (!this.startPromise) {
+      this.startPromise = this.runStart().finally(() => {
+        this.startPromise = null
+      })
+    }
+    return this.startPromise
+  }
 
+  /** The actual handshake — run at most once concurrently via `start()`'s memo. */
+  private async runStart(): Promise<void> {
     let onError!: (err: Error) => void
     let onExit!: (info: { code: number | null; signal: NodeJS.Signals | null }) => void
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useReducer, useRef, useState, type JSX, type ReactNode } fro
 import type {
   AuthMethod,
   ListMetadataResult,
+  ThreadConnection,
   ThreadMeta,
   VibeDetectResult,
 } from '../../shared/ipc'
@@ -12,24 +13,45 @@ import {
   signedInAuthViewState,
 } from './auth/auth-view'
 import { routeThreadResult, type ConnectState } from './connection/routing'
+import {
+  connectedWorkspaceIds,
+  connectionsReducer,
+  initialConnections,
+  selectedConnection,
+  shouldConnect,
+} from './connection/connections'
 import { ConnectedWorkspace } from './connection/ConnectedWorkspace'
+import { ColdThread } from './conversation/ColdThread'
 import { Shell } from './shell/Shell'
+import { findSelectedThread, initialNavState, navReducer } from './shell/nav-reducer'
 
 /**
  * Thin glue (ADR-0006): App owns IPC/data wiring — detection, the persisted
- * Workspace/Thread metadata, and the connect flow — and renders the persistent
- * `<Shell>`. The shell owns navigation (its pure nav reducer) and the two-pane
- * layout; App feeds it the cold list, the sidebar's top controls, and the
- * connection-active outlet, plus the connect-flow callbacks.
+ * Workspace/Thread metadata, NAVIGATION (the pure nav reducer), and the
+ * PER-WORKSPACE connection registry — and renders the persistent `<Shell>`, which
+ * is now a presentational two-pane layout fed a fully-computed outlet.
  *
- * Connection/auth states (connecting / not-signed-in / error / connected) still
- * route as before, but now INTO the outlet (`connectionOutlet`) rather than
- * swapping the whole view — the sidebar stays put. TB4 (#49) moves these inline.
+ * The warm-agent pool (TB2 #47) keeps many Workspaces' agents alive at once, so
+ * connection state is tracked PER Workspace (`connections`, keyed by `workspaceId`)
+ * rather than TB1's single `connect`. Selecting a Workspace connect-or-REUSES its
+ * warm agent and routes the outlet to THAT Workspace; every connected Workspace's
+ * view stays MOUNTED (hidden when not selected) so its background turn keeps
+ * streaming and switching back is instant with no re-handshake. The outlet is
+ * routed off the NAV SELECTION (not a single global connect), so a cold click on a
+ * never-connected Workspace replays correctly even after another connected
+ * (TB1-review finding 2); the sidebar suppresses per-Thread highlights for a
+ * connected Workspace, whose live view owns Thread selection (finding 1).
  */
 export function App(): JSX.Element {
   const [detect, setDetect] = useState<VibeDetectResult | null>(null)
   const [loading, setLoading] = useState(true)
-  const [connect, setConnect] = useState<ConnectState>({ status: 'idle' })
+  const [opening, setOpening] = useState(false)
+  // Navigation (decision 2): WHICH Workspace/Thread the user is looking at —
+  // lifted here so the connect flow (Open project, Continue, sign-in) can drive it.
+  const [nav, navDispatch] = useReducer(navReducer, initialNavState)
+  // Per-Workspace connection registry (decision 3): one ConnectState per warm
+  // Workspace, so switching between two is instant and both keep streaming.
+  const [connections, connDispatch] = useReducer(connectionsReducer, initialConnections)
   // Persisted Workspaces + Threads (ADR-0005), listed cold on launch from
   // metadata alone — no agent spawned, no transcript loaded.
   const [recents, setRecents] = useState<ListMetadataResult>([])
@@ -49,7 +71,9 @@ export function App(): JSX.Element {
    * Delete a persisted Thread (TB6): main removes its metadata + JSONL and
    * best-effort closes any live session; we then re-fetch so it disappears from
    * the list. The shell derives its selected (cold) Thread from `recents`, so a
-   * deleted-and-selected Thread collapses to the placeholder on its own.
+   * deleted-and-selected Thread collapses to the placeholder on its own. Gated in
+   * the sidebar to NON-connected Workspaces, so we never delete a Thread a warm
+   * agent is hosting out from under it.
    */
   async function deleteThread(thread: ThreadMeta): Promise<void> {
     await window.api.deleteThread(thread.id)
@@ -61,58 +85,146 @@ export function App(): JSX.Element {
     void refreshRecents()
   }, [])
 
-  async function openProject(): Promise<void> {
-    const workspaceDir = await window.api.openWorkspaceDialog()
-    if (!workspaceDir) return
-    setConnect({ status: 'connecting', workspaceDir })
-    setConnect(routeThreadResult(await window.api.startThread({ workspaceDir })))
-    // Main has now persisted the Workspace (and any Thread); reflect it in the list.
+  /**
+   * Select a Workspace from the sidebar: pin it in the nav reducer and
+   * connect-OR-REUSE its warm agent. A never-connected (or errored) Workspace
+   * lazily spawns its agent; a warm one (connecting / not-signed-in / connected) is
+   * reused as-is — instant, no second spawn or handshake.
+   */
+  function selectWorkspace(workspaceId: string): void {
+    navDispatch({ type: 'select-workspace', workspaceId })
+    if (shouldConnect(connections[workspaceId])) void connectWorkspace(workspaceId)
+  }
+
+  /** Spawn-or-reuse a Workspace's agent and record its connection (keyed by id). */
+  async function connectWorkspace(workspaceId: string): Promise<void> {
+    const workspace = recents.find((w) => w.id === workspaceId)
+    if (!workspace) return
+    connDispatch({ type: 'set', workspaceId, state: { status: 'connecting', workspaceDir: workspace.dir } })
+    const result = await window.api.startThread({ workspaceDir: workspace.dir })
+    connDispatch({ type: 'set', workspaceId, state: routeThreadResult(result) })
     void refreshRecents()
   }
 
-  // After sign-in (or in-place re-auth) the agent is already started + signed in;
-  // open a Thread on it and land in a connected conversation.
-  async function continueToThread(agentId: string, workspaceDir: string): Promise<void> {
-    setConnect({ status: 'connecting', workspaceDir })
-    setConnect(routeThreadResult(await window.api.openThread({ agentId })))
+  async function openProject(): Promise<void> {
+    const workspaceDir = await window.api.openWorkspaceDialog()
+    if (!workspaceDir) return
+    setOpening(true)
+    try {
+      const result = await window.api.startThread({ workspaceDir })
+      // Main has now persisted the Workspace (even on not-signed-in / error, since
+      // it records the open BEFORE the handshake), so re-fetch to learn its minted
+      // id, then key the connection by it and select it.
+      const list = await window.api.listMetadata()
+      setRecents(list)
+      const ws = list.find((w) => w.dir === workspaceDir)
+      if (!ws) return // degraded (no store) — nothing to key/select
+      connDispatch({ type: 'set', workspaceId: ws.id, state: routeThreadResult(result) })
+      navDispatch({ type: 'select-workspace', workspaceId: ws.id })
+    } finally {
+      setOpening(false)
+    }
+  }
+
+  // After sign-in (or in-place re-auth) the Workspace's warm agent is already
+  // started + signed in; open a Thread on it and land in a connected conversation.
+  async function continueToThread(workspaceId: string, agentId: string): Promise<void> {
+    connDispatch({ type: 'set', workspaceId, state: routeThreadResult(await window.api.openThread({ agentId })) })
+    void refreshRecents()
   }
 
   /**
-   * Continue a reopened Thread from the sidebar's cold list (TB4 #33). No agent
-   * runs for a cold-list Thread, so we spawn its Workspace agent via `startThread`,
-   * passing `continueThreadId` so main opens NO extra Thread and instead seeds the
-   * connection with THIS Thread (its first prompt drives the `session/load`
-   * resume). The connection thread IS the continued one, so it lands selected +
-   * live with no separate plumbing. The Workspace dir comes from the cold list (a
-   * `ThreadMeta` carries only `workspaceId`).
+   * Continue a reopened Thread from the sidebar's cold list (TB4 #33). Spawn-or-
+   * reuse its Workspace agent via `startThread`, passing `continueThreadId` so main
+   * opens NO extra Thread and instead seeds the connection with THIS Thread (its
+   * first prompt drives the `session/load` resume). Select the Workspace so the
+   * outlet routes to its now-connected view.
    */
   async function continueColdThread(thread: ThreadMeta): Promise<void> {
     const workspace = recents.find((w) => w.id === thread.workspaceId)
     if (!workspace) return
-    setConnect({ status: 'connecting', workspaceDir: workspace.dir })
-    setConnect(
-      routeThreadResult(
-        await window.api.startThread({ workspaceDir: workspace.dir, continueThreadId: thread.id }),
-      ),
-    )
+    navDispatch({ type: 'select-workspace', workspaceId: workspace.id })
+    connDispatch({ type: 'set', workspaceId: workspace.id, state: { status: 'connecting', workspaceDir: workspace.dir } })
+    const result = await window.api.startThread({ workspaceDir: workspace.dir, continueThreadId: thread.id })
+    connDispatch({ type: 'set', workspaceId: workspace.id, state: routeThreadResult(result) })
     void refreshRecents()
   }
 
-  /** Sign-out / mid-session expiry: drop back to the sign-in panel (same agent). */
-  function toSignInPanel(agentId: string, workspaceDir: string, authMethods: AuthMethod[]): void {
-    setConnect({ status: 'not-signed-in', agentId, workspaceDir, authMethods })
+  /** Sign-out / mid-session expiry: drop a Workspace back to its sign-in panel
+   *  (same warm agent — never respawned). */
+  function toSignInPanel(workspaceId: string, agentId: string, workspaceDir: string, authMethods: AuthMethod[]): void {
+    connDispatch({ type: 'set', workspaceId, state: { status: 'not-signed-in', agentId, workspaceDir, authMethods } })
   }
-
-  const connecting = connect.status === 'connecting'
 
   // The sidebar's pinned top: the environment check + the Open-project control.
   const sidebarTop = (
     <div className="shell__top">
       <Environment detect={detect} loading={loading} onRecheck={() => void runDetect()} />
-      <button className="btn shell__open" onClick={() => void openProject()} disabled={connecting}>
-        {connecting ? 'Connecting…' : 'Open project'}
+      <button className="btn shell__open" onClick={() => void openProject()} disabled={opening}>
+        {opening ? 'Connecting…' : 'Open project'}
       </button>
     </div>
+  )
+
+  const connectedIds = connectedWorkspaceIds(connections)
+  const selected = selectedConnection(connections, nav.selectedWorkspaceId)
+
+  /** The connected view for a Workspace (SignedInBar + ConnectedWorkspace). */
+  function renderConnected(thread: ThreadConnection): ReactNode {
+    return (
+      <>
+        {/* Key by agentId (like Conversation) so its useReducer seed resets across
+            connections — a new agent can't inherit the prior session's sign-out gate. */}
+        <SignedInBar
+          key={`bar-${thread.agentId}`}
+          agentId={thread.agentId}
+          authMethods={thread.authMethods}
+          signOutAvailable={thread.signOutAvailable}
+          onSignedOut={(authMethods) =>
+            toSignInPanel(thread.workspaceId, thread.agentId, thread.workspaceDir, authMethods)
+          }
+        />
+        {/* Key by agentId so per-Workspace Thread state can't bleed across
+            connections. Hosts multiple Threads on the one agent + switching (TB5). */}
+        <ConnectedWorkspace
+          key={thread.agentId}
+          connection={thread}
+          threads={threadsForWorkspace(recents, thread.workspaceId)}
+          refreshRecents={refreshRecents}
+          onAuthExpired={(authMethods) =>
+            toSignInPanel(thread.workspaceId, thread.agentId, thread.workspaceDir, authMethods)
+          }
+        />
+      </>
+    )
+  }
+
+  // The outlet: every connected Workspace stays MOUNTED (hidden unless selected) so
+  // its background turn keeps streaming and a switch-back is instant; the selected
+  // Workspace's transient state (connecting / sign-in / error) or its cold Thread
+  // renders inline. Routed off the nav selection, so cold clicks always route right.
+  const outlet = (
+    <>
+      {connectedIds.map((wid) => {
+        const conn = connections[wid]
+        if (conn.status !== 'connected') return null
+        return (
+          <div key={wid} className="shell__connection" hidden={wid !== nav.selectedWorkspaceId}>
+            {renderConnected(conn.thread)}
+          </div>
+        )
+      })}
+      {selected.status === 'connected'
+        ? null // rendered (visible) in the keep-mounted map above
+        : selected.status !== 'idle'
+          ? renderTransientOutlet(selected, {
+              continueToThread: (agentId) => void continueToThread(nav.selectedWorkspaceId ?? '', agentId),
+            })
+          : renderColdOutlet(recents, nav, {
+              onClose: () => navDispatch({ type: 'clear' }),
+              onContinue: (thread) => void continueColdThread(thread),
+            })}
+    </>
   )
 
   return (
@@ -125,13 +237,11 @@ export function App(): JSX.Element {
       <Shell
         workspaces={recents}
         sidebarTop={sidebarTop}
-        connectionOutlet={renderConnectionOutlet(connect, {
-          continueToThread,
-          toSignInPanel,
-          refreshRecents,
-          threads: connect.status === 'connected' ? threadsForWorkspace(recents, connect.thread.workspaceId) : [],
-        })}
-        onContinueColdThread={(thread) => void continueColdThread(thread)}
+        nav={nav}
+        connectedWorkspaceIds={connectedIds}
+        outlet={outlet}
+        onSelectWorkspace={selectWorkspace}
+        onSelectThread={(workspaceId, threadId) => navDispatch({ type: 'select-thread', workspaceId, threadId })}
         onDeleteThread={deleteThread}
       />
     </div>
@@ -139,23 +249,15 @@ export function App(): JSX.Element {
 }
 
 /**
- * The connection-active outlet (everything but `idle`). Routed exactly as before,
- * now rendered INTO the shell outlet rather than swapping the whole view — the
- * sidebar persists across it. `null` on `idle` hands the outlet back to the shell's
- * nav-selected cold Thread (or placeholder). TB4 (#49) folds these inline.
+ * The selected Workspace's NON-connected outlet state (connecting / not-signed-in /
+ * error). Only the selected Workspace shows a transient view; connected Workspaces
+ * render via the keep-mounted map instead.
  */
-function renderConnectionOutlet(
+function renderTransientOutlet(
   connect: ConnectState,
-  handlers: {
-    continueToThread: (agentId: string, workspaceDir: string) => void
-    toSignInPanel: (agentId: string, workspaceDir: string, authMethods: AuthMethod[]) => void
-    refreshRecents: () => Promise<void>
-    threads: ThreadMeta[]
-  },
-): ReactNode | null {
+  handlers: { continueToThread: (agentId: string) => void },
+): ReactNode {
   switch (connect.status) {
-    case 'idle':
-      return null
     case 'connecting':
       return (
         <p className="hint">
@@ -169,7 +271,7 @@ function renderConnectionOutlet(
           key={connect.agentId}
           agentId={connect.agentId}
           authMethods={connect.authMethods}
-          onSignedIn={() => handlers.continueToThread(connect.agentId, connect.workspaceDir)}
+          onSignedIn={() => handlers.continueToThread(connect.agentId)}
         />
       )
     case 'error':
@@ -180,35 +282,40 @@ function renderConnectionOutlet(
           {connect.hint && <div className="alert__hint">{connect.hint}</div>}
         </div>
       )
-    case 'connected':
-      return (
-        <>
-          {/* Key by agentId (like Conversation) so its useReducer seed resets
-              across connections — a new agent can't inherit the prior session's
-              sign-out gate. */}
-          <SignedInBar
-            key={connect.thread.agentId}
-            agentId={connect.thread.agentId}
-            authMethods={connect.thread.authMethods}
-            signOutAvailable={connect.thread.signOutAvailable}
-            onSignedOut={(authMethods) =>
-              handlers.toSignInPanel(connect.thread.agentId, connect.thread.workspaceDir, authMethods)
-            }
-          />
-          {/* Key by agentId so the per-Workspace Thread state can't bleed across
-              connections. Hosts multiple Threads on the one agent + switching (TB5). */}
-          <ConnectedWorkspace
-            key={connect.thread.agentId}
-            connection={connect.thread}
-            threads={handlers.threads}
-            refreshRecents={handlers.refreshRecents}
-            onAuthExpired={(authMethods) =>
-              handlers.toSignInPanel(connect.thread.agentId, connect.thread.workspaceDir, authMethods)
-            }
-          />
-        </>
-      )
+    default:
+      return null
   }
+}
+
+/**
+ * The idle (no live agent) outlet for the selected Workspace: the nav-selected cold
+ * Thread replayed read-only from JSONL (TB3) with a Continue affordance (TB4), or a
+ * placeholder when nothing is selected. Reached only when the selected Workspace has
+ * no connection — so a cold click after another Workspace connected still routes here.
+ */
+function renderColdOutlet(
+  recents: ListMetadataResult,
+  nav: { selectedWorkspaceId: string | null; selectedThreadId: string | null },
+  handlers: { onClose: () => void; onContinue: (thread: ThreadMeta) => void },
+): ReactNode {
+  const selectedThread = findSelectedThread(recents, nav)
+  if (!selectedThread) {
+    return (
+      <div className="shell__empty">
+        <p className="hint">
+          Select a thread from the sidebar to view it, or open a project to start a live agent.
+        </p>
+      </div>
+    )
+  }
+  return (
+    <ColdThread
+      key={selectedThread.id}
+      thread={selectedThread}
+      onClose={handlers.onClose}
+      onContinue={() => handlers.onContinue(selectedThread)}
+    />
+  )
 }
 
 /** The environment check: whether `vibe` / `vibe-acp` are installed + reachable. */

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useReducer, useRef, useState, type JSX, type ReactNode } fro
 import type {
   AuthMethod,
   ListMetadataResult,
+  StartThreadResult,
   ThreadConnection,
   ThreadMeta,
   VibeDetectResult,
@@ -55,6 +56,10 @@ export function App(): JSX.Element {
   // Persisted Workspaces + Threads (ADR-0005), listed cold on launch from
   // metadata alone — no agent spawned, no transcript loaded.
   const [recents, setRecents] = useState<ListMetadataResult>([])
+  // Workspaces with a connect IN FLIGHT, tracked synchronously so a fast double-
+  // select can't fire two `startThread`s (the `connections` closure is stale
+  // within a render frame, so a state check alone would let both through).
+  const connectingRef = useRef<Set<string>>(new Set())
 
   async function runDetect(): Promise<void> {
     setLoading(true)
@@ -93,6 +98,9 @@ export function App(): JSX.Element {
    */
   function selectWorkspace(workspaceId: string): void {
     navDispatch({ type: 'select-workspace', workspaceId })
+    // Ignore a select while this Workspace's connect is already in flight (a fast
+    // double-click) — the ref read is synchronous, so both clicks see it.
+    if (connectingRef.current.has(workspaceId)) return
     if (shouldConnect(connections[workspaceId])) void connectWorkspace(workspaceId)
   }
 
@@ -100,15 +108,28 @@ export function App(): JSX.Element {
   async function connectWorkspace(workspaceId: string): Promise<void> {
     const workspace = recents.find((w) => w.id === workspaceId)
     if (!workspace) return
+    connectingRef.current.add(workspaceId)
     connDispatch({ type: 'set', workspaceId, state: { status: 'connecting', workspaceDir: workspace.dir } })
-    const result = await window.api.startThread({ workspaceDir: workspace.dir })
-    connDispatch({ type: 'set', workspaceId, state: routeThreadResult(result) })
-    void refreshRecents()
+    try {
+      const result = await window.api.startThread({ workspaceDir: workspace.dir })
+      connDispatch({ type: 'set', workspaceId, state: routeThreadResult(result) })
+      void refreshRecents()
+    } finally {
+      connectingRef.current.delete(workspaceId)
+    }
   }
 
   async function openProject(): Promise<void> {
     const workspaceDir = await window.api.openWorkspaceDialog()
     if (!workspaceDir) return
+    // Already warm + connected? REUSE it — just select it. Re-opening would mint a
+    // junk empty Thread on the (unchanged-agentId) ConnectedWorkspace, which won't
+    // remount to show it.
+    const warm = recents.find((w) => w.dir === workspaceDir)
+    if (warm && connections[warm.id]?.status === 'connected') {
+      navDispatch({ type: 'select-workspace', workspaceId: warm.id })
+      return
+    }
     setOpening(true)
     try {
       const result = await window.api.startThread({ workspaceDir })
@@ -118,7 +139,14 @@ export function App(): JSX.Element {
       const list = await window.api.listMetadata()
       setRecents(list)
       const ws = list.find((w) => w.dir === workspaceDir)
-      if (!ws) return // degraded (no store) — nothing to key/select
+      if (!ws) {
+        // Degraded (no store / failed list): we can't key or select this
+        // connection, so dispose the just-spawned agent rather than leak a warm
+        // connected child the renderer can never reach until quit.
+        const agentId = agentIdOfResult(result)
+        if (agentId) void window.api.stopAgent(agentId)
+        return
+      }
       connDispatch({ type: 'set', workspaceId: ws.id, state: routeThreadResult(result) })
       navDispatch({ type: 'select-workspace', workspaceId: ws.id })
     } finally {
@@ -246,6 +274,18 @@ export function App(): JSX.Element {
       />
     </div>
   )
+}
+
+/**
+ * The pool-minted `agentId` a `startThread` result carries, when any — present on
+ * a connected (`thread.agentId`) or not-signed-in (`agentId`) result, absent on a
+ * non-auth error (main already disposed that agent). Used to dispose a warm agent
+ * the renderer can't key in degraded mode (no store).
+ */
+function agentIdOfResult(result: StartThreadResult): string | null {
+  if (result.ok) return result.thread.agentId
+  if (result.kind === 'not-signed-in') return result.agentId
+  return null
 }
 
 /**

--- a/src/renderer/src/connection/connections.test.ts
+++ b/src/renderer/src/connection/connections.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+import {
+  connectedWorkspaceIds,
+  connectionsReducer,
+  initialConnections,
+  selectedConnection,
+  shouldConnect,
+  type ConnectionMap,
+} from './connections'
+import type { ConnectState } from './routing'
+import type { AuthMethod, ThreadConnection } from '../../../shared/ipc'
+
+/**
+ * Per-Workspace connection registry (ADR-0006, TB2 #47): the renderer keeps a
+ * ConnectState PER Workspace so switching between warm Workspaces is instant and
+ * both keep streaming. Pure reducer + derivations, like the nav reducer.
+ */
+
+const AUTH_METHODS: AuthMethod[] = [{ id: 'browser-auth-delegated', name: 'Sign in' }]
+
+function connected(workspaceId: string, agentId: string): ConnectState {
+  const thread: ThreadConnection = {
+    agentId,
+    workspaceDir: `/proj/${workspaceId}`,
+    threadId: `t-${workspaceId}`,
+    workspaceId,
+    sessionId: `s-${workspaceId}`,
+    title: null,
+    modes: null,
+    models: null,
+    signOutAvailable: true,
+    authMethods: AUTH_METHODS,
+  }
+  return { status: 'connected', thread }
+}
+
+describe('connectionsReducer', () => {
+  it('starts empty', () => {
+    expect(initialConnections).toEqual({})
+  })
+
+  it('set adds a Workspace connection without disturbing the others', () => {
+    const a = connectionsReducer(initialConnections, { type: 'set', workspaceId: 'w1', state: connected('w1', 'a1') })
+    const b = connectionsReducer(a, { type: 'set', workspaceId: 'w2', state: connected('w2', 'a2') })
+
+    expect(Object.keys(b)).toEqual(['w1', 'w2'])
+    expect(b.w1).toEqual(connected('w1', 'a1')) // w1 untouched when w2 connects
+  })
+
+  it('set replaces a Workspace connection in place (e.g. connecting -> connected)', () => {
+    const connecting: ConnectState = { status: 'connecting', workspaceDir: '/proj/w1' }
+    const a = connectionsReducer(initialConnections, { type: 'set', workspaceId: 'w1', state: connecting })
+    const b = connectionsReducer(a, { type: 'set', workspaceId: 'w1', state: connected('w1', 'a1') })
+
+    expect(b.w1.status).toBe('connected')
+  })
+
+  it('clear removes one Workspace connection (and is a no-op for an absent one)', () => {
+    const a = connectionsReducer(initialConnections, { type: 'set', workspaceId: 'w1', state: connected('w1', 'a1') })
+    const cleared = connectionsReducer(a, { type: 'clear', workspaceId: 'w1' })
+    expect(cleared).toEqual({})
+
+    const same = connectionsReducer(a, { type: 'clear', workspaceId: 'absent' })
+    expect(same).toBe(a) // unchanged reference: no spurious re-render
+  })
+})
+
+describe('selectedConnection', () => {
+  const map: ConnectionMap = { w1: connected('w1', 'a1') }
+
+  it('returns the selected Workspace connection', () => {
+    expect(selectedConnection(map, 'w1').status).toBe('connected')
+  })
+
+  it('returns idle when nothing is selected', () => {
+    expect(selectedConnection(map, null)).toEqual({ status: 'idle' })
+  })
+
+  it('returns idle for a never-connected Workspace (cold clicks route correctly post-connect)', () => {
+    // w2 was never connected even though w1 is connected — the outlet for w2 is
+    // idle, so its cold thread replays instead of being shadowed by w1 (finding 2).
+    expect(selectedConnection(map, 'w2')).toEqual({ status: 'idle' })
+  })
+})
+
+describe('connectedWorkspaceIds', () => {
+  it('lists only the connected Workspaces (the keep-mounted set)', () => {
+    const map: ConnectionMap = {
+      w1: connected('w1', 'a1'),
+      w2: { status: 'connecting', workspaceDir: '/proj/w2' },
+      w3: connected('w3', 'a3'),
+      w4: { status: 'not-signed-in', agentId: 'a4', workspaceDir: '/proj/w4', authMethods: AUTH_METHODS },
+    }
+    expect(connectedWorkspaceIds(map).sort()).toEqual(['w1', 'w3'])
+  })
+})
+
+describe('shouldConnect', () => {
+  it('connects a never-seen Workspace and re-tries an errored one', () => {
+    expect(shouldConnect(undefined)).toBe(true)
+    expect(shouldConnect({ status: 'idle' })).toBe(true)
+    expect(shouldConnect({ status: 'error', message: 'boom', hint: null })).toBe(true)
+  })
+
+  it('REUSES a connecting / not-signed-in / connected Workspace (no respawn)', () => {
+    expect(shouldConnect({ status: 'connecting', workspaceDir: '/proj/w1' })).toBe(false)
+    expect(
+      shouldConnect({ status: 'not-signed-in', agentId: 'a1', workspaceDir: '/proj/w1', authMethods: AUTH_METHODS }),
+    ).toBe(false)
+    expect(shouldConnect(connected('w1', 'a1'))).toBe(false)
+  })
+})

--- a/src/renderer/src/connection/connections.ts
+++ b/src/renderer/src/connection/connections.ts
@@ -1,0 +1,68 @@
+import type { ConnectState } from './routing'
+
+/**
+ * Per-Workspace connection registry (ADR-0006 decision 3, TB2 #47). The warm pool
+ * keeps MANY agents alive at once, so the renderer tracks a `ConnectState` PER
+ * Workspace (keyed by our minted `workspaceId`) instead of TB1's single `connect`.
+ * Switching between two warm Workspaces is then instant — each keeps its own
+ * connected view (and its background turn keeps streaming) while the user looks at
+ * the other. A pure reducer + derivations (no React, no IPC), mirroring the nav
+ * reducer (ADR-0001 / decision 2).
+ */
+export type ConnectionMap = Readonly<Record<string, ConnectState>>
+
+export type ConnectionAction =
+  | { type: 'set'; workspaceId: string; state: ConnectState }
+  | { type: 'clear'; workspaceId: string }
+
+export const initialConnections: ConnectionMap = {}
+
+export function connectionsReducer(state: ConnectionMap, action: ConnectionAction): ConnectionMap {
+  switch (action.type) {
+    case 'set':
+      return { ...state, [action.workspaceId]: action.state }
+    case 'clear': {
+      if (!(action.workspaceId in state)) return state
+      const next = { ...state }
+      delete next[action.workspaceId]
+      return next
+    }
+  }
+}
+
+/**
+ * The connection for the selected Workspace, or `idle` when none is selected or
+ * that Workspace was never connected. The outlet routes off THIS (not a single
+ * global `connect`), so a cold click on a never-connected Workspace correctly
+ * yields `idle` even after another Workspace connected — the TB1 finding (2)
+ * ("cold clicks dead once connected") can't recur.
+ */
+export function selectedConnection(
+  connections: ConnectionMap,
+  workspaceId: string | null,
+): ConnectState {
+  if (!workspaceId) return { status: 'idle' }
+  return connections[workspaceId] ?? { status: 'idle' }
+}
+
+/**
+ * The Workspaces with a live (connected) agent. Their connection views stay
+ * MOUNTED (hidden when not selected) so a background turn keeps streaming and the
+ * agent is never torn down on a switch — switching back is instant with no
+ * re-handshake.
+ */
+export function connectedWorkspaceIds(connections: ConnectionMap): string[] {
+  return Object.keys(connections).filter((id) => connections[id].status === 'connected')
+}
+
+/**
+ * Whether selecting a Workspace should kick off a connect (lazy spawn) vs. REUSE
+ * what's already there. A never-connected (`idle`/absent) Workspace connects; a
+ * prior `error` re-tries; a `connecting` / `not-signed-in` / `connected` Workspace
+ * is reused as-is — so reselecting a warm-but-unauthed Workspace shows its sign-in
+ * panel on the SAME warm agent rather than respawning it.
+ */
+export function shouldConnect(state: ConnectState | undefined): boolean {
+  if (!state) return true
+  return state.status === 'idle' || state.status === 'error'
+}

--- a/src/renderer/src/shell/Shell.tsx
+++ b/src/renderer/src/shell/Shell.tsx
@@ -1,53 +1,51 @@
-import { useReducer, useState, type JSX, type ReactNode } from 'react'
+import { useState, type JSX, type ReactNode } from 'react'
 import type { ListMetadataResult, ThreadMeta } from '../../../shared/ipc'
-import { ColdThread } from '../conversation/ColdThread'
-import { findSelectedThread, initialNavState, navReducer, type NavState } from './nav-reducer'
+import type { NavState } from './nav-reducer'
 
 /**
  * The persistent two-pane app shell (ADR-0006 decision 1): a left sidebar that
- * stays mounted and a right conversation OUTLET whose content swaps. Selection is
- * a pure nav reducer at this root (decision 2) — no router, no UI store.
+ * stays mounted and a right conversation OUTLET whose content swaps. Navigation
+ * (the pure nav reducer, decision 2) and the per-Workspace connection registry
+ * (decision 3) live in App now; Shell is the presentational layout — it renders the
+ * always-there sidebar (the Workspace switcher + each Workspace's Threads) and the
+ * App-computed `outlet`. The sidebar element is fixed, so navigating never unmounts
+ * it — the whole point of the shell.
  *
- * The sidebar lists the persisted Workspaces + Threads (cold metadata) and is the
- * always-there navigation surface. The outlet shows EITHER the connection-active
- * view App routes in (`connectionOutlet` — connecting / sign-in / error / the live
- * `ConnectedWorkspace`; TB4 #49 moves these inline), OR, on the idle path, the
- * nav-selected cold Thread replayed read-only (`ColdThread`). Both render INTO the
- * same outlet element while the sidebar element is fixed, so navigating never
- * unmounts the sidebar — that's the whole point of the shell.
- *
- * The warm-agent pool (decision 3) and a unified live/cold Thread list are TB2
- * (#47); here the sidebar is the cold list and live Threads surface only inside
- * the `connectionOutlet`.
+ * Two TB1-review findings are resolved by this split (TB2 #47): the outlet is
+ * routed off the nav SELECTION (App), so a cold click on a never-connected
+ * Workspace replays correctly even after another connected (finding 2); and a
+ * connected Workspace's per-Thread highlight is SUPPRESSED here, since its live view
+ * (in the outlet) owns Thread selection — the sidebar and outlet can't disagree
+ * (finding 1). The unified live/cold Thread list is TB3 (#48).
  */
 export function Shell({
   workspaces,
   sidebarTop,
-  connectionOutlet,
-  onContinueColdThread,
+  nav,
+  connectedWorkspaceIds,
+  outlet,
+  onSelectWorkspace,
+  onSelectThread,
   onDeleteThread,
 }: {
   /** Persisted Workspaces + Threads for the sidebar list (cold metadata). */
   workspaces: ListMetadataResult
   /** App-owned controls pinned above the list (Open project + environment status). */
   sidebarTop: ReactNode
-  /** The connection-active outlet (non-idle connect states), or null on the idle path. */
-  connectionOutlet: ReactNode | null
-  /** Continue a selected cold Thread live (TB4 #33) — App drives the connect flow. */
-  onContinueColdThread: (thread: ThreadMeta) => void
+  /** The current navigation selection (controlled by App). */
+  nav: NavState
+  /** Workspace ids with a live agent — suppress their Thread highlight + delete. */
+  connectedWorkspaceIds: string[]
+  /** The fully-computed conversation outlet (connection views / cold replay). */
+  outlet: ReactNode
+  /** Select a Workspace — App pins it in nav and connect-or-reuses its warm agent. */
+  onSelectWorkspace: (workspaceId: string) => void
+  /** Select a Thread — App pins it in nav (the idle outlet then replays it). */
+  onSelectThread: (workspaceId: string, threadId: string) => void
   /** Delete a Thread (TB6) — removes its metadata + JSONL, then refreshes the list. */
   onDeleteThread: (thread: ThreadMeta) => Promise<void>
 }): JSX.Element {
-  const [nav, dispatch] = useReducer(navReducer, initialNavState)
-  const selectedThread = findSelectedThread(workspaces, nav)
-  // Offer delete only while NO connection is active (`connectionOutlet` null). The
-  // always-mounted sidebar would otherwise expose delete DURING a live connection,
-  // letting a user remove the Thread the agent is hosting out from under it —
-  // orphaning the live conversation, whose next prompt would write a deleted/
-  // recreated JSONL. On `origin/main` delete lived in the idle-gated cold list and
-  // was structurally impossible while connected; we preserve that invariant. Safe
-  // live-list delete (with teardown) is TB2/TB3 (#47/#48).
-  const deletable = connectionOutlet === null
+  const connected = new Set(connectedWorkspaceIds)
 
   return (
     <div className="shell">
@@ -56,34 +54,14 @@ export function Shell({
         <WorkspaceNav
           workspaces={workspaces}
           nav={nav}
-          deletable={deletable}
-          onSelectWorkspace={(workspaceId) => dispatch({ type: 'select-workspace', workspaceId })}
-          onSelectThread={(workspaceId, threadId) =>
-            dispatch({ type: 'select-thread', workspaceId, threadId })
-          }
+          connected={connected}
+          onSelectWorkspace={onSelectWorkspace}
+          onSelectThread={onSelectThread}
           onDeleteThread={onDeleteThread}
         />
       </aside>
 
-      <main className="shell__outlet">
-        {connectionOutlet ??
-          (selectedThread ? (
-            // Idle path: reopen the selected Thread read-only from its JSONL (TB3),
-            // with a Continue affordance that hands back to App's connect flow (TB4).
-            <ColdThread
-              key={selectedThread.id}
-              thread={selectedThread}
-              onClose={() => dispatch({ type: 'clear' })}
-              onContinue={() => onContinueColdThread(selectedThread)}
-            />
-          ) : (
-            <div className="shell__empty">
-              <p className="hint">
-                Select a thread from the sidebar to view it, or open a project to start a live agent.
-              </p>
-            </div>
-          ))}
-      </main>
+      <main className="shell__outlet">{outlet}</main>
     </div>
   )
 }
@@ -91,21 +69,24 @@ export function Shell({
 /**
  * The sidebar's navigation list: persisted Workspaces with their Threads, most-
  * recent-first, rendered from cold metadata alone — NO `vibe-acp` spawned. The
- * selected Workspace / Thread are highlighted; clicking a Thread selects it (the
- * outlet then reopens it read-only). Delete (TB6) is preserved per row.
+ * selected Workspace is highlighted; clicking one selects it (App connect-or-reuses
+ * its warm agent). A Thread row highlights only when its Workspace is NOT connected
+ * (a connected Workspace's live view owns Thread selection — finding 1). Delete
+ * (TB6) is offered only for a non-connected Workspace's Threads, so we never remove
+ * a Thread a warm agent is hosting.
  */
 function WorkspaceNav({
   workspaces,
   nav,
-  deletable,
+  connected,
   onSelectWorkspace,
   onSelectThread,
   onDeleteThread,
 }: {
   workspaces: ListMetadataResult
   nav: NavState
-  /** Whether per-row delete is offered (false while a connection is active). */
-  deletable: boolean
+  /** Workspace ids with a live agent (suppress Thread highlight + delete). */
+  connected: ReadonlySet<string>
   onSelectWorkspace: (workspaceId: string) => void
   onSelectThread: (workspaceId: string, threadId: string) => void
   onDeleteThread: (thread: ThreadMeta) => Promise<void>
@@ -117,37 +98,43 @@ function WorkspaceNav({
     <nav className="recents">
       <div className="recents__title">Workspaces</div>
       <ul className="recents__list">
-        {workspaces.map((w) => (
-          <li key={w.id} className="recents__workspace">
-            <button
-              className={
-                w.id === nav.selectedWorkspaceId
-                  ? 'recents__ws-name recents__ws-name--active'
-                  : 'recents__ws-name'
-              }
-              title={w.dir}
-              onClick={() => onSelectWorkspace(w.id)}
-            >
-              {w.displayName}
-            </button>
-            {w.threads.length > 0 ? (
-              <ul className="recents__threads">
-                {w.threads.map((t) => (
-                  <NavThread
-                    key={t.id}
-                    thread={t}
-                    selected={t.id === nav.selectedThreadId}
-                    deletable={deletable}
-                    onOpen={() => onSelectThread(w.id, t.id)}
-                    onDelete={onDeleteThread}
-                  />
-                ))}
-              </ul>
-            ) : (
-              <div className="recents__empty">No threads yet</div>
-            )}
-          </li>
-        ))}
+        {workspaces.map((w) => {
+          const isConnected = connected.has(w.id)
+          return (
+            <li key={w.id} className="recents__workspace">
+              <button
+                className={
+                  w.id === nav.selectedWorkspaceId
+                    ? 'recents__ws-name recents__ws-name--active'
+                    : 'recents__ws-name'
+                }
+                title={w.dir}
+                onClick={() => onSelectWorkspace(w.id)}
+              >
+                {w.displayName}
+              </button>
+              {w.threads.length > 0 ? (
+                <ul className="recents__threads">
+                  {w.threads.map((t) => (
+                    <NavThread
+                      key={t.id}
+                      thread={t}
+                      // Suppress the per-Thread highlight for a connected Workspace —
+                      // its live outlet owns Thread selection (finding 1).
+                      selected={!isConnected && t.id === nav.selectedThreadId}
+                      // No delete while the Workspace's agent is live (it may host it).
+                      deletable={!isConnected}
+                      onOpen={() => onSelectThread(w.id, t.id)}
+                      onDelete={onDeleteThread}
+                    />
+                  ))}
+                </ul>
+              ) : (
+                <div className="recents__empty">No threads yet</div>
+              )}
+            </li>
+          )
+        })}
       </ul>
     </nav>
   )
@@ -156,10 +143,10 @@ function WorkspaceNav({
 /**
  * One Thread row in the sidebar: selecting it on click (the outlet reopens it
  * read-only — TB3), highlighted when selected, with a delete control (TB6) shown
- * only when `deletable` (i.e. no live connection — see Shell). Delete is two-step —
- * a first click arms an INLINE confirm (Delete / Cancel) rather than a native
- * `confirm()` (which would block the renderer), so a single misclick can't nuke a
- * Thread's history.
+ * only when `deletable` (i.e. its Workspace has no live connection — see Shell).
+ * Delete is two-step — a first click arms an INLINE confirm (Delete / Cancel)
+ * rather than a native `confirm()` (which would block the renderer), so a single
+ * misclick can't nuke a Thread's history.
  */
 function NavThread({
   thread,


### PR DESCRIPTION
## What this is

TB2 (closes #47) — UI/layout-shell epic (PRD #45, ADR-0006 decision 3). Replaces the dispose-then-respawn agent model with a **warm-agent pool keyed by Workspace**, and tracks connection state **per Workspace** in the renderer. Selecting a Workspace lazily spawns its agent and keeps it warm; reselecting reuses it (no re-handshake); switching away never tears it down. **Navigation is now decoupled from connection.**

## Behavior

- **`AgentPool` (main, `agent-pool.ts`):** keyed by Workspace dir, spawn-once + reuse, sole teardown path (`dispose`/`disposeAll`), injected factory (tested with a fake — no live vibe-acp). Mints the renderer-facing `agentId`. The old `disposeAgentsForWorkspace` dedup folds into reuse.
- **Per-Workspace connections (renderer, `connections.ts`):** a pure reducer keyed by `workspaceId`; every connected Workspace's view stays **mounted (hidden when unselected)** so background turns keep streaming and switch-back is instant. The outlet routes off the **nav selection**, not a single global connect.
- **Instant switching demo:** open A → start a turn → switch to B (spawns) → switch back to A instantly, no re-handshake, A's turn still streaming.
- Resolves both TB1-review findings: selection single-source-of-truth (sidebar highlight suppressed for a connected Workspace; live view owns Thread selection) and cold clicks routing correctly after a connection.

## Review

Implemented via the team loop: independent verification + an adversarial review. The two headline risks were **proven clean** — no cross-agent event bleed (per-agent `agentId` guard + per-agent tee keying) and pool↔renderer stay consistent. **No MUST-FIX.** Folded 3 SHOULD-fixes:
1. **`WorkspaceAgent.start()` concurrency-safety** — memoize the in-flight handshake so a fast double-select can't dispose the just-spawned child (+ regression test for concurrent `start()`).
2. **Degraded-mode agent leak** — `openProject`'s no-store bail disposes the orphaned warm agent.
3. **Orphan Thread on re-open** — re-opening an already-warm Workspace reuses/selects it instead of minting a junk Thread.

Deferred with a tracking note on #48 (TB3): the hidden-Workspace permission prompt → a sidebar "needs attention" badge belongs with TB3's live indicators.

## Scope

No idle-evict, no warm-count cap — **TB5 (#50)**; the pool owns lifecycle so eviction hooks into its own `dispose`. (`acp:event` listener fan-out is bounded once TB5 caps warm count — cosmetic Node warning only until then.)

## Gates

`lint` ✓ · `typecheck` ✓ · `build` ✓ · `test` ✓ — **204 tests** (19 files; +21 vs TB1's 183).

🤖 Generated with [Claude Code](https://claude.com/claude-code)