### PR TITLE
TB3 (#48): unified cold+live Thread list with streaming + needs-attention indicators

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -30,7 +30,12 @@ import {
 import { ConnectedWorkspace } from './connection/ConnectedWorkspace'
 import { routeThreadSelection, seedSessionId } from './connection/thread-selection'
 import { ColdThread } from './conversation/ColdThread'
-import { setThreadStatus, type ThreadStatus, type ThreadStatusMap } from './conversation/thread-status'
+import {
+  clearThreadStatus,
+  setThreadStatus,
+  type ThreadStatus,
+  type ThreadStatusMap,
+} from './conversation/thread-status'
 import { Shell, type WorkspaceFlags } from './shell/Shell'
 import { findSelectedThread, initialNavState, navReducer } from './shell/nav-reducer'
 import { deriveUnifiedThreads, workspaceFlags, type UnifiedThreadRow } from './shell/unified-threads'
@@ -108,22 +113,29 @@ export function App(): JSX.Element {
   /**
    * Delete a Thread from the unified list (TB6 + #48 safe-delete). Main removes its
    * metadata + JSONL and best-effort closes any live session. The sidebar only
-   * offers delete for a NON-streaming, NON-primary Thread (see `protectedThreadId`),
-   * so we never tear a Thread out from under the agent mid-stream. When the deleted
-   * Thread WAS hosted live we drop it from the Workspace's live-state and, if it was
-   * the one on screen, fall back to the connection's (always-live) primary Thread —
-   * so the outlet never points at a torn-down session. Then re-fetch.
+   * offers delete for a row `isThreadDeletable` proves safe (a cold row, or the
+   * active+idle non-primary live row), so we never tear a Thread out from under the
+   * agent mid-stream.
+   *
+   * Reselection is gated on SELECTION, not liveness: `active`/`nav.selectedThreadId`
+   * can legitimately point at a COLD (history) row, and dropping it from `recents`
+   * would leave the outlet/sidebar pinned to a now-gone Thread. So whenever the
+   * deleted Thread is the active/selected one of a CONNECTED Workspace, reselect the
+   * connection's (always-live) primary Thread. The `wt remove` (drop from live-state)
+   * runs ONLY when it was live; its stale status entry is cleared either way.
    */
   async function deleteThread(thread: ThreadMeta): Promise<void> {
     await window.api.deleteThread(thread.id)
     const wts = workspaceThreadStateFor(workspaceThreads, thread.workspaceId)
     if (wts?.live.has(thread.id)) {
       wtDispatch({ type: 'remove', workspaceId: thread.workspaceId, threadId: thread.id })
-      const conn = connections[thread.workspaceId]
-      if (conn?.status === 'connected' && wts.active === thread.id) {
-        selectThreadInWorkspace(thread.workspaceId, conn.thread.threadId)
-      }
     }
+    const conn = connections[thread.workspaceId]
+    const wasSelected = wts?.active === thread.id || nav.selectedThreadId === thread.id
+    if (conn?.status === 'connected' && wasSelected) {
+      selectThreadInWorkspace(thread.workspaceId, conn.thread.threadId)
+    }
+    setStatuses((prev) => clearThreadStatus(prev, thread.id))
     await refreshRecents()
   }
 
@@ -316,6 +328,10 @@ export function App(): JSX.Element {
   // cold/idle one lists its persisted Threads (clicking replays them, no agent).
   let rows: UnifiedThreadRow[] = []
   let protectedThreadId: string | null = null
+  // The active (mounted, observable) Thread of the selected Workspace — a live row
+  // is only deletable when it's this one and idle (we can't observe a non-active
+  // sibling's turn; #53). Null when the selected Workspace has no live connection.
+  let selectedActiveId: string | null = null
   let canCreateThread = false
   if (selectedWs) {
     const cold = threadsForWorkspace(recents, selectedWs)
@@ -329,6 +345,7 @@ export function App(): JSX.Element {
         statuses,
       })
       protectedThreadId = conn.threadId
+      selectedActiveId = wts?.active ?? conn.threadId
       canCreateThread = true
     } else {
       rows = deriveUnifiedThreads({ cold, live: [], liveThreadIds: NO_LIVE, statuses })
@@ -387,6 +404,11 @@ export function App(): JSX.Element {
   // and a switch-back is instant; the selected Workspace's transient state
   // (connecting / sign-in / error) or its cold Thread renders inline. Routed off the
   // nav selection, so cold clicks always route right.
+  //
+  // LIMITATION (follow-up #53): only the ACTIVE Thread per Workspace is mounted, so a
+  // non-active live sibling's turn is unobservable — its streaming/needs-attention
+  // indicators don't update and it stays non-deletable while in the background. We
+  // ship active-only indicators now; mounting all live siblings is deferred to #53.
   const outlet = (
     <>
       {connectedIds.map((wid) => {
@@ -425,6 +447,7 @@ export function App(): JSX.Element {
         workspaceFlags={wsFlags}
         rows={rows}
         protectedThreadId={protectedThreadId}
+        activeThreadId={selectedActiveId}
         canCreateThread={canCreateThread}
         creatingThread={creatingThread}
         outlet={outlet}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useReducer, useRef, useState, type JSX, type ReactNode } from 'react'
+import { useCallback, useEffect, useReducer, useRef, useState, type JSX, type ReactNode } from 'react'
 import type {
   AuthMethod,
   ListMetadataResult,
@@ -21,10 +21,22 @@ import {
   selectedConnection,
   shouldConnect,
 } from './connection/connections'
+import {
+  initialWorkspaceThreads,
+  workspaceThreadsReducer,
+  workspaceThreadStateFor,
+  type WorkspaceThreadState,
+} from './connection/workspace-threads'
 import { ConnectedWorkspace } from './connection/ConnectedWorkspace'
+import { routeThreadSelection, seedSessionId } from './connection/thread-selection'
 import { ColdThread } from './conversation/ColdThread'
-import { Shell } from './shell/Shell'
+import { setThreadStatus, type ThreadStatus, type ThreadStatusMap } from './conversation/thread-status'
+import { Shell, type WorkspaceFlags } from './shell/Shell'
 import { findSelectedThread, initialNavState, navReducer } from './shell/nav-reducer'
+import { deriveUnifiedThreads, workspaceFlags, type UnifiedThreadRow } from './shell/unified-threads'
+
+/** A stable empty live-set for Workspaces with no live-state yet (no re-alloc). */
+const NO_LIVE: ReadonlySet<string> = new Set()
 
 /**
  * Thin glue (ADR-0006): App owns IPC/data wiring — detection, the persisted
@@ -53,13 +65,34 @@ export function App(): JSX.Element {
   // Per-Workspace connection registry (decision 3): one ConnectState per warm
   // Workspace, so switching between two is instant and both keep streaming.
   const [connections, connDispatch] = useReducer(connectionsReducer, initialConnections)
+  // Per-Workspace, per-session Thread state (TB3 #48): the live set, bound sessions,
+  // and the active (kept-mounted) Thread — lifted OUT of ConnectedWorkspace so the
+  // sidebar + nav reducer are the single source of truth for selection/live-state.
+  const [workspaceThreads, wtDispatch] = useReducer(workspaceThreadsReducer, initialWorkspaceThreads)
+  // Per-Thread live status (TB3 #48), reported UP from each live Conversation:
+  // streaming (turn in flight) + needsAttention (pending permission). Keyed by
+  // threadId; the fold returns the same ref when unchanged so reports never loop.
+  const [statuses, setStatuses] = useState<ThreadStatusMap>({})
   // Persisted Workspaces + Threads (ADR-0005), listed cold on launch from
   // metadata alone — no agent spawned, no transcript loaded.
   const [recents, setRecents] = useState<ListMetadataResult>([])
+  // A draft mint in flight — guards New-thread against a double mint.
+  const [creatingThread, setCreatingThread] = useState(false)
+  const creatingRef = useRef(false)
   // Workspaces with a connect IN FLIGHT, tracked synchronously so a fast double-
   // select can't fire two `startThread`s (the `connections` closure is stale
   // within a render frame, so a state check alone would let both through).
   const connectingRef = useRef<Set<string>>(new Set())
+  // The committed selected Workspace, read synchronously by an async connect to
+  // decide whether to pull focus to its just-opened Thread (don't yank focus if the
+  // user has since switched away). Mirrors the latest rendered nav selection.
+  const selectionRef = useRef<string | null>(nav.selectedWorkspaceId)
+  selectionRef.current = nav.selectedWorkspaceId
+
+  /** Fold a live Conversation's reported status into the registry (stable identity). */
+  const reportStatus = useCallback((s: { threadId: string } & ThreadStatus): void => {
+    setStatuses((prev) => setThreadStatus(prev, s.threadId, { streaming: s.streaming, needsAttention: s.needsAttention }))
+  }, [])
 
   async function runDetect(): Promise<void> {
     setLoading(true)
@@ -73,16 +106,81 @@ export function App(): JSX.Element {
   }
 
   /**
-   * Delete a persisted Thread (TB6): main removes its metadata + JSONL and
-   * best-effort closes any live session; we then re-fetch so it disappears from
-   * the list. The shell derives its selected (cold) Thread from `recents`, so a
-   * deleted-and-selected Thread collapses to the placeholder on its own. Gated in
-   * the sidebar to NON-connected Workspaces, so we never delete a Thread a warm
-   * agent is hosting out from under it.
+   * Delete a Thread from the unified list (TB6 + #48 safe-delete). Main removes its
+   * metadata + JSONL and best-effort closes any live session. The sidebar only
+   * offers delete for a NON-streaming, NON-primary Thread (see `protectedThreadId`),
+   * so we never tear a Thread out from under the agent mid-stream. When the deleted
+   * Thread WAS hosted live we drop it from the Workspace's live-state and, if it was
+   * the one on screen, fall back to the connection's (always-live) primary Thread —
+   * so the outlet never points at a torn-down session. Then re-fetch.
    */
   async function deleteThread(thread: ThreadMeta): Promise<void> {
     await window.api.deleteThread(thread.id)
+    const wts = workspaceThreadStateFor(workspaceThreads, thread.workspaceId)
+    if (wts?.live.has(thread.id)) {
+      wtDispatch({ type: 'remove', workspaceId: thread.workspaceId, threadId: thread.id })
+      const conn = connections[thread.workspaceId]
+      if (conn?.status === 'connected' && wts.active === thread.id) {
+        selectThreadInWorkspace(thread.workspaceId, conn.thread.threadId)
+      }
+    }
     await refreshRecents()
+  }
+
+  /**
+   * Record a Workspace connect outcome: set its ConnectState and, when connected,
+   * (re)seed its per-session live-state with the agent's auto-opened Thread. Pull
+   * focus to that Thread when the user is still on this Workspace (`focus`, or the
+   * live selection still matches) — so the sidebar highlights the live Thread and
+   * the outlet routes to it, without yanking focus from a Workspace switched-to
+   * while this connect was in flight.
+   */
+  function applyConnectResult(workspaceId: string, state: ConnectState, focus: boolean): void {
+    connDispatch({ type: 'set', workspaceId, state })
+    if (state.status !== 'connected') return
+    wtDispatch({
+      type: 'connect',
+      workspaceId,
+      threadId: state.thread.threadId,
+      sessionId: state.thread.sessionId,
+    })
+    if (focus || selectionRef.current === workspaceId) {
+      navDispatch({ type: 'select-thread', workspaceId, threadId: state.thread.threadId })
+    }
+  }
+
+  /**
+   * Select a Thread from the sidebar (TB3 #48): pin it in nav (the single source of
+   * truth) and, for a connected Workspace, remember it as the active (kept-mounted)
+   * Thread so backgrounding the Workspace keeps it streaming.
+   */
+  function selectThreadInWorkspace(workspaceId: string, threadId: string): void {
+    navDispatch({ type: 'select-thread', workspaceId, threadId })
+    if (workspaceThreadStateFor(workspaceThreads, workspaceId)) {
+      wtDispatch({ type: 'select', workspaceId, threadId })
+    }
+  }
+
+  /**
+   * New-thread (TB5 draft) from the unified list: mint a durable id (no ACP session
+   * until its first prompt) on the selected Workspace's live agent, host it live +
+   * select it, then refresh so it lands in the persisted list. No residue if
+   * abandoned — it's a metadata-only record via the existing draft path.
+   */
+  async function newThread(workspaceId: string): Promise<void> {
+    if (creatingRef.current) return
+    creatingRef.current = true
+    setCreatingThread(true)
+    try {
+      const result = await window.api.createDraft({ workspaceId })
+      if (!result.ok) return
+      wtDispatch({ type: 'open', workspaceId, threadId: result.thread.id })
+      navDispatch({ type: 'select-thread', workspaceId, threadId: result.thread.id })
+      await refreshRecents()
+    } finally {
+      creatingRef.current = false
+      setCreatingThread(false)
+    }
   }
 
   useEffect(() => {
@@ -97,7 +195,12 @@ export function App(): JSX.Element {
    * reused as-is — instant, no second spawn or handshake.
    */
   function selectWorkspace(workspaceId: string): void {
-    navDispatch({ type: 'select-workspace', workspaceId })
+    // Restore this Workspace's remembered active Thread (TB3 #48) so the sidebar
+    // highlights it and the kept-mounted outlet shows it again; a never-connected
+    // Workspace just pins the Workspace (its cold list drives the cold outlet).
+    const wts = workspaceThreadStateFor(workspaceThreads, workspaceId)
+    if (wts) navDispatch({ type: 'select-thread', workspaceId, threadId: wts.active })
+    else navDispatch({ type: 'select-workspace', workspaceId })
     // Ignore a select while this Workspace's connect is already in flight (a fast
     // double-click) — the ref read is synchronous, so both clicks see it.
     if (connectingRef.current.has(workspaceId)) return
@@ -112,7 +215,7 @@ export function App(): JSX.Element {
     connDispatch({ type: 'set', workspaceId, state: { status: 'connecting', workspaceDir: workspace.dir } })
     try {
       const result = await window.api.startThread({ workspaceDir: workspace.dir })
-      connDispatch({ type: 'set', workspaceId, state: routeThreadResult(result) })
+      applyConnectResult(workspaceId, routeThreadResult(result), false)
       void refreshRecents()
     } finally {
       connectingRef.current.delete(workspaceId)
@@ -147,8 +250,8 @@ export function App(): JSX.Element {
         if (agentId) void window.api.stopAgent(agentId)
         return
       }
-      connDispatch({ type: 'set', workspaceId: ws.id, state: routeThreadResult(result) })
       navDispatch({ type: 'select-workspace', workspaceId: ws.id })
+      applyConnectResult(ws.id, routeThreadResult(result), true)
     } finally {
       setOpening(false)
     }
@@ -157,7 +260,7 @@ export function App(): JSX.Element {
   // After sign-in (or in-place re-auth) the Workspace's warm agent is already
   // started + signed in; open a Thread on it and land in a connected conversation.
   async function continueToThread(workspaceId: string, agentId: string): Promise<void> {
-    connDispatch({ type: 'set', workspaceId, state: routeThreadResult(await window.api.openThread({ agentId })) })
+    applyConnectResult(workspaceId, routeThreadResult(await window.api.openThread({ agentId })), true)
     void refreshRecents()
   }
 
@@ -174,7 +277,9 @@ export function App(): JSX.Element {
     navDispatch({ type: 'select-workspace', workspaceId: workspace.id })
     connDispatch({ type: 'set', workspaceId: workspace.id, state: { status: 'connecting', workspaceDir: workspace.dir } })
     const result = await window.api.startThread({ workspaceDir: workspace.dir, continueThreadId: thread.id })
-    connDispatch({ type: 'set', workspaceId: workspace.id, state: routeThreadResult(result) })
+    // Main opened NO extra Thread — the continued Thread IS the connection Thread, so
+    // `applyConnectResult` seeds it live + selects it (its first prompt drives resume).
+    applyConnectResult(workspace.id, routeThreadResult(result), true)
     void refreshRecents()
   }
 
@@ -195,49 +300,100 @@ export function App(): JSX.Element {
   )
 
   const connectedIds = connectedWorkspaceIds(connections)
-  const selected = selectedConnection(connections, nav.selectedWorkspaceId)
+  const selectedWs = nav.selectedWorkspaceId
+  const selected = selectedConnection(connections, selectedWs)
 
-  /** The connected view for a Workspace (SignedInBar + ConnectedWorkspace). */
-  function renderConnected(thread: ThreadConnection): ReactNode {
+  // Per-Workspace rolled-up live status for the switcher badges — what flags a
+  // BACKGROUND Workspace blocked on a permission prompt (the deferred TB2 finding).
+  const wsFlags: Record<string, WorkspaceFlags> = {}
+  for (const wid of connectedIds) {
+    const wts = workspaceThreadStateFor(workspaceThreads, wid)
+    wsFlags[wid] = workspaceFlags(wts?.live ?? NO_LIVE, statuses)
+  }
+
+  // The ONE unified Thread list (cold + live merged) for the SELECTED Workspace,
+  // plus its New/delete affordances. A connected Workspace merges its live set; a
+  // cold/idle one lists its persisted Threads (clicking replays them, no agent).
+  let rows: UnifiedThreadRow[] = []
+  let protectedThreadId: string | null = null
+  let canCreateThread = false
+  if (selectedWs) {
+    const cold = threadsForWorkspace(recents, selectedWs)
+    if (selected.status === 'connected') {
+      const conn = selected.thread
+      const wts = workspaceThreadStateFor(workspaceThreads, selectedWs)
+      rows = deriveUnifiedThreads({
+        cold,
+        live: liveMetasFor(conn, cold, wts),
+        liveThreadIds: wts?.live ?? new Set([conn.threadId]),
+        statuses,
+      })
+      protectedThreadId = conn.threadId
+      canCreateThread = true
+    } else {
+      rows = deriveUnifiedThreads({ cold, live: [], liveThreadIds: NO_LIVE, statuses })
+    }
+  }
+
+  /** The connected view for a Workspace (SignedInBar + the controlled outlet). */
+  function renderConnected(conn: ThreadConnection): ReactNode {
+    const wts = workspaceThreadStateFor(workspaceThreads, conn.workspaceId)
+    const cold = threadsForWorkspace(recents, conn.workspaceId)
+    const activeId = wts?.active ?? conn.threadId
+    const activeThread =
+      [...liveMetasFor(conn, cold, wts), ...cold].find((t) => t.id === activeId) ?? synthConnectionMeta(conn)
+    // Route + seed via the same pure helpers the cold list uses: live-set membership
+    // decides live-vs-cold; a session bound this session wins over the persisted cursor.
+    const liveIds = wts?.live ?? new Set([conn.threadId])
+    const isLive = routeThreadSelection(activeThread, liveIds) === 'live'
+    const seed = seedSessionId(activeThread, wts?.bound ?? {})
     return (
       <>
         {/* Key by agentId (like Conversation) so its useReducer seed resets across
             connections — a new agent can't inherit the prior session's sign-out gate. */}
         <SignedInBar
-          key={`bar-${thread.agentId}`}
-          agentId={thread.agentId}
-          authMethods={thread.authMethods}
-          signOutAvailable={thread.signOutAvailable}
-          onSignedOut={(authMethods) =>
-            toSignInPanel(thread.workspaceId, thread.agentId, thread.workspaceDir, authMethods)
-          }
+          key={`bar-${conn.agentId}`}
+          agentId={conn.agentId}
+          authMethods={conn.authMethods}
+          signOutAvailable={conn.signOutAvailable}
+          onSignedOut={(authMethods) => toSignInPanel(conn.workspaceId, conn.agentId, conn.workspaceDir, authMethods)}
         />
-        {/* Key by agentId so per-Workspace Thread state can't bleed across
-            connections. Hosts multiple Threads on the one agent + switching (TB5). */}
+        {/* Key by agentId so per-Workspace state can't bleed across connections.
+            A controlled outlet now (TB3 #48): the sidebar drives selection; this just
+            renders App's chosen active Thread live or cold. */}
         <ConnectedWorkspace
-          key={thread.agentId}
-          connection={thread}
-          threads={threadsForWorkspace(recents, thread.workspaceId)}
-          refreshRecents={refreshRecents}
-          onAuthExpired={(authMethods) =>
-            toSignInPanel(thread.workspaceId, thread.agentId, thread.workspaceDir, authMethods)
+          key={conn.agentId}
+          connection={conn}
+          activeThread={activeThread}
+          isLive={isLive}
+          seedSessionId={seed}
+          onBound={(sessionId) =>
+            wtDispatch({ type: 'bind', workspaceId: conn.workspaceId, threadId: activeThread.id, sessionId })
           }
+          onContinue={() => {
+            wtDispatch({ type: 'open', workspaceId: conn.workspaceId, threadId: activeThread.id })
+            navDispatch({ type: 'select-thread', workspaceId: conn.workspaceId, threadId: activeThread.id })
+          }}
+          onCloseCold={() => selectThreadInWorkspace(conn.workspaceId, conn.threadId)}
+          onAuthExpired={(authMethods) => toSignInPanel(conn.workspaceId, conn.agentId, conn.workspaceDir, authMethods)}
+          onStatusChange={reportStatus}
         />
       </>
     )
   }
 
   // The outlet: every connected Workspace stays MOUNTED (hidden unless selected) so
-  // its background turn keeps streaming and a switch-back is instant; the selected
-  // Workspace's transient state (connecting / sign-in / error) or its cold Thread
-  // renders inline. Routed off the nav selection, so cold clicks always route right.
+  // its active Thread's turn keeps streaming and reports status (the sidebar badge),
+  // and a switch-back is instant; the selected Workspace's transient state
+  // (connecting / sign-in / error) or its cold Thread renders inline. Routed off the
+  // nav selection, so cold clicks always route right.
   const outlet = (
     <>
       {connectedIds.map((wid) => {
         const conn = connections[wid]
         if (conn.status !== 'connected') return null
         return (
-          <div key={wid} className="shell__connection" hidden={wid !== nav.selectedWorkspaceId}>
+          <div key={wid} className="shell__connection" hidden={wid !== selectedWs}>
             {renderConnected(conn.thread)}
           </div>
         )
@@ -246,7 +402,7 @@ export function App(): JSX.Element {
         ? null // rendered (visible) in the keep-mounted map above
         : selected.status !== 'idle'
           ? renderTransientOutlet(selected, {
-              continueToThread: (agentId) => void continueToThread(nav.selectedWorkspaceId ?? '', agentId),
+              continueToThread: (agentId) => void continueToThread(selectedWs ?? '', agentId),
             })
           : renderColdOutlet(recents, nav, {
               onClose: () => navDispatch({ type: 'clear' }),
@@ -266,14 +422,63 @@ export function App(): JSX.Element {
         workspaces={recents}
         sidebarTop={sidebarTop}
         nav={nav}
-        connectedWorkspaceIds={connectedIds}
+        workspaceFlags={wsFlags}
+        rows={rows}
+        protectedThreadId={protectedThreadId}
+        canCreateThread={canCreateThread}
+        creatingThread={creatingThread}
         outlet={outlet}
         onSelectWorkspace={selectWorkspace}
-        onSelectThread={(workspaceId, threadId) => navDispatch({ type: 'select-thread', workspaceId, threadId })}
+        onSelectThread={selectThreadInWorkspace}
+        onNewThread={() => selectedWs && void newThread(selectedWs)}
         onDeleteThread={deleteThread}
       />
     </div>
   )
+}
+
+/**
+ * The metas for a Workspace's live Threads (TB3 #48), feeding the unified-list
+ * merge. A live Thread already in the cold list reuses that meta; one not yet
+ * persisted is synthesized so it shows immediately — the agent's auto-opened Thread
+ * (before the metadata refresh lands) or a freshly minted draft (its bound session,
+ * if any, seeds its live view).
+ */
+function liveMetasFor(
+  conn: ThreadConnection,
+  cold: ThreadMeta[],
+  wts: WorkspaceThreadState | null,
+): ThreadMeta[] {
+  const byId = new Map(cold.map((t) => [t.id, t]))
+  const ids = wts ? wts.live : new Set([conn.threadId])
+  const metas: ThreadMeta[] = []
+  for (const id of ids) {
+    const existing = byId.get(id)
+    if (existing) metas.push(existing)
+    else if (id === conn.threadId) metas.push(synthConnectionMeta(conn))
+    else
+      metas.push({
+        id,
+        workspaceId: conn.workspaceId,
+        sessionId: wts?.bound[id] ?? null,
+        title: null,
+        createdAt: 0,
+        lastActiveAt: 0,
+      })
+  }
+  return metas
+}
+
+/** Synthesize the connection's auto-opened Thread meta (when the list lags). */
+function synthConnectionMeta(conn: ThreadConnection): ThreadMeta {
+  return {
+    id: conn.threadId,
+    workspaceId: conn.workspaceId,
+    sessionId: conn.sessionId,
+    title: conn.title,
+    createdAt: 0,
+    lastActiveAt: 0,
+  }
 }
 
 /**

--- a/src/renderer/src/connection/ConnectedWorkspace.tsx
+++ b/src/renderer/src/connection/ConnectedWorkspace.tsx
@@ -1,155 +1,71 @@
-import { useState, type JSX } from 'react'
+import { type JSX } from 'react'
 import type { AuthMethod, ThreadConnection, ThreadMeta } from '../../../shared/ipc'
 import { ColdThread } from '../conversation/ColdThread'
 import { Conversation } from '../conversation/Conversation'
-import { routeThreadSelection, seedSessionId } from './thread-selection'
+import type { ThreadStatus } from '../conversation/thread-status'
 
 /**
- * A connected Workspace hosting MULTIPLE Threads on one `vibe-acp` agent (TB5
- * #34). Lists the Workspace's Threads, mints new drafts (`New Thread` — a durable
- * id with NO ACP session until its first prompt), and switches between them: a
- * Thread hosted live this session renders as a live `Conversation` (binding its
- * draft session on the first prompt); one bound in a prior launch replays
- * read-only from JSONL (`ColdThread`) until TB4 adds `session/load`.
+ * A connected Workspace's conversation OUTLET (ADR-0006, TB3 #48). It no longer
+ * owns a Thread switcher or any selection/live-state — those are lifted to App (the
+ * unified sidebar drives selection; `workspace-threads` holds the per-Workspace
+ * live set + bound sessions + active Thread). This is now a thin CONTROLLED view:
+ * given the connection and the App-chosen `active` Thread, it renders that Thread
+ * live (`Conversation`, binding its draft session on the first prompt) or, when the
+ * Thread isn't hosted on this session's agent, read-only from JSONL (`ColdThread`)
+ * with a Continue affordance that promotes it live.
  *
- * Thread metadata comes from the cold list (`recents`); the agent context
- * (agentId, our minted ids) comes from the initial `connection`. `liveThreadIds`
- * tracks which Threads are hosted on THIS agent — the auto-opened one plus drafts
- * created since connecting — and is the source of truth for live-vs-cold routing.
+ * It stays MOUNTED (hidden) for a background Workspace so its turn keeps streaming
+ * and its status keeps reporting (`onStatusChange`) — which is what lets the sidebar
+ * flag a background Workspace blocked on an unanswerable permission prompt.
  */
 export function ConnectedWorkspace({
   connection,
-  threads,
-  refreshRecents,
+  activeThread,
+  isLive,
+  seedSessionId,
+  onBound,
+  onContinue,
+  onCloseCold,
   onAuthExpired,
+  onStatusChange,
 }: {
   connection: ThreadConnection
-  /** The Workspace's persisted Threads (most-recent-first) from the cold list. */
-  threads: ThreadMeta[]
-  /** Re-fetch the metadata list (after minting a draft) so it appears immediately. */
-  refreshRecents: () => Promise<void>
+  /** The Thread App chose to show (its remembered active Thread for this Workspace). */
+  activeThread: ThreadMeta
+  /** Whether `activeThread` is hosted live on this session's agent (vs cold replay). */
+  isLive: boolean
+  /** The session to seed a live view with (bound-this-session wins over the cursor). */
+  seedSessionId: string | null
+  /** A draft's first prompt bound its session — lift it to App's live-state. */
+  onBound: (sessionId: string) => void
+  /** Promote the (cold) active Thread to live (Continue) — App hosts + reselects it. */
+  onContinue: () => void
+  /** Back out of a cold view to the connection's primary live Thread. */
+  onCloseCold: () => void
   /** Mid-session expiry (-32000): route to in-place re-auth with these methods. */
   onAuthExpired: (authMethods: AuthMethod[]) => void
+  /** Report the active live Thread's status UP for the unified sidebar indicators. */
+  onStatusChange: (status: { threadId: string } & ThreadStatus) => void
 }): JSX.Element {
-  // A continue-from-cold-launch lands here with the CONTINUED Thread already AS the
-  // connection thread (main opened no extra Thread, TB4 #33) — so it's live +
-  // selected by default, with no separate continue plumbing.
-  const [liveThreadIds, setLiveThreadIds] = useState<ReadonlySet<string>>(
-    () => new Set([connection.threadId]),
-  )
-  const [selectedThreadId, setSelectedThreadId] = useState(connection.threadId)
-  // Sessions bound this session (TB5): a draft's first prompt mints one, lifted
-  // here so switching away and back re-seeds it instead of re-minting.
-  const [boundSessions, setBoundSessions] = useState<Record<string, string>>(() =>
-    connection.sessionId ? { [connection.threadId]: connection.sessionId } : {},
-  )
-  const [busy, setBusy] = useState(false)
-
-  // The agent always hosts at least its auto-opened Thread — ensure it's listed
-  // even before the metadata list refresh that includes it has landed.
-  const list = withConnectionThread(threads, connection)
-  const selected = list.find((t) => t.id === selectedThreadId) ?? list[0]
-  const view = routeThreadSelection(selected, liveThreadIds)
-
-  async function newThread(): Promise<void> {
-    if (busy) return
-    setBusy(true)
-    try {
-      const result = await window.api.createDraft({ workspaceId: connection.workspaceId })
-      if (!result.ok) return
-      // The draft is hosted on THIS agent (its session binds on first prompt).
-      setLiveThreadIds((prev) => new Set(prev).add(result.thread.id))
-      await refreshRecents()
-      setSelectedThreadId(result.thread.id)
-    } finally {
-      setBusy(false)
-    }
-  }
-
-  // The session to seed the selected Thread with: the one bound this session (if
-  // any) wins over the persisted cursor, so a bound draft isn't re-minted on switch.
-  const seedSession = seedSessionId(selected, boundSessions)
-
-  // Continue a reopened (cold) Thread (TB4 #33): promote it to live + select it.
-  // Its persisted `sessionId` cursor seeds the live view, so the FIRST prompt drives
-  // `ensureBoundSession`'s resume path (`session/load`, re-binding fresh on failure).
-  function continueThread(threadId: string): void {
-    setLiveThreadIds((prev) => new Set(prev).add(threadId))
-    setSelectedThreadId(threadId)
-  }
-
   return (
     <div className="workspace">
-      <div className="workspace__bar">
-        <span className="workspace__name" title={connection.workspaceDir}>
-          {connection.workspaceDir}
-        </span>
-        <button className="btn" onClick={() => void newThread()} disabled={busy}>
-          New Thread
-        </button>
-      </div>
-
-      <ul className="workspace__threads">
-        {list.map((t) => (
-          <li key={t.id}>
-            <button
-              className={
-                t.id === selected.id ? 'workspace__thread workspace__thread--active' : 'workspace__thread'
-              }
-              onClick={() => setSelectedThreadId(t.id)}
-            >
-              <span className="workspace__thread-label">{threadLabel(t, liveThreadIds)}</span>
-              {!liveThreadIds.has(t.id) && <span className="badge">history</span>}
-            </button>
-          </li>
-        ))}
-      </ul>
-
-      {view === 'live' ? (
+      {isLive ? (
         <Conversation
-          key={selected.id}
+          key={activeThread.id}
           thread={{
             agentId: connection.agentId,
-            threadId: selected.id,
+            threadId: activeThread.id,
             workspaceId: connection.workspaceId,
-            sessionId: seedSession,
-            title: selected.title,
+            sessionId: seedSessionId,
+            title: activeThread.title,
           }}
           onAuthExpired={onAuthExpired}
-          onBound={(sessionId) =>
-            setBoundSessions((prev) => ({ ...prev, [selected.id]: sessionId }))
-          }
+          onBound={onBound}
+          onStatusChange={onStatusChange}
         />
       ) : (
-        <ColdThread
-          key={selected.id}
-          thread={selected}
-          onClose={() => setSelectedThreadId(connection.threadId)}
-          onContinue={() => continueThread(selected.id)}
-        />
+        <ColdThread key={activeThread.id} thread={activeThread} onClose={onCloseCold} onContinue={onContinue} />
       )}
     </div>
   )
-}
-
-/** Ensure the agent's auto-opened Thread is present (synthesized if the list lags). */
-function withConnectionThread(threads: ThreadMeta[], connection: ThreadConnection): ThreadMeta[] {
-  if (threads.some((t) => t.id === connection.threadId)) return threads
-  const synthesized: ThreadMeta = {
-    id: connection.threadId,
-    workspaceId: connection.workspaceId,
-    sessionId: connection.sessionId,
-    title: connection.title,
-    createdAt: 0,
-    lastActiveAt: 0,
-  }
-  return [synthesized, ...threads]
-}
-
-/** A Thread's list label — its title, or a draft/placeholder until one arrives. */
-function threadLabel(thread: ThreadMeta, liveThreadIds: ReadonlySet<string>): string {
-  if (thread.title) return thread.title
-  // A live, session-less Thread is a fresh draft awaiting its first prompt.
-  if (liveThreadIds.has(thread.id) && thread.sessionId === null) return 'New thread (draft)'
-  return 'Untitled thread'
 }

--- a/src/renderer/src/connection/workspace-threads.test.ts
+++ b/src/renderer/src/connection/workspace-threads.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest'
+import {
+  initialWorkspaceThreads,
+  workspaceThreadsReducer,
+  workspaceThreadStateFor,
+  type WorkspaceThreadsState,
+} from './workspace-threads'
+
+/**
+ * Per-Workspace, per-session Thread state lifted out of ConnectedWorkspace (TB3
+ * #48): the live set, bound sessions, and the active (kept-mounted) Thread, keyed
+ * by Workspace so several warm Workspaces coexist. Pure reducer + derivation.
+ */
+
+describe('workspaceThreadsReducer', () => {
+  it('connect seeds the live set + active with the auto-opened Thread', () => {
+    const s = workspaceThreadsReducer(initialWorkspaceThreads, {
+      type: 'connect',
+      workspaceId: 'w1',
+      threadId: 't-open',
+      sessionId: 's1',
+    })
+    expect([...s.w1.live]).toEqual(['t-open'])
+    expect(s.w1.bound).toEqual({ 't-open': 's1' })
+    expect(s.w1.active).toBe('t-open')
+  })
+
+  it('connect with a null session seeds no bound entry (a continued/never-bound Thread)', () => {
+    const s = workspaceThreadsReducer(initialWorkspaceThreads, {
+      type: 'connect',
+      workspaceId: 'w1',
+      threadId: 't-cont',
+      sessionId: null,
+    })
+    expect(s.w1.bound).toEqual({})
+    expect([...s.w1.live]).toEqual(['t-cont'])
+  })
+
+  it('connect resets a reconnecting Workspace (new agent drops prior drafts)', () => {
+    let s = workspaceThreadsReducer(initialWorkspaceThreads, {
+      type: 'connect',
+      workspaceId: 'w1',
+      threadId: 't-open',
+      sessionId: 's1',
+    })
+    s = workspaceThreadsReducer(s, { type: 'open', workspaceId: 'w1', threadId: 'draft' })
+    s = workspaceThreadsReducer(s, { type: 'connect', workspaceId: 'w1', threadId: 't-new', sessionId: 's2' })
+    expect([...s.w1.live]).toEqual(['t-new']) // 'draft' gone with the old agent
+    expect(s.w1.active).toBe('t-new')
+  })
+
+  it('open hosts a new Thread live and makes it active', () => {
+    let s = workspaceThreadsReducer(initialWorkspaceThreads, {
+      type: 'connect',
+      workspaceId: 'w1',
+      threadId: 't-open',
+      sessionId: null,
+    })
+    s = workspaceThreadsReducer(s, { type: 'open', workspaceId: 'w1', threadId: 'draft' })
+    expect([...s.w1.live].sort()).toEqual(['draft', 't-open'])
+    expect(s.w1.active).toBe('draft')
+  })
+
+  it('open on an unconnected Workspace is a no-op (no agent to host it)', () => {
+    const s = workspaceThreadsReducer(initialWorkspaceThreads, {
+      type: 'open',
+      workspaceId: 'w1',
+      threadId: 'draft',
+    })
+    expect(s).toBe(initialWorkspaceThreads)
+  })
+
+  it('select changes the active Thread only (no live-set change)', () => {
+    let s = workspaceThreadsReducer(initialWorkspaceThreads, {
+      type: 'connect',
+      workspaceId: 'w1',
+      threadId: 't-open',
+      sessionId: null,
+    })
+    s = workspaceThreadsReducer(s, { type: 'open', workspaceId: 'w1', threadId: 'draft' })
+    s = workspaceThreadsReducer(s, { type: 'select', workspaceId: 'w1', threadId: 't-open' })
+    expect(s.w1.active).toBe('t-open')
+    expect([...s.w1.live].sort()).toEqual(['draft', 't-open'])
+  })
+
+  it('select to the same active Thread returns the same state reference', () => {
+    const s = workspaceThreadsReducer(initialWorkspaceThreads, {
+      type: 'connect',
+      workspaceId: 'w1',
+      threadId: 't-open',
+      sessionId: null,
+    })
+    expect(workspaceThreadsReducer(s, { type: 'select', workspaceId: 'w1', threadId: 't-open' })).toBe(s)
+  })
+
+  it('bind records a session bound this session', () => {
+    let s = workspaceThreadsReducer(initialWorkspaceThreads, {
+      type: 'connect',
+      workspaceId: 'w1',
+      threadId: 't-open',
+      sessionId: null,
+    })
+    s = workspaceThreadsReducer(s, { type: 'open', workspaceId: 'w1', threadId: 'draft' })
+    s = workspaceThreadsReducer(s, { type: 'bind', workspaceId: 'w1', threadId: 'draft', sessionId: 'sD' })
+    expect(s.w1.bound).toEqual({ draft: 'sD' })
+  })
+
+  it('bind with an unchanged session returns the same state reference', () => {
+    const s = workspaceThreadsReducer(initialWorkspaceThreads, {
+      type: 'connect',
+      workspaceId: 'w1',
+      threadId: 't-open',
+      sessionId: 's1',
+    })
+    expect(workspaceThreadsReducer(s, { type: 'bind', workspaceId: 'w1', threadId: 't-open', sessionId: 's1' })).toBe(s)
+  })
+
+  it('remove drops a live Thread + its bound session (delete teardown)', () => {
+    let s = workspaceThreadsReducer(initialWorkspaceThreads, {
+      type: 'connect',
+      workspaceId: 'w1',
+      threadId: 't-open',
+      sessionId: 's1',
+    })
+    s = workspaceThreadsReducer(s, { type: 'open', workspaceId: 'w1', threadId: 'draft' })
+    s = workspaceThreadsReducer(s, { type: 'bind', workspaceId: 'w1', threadId: 'draft', sessionId: 'sD' })
+    s = workspaceThreadsReducer(s, { type: 'remove', workspaceId: 'w1', threadId: 'draft' })
+    expect([...s.w1.live]).toEqual(['t-open'])
+    expect(s.w1.bound).toEqual({ 't-open': 's1' })
+  })
+
+  it('remove of a non-live Thread is a no-op', () => {
+    const s = workspaceThreadsReducer(initialWorkspaceThreads, {
+      type: 'connect',
+      workspaceId: 'w1',
+      threadId: 't-open',
+      sessionId: null,
+    })
+    expect(workspaceThreadsReducer(s, { type: 'remove', workspaceId: 'w1', threadId: 'cold' })).toBe(s)
+  })
+
+  it('keeps Workspaces independent (one connect does not disturb another)', () => {
+    let s = workspaceThreadsReducer(initialWorkspaceThreads, {
+      type: 'connect',
+      workspaceId: 'w1',
+      threadId: 't1',
+      sessionId: null,
+    })
+    s = workspaceThreadsReducer(s, { type: 'connect', workspaceId: 'w2', threadId: 't2', sessionId: null })
+    expect(Object.keys(s).sort()).toEqual(['w1', 'w2'])
+    expect(s.w1.active).toBe('t1')
+  })
+})
+
+describe('workspaceThreadStateFor', () => {
+  const state: WorkspaceThreadsState = {
+    w1: { live: new Set(['t1']), bound: {}, active: 't1' },
+  }
+  it('returns a Workspace live-state', () => {
+    expect(workspaceThreadStateFor(state, 'w1')?.active).toBe('t1')
+  })
+  it('returns null for an unconnected or unselected Workspace', () => {
+    expect(workspaceThreadStateFor(state, 'w2')).toBeNull()
+    expect(workspaceThreadStateFor(state, null)).toBeNull()
+  })
+})

--- a/src/renderer/src/connection/workspace-threads.ts
+++ b/src/renderer/src/connection/workspace-threads.ts
@@ -1,0 +1,102 @@
+/**
+ * Per-Workspace, per-session Thread state (ADR-0006, TB3 #48) — lifted OUT of
+ * `ConnectedWorkspace` so the sidebar (and the nav reducer) is the single source
+ * of truth for selection and live-state, and `ConnectedWorkspace` becomes a
+ * controlled outlet. The warm pool keeps several Workspaces live at once, so this
+ * is keyed by `workspaceId`, mirroring the connection registry.
+ *
+ * Per Workspace we track exactly what `ConnectedWorkspace` used to own internally:
+ * - `live`: which Threads are hosted on THIS session's agent (the auto-opened
+ *   Thread + drafts/continued Threads) — the source of truth for live-vs-cold
+ *   routing (mirrors `routeThreadSelection`), NOT a stale persisted `sessionId`.
+ * - `bound`: sessions minted this session (threadId -> sessionId), so switching
+ *   away from a just-bound draft and back re-seeds it instead of re-minting.
+ * - `active`: the Thread this Workspace is currently showing. Lifted so a
+ *   BACKGROUND (hidden) Workspace keeps its in-flight Thread mounted/streaming
+ *   while the user looks elsewhere — the keep-mounted outlet renders `active`.
+ *
+ * A pure reducer + derivation (no React, no IPC), like the nav/connection reducers.
+ */
+export interface WorkspaceThreadState {
+  live: ReadonlySet<string>
+  bound: Readonly<Record<string, string>>
+  active: string
+}
+
+export type WorkspaceThreadsState = Readonly<Record<string, WorkspaceThreadState>>
+
+export type WorkspaceThreadsAction =
+  // A Workspace (re)connected: reset its live-state to the agent's auto-opened
+  // Thread. Fired once per connection — a reconnect (new agent) deliberately drops
+  // the prior session's drafts (their sessions died with the old process).
+  | { type: 'connect'; workspaceId: string; threadId: string; sessionId: string | null }
+  // A draft was minted or a cold Thread continued: host it live and make it active.
+  | { type: 'open'; workspaceId: string; threadId: string }
+  // Switch which Thread the Workspace is showing (kept mounted when backgrounded).
+  | { type: 'select'; workspaceId: string; threadId: string }
+  // A draft's first prompt bound its session (`thread:bound`) — record it.
+  | { type: 'bind'; workspaceId: string; threadId: string; sessionId: string }
+  // A live Thread was deleted (TB6): drop it from the live set + its bound session.
+  | { type: 'remove'; workspaceId: string; threadId: string }
+
+export const initialWorkspaceThreads: WorkspaceThreadsState = {}
+
+export function workspaceThreadsReducer(
+  state: WorkspaceThreadsState,
+  action: WorkspaceThreadsAction,
+): WorkspaceThreadsState {
+  switch (action.type) {
+    case 'connect':
+      return {
+        ...state,
+        [action.workspaceId]: {
+          live: new Set([action.threadId]),
+          bound: action.sessionId ? { [action.threadId]: action.sessionId } : {},
+          active: action.threadId,
+        },
+      }
+    case 'open': {
+      const cur = state[action.workspaceId]
+      if (!cur) return state
+      const live = new Set(cur.live)
+      live.add(action.threadId)
+      return { ...state, [action.workspaceId]: { ...cur, live, active: action.threadId } }
+    }
+    case 'select': {
+      const cur = state[action.workspaceId]
+      if (!cur || cur.active === action.threadId) return state
+      return { ...state, [action.workspaceId]: { ...cur, active: action.threadId } }
+    }
+    case 'bind': {
+      const cur = state[action.workspaceId]
+      if (!cur || cur.bound[action.threadId] === action.sessionId) return state
+      return {
+        ...state,
+        [action.workspaceId]: {
+          ...cur,
+          bound: { ...cur.bound, [action.threadId]: action.sessionId },
+        },
+      }
+    }
+    case 'remove': {
+      const cur = state[action.workspaceId]
+      if (!cur || !cur.live.has(action.threadId)) return state
+      const live = new Set(cur.live)
+      live.delete(action.threadId)
+      const bound = { ...cur.bound }
+      delete bound[action.threadId]
+      // `active` is left to the caller: deleting the active Thread is paired with a
+      // `select` back to the connection's primary Thread (which is never deletable).
+      return { ...state, [action.workspaceId]: { ...cur, live, bound } }
+    }
+  }
+}
+
+/** A Workspace's live-state, or null when it has never connected this session. */
+export function workspaceThreadStateFor(
+  state: WorkspaceThreadsState,
+  workspaceId: string | null,
+): WorkspaceThreadState | null {
+  if (!workspaceId) return null
+  return state[workspaceId] ?? null
+}

--- a/src/renderer/src/conversation/Conversation.tsx
+++ b/src/renderer/src/conversation/Conversation.tsx
@@ -16,6 +16,7 @@ import {
 } from './reducer'
 import { eventBelongsToThread } from './event-routing'
 import { replayTranscript } from './replay'
+import { deriveThreadStatus, type ThreadStatus } from './thread-status'
 
 /** Process-local counter for unique echoed-prompt ids. */
 let promptSeq = 0
@@ -47,6 +48,7 @@ export function Conversation({
   thread,
   onAuthExpired,
   onBound,
+  onStatusChange,
 }: {
   thread: LiveThread
   /** Mid-session expiry (-32000): route to in-place re-auth with these methods. */
@@ -54,6 +56,10 @@ export function Conversation({
   /** The Thread's session once bound (TB5) — lifts it so a switch-away-and-back
    *  re-seeds the bound session instead of re-minting it. */
   onBound?: (sessionId: string) => void
+  /** Report this Thread's live status UP to the shell (TB3 #48) so the unified
+   *  sidebar shows streaming / needs-attention indicators — even for a hidden,
+   *  background Workspace whose turn is blocked on an unanswerable prompt. */
+  onStatusChange?: (status: { threadId: string } & ThreadStatus) => void
 }): JSX.Element {
   const [state, dispatch] = useReducer(conversationReducer, initialConversationState)
   const [draft, setDraft] = useState('')
@@ -66,6 +72,10 @@ export function Conversation({
   // Keep the lift callback in a ref so the bound subscription needn't depend on it.
   const onBoundRef = useRef(onBound)
   onBoundRef.current = onBound
+  // Likewise for the status report — read live in an effect so a changing callback
+  // identity never re-subscribes anything, and so the report never runs in render.
+  const onStatusRef = useRef(onStatusChange)
+  onStatusRef.current = onStatusChange
   const listRef = useRef<HTMLDivElement>(null)
   // True once any live event has been folded in: guards the async hydrate from
   // clobbering events that streamed in before the JSONL read resolved.
@@ -128,6 +138,18 @@ export function Conversation({
     const list = listRef.current
     if (list) list.scrollTop = list.scrollHeight
   }, [state.items])
+
+  // Report this Thread's live status (streaming / needs-attention) UP to the shell
+  // on every transition (TB3 #48). Derived from the reducer (the source of truth);
+  // we only surface the two flags. The shell folds an unchanged report to the same
+  // map reference, so this can't drive a status->render->report loop even with
+  // several keep-mounted background Conversations reporting at once. On unmount we
+  // clear our flags so a torn-down (or switched-away) Thread leaves no stale badge.
+  const { streaming, needsAttention } = deriveThreadStatus(state)
+  useEffect(() => {
+    onStatusRef.current?.({ threadId: thread.threadId, streaming, needsAttention })
+    return () => onStatusRef.current?.({ threadId: thread.threadId, streaming: false, needsAttention: false })
+  }, [thread.threadId, streaming, needsAttention])
 
   async function send(): Promise<void> {
     const text = draft.trim()

--- a/src/renderer/src/conversation/thread-status.test.ts
+++ b/src/renderer/src/conversation/thread-status.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { deriveThreadStatus, setThreadStatus, type ThreadStatusMap } from './thread-status'
+import { clearThreadStatus, deriveThreadStatus, setThreadStatus, type ThreadStatusMap } from './thread-status'
 import type { ConversationItem, PermissionItem } from './reducer'
 
 /**
@@ -70,5 +70,22 @@ describe('setThreadStatus (render-loop guard)', () => {
     expect(next).not.toBe(map)
     expect(next.t1).toEqual({ streaming: false, needsAttention: true })
     expect(next.t2).toBe(map.t2) // sibling reference preserved
+  })
+})
+
+describe('clearThreadStatus (drop a deleted Thread)', () => {
+  it('removes a Thread entry so it does not linger after delete', () => {
+    const map: ThreadStatusMap = {
+      t1: { streaming: true, needsAttention: false },
+      t2: { streaming: false, needsAttention: true },
+    }
+    const next = clearThreadStatus(map, 't1')
+    expect('t1' in next).toBe(false)
+    expect(next.t2).toBe(map.t2) // sibling reference preserved
+  })
+
+  it('returns the SAME map reference when the Thread is absent', () => {
+    const map: ThreadStatusMap = { t1: { streaming: false, needsAttention: false } }
+    expect(clearThreadStatus(map, 'gone')).toBe(map)
   })
 })

--- a/src/renderer/src/conversation/thread-status.test.ts
+++ b/src/renderer/src/conversation/thread-status.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { deriveThreadStatus, setThreadStatus, type ThreadStatusMap } from './thread-status'
+import type { ConversationItem, PermissionItem } from './reducer'
+
+/**
+ * Per-Thread status surfaced from a live Conversation to the unified sidebar
+ * (TB3 #48): `streaming` (turn in flight) and `needsAttention` (a pending
+ * permission). Pure derivation + a render-loop-safe registry fold.
+ */
+
+function permission(chosenOptionId: string | null): PermissionItem {
+  return {
+    kind: 'permission',
+    id: 'p1',
+    requestId: 7,
+    toolCallId: null,
+    options: [],
+    chosenOptionId,
+    chosenName: chosenOptionId ? 'Allow' : null,
+  }
+}
+
+const assistant: ConversationItem = { kind: 'assistant', id: 'a1', messageId: 'm1', text: 'hi' }
+
+describe('deriveThreadStatus', () => {
+  it('reports streaming while a turn is in flight', () => {
+    expect(deriveThreadStatus({ isProcessing: true, items: [] })).toEqual({
+      streaming: true,
+      needsAttention: false,
+    })
+  })
+
+  it('reports idle when no turn is in flight and no permission pending', () => {
+    expect(deriveThreadStatus({ isProcessing: false, items: [assistant] })).toEqual({
+      streaming: false,
+      needsAttention: false,
+    })
+  })
+
+  it('reports needsAttention while a permission request is unanswered', () => {
+    expect(
+      deriveThreadStatus({ isProcessing: true, items: [permission(null)] }).needsAttention,
+    ).toBe(true)
+  })
+
+  it('drops needsAttention once the permission has been answered', () => {
+    expect(
+      deriveThreadStatus({ isProcessing: false, items: [permission('opt-allow')] }).needsAttention,
+    ).toBe(false)
+  })
+})
+
+describe('setThreadStatus (render-loop guard)', () => {
+  it('adds a Thread status', () => {
+    const next = setThreadStatus({}, 't1', { streaming: true, needsAttention: false })
+    expect(next.t1).toEqual({ streaming: true, needsAttention: false })
+  })
+
+  it('returns the SAME map reference when the status is unchanged', () => {
+    const map: ThreadStatusMap = { t1: { streaming: true, needsAttention: false } }
+    expect(setThreadStatus(map, 't1', { streaming: true, needsAttention: false })).toBe(map)
+  })
+
+  it('returns a new map when a flag changes, leaving siblings untouched', () => {
+    const map: ThreadStatusMap = {
+      t1: { streaming: true, needsAttention: false },
+      t2: { streaming: false, needsAttention: false },
+    }
+    const next = setThreadStatus(map, 't1', { streaming: false, needsAttention: true })
+    expect(next).not.toBe(map)
+    expect(next.t1).toEqual({ streaming: false, needsAttention: true })
+    expect(next.t2).toBe(map.t2) // sibling reference preserved
+  })
+})

--- a/src/renderer/src/conversation/thread-status.ts
+++ b/src/renderer/src/conversation/thread-status.ts
@@ -50,3 +50,15 @@ export function setThreadStatus(
   }
   return { ...map, [threadId]: status }
 }
+
+/**
+ * Drop a Thread's entry from the registry (pure) — used on delete so a removed
+ * Thread doesn't linger as a stale `{false, false}` for the rest of the session.
+ * Returns the SAME map reference when the Thread isn't present (no re-render).
+ */
+export function clearThreadStatus(map: ThreadStatusMap, threadId: string): ThreadStatusMap {
+  if (!(threadId in map)) return map
+  const next = { ...map }
+  delete next[threadId]
+  return next
+}

--- a/src/renderer/src/conversation/thread-status.ts
+++ b/src/renderer/src/conversation/thread-status.ts
@@ -1,0 +1,52 @@
+import type { ConversationItem } from './reducer'
+
+/**
+ * A live Thread's status, surfaced UP from its `Conversation` to the shell so the
+ * unified sidebar list (TB3 #48) can show indicators WITHOUT owning the
+ * conversation reducer: `streaming` while a turn is in flight, `needsAttention`
+ * while a `session/request_permission` is unanswered. The `Conversation` reducer
+ * stays the source of truth; we only report these two transitions out.
+ */
+export interface ThreadStatus {
+  /** A turn is in flight (`isProcessing`) — drives the streaming indicator. */
+  streaming: boolean
+  /** A permission request is pending an answer — drives the attention badge. */
+  needsAttention: boolean
+}
+
+export type ThreadStatusMap = Readonly<Record<string, ThreadStatus>>
+
+/**
+ * Derive a Thread's reportable status from its conversation state (pure). A turn
+ * in flight is `streaming`; a still-pending permission row (`chosenOptionId ===
+ * null`) is `needsAttention` — the latter is what flags a BACKGROUND Workspace
+ * whose hidden turn is blocked on an unanswerable prompt (the deferred TB2
+ * finding), so the user can spot it in the sidebar and switch to it.
+ */
+export function deriveThreadStatus(state: {
+  isProcessing: boolean
+  items: ConversationItem[]
+}): ThreadStatus {
+  const needsAttention = state.items.some(
+    (item) => item.kind === 'permission' && item.chosenOptionId === null,
+  )
+  return { streaming: state.isProcessing, needsAttention }
+}
+
+/**
+ * Fold a Thread's reported status into the registry (pure). Returns the SAME map
+ * reference when nothing changed, so a Conversation re-reporting an unchanged
+ * status can't trigger a render — the guard against a status->render->report loop
+ * across several keep-mounted background Conversations.
+ */
+export function setThreadStatus(
+  map: ThreadStatusMap,
+  threadId: string,
+  status: ThreadStatus,
+): ThreadStatusMap {
+  const prev = map[threadId]
+  if (prev && prev.streaming === status.streaming && prev.needsAttention === status.needsAttention) {
+    return map
+  }
+  return { ...map, [threadId]: status }
+}

--- a/src/renderer/src/shell/Shell.tsx
+++ b/src/renderer/src/shell/Shell.tsx
@@ -1,7 +1,7 @@
 import { useState, type JSX, type ReactNode } from 'react'
 import type { ListMetadataResult, ThreadMeta } from '../../../shared/ipc'
 import type { NavState } from './nav-reducer'
-import type { UnifiedThreadRow } from './unified-threads'
+import { isThreadDeletable, type UnifiedThreadRow } from './unified-threads'
 
 /** A Workspace's rolled-up live status, for its switcher row. */
 export interface WorkspaceFlags {
@@ -32,6 +32,7 @@ export function Shell({
   workspaceFlags,
   rows,
   protectedThreadId,
+  activeThreadId,
   canCreateThread,
   creatingThread,
   outlet,
@@ -52,6 +53,9 @@ export function Shell({
   rows: UnifiedThreadRow[]
   /** The connection's primary Thread (never deletable mid-connection), or null. */
   protectedThreadId: string | null
+  /** The selected Workspace's active (mounted) Thread — a live row is deletable only
+   *  when it IS this one (we can't observe a non-active sibling's turn; #53). */
+  activeThreadId: string | null
   /** Whether New-thread is available (the selected Workspace is connected). */
   canCreateThread: boolean
   /** A draft mint is in flight — disable New-thread to avoid a double mint. */
@@ -77,6 +81,7 @@ export function Shell({
           workspaceFlags={workspaceFlags}
           rows={rows}
           protectedThreadId={protectedThreadId}
+          activeThreadId={activeThreadId}
           canCreateThread={canCreateThread}
           creatingThread={creatingThread}
           onSelectWorkspace={onSelectWorkspace}
@@ -104,6 +109,7 @@ function WorkspaceNav({
   workspaceFlags,
   rows,
   protectedThreadId,
+  activeThreadId,
   canCreateThread,
   creatingThread,
   onSelectWorkspace,
@@ -116,6 +122,7 @@ function WorkspaceNav({
   workspaceFlags: Readonly<Record<string, WorkspaceFlags>>
   rows: UnifiedThreadRow[]
   protectedThreadId: string | null
+  activeThreadId: string | null
   canCreateThread: boolean
   creatingThread: boolean
   onSelectWorkspace: (workspaceId: string) => void
@@ -159,10 +166,11 @@ function WorkspaceNav({
                         key={row.thread.id}
                         row={row}
                         selected={row.thread.id === nav.selectedThreadId}
-                        // Safe delete (TB6 / #48): never delete the connection's
-                        // primary Thread (the agent is actively hosting it) or one
-                        // mid-stream — both are the TB1 delete-while-hosted hazard.
-                        deletable={!row.streaming && row.thread.id !== protectedThreadId}
+                        // Safe delete (TB6 / #48), decided by the pure gate: a cold row
+                        // always; the primary never; a live row only when it's the
+                        // active, idle row (a non-active live sibling's turn is
+                        // unobservable, so it stays non-deletable — the TB1 hazard).
+                        deletable={isThreadDeletable(row, activeThreadId, protectedThreadId)}
                         onOpen={() => onSelectThread(w.id, row.thread.id)}
                         onDelete={onDeleteThread}
                       />

--- a/src/renderer/src/shell/Shell.tsx
+++ b/src/renderer/src/shell/Shell.tsx
@@ -1,52 +1,72 @@
 import { useState, type JSX, type ReactNode } from 'react'
 import type { ListMetadataResult, ThreadMeta } from '../../../shared/ipc'
 import type { NavState } from './nav-reducer'
+import type { UnifiedThreadRow } from './unified-threads'
+
+/** A Workspace's rolled-up live status, for its switcher row. */
+export interface WorkspaceFlags {
+  streaming: boolean
+  needsAttention: boolean
+}
 
 /**
  * The persistent two-pane app shell (ADR-0006 decision 1): a left sidebar that
  * stays mounted and a right conversation OUTLET whose content swaps. Navigation
  * (the pure nav reducer, decision 2) and the per-Workspace connection registry
- * (decision 3) live in App now; Shell is the presentational layout — it renders the
- * always-there sidebar (the Workspace switcher + each Workspace's Threads) and the
- * App-computed `outlet`. The sidebar element is fixed, so navigating never unmounts
- * it — the whole point of the shell.
+ * (decision 3) live in App; Shell is the presentational layout.
  *
- * Two TB1-review findings are resolved by this split (TB2 #47): the outlet is
- * routed off the nav SELECTION (App), so a cold click on a never-connected
- * Workspace replays correctly even after another connected (finding 2); and a
- * connected Workspace's per-Thread highlight is SUPPRESSED here, since its live view
- * (in the outlet) owns Thread selection — the sidebar and outlet can't disagree
- * (finding 1). The unified live/cold Thread list is TB3 (#48).
+ * TB3 (#48) collapses the two competing Thread lists — the TB1 cold-only sidebar
+ * and `ConnectedWorkspace`'s internal switcher — into ONE unified list per
+ * Workspace. The Workspace switcher pins at top; the SELECTED Workspace expands to
+ * its unified rows (cold + live merged, deduped, most-recent-first), each row
+ * showing a live/history badge, a streaming indicator, a needs-attention badge, and
+ * an inline (safe) delete. A New-thread control mints a draft on the live agent.
+ * Selection is the nav reducer's alone, so the sidebar and outlet can never
+ * disagree. A background Workspace blocked on a permission prompt surfaces a
+ * needs-attention badge on its switcher row (the deferred TB2 finding).
  */
 export function Shell({
   workspaces,
   sidebarTop,
   nav,
-  connectedWorkspaceIds,
+  workspaceFlags,
+  rows,
+  protectedThreadId,
+  canCreateThread,
+  creatingThread,
   outlet,
   onSelectWorkspace,
   onSelectThread,
+  onNewThread,
   onDeleteThread,
 }: {
-  /** Persisted Workspaces + Threads for the sidebar list (cold metadata). */
+  /** Persisted Workspaces (cold metadata) for the switcher rows + display names. */
   workspaces: ListMetadataResult
   /** App-owned controls pinned above the list (Open project + environment status). */
   sidebarTop: ReactNode
   /** The current navigation selection (controlled by App). */
   nav: NavState
-  /** Workspace ids with a live agent — suppress their Thread highlight + delete. */
-  connectedWorkspaceIds: string[]
+  /** Per-Workspace rolled-up live status, keyed by Workspace id (switcher badges). */
+  workspaceFlags: Readonly<Record<string, WorkspaceFlags>>
+  /** The unified rows (cold + live) for the SELECTED Workspace. */
+  rows: UnifiedThreadRow[]
+  /** The connection's primary Thread (never deletable mid-connection), or null. */
+  protectedThreadId: string | null
+  /** Whether New-thread is available (the selected Workspace is connected). */
+  canCreateThread: boolean
+  /** A draft mint is in flight — disable New-thread to avoid a double mint. */
+  creatingThread: boolean
   /** The fully-computed conversation outlet (connection views / cold replay). */
   outlet: ReactNode
   /** Select a Workspace — App pins it in nav and connect-or-reuses its warm agent. */
   onSelectWorkspace: (workspaceId: string) => void
-  /** Select a Thread — App pins it in nav (the idle outlet then replays it). */
+  /** Select a Thread — App pins it in nav and (if live) remembers it as active. */
   onSelectThread: (workspaceId: string, threadId: string) => void
-  /** Delete a Thread (TB6) — removes its metadata + JSONL, then refreshes the list. */
+  /** Mint a New-thread draft on the selected Workspace's live agent. */
+  onNewThread: () => void
+  /** Delete a Thread (TB6) — main tears down any live session, then the list refreshes. */
   onDeleteThread: (thread: ThreadMeta) => Promise<void>
 }): JSX.Element {
-  const connected = new Set(connectedWorkspaceIds)
-
   return (
     <div className="shell">
       <aside className="shell__sidebar">
@@ -54,9 +74,14 @@ export function Shell({
         <WorkspaceNav
           workspaces={workspaces}
           nav={nav}
-          connected={connected}
+          workspaceFlags={workspaceFlags}
+          rows={rows}
+          protectedThreadId={protectedThreadId}
+          canCreateThread={canCreateThread}
+          creatingThread={creatingThread}
           onSelectWorkspace={onSelectWorkspace}
           onSelectThread={onSelectThread}
+          onNewThread={onNewThread}
           onDeleteThread={onDeleteThread}
         />
       </aside>
@@ -67,28 +92,35 @@ export function Shell({
 }
 
 /**
- * The sidebar's navigation list: persisted Workspaces with their Threads, most-
- * recent-first, rendered from cold metadata alone — NO `vibe-acp` spawned. The
- * selected Workspace is highlighted; clicking one selects it (App connect-or-reuses
- * its warm agent). A Thread row highlights only when its Workspace is NOT connected
- * (a connected Workspace's live view owns Thread selection — finding 1). Delete
- * (TB6) is offered only for a non-connected Workspace's Threads, so we never remove
- * a Thread a warm agent is hosting.
+ * The sidebar's navigation list: the Workspace switcher, with the SELECTED
+ * Workspace expanded to its unified Thread list (TB3 #48). A non-selected
+ * Workspace shows only its name + a rolled-up live status (a streaming dot / a
+ * needs-attention badge), so a background Workspace blocked on a permission prompt
+ * is visible without expanding it.
  */
 function WorkspaceNav({
   workspaces,
   nav,
-  connected,
+  workspaceFlags,
+  rows,
+  protectedThreadId,
+  canCreateThread,
+  creatingThread,
   onSelectWorkspace,
   onSelectThread,
+  onNewThread,
   onDeleteThread,
 }: {
   workspaces: ListMetadataResult
   nav: NavState
-  /** Workspace ids with a live agent (suppress Thread highlight + delete). */
-  connected: ReadonlySet<string>
+  workspaceFlags: Readonly<Record<string, WorkspaceFlags>>
+  rows: UnifiedThreadRow[]
+  protectedThreadId: string | null
+  canCreateThread: boolean
+  creatingThread: boolean
   onSelectWorkspace: (workspaceId: string) => void
   onSelectThread: (workspaceId: string, threadId: string) => void
+  onNewThread: () => void
   onDeleteThread: (thread: ThreadMeta) => Promise<void>
 }): JSX.Element {
   if (workspaces.length === 0) {
@@ -99,38 +131,51 @@ function WorkspaceNav({
       <div className="recents__title">Workspaces</div>
       <ul className="recents__list">
         {workspaces.map((w) => {
-          const isConnected = connected.has(w.id)
+          const isSelected = w.id === nav.selectedWorkspaceId
+          const flags = workspaceFlags[w.id]
           return (
             <li key={w.id} className="recents__workspace">
               <button
                 className={
-                  w.id === nav.selectedWorkspaceId
-                    ? 'recents__ws-name recents__ws-name--active'
-                    : 'recents__ws-name'
+                  isSelected ? 'recents__ws-name recents__ws-name--active' : 'recents__ws-name'
                 }
                 title={w.dir}
                 onClick={() => onSelectWorkspace(w.id)}
               >
                 {w.displayName}
+                {flags?.streaming && <span className="dot dot--pending ws-streaming" aria-label="streaming" />}
+                {flags?.needsAttention && (
+                  <span className="badge badge--attention" title="A thread needs your attention">
+                    needs you
+                  </span>
+                )}
               </button>
-              {w.threads.length > 0 ? (
-                <ul className="recents__threads">
-                  {w.threads.map((t) => (
-                    <NavThread
-                      key={t.id}
-                      thread={t}
-                      // Suppress the per-Thread highlight for a connected Workspace —
-                      // its live outlet owns Thread selection (finding 1).
-                      selected={!isConnected && t.id === nav.selectedThreadId}
-                      // No delete while the Workspace's agent is live (it may host it).
-                      deletable={!isConnected}
-                      onOpen={() => onSelectThread(w.id, t.id)}
-                      onDelete={onDeleteThread}
-                    />
-                  ))}
-                </ul>
-              ) : (
-                <div className="recents__empty">No threads yet</div>
+
+              {isSelected &&
+                (rows.length > 0 ? (
+                  <ul className="recents__threads">
+                    {rows.map((row) => (
+                      <NavThread
+                        key={row.thread.id}
+                        row={row}
+                        selected={row.thread.id === nav.selectedThreadId}
+                        // Safe delete (TB6 / #48): never delete the connection's
+                        // primary Thread (the agent is actively hosting it) or one
+                        // mid-stream — both are the TB1 delete-while-hosted hazard.
+                        deletable={!row.streaming && row.thread.id !== protectedThreadId}
+                        onOpen={() => onSelectThread(w.id, row.thread.id)}
+                        onDelete={onDeleteThread}
+                      />
+                    ))}
+                  </ul>
+                ) : (
+                  <div className="recents__empty">No threads yet</div>
+                ))}
+
+              {isSelected && canCreateThread && (
+                <button className="btn btn--ghost recents__new" onClick={onNewThread} disabled={creatingThread}>
+                  {creatingThread ? 'Creating…' : '+ New thread'}
+                </button>
               )}
             </li>
           )
@@ -141,21 +186,19 @@ function WorkspaceNav({
 }
 
 /**
- * One Thread row in the sidebar: selecting it on click (the outlet reopens it
- * read-only — TB3), highlighted when selected, with a delete control (TB6) shown
- * only when `deletable` (i.e. its Workspace has no live connection — see Shell).
- * Delete is two-step — a first click arms an INLINE confirm (Delete / Cancel)
- * rather than a native `confirm()` (which would block the renderer), so a single
- * misclick can't nuke a Thread's history.
+ * One unified Thread row: its label, a live (●) vs `history` badge, a streaming
+ * indicator and a needs-attention badge driven by the status registry, and a
+ * two-step inline delete (TB6) shown only when `deletable`. Clicking selects it →
+ * the outlet routes live `Conversation` vs cold `ColdThread`.
  */
 function NavThread({
-  thread,
+  row,
   selected,
   deletable,
   onOpen,
   onDelete,
 }: {
-  thread: ThreadMeta
+  row: UnifiedThreadRow
   selected: boolean
   deletable: boolean
   onOpen: () => void
@@ -168,7 +211,15 @@ function NavThread({
         className={selected ? 'recents__thread-btn recents__thread-btn--active' : 'recents__thread-btn'}
         onClick={onOpen}
       >
-        {threadLabel(thread)}
+        <span className={row.live ? 'dot dot--ok' : 'dot dot--idle'} aria-hidden />
+        <span className="recents__thread-label">{threadLabel(row)}</span>
+        {row.streaming && <span className="recents__thread-streaming" title="Streaming">⟳</span>}
+        {!row.live && <span className="badge badge--history">history</span>}
+        {row.needsAttention && (
+          <span className="badge badge--attention" title="Awaiting your response">
+            !
+          </span>
+        )}
       </button>
       {!deletable ? null : confirming ? (
         <span className="recents__thread-confirm">
@@ -176,7 +227,7 @@ function NavThread({
             className="btn btn--ghost btn--danger"
             onClick={() => {
               setConfirming(false)
-              void onDelete(thread)
+              void onDelete(row.thread)
             }}
           >
             Delete
@@ -199,7 +250,10 @@ function NavThread({
   )
 }
 
-/** A Thread's list label — its title, or a placeholder until one arrives. */
-function threadLabel(thread: ThreadMeta): string {
-  return thread.title ?? 'Untitled thread'
+/** A Thread's list label — its title, a draft placeholder, or a fallback. */
+function threadLabel(row: UnifiedThreadRow): string {
+  if (row.thread.title) return row.thread.title
+  // A live, session-less Thread is a fresh draft awaiting its first prompt.
+  if (row.live && row.thread.sessionId === null) return 'New thread (draft)'
+  return 'Untitled thread'
 }

--- a/src/renderer/src/shell/unified-threads.test.ts
+++ b/src/renderer/src/shell/unified-threads.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { deriveUnifiedThreads, workspaceFlags } from './unified-threads'
+import { deriveUnifiedThreads, isThreadDeletable, workspaceFlags, type UnifiedThreadRow } from './unified-threads'
 import type { ThreadStatusMap } from '../conversation/thread-status'
 import type { ThreadMeta } from '../../../shared/ipc'
 
@@ -108,5 +108,40 @@ describe('workspaceFlags (background Workspace roll-up)', () => {
   it('ignores statuses of Threads not in this Workspace live set', () => {
     const statuses: ThreadStatusMap = { other: { streaming: true, needsAttention: true } }
     expect(workspaceFlags(new Set(['a']), statuses)).toEqual({ streaming: false, needsAttention: false })
+  })
+})
+
+describe('isThreadDeletable (safe-delete gate)', () => {
+  function row(id: string, opts: Partial<UnifiedThreadRow> = {}): UnifiedThreadRow {
+    return { thread: thread(id), live: false, streaming: false, needsAttention: false, ...opts }
+  }
+
+  it('allows deleting a cold row (no live session to tear out from under)', () => {
+    expect(isThreadDeletable(row('c'), 'active', 'primary')).toBe(true)
+    // Even if it happens to be the active selection (a cold row being replayed).
+    expect(isThreadDeletable(row('c'), 'c', 'primary')).toBe(true)
+  })
+
+  it('never allows deleting the connection primary Thread mid-connection', () => {
+    expect(isThreadDeletable(row('primary', { live: true }), 'primary', 'primary')).toBe(false)
+  })
+
+  it('allows deleting the active, idle, non-primary live row', () => {
+    expect(isThreadDeletable(row('a', { live: true }), 'a', 'primary')).toBe(true)
+  })
+
+  it('forbids deleting the active live row while it is streaming', () => {
+    expect(isThreadDeletable(row('a', { live: true, streaming: true }), 'a', 'primary')).toBe(false)
+  })
+
+  it('forbids deleting a NON-active live row (its turn is unobservable; #53)', () => {
+    // A backgrounded live sibling reports streaming:false because it is unmounted —
+    // we cannot prove it idle, so it must not be deletable (the TB1 hazard).
+    expect(isThreadDeletable(row('b', { live: true, streaming: false }), 'a', 'primary')).toBe(false)
+  })
+
+  it('treats every live row as non-active when there is no active/primary (defensive)', () => {
+    expect(isThreadDeletable(row('a', { live: true }), null, null)).toBe(false)
+    expect(isThreadDeletable(row('c'), null, null)).toBe(true) // cold still deletable
   })
 })

--- a/src/renderer/src/shell/unified-threads.test.ts
+++ b/src/renderer/src/shell/unified-threads.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+import { deriveUnifiedThreads, workspaceFlags } from './unified-threads'
+import type { ThreadStatusMap } from '../conversation/thread-status'
+import type { ThreadMeta } from '../../../shared/ipc'
+
+/**
+ * The unified cold+live Thread list (ADR-0006, TB3 #48): a Workspace's persisted
+ * Threads and its live (this-session) Threads merged into ONE deduped,
+ * most-recent-first list with per-row live/streaming/needsAttention flags. Pure —
+ * no React, no IPC. This replaces the TB1 cold-only sidebar AND the TB2
+ * `ConnectedWorkspace` internal switcher (single source of truth).
+ */
+
+function thread(id: string, sessionId: string | null = null): ThreadMeta {
+  return { id, workspaceId: 'w1', sessionId, title: id, createdAt: 1, lastActiveAt: 1 }
+}
+
+const noStatus: ThreadStatusMap = {}
+
+describe('deriveUnifiedThreads', () => {
+  it('lists cold Threads in order with live=false when nothing is hosted', () => {
+    const cold = [thread('a'), thread('b')]
+    const rows = deriveUnifiedThreads({ cold, live: [], liveThreadIds: new Set(), statuses: noStatus })
+    expect(rows.map((r) => r.thread.id)).toEqual(['a', 'b'])
+    expect(rows.every((r) => !r.live)).toBe(true)
+  })
+
+  it('flags a cold Thread that is also hosted live (no duplicate row)', () => {
+    const cold = [thread('a', 's-a'), thread('b')]
+    const rows = deriveUnifiedThreads({
+      cold,
+      live: [thread('a', 's-a')],
+      liveThreadIds: new Set(['a']),
+      statuses: noStatus,
+    })
+    expect(rows.map((r) => r.thread.id)).toEqual(['a', 'b']) // deduped — 'a' once
+    expect(rows.find((r) => r.thread.id === 'a')?.live).toBe(true)
+    expect(rows.find((r) => r.thread.id === 'b')?.live).toBe(false)
+  })
+
+  it('prepends a live-only Thread (a fresh draft not yet persisted) as the newest', () => {
+    const cold = [thread('a'), thread('b')]
+    const draft = thread('draft', null)
+    const rows = deriveUnifiedThreads({
+      cold,
+      live: [draft],
+      liveThreadIds: new Set(['draft']),
+      statuses: noStatus,
+    })
+    expect(rows.map((r) => r.thread.id)).toEqual(['draft', 'a', 'b'])
+    expect(rows[0].live).toBe(true)
+  })
+
+  it('dedupes a live Thread that appears twice in the live input', () => {
+    const rows = deriveUnifiedThreads({
+      cold: [],
+      live: [thread('x'), thread('x')],
+      liveThreadIds: new Set(['x']),
+      statuses: noStatus,
+    })
+    expect(rows.map((r) => r.thread.id)).toEqual(['x'])
+  })
+
+  it('surfaces streaming + needsAttention per row from the status registry', () => {
+    const cold = [thread('a'), thread('b'), thread('c')]
+    const statuses: ThreadStatusMap = {
+      a: { streaming: true, needsAttention: false },
+      b: { streaming: false, needsAttention: true },
+    }
+    const rows = deriveUnifiedThreads({
+      cold,
+      live: [],
+      liveThreadIds: new Set(['a', 'b', 'c']),
+      statuses,
+    })
+    expect(rows.find((r) => r.thread.id === 'a')).toMatchObject({ streaming: true, needsAttention: false })
+    expect(rows.find((r) => r.thread.id === 'b')).toMatchObject({ streaming: false, needsAttention: true })
+    // No status entry => both flags default false.
+    expect(rows.find((r) => r.thread.id === 'c')).toMatchObject({ streaming: false, needsAttention: false })
+  })
+
+  it('uses the persisted cold meta (fresher title) for a Thread present in both', () => {
+    const coldMeta = { ...thread('a'), title: 'Renamed' }
+    const liveMeta = { ...thread('a'), title: null }
+    const rows = deriveUnifiedThreads({
+      cold: [coldMeta],
+      live: [liveMeta],
+      liveThreadIds: new Set(['a']),
+      statuses: noStatus,
+    })
+    expect(rows[0].thread.title).toBe('Renamed')
+  })
+})
+
+describe('workspaceFlags (background Workspace roll-up)', () => {
+  it('is clear when no live Thread has a status', () => {
+    expect(workspaceFlags(new Set(['a', 'b']), {})).toEqual({ streaming: false, needsAttention: false })
+  })
+
+  it('rolls up streaming/needsAttention across a Workspace live Threads', () => {
+    const statuses: ThreadStatusMap = {
+      a: { streaming: false, needsAttention: true }, // a hidden Workspace blocked on a prompt
+      b: { streaming: true, needsAttention: false },
+    }
+    expect(workspaceFlags(new Set(['a', 'b']), statuses)).toEqual({ streaming: true, needsAttention: true })
+  })
+
+  it('ignores statuses of Threads not in this Workspace live set', () => {
+    const statuses: ThreadStatusMap = { other: { streaming: true, needsAttention: true } }
+    expect(workspaceFlags(new Set(['a']), statuses)).toEqual({ streaming: false, needsAttention: false })
+  })
+})

--- a/src/renderer/src/shell/unified-threads.ts
+++ b/src/renderer/src/shell/unified-threads.ts
@@ -62,6 +62,32 @@ export function deriveUnifiedThreads(args: {
 }
 
 /**
+ * Whether a unified row may be deleted (pure — the safe-delete gate, TB6 / #48).
+ *
+ * The hazard: only the ACTIVE Thread is mounted, so a non-active LIVE Thread's
+ * `Conversation` is unmounted and reports `streaming: false` — we CANNOT observe
+ * whether its turn is still running on the agent (the non-active-sibling indicator
+ * gap, follow-up #53). Deleting it would best-effort close a possibly-mid-turn
+ * session (the TB1 hazard), so a live Thread is deletable ONLY when it's the active
+ * (mounted, observable) row AND idle AND not the primary:
+ * - a cold row is always deletable (no live session to tear out from under);
+ * - the connection's primary Thread is never deletable mid-connection;
+ * - a live non-primary row is deletable only when it's the active, non-streaming row.
+ *
+ * `activeId`/`primaryThreadId` are null for a Workspace with no live connection
+ * (all rows are cold then).
+ */
+export function isThreadDeletable(
+  row: UnifiedThreadRow,
+  activeId: string | null,
+  primaryThreadId: string | null,
+): boolean {
+  if (!row.live) return true
+  if (row.thread.id === primaryThreadId) return false
+  return row.thread.id === activeId && !row.streaming
+}
+
+/**
  * A Workspace-level roll-up of its live Threads' status (pure), for the Workspace
  * switcher row: `streaming` if ANY of its live Threads has a turn in flight,
  * `needsAttention` if ANY is blocked on a permission. This is what flags a

--- a/src/renderer/src/shell/unified-threads.ts
+++ b/src/renderer/src/shell/unified-threads.ts
@@ -1,0 +1,85 @@
+import type { ThreadMeta } from '../../../shared/ipc'
+import type { ThreadStatus, ThreadStatusMap } from '../conversation/thread-status'
+
+/**
+ * One row of the unified sidebar Thread list (ADR-0006, TB3 #48): a Workspace's
+ * Threads — COLD (persisted, from metadata/JSONL) and LIVE (hosted on the warm
+ * agent this session) — merged into ONE list, each row carrying the flags the
+ * sidebar renders. There is no second list: this replaces both the cold-only
+ * sidebar (TB1) and `ConnectedWorkspace`'s internal switcher (TB2).
+ */
+export interface UnifiedThreadRow {
+  thread: ThreadMeta
+  /** Hosted on the current agent this session (live conversation, not replay). */
+  live: boolean
+  /** A turn is in flight on this Thread (from the status registry). */
+  streaming: boolean
+  /** A permission request is pending an answer (from the status registry). */
+  needsAttention: boolean
+}
+
+/**
+ * Merge a Workspace's cold + live Threads into the unified, deduped,
+ * most-recent-first row list (pure — the load-bearing core of TB3).
+ *
+ * `cold` is the persisted list (already most-recent-first, ADR-0005); `live`
+ * carries the metas for Threads hosted this session, INCLUDING any not yet in the
+ * cold list (a freshly-minted draft, or the agent's auto-opened Thread before the
+ * metadata refresh lands). A live Thread already present in cold is kept ONCE
+ * (deduped by id) using the persisted meta (its title/timestamps are fresher);
+ * live-only Threads are the newest, so they lead. Membership in `liveThreadIds`
+ * — not the mere presence of a `sessionId` — decides the `live` flag, mirroring
+ * `routeThreadSelection`. Each row's `streaming`/`needsAttention` come from the
+ * status registry (absent => false), so a background Workspace's blocked turn
+ * still surfaces a badge.
+ */
+export function deriveUnifiedThreads(args: {
+  cold: ThreadMeta[]
+  live: ThreadMeta[]
+  liveThreadIds: ReadonlySet<string>
+  statuses: ThreadStatusMap
+}): UnifiedThreadRow[] {
+  const { cold, live, liveThreadIds, statuses } = args
+  const coldIds = new Set(cold.map((t) => t.id))
+  // Live-only Threads (not yet persisted) lead — they were just created/opened.
+  const liveOnly = live.filter((t) => !coldIds.has(t.id))
+  const ordered = [...liveOnly, ...cold]
+
+  const seen = new Set<string>()
+  const rows: UnifiedThreadRow[] = []
+  for (const thread of ordered) {
+    if (seen.has(thread.id)) continue // dedup defensively (e.g. a dup within `live`)
+    seen.add(thread.id)
+    const status: ThreadStatus | undefined = statuses[thread.id]
+    rows.push({
+      thread,
+      live: liveThreadIds.has(thread.id),
+      streaming: status?.streaming ?? false,
+      needsAttention: status?.needsAttention ?? false,
+    })
+  }
+  return rows
+}
+
+/**
+ * A Workspace-level roll-up of its live Threads' status (pure), for the Workspace
+ * switcher row: `streaming` if ANY of its live Threads has a turn in flight,
+ * `needsAttention` if ANY is blocked on a permission. This is what flags a
+ * BACKGROUND (hidden) Workspace whose turn is wedged on an unanswerable prompt
+ * (the deferred TB2 finding) right on its switcher row, so the user can switch to
+ * it even though its Thread list isn't expanded.
+ */
+export function workspaceFlags(
+  liveThreadIds: ReadonlySet<string>,
+  statuses: ThreadStatusMap,
+): { streaming: boolean; needsAttention: boolean } {
+  let streaming = false
+  let needsAttention = false
+  for (const id of liveThreadIds) {
+    const status = statuses[id]
+    if (!status) continue
+    if (status.streaming) streaming = true
+    if (status.needsAttention) needsAttention = true
+  }
+  return { streaming, needsAttention }
+}

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -356,9 +356,13 @@ body {
   background: var(--bad-tint);
 }
 
-/* Clickable Thread in the cold list — reopens its saved conversation (TB3). */
+/* Clickable Thread in the unified list (TB3 #48): a live/cold dot, the label, and
+   any streaming / history / needs-attention indicators on one row. */
 .recents__thread-btn {
   width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 6px;
   text-align: left;
   background: none;
   border: none;
@@ -373,6 +377,57 @@ body {
 .recents__thread-btn:hover {
   color: var(--accent-text);
   background: var(--accent-tint);
+}
+
+.recents__thread-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* An idle (cold, not hosted live) Thread's dot — muted vs the live --ok dot. */
+.dot--idle {
+  background: var(--border);
+}
+
+/* The per-row streaming indicator (a turn in flight on a live Thread). */
+.recents__thread-streaming {
+  flex: none;
+  color: var(--accent-text);
+  animation: pulse 1.2s ease-in-out infinite;
+}
+
+/* New-thread control under the selected Workspace's unified list. */
+.recents__new {
+  margin-top: 6px;
+  padding: 2px 8px;
+  font-size: 11px;
+}
+
+/* A Workspace-switcher streaming dot (any live Thread mid-turn). */
+.ws-streaming {
+  margin-left: 6px;
+  vertical-align: middle;
+}
+
+/* Compact list badges: a muted 'history' for cold rows, an alert
+   'needs-attention' badge surfaced even on a background Workspace's row. */
+.badge--history {
+  flex: none;
+  background: var(--accent-tint);
+  color: var(--accent-text);
+  border-color: var(--accent-tint-border);
+  padding: 1px 7px;
+}
+
+.badge--attention {
+  flex: none;
+  background: var(--bad-tint);
+  color: var(--bad);
+  border-color: var(--bad-tint-border);
+  padding: 1px 7px;
+  margin-left: 6px;
 }
 
 /* The read-only reopened-Thread view (TB3): a muted variant of the live conv. */


### PR DESCRIPTION
## What this is

TB3 (closes #48) — UI/layout-shell epic (PRD #45, ADR-0006). Collapses the **two competing thread lists** (the shell sidebar's cold list + `ConnectedWorkspace`'s internal live switcher) into **ONE unified sidebar list per Workspace**, with the nav reducer as the single source of truth for selection. `ConnectedWorkspace` becomes a thin controlled outlet.

## Behavior

- **Unified list (`shell/unified-threads.ts`):** pure `deriveUnifiedThreads` merges cold (persisted) + live (hosted this session) Threads, deduped by id, most-recent-first, each row flagged `live` / `streaming` / `needsAttention`.
- **Lifted state (`connection/workspace-threads.ts`):** per-Workspace `{live, bound, active}` lifted out of `ConnectedWorkspace` so the sidebar + nav drive selection; the outlet is now controlled.
- **Status registry (`conversation/thread-status.ts`):** each live `Conversation` reports `streaming` (turn in flight) + `needsAttention` (pending permission) UP via `onStatusChange`; `setThreadStatus` returns the same ref when unchanged (render-loop guard), cleared on unmount.
- **Indicators:** sidebar rows show live ● vs `history`, a streaming spinner, and a **needs-attention badge** — including a per-Workspace roll-up on the switcher row, which resolves the deferred TB2 hidden-Workspace permission gap (a background Workspace blocked on approval shows "needs you").
- **New-thread** (draft) + **safe inline delete** wired into the list.

## Review

Team loop: independent verification + adversarial review. Pure modules + the active↔nav connect/focus logic verified clean; the big `ConnectedWorkspace` lift is regression-free. Folded:
- **MUST-FIX** — deleting the active *cold* Thread no longer leaves a dangling selection (reselect-to-primary now keys on selection, not liveness).
- **Delete-safety** — pure `isThreadDeletable` predicate: a live non-primary Thread is deletable only when it's the active, idle row — a backgrounded-mid-stream sibling is **not** deletable, keeping the TB1 mid-stream-close hazard dead.
- **NIT** — a deleted Thread's status entry is cleared.

## Known limitation (filed as #53)

Streaming/needs-attention indicators reflect each Workspace's **active** Thread only (one mounted `Conversation` per Workspace). A turn on a *non-active sibling* within a Workspace won't show an indicator until selected. Headline cases work (active thread; backgrounding a whole Workspace whose active thread is blocked). Full per-thread coverage is **#53** (keep-all-live-mounted or main-side status), naturally paired with TB5's listener cap.

## Gates

`lint` ✓ · `typecheck` ✓ · `build` ✓ · `test` ✓ — **242 tests** (22 files; +38 vs TB2's 204).

🤖 Generated with [Claude Code](https://claude.com/claude-code)