### PR TITLE
TB4 (#49): in-shell connection & auth states — relocate Environment to first-run/settings

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -37,6 +37,7 @@ import {
   type ThreadStatusMap,
 } from './conversation/thread-status'
 import { Shell, type WorkspaceFlags } from './shell/Shell'
+import { firstRunState, type FirstRunState } from './shell/first-run'
 import { findSelectedThread, initialNavState, navReducer } from './shell/nav-reducer'
 import { deriveUnifiedThreads, workspaceFlags, type UnifiedThreadRow } from './shell/unified-threads'
 
@@ -64,6 +65,10 @@ export function App(): JSX.Element {
   const [detect, setDetect] = useState<VibeDetectResult | null>(null)
   const [loading, setLoading] = useState(true)
   const [opening, setOpening] = useState(false)
+  // Whether the on-demand environment/settings panel is open in the sidebar. The
+  // env check is no longer a permanent top-level card (#49) — it's reachable here,
+  // and surfaced prominently in the outlet only when it matters (first-run).
+  const [showSettings, setShowSettings] = useState(false)
   // Navigation (decision 2): WHICH Workspace/Thread the user is looking at —
   // lifted here so the connect flow (Open project, Continue, sign-in) can drive it.
   const [nav, navDispatch] = useReducer(navReducer, initialNavState)
@@ -301,13 +306,29 @@ export function App(): JSX.Element {
     connDispatch({ type: 'set', workspaceId, state: { status: 'not-signed-in', agentId, workspaceDir, authMethods } })
   }
 
-  // The sidebar's pinned top: the environment check + the Open-project control.
+  // The sidebar's pinned top: the Open-project control + a settings affordance that
+  // reveals the environment status on demand (#49). The env card is no longer pinned
+  // permanently — it lives behind this gear once everything's installed, and is
+  // surfaced prominently in the outlet's first-run state when something's missing.
   const sidebarTop = (
     <div className="shell__top">
-      <Environment detect={detect} loading={loading} onRecheck={() => void runDetect()} />
-      <button className="btn shell__open" onClick={() => void openProject()} disabled={opening}>
-        {opening ? 'Connecting…' : 'Open project'}
-      </button>
+      <div className="shell__top-row">
+        <button className="btn shell__open" onClick={() => void openProject()} disabled={opening}>
+          {opening ? 'Connecting…' : 'Open project'}
+        </button>
+        <button
+          className="btn btn--ghost shell__settings"
+          aria-label="Environment & settings"
+          title="Environment & settings"
+          aria-expanded={showSettings}
+          onClick={() => setShowSettings((s) => !s)}
+        >
+          ⚙
+        </button>
+      </div>
+      {showSettings && (
+        <Environment detect={detect} loading={loading} onRecheck={() => void runDetect()} />
+      )}
     </div>
   )
 
@@ -425,11 +446,24 @@ export function App(): JSX.Element {
         : selected.status !== 'idle'
           ? renderTransientOutlet(selected, {
               continueToThread: (agentId) => void continueToThread(selectedWs ?? '', agentId),
+              onRetry: () => selectedWs && void connectWorkspace(selectedWs),
             })
-          : renderColdOutlet(recents, nav, {
-              onClose: () => navDispatch({ type: 'clear' }),
-              onContinue: (thread) => void continueColdThread(thread),
-            })}
+          : renderColdOutlet(
+              recents,
+              nav,
+              {
+                onClose: () => navDispatch({ type: 'clear' }),
+                onContinue: (thread) => void continueColdThread(thread),
+              },
+              <EmptyState
+                state={firstRunState(detect, recents)}
+                detect={detect}
+                loading={loading}
+                opening={opening}
+                onRecheck={() => void runDetect()}
+                onOpenProject={() => void openProject()}
+              />,
+            )}
     </>
   )
 
@@ -523,15 +557,19 @@ function agentIdOfResult(result: StartThreadResult): string | null {
  */
 function renderTransientOutlet(
   connect: ConnectState,
-  handlers: { continueToThread: (agentId: string) => void },
+  handlers: { continueToThread: (agentId: string) => void; onRetry: () => void },
 ): ReactNode {
   switch (connect.status) {
     case 'connecting':
       return (
-        <p className="hint">
-          Launching <code>vibe-acp</code> in <code>{connect.workspaceDir}</code> and running the ACP
-          handshake…
-        </p>
+        <div className="connecting">
+          <span className="dot dot--pending" aria-hidden />
+          <div className="connecting__title">Connecting…</div>
+          <div className="connecting__message">
+            Launching <code>vibe-acp</code> in <code>{connect.workspaceDir}</code> and running the
+            ACP handshake.
+          </div>
+        </div>
       )
     case 'not-signed-in':
       return (
@@ -548,6 +586,9 @@ function renderTransientOutlet(
           <div className="alert__title">Couldn’t connect</div>
           <div className="alert__message">{connect.message}</div>
           {connect.hint && <div className="alert__hint">{connect.hint}</div>}
+          <button className="btn alert__action" onClick={handlers.onRetry}>
+            Retry
+          </button>
         </div>
       )
     default:
@@ -565,17 +606,10 @@ function renderColdOutlet(
   recents: ListMetadataResult,
   nav: { selectedWorkspaceId: string | null; selectedThreadId: string | null },
   handlers: { onClose: () => void; onContinue: (thread: ThreadMeta) => void },
+  empty: ReactNode,
 ): ReactNode {
   const selectedThread = findSelectedThread(recents, nav)
-  if (!selectedThread) {
-    return (
-      <div className="shell__empty">
-        <p className="hint">
-          Select a thread from the sidebar to view it, or open a project to start a live agent.
-        </p>
-      </div>
-    )
-  }
+  if (!selectedThread) return empty
   return (
     <ColdThread
       key={selectedThread.id}
@@ -583,6 +617,60 @@ function renderColdOutlet(
       onClose={handlers.onClose}
       onContinue={() => handlers.onContinue(selectedThread)}
     />
+  )
+}
+
+/**
+ * The first-run / empty outlet shown when nothing is connected or selected (#49).
+ * Driven by the pure `firstRunState`: when `vibe` / `vibe-acp` is missing the env
+ * status is surfaced PROMINENTLY here (the user can't proceed until it's installed);
+ * when the toolchain's present but no Workspaces exist it nudges Open-project; once
+ * everything's set up it's a neutral placeholder (env tucked behind settings).
+ */
+function EmptyState({
+  state,
+  detect,
+  loading,
+  opening,
+  onRecheck,
+  onOpenProject,
+}: {
+  state: FirstRunState
+  detect: VibeDetectResult | null
+  loading: boolean
+  opening: boolean
+  onRecheck: () => void
+  onOpenProject: () => void
+}): JSX.Element {
+  if (state === 'needs-install') {
+    return (
+      <div className="empty empty--install">
+        <div className="empty__title">Install Mistral Vibe to get started</div>
+        <p className="hint">
+          vibe-mistro drives the <code>vibe-acp</code> ACP server. Install the Mistral Vibe CLI and{' '}
+          <code>vibe-acp</code>, then re-check below.
+        </p>
+        <Environment detect={detect} loading={loading} onRecheck={onRecheck} />
+      </div>
+    )
+  }
+  if (state === 'no-workspaces') {
+    return (
+      <div className="empty">
+        <div className="empty__title">No workspaces yet</div>
+        <p className="hint">Open a project to spawn its agent and start a thread.</p>
+        <button className="btn" onClick={onOpenProject} disabled={opening}>
+          {opening ? 'Connecting…' : 'Open project'}
+        </button>
+      </div>
+    )
+  }
+  return (
+    <div className="shell__empty">
+      <p className="hint">
+        Select a thread from the sidebar to view it, or open a project to start a live agent.
+      </p>
+    </div>
   )
 }
 

--- a/src/renderer/src/shell/first-run.test.ts
+++ b/src/renderer/src/shell/first-run.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { firstRunState } from './first-run'
+import type { ListMetadataResult, VibeDetectResult, WorkspaceThreads } from '../../../shared/ipc'
+
+/**
+ * Pure first-run derivation: decide what the outlet foregrounds when nothing is
+ * connected/selected, driving where the environment status is surfaced (prominent
+ * on a fresh machine vs tucked into settings once it's all installed — #49).
+ */
+
+const FOUND: VibeDetectResult = {
+  vibeFound: true,
+  vibeAcpFound: true,
+  vibeVersion: '0.1.0',
+  vibeAcpPath: '/abs/vibe-acp',
+  error: null,
+}
+
+const WS: WorkspaceThreads = {
+  id: 'w1',
+  dir: '/abs/ws',
+  displayName: 'ws',
+  lastOpenedAt: 0,
+  threads: [],
+}
+
+const RECENTS: ListMetadataResult = [WS]
+
+describe('firstRunState', () => {
+  it('is needs-install when vibe-acp is missing (the blocking dependency)', () => {
+    expect(firstRunState({ ...FOUND, vibeAcpFound: false }, RECENTS)).toBe('needs-install')
+  })
+
+  it('is needs-install when the vibe CLI is missing', () => {
+    expect(firstRunState({ ...FOUND, vibeFound: false }, [])).toBe('needs-install')
+  })
+
+  it('needs-install wins over no-workspaces (missing toolchain blocks regardless)', () => {
+    expect(firstRunState({ ...FOUND, vibeAcpFound: false }, [])).toBe('needs-install')
+  })
+
+  it('is no-workspaces when everything is detected but no Workspaces exist', () => {
+    expect(firstRunState(FOUND, [])).toBe('no-workspaces')
+  })
+
+  it('is idle when detected and Workspaces exist', () => {
+    expect(firstRunState(FOUND, RECENTS)).toBe('idle')
+  })
+
+  it('does not flash needs-install while detection is still pending', () => {
+    expect(firstRunState(null, RECENTS)).toBe('idle')
+    expect(firstRunState(null, [])).toBe('no-workspaces')
+  })
+})

--- a/src/renderer/src/shell/first-run.ts
+++ b/src/renderer/src/shell/first-run.ts
@@ -1,0 +1,28 @@
+import type { ListMetadataResult, VibeDetectResult } from '../../../shared/ipc'
+
+/**
+ * What the main area should foreground when nothing is connected/selected:
+ * - `needs-install` — detection finished and `vibe` / `vibe-acp` is missing, so the
+ *   user can't do anything until they install it; the environment status is surfaced
+ *   prominently in the outlet rather than tucked away in settings.
+ * - `no-workspaces` — the toolchain is present but no Workspaces have been opened yet,
+ *   so the empty state nudges Open-project.
+ * - `idle` — everything's installed and Workspaces exist; the empty state is just a
+ *   neutral placeholder and the environment status lives behind the settings affordance.
+ */
+export type FirstRunState = 'needs-install' | 'no-workspaces' | 'idle'
+
+/**
+ * Pure derivation (no React, no IPC) of the first-run / empty-state to show. A
+ * still-pending detection (`detect === null`) is NOT treated as missing — we don't
+ * flash `needs-install` before the check resolves. `needs-install` wins over
+ * `no-workspaces`: a missing toolchain blocks regardless of how many Workspaces exist.
+ */
+export function firstRunState(
+  detect: VibeDetectResult | null,
+  recents: ListMetadataResult,
+): FirstRunState {
+  if (detect !== null && (!detect.vibeFound || !detect.vibeAcpFound)) return 'needs-install'
+  if (recents.length === 0) return 'no-workspaces'
+  return 'idle'
+}

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -101,14 +101,65 @@ body {
   max-width: 420px;
 }
 
+/* First-run / empty outlet (#49): Open-project nudge, or the env status surfaced
+   prominently when the toolchain's missing. */
+.empty {
+  max-width: 460px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.empty__title {
+  font-weight: 600;
+  font-size: 15px;
+}
+
+/* A centered, cohesive inline connecting panel for the selected Workspace (#49) —
+   replaces the bare hint so it reads as an intentional outlet state. */
+.connecting {
+  max-width: 420px;
+  margin: 56px auto 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 8px;
+}
+
+.connecting__title {
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.connecting__message {
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
 .shell__top {
   display: flex;
   flex-direction: column;
   gap: 12px;
 }
 
+/* Open-project + the settings gear share the top row; Open-project takes the slack. */
+.shell__top-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .shell__open {
-  align-self: flex-start;
+  flex: 1;
+}
+
+.shell__settings {
+  flex: none;
+  padding: 6px 10px;
+  line-height: 1;
 }
 
 .env {
@@ -521,6 +572,12 @@ body {
   color: var(--muted);
   font-size: 12px;
   line-height: 1.4;
+}
+
+/* Retry affordance on the inline error panel (#49) — re-triggers the connect. */
+.alert__action {
+  align-self: flex-start;
+  margin-top: 4px;
 }
 
 .signin {


### PR DESCRIPTION
## What this is

TB4 (closes #49) — UI/layout-shell epic (PRD #45, ADR-0006). The smallest slice: connection/auth states already render inline in the per-Workspace outlet (from TB1/TB2), so this finishes the job — **relocating the Environment/detect card** out of the permanent sidebar and **polishing the inline panels**.

## Behavior

- **Environment relocated:** no longer a permanent top-level card. The sidebar top is now `Open project` + a settings **gear** that reveals the env status (vibe / vibe-acp / version / Re-check) on demand. It's surfaced **prominently in the outlet** only when it matters, via a new `EmptyState` driven by a pure helper.
- **`firstRunState(detect, recents)` (pure, tested):** `needs-install` (vibe/vibe-acp missing — wins over empty; never flashes before detection resolves) → env front-and-center; `no-workspaces` → nudge Open-project; `idle` → neutral placeholder, env tucked behind the gear.
- **Inline panel polish:** `connecting` → a centered panel with the workspace dir; `error` → a panel with a **Retry** that re-triggers the connect for that Workspace. `not-signed-in` (`SignInPanel`) and the connected/expiry paths are unchanged.

## Auth untouched (ADR-0003)

`authReducer`, `SignInPanel`, `SignedInBar`, sign-in/sign-out/mid-session-expiry flows, `toSignInPanel`/`onAuthExpired` — **byte-identical** (verified: `src/renderer/src/auth/` diff empty; no auth tokens in the App.tsx diff). This slice is about WHERE/HOW connection+env states render, not how auth works.

## Verification

Independent verification by the lead (in lieu of a separate adversarial pass given the small presentational surface): gates green; auth dir + flows confirmed untouched; the empty-vs-cold outlet routing traced (`renderColdOutlet` returns the EmptyState only when nothing's selected and only on the idle path — a selected cold Thread still renders `ColdThread`); `firstRunState` precedence unit-tested.

## Note

`firstRunState` treats **either** `vibe` or `vibe-acp` missing as `needs-install` (the issue example named only vibe-acp) — the more correct "can't proceed" gate, matching brand.md/PRD's "vibe/vibe-acp found".

## Gates

`lint` ✓ · `typecheck` ✓ · `build` ✓ · `test` ✓ — **248 tests** (23 files; +6 `firstRunState`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)