### PR TITLE
TB5 (#50): bound the warm-agent pool — idle-evict + LRU cap with protection

### DIFF
--- a/src/main/agent-pool.test.ts
+++ b/src/main/agent-pool.test.ts
@@ -307,3 +307,67 @@ describe('AgentPool — warm-count cap (TB5 #50)', () => {
     expect(pool.agents()).toHaveLength(3)
   })
 })
+
+/**
+ * Graceful teardown injection (TB5 #50, acceptance #3): the pool routes ALL exits
+ * (explicit dispose, idle-evict, cap-trim) through the injected `disposeAgent` so
+ * production can best-effort `session/close` THEN terminate — while the fake-agent
+ * tests above keep using the default `stop()` disposer unchanged.
+ */
+describe('AgentPool — injected disposeAgent (graceful teardown)', () => {
+  /** A pool whose teardown is recorded (not a raw stop) — the production wiring shape. */
+  function makeGracefulPool(now?: () => number): {
+    pool: AgentPool<FakeAgent>
+    disposed: FakeAgent[]
+  } {
+    const factory = fakeFactory()
+    let n = 0
+    const disposed: FakeAgent[] = []
+    const pool = new AgentPool<FakeAgent>({
+      createAgent: factory.create,
+      mintId: () => `a${++n}`,
+      now,
+      disposeAgent: (agent) => disposed.push(agent),
+    })
+    return { pool, disposed }
+  }
+
+  it('routes an explicit dispose through disposeAgent (not a direct stop), maps updated first', () => {
+    const { pool, disposed } = makeGracefulPool()
+    const { agentId, agent } = pool.acquire('/proj/a')
+
+    pool.dispose(agentId)
+
+    expect(disposed).toEqual([agent]) // the injected disposer ran for this agent
+    expect(agent.stops).toBe(0) // the pool did NOT bypass it with a raw stop()
+    // Maps are already consistent (updated before the async teardown) — re-warmable.
+    expect(pool.get(agentId)).toBeNull()
+    expect(pool.getByWorkspace('/proj/a')).toBeNull()
+  })
+
+  it('routes an idle eviction through disposeAgent for the evicted id', () => {
+    const clock = fakeClock(0)
+    const { pool, disposed } = makeGracefulPool(clock.now)
+    const a = pool.acquire('/proj/a')
+
+    clock.set(20_000)
+    const evicted = pool.evictIdle({ idleMs: 5_000, isProtected: UNPROTECTED })
+
+    expect(evicted).toEqual([a.agentId])
+    expect(disposed).toEqual([a.agent]) // graceful teardown, not stop()
+    expect(a.agent.stops).toBe(0)
+  })
+
+  it('routes a cap-trim through disposeAgent for the LRU id', () => {
+    const clock = fakeClock(0)
+    const { pool, disposed } = makeGracefulPool(clock.now)
+    const a = pool.acquire('/proj/a')
+    clock.set(1_000)
+    pool.acquire('/proj/b')
+
+    const evicted = pool.enforceCap({ maxWarm: 1, isProtected: UNPROTECTED })
+
+    expect(evicted).toEqual([a.agentId])
+    expect(disposed).toEqual([a.agent])
+  })
+})

--- a/src/main/agent-pool.test.ts
+++ b/src/main/agent-pool.test.ts
@@ -34,12 +34,21 @@ function fakeFactory(): { create: (workspaceDir: string) => FakeAgent; spawns: n
 }
 
 /** A pool over the fake factory, with a deterministic id sequence for assertions. */
-function makePool(): { pool: AgentPool<FakeAgent>; factory: ReturnType<typeof fakeFactory> } {
+function makePool(now?: () => number): { pool: AgentPool<FakeAgent>; factory: ReturnType<typeof fakeFactory> } {
   const factory = fakeFactory()
   let n = 0
-  const pool = new AgentPool<FakeAgent>({ createAgent: factory.create, mintId: () => `a${++n}` })
+  const pool = new AgentPool<FakeAgent>({ createAgent: factory.create, mintId: () => `a${++n}`, now })
   return { pool, factory }
 }
+
+/** A mutable injected clock (TB5 #50): advance it to age agents — no real timers. */
+function fakeClock(start = 0): { now: () => number; set: (t: number) => void } {
+  let t = start
+  return { now: () => t, set: (next) => void (t = next) }
+}
+
+/** Never protect any agent — the default policy input when protection isn't under test. */
+const UNPROTECTED = (): boolean => false
 
 describe('AgentPool — lazy-spawn-once + reuse-by-Workspace', () => {
   it('spawns an agent on first acquire and returns a minted id (created=true)', () => {
@@ -151,5 +160,150 @@ describe('AgentPool — explicit dispose (the TB5 eviction seam)', () => {
     expect(a.stops).toBe(1)
     expect(b.stops).toBe(1)
     expect(pool.agents()).toHaveLength(0)
+  })
+})
+
+/**
+ * Idle-evict (TB5 #50): the periodic sweep disposes an agent with no activity for
+ * the configured timeout, EXCEPT the protected (on-screen / mid-turn) ones —
+ * exercised with an INJECTED clock so no real timer or process is involved.
+ */
+describe('AgentPool — idle eviction (TB5 #50)', () => {
+  it('stamps lastActiveAt on spawn and evicts only the stale, unprotected agent (returning its id)', () => {
+    const clock = fakeClock(0)
+    const { pool, factory } = makePool(clock.now)
+
+    const a = pool.acquire('/proj/a') // active at t=0
+    clock.set(8_000)
+    pool.acquire('/proj/b') // active at t=8_000
+
+    clock.set(10_000)
+    // idleMs 5_000 -> cutoff 5_000: a (t=0) is stale, b (t=8_000) is fresh.
+    const evicted = pool.evictIdle({ idleMs: 5_000, isProtected: UNPROTECTED })
+
+    expect(evicted).toEqual([a.agentId])
+    expect(a.agent.stops).toBe(1)
+    expect(pool.getByWorkspace('/proj/a')).toBeNull()
+    expect(pool.getByWorkspace('/proj/b')).not.toBeNull()
+    // A re-select of the evicted Workspace re-warms transparently (fresh spawn).
+    clock.set(11_000)
+    const rewarmed = pool.acquire('/proj/a')
+    expect(factory.spawns).toBe(3)
+    expect(rewarmed.created).toBe(true)
+    expect(rewarmed.agent).not.toBe(a.agent)
+  })
+
+  it('REUSE refreshes lastActiveAt, so a re-selected Workspace is not evicted as idle', () => {
+    const clock = fakeClock(0)
+    const { pool } = makePool(clock.now)
+
+    const a = pool.acquire('/proj/a') // t=0
+    clock.set(8_000)
+    pool.acquire('/proj/a') // reuse -> refreshes to t=8_000
+
+    clock.set(10_000)
+    const evicted = pool.evictIdle({ idleMs: 5_000, isProtected: UNPROTECTED })
+
+    expect(evicted).toEqual([])
+    expect(a.agent.stops).toBe(0)
+  })
+
+  it('touch refreshes lastActiveAt (an unknown id is a no-op)', () => {
+    const clock = fakeClock(0)
+    const { pool } = makePool(clock.now)
+
+    const a = pool.acquire('/proj/a') // t=0
+    clock.set(8_000)
+    pool.touch(a.agentId)
+    expect(() => pool.touch('nope')).not.toThrow()
+
+    clock.set(10_000)
+    expect(pool.evictIdle({ idleMs: 5_000, isProtected: UNPROTECTED })).toEqual([])
+    expect(a.agent.stops).toBe(0)
+  })
+
+  it('NEVER evicts a protected (selected / mid-turn) agent, even when stale', () => {
+    const clock = fakeClock(0)
+    const { pool } = makePool(clock.now)
+
+    const a = pool.acquire('/proj/a') // t=0, will be stale but protected
+    clock.set(20_000)
+
+    const evicted = pool.evictIdle({ idleMs: 5_000, isProtected: (id) => id === a.agentId })
+
+    expect(evicted).toEqual([])
+    expect(a.agent.stops).toBe(0)
+    expect(pool.getByWorkspace('/proj/a')).not.toBeNull()
+  })
+})
+
+/**
+ * Warm-count cap (TB5 #50): exceeding M warm agents disposes the LEAST-recently-
+ * active one — never a protected (on-screen / mid-turn) agent, even when honoring
+ * that means staying over cap. The just-acquired agent is most-recent, so the cap
+ * trims a background Workspace, never the one the user just selected.
+ */
+describe('AgentPool — warm-count cap (TB5 #50)', () => {
+  it('evicts the LRU non-protected agent when over cap (returning its id)', () => {
+    const clock = fakeClock(0)
+    const { pool } = makePool(clock.now)
+
+    const a = pool.acquire('/proj/a') // t=0  (LRU)
+    clock.set(1_000)
+    pool.acquire('/proj/b') // t=1_000
+    clock.set(2_000)
+    pool.acquire('/proj/c') // t=2_000
+
+    const evicted = pool.enforceCap({ maxWarm: 2, isProtected: UNPROTECTED })
+
+    expect(evicted).toEqual([a.agentId]) // the least-recently-active
+    expect(a.agent.stops).toBe(1)
+    expect(pool.agents()).toHaveLength(2)
+    expect(pool.getByWorkspace('/proj/b')).not.toBeNull()
+    expect(pool.getByWorkspace('/proj/c')).not.toBeNull()
+  })
+
+  it('is a no-op while at or under the cap', () => {
+    const { pool } = makePool()
+    pool.acquire('/proj/a')
+    pool.acquire('/proj/b')
+
+    expect(pool.enforceCap({ maxWarm: 2, isProtected: UNPROTECTED })).toEqual([])
+    expect(pool.agents()).toHaveLength(2)
+  })
+
+  it('SKIPS a protected LRU and trims the next non-protected agent instead', () => {
+    const clock = fakeClock(0)
+    const { pool } = makePool(clock.now)
+
+    const a = pool.acquire('/proj/a') // t=0   (LRU, but protected — mid-turn)
+    clock.set(1_000)
+    const b = pool.acquire('/proj/b') // t=1_000 (next LRU, unprotected)
+    clock.set(2_000)
+    pool.acquire('/proj/c') // t=2_000
+
+    const evicted = pool.enforceCap({ maxWarm: 2, isProtected: (id) => id === a.agentId })
+
+    expect(evicted).toEqual([b.agentId]) // protected a survived; b trimmed
+    expect(a.agent.stops).toBe(0)
+    expect(b.agent.stops).toBe(1)
+    expect(pool.getByWorkspace('/proj/a')).not.toBeNull()
+  })
+
+  it('STAYS over cap rather than evict a protected agent (protection wins)', () => {
+    const clock = fakeClock(0)
+    const { pool } = makePool(clock.now)
+
+    const a = pool.acquire('/proj/a')
+    clock.set(1_000)
+    const b = pool.acquire('/proj/b')
+    clock.set(2_000)
+    const c = pool.acquire('/proj/c')
+    const allProtected = new Set([a.agentId, b.agentId, c.agentId])
+
+    const evicted = pool.enforceCap({ maxWarm: 2, isProtected: (id) => allProtected.has(id) })
+
+    expect(evicted).toEqual([]) // nothing killable — left over cap
+    expect(pool.agents()).toHaveLength(3)
   })
 })

--- a/src/main/agent-pool.ts
+++ b/src/main/agent-pool.ts
@@ -71,6 +71,16 @@ export interface AgentPoolOptions<A extends PoolAgent> {
    * it). Tests inject a fake clock so eviction is exercised with NO real timers.
    */
   now?: () => number
+  /**
+   * How to tear an agent down when it leaves the pool (TB5 #50). Defaults to a
+   * plain `agent.stop()` (the minimal `PoolAgent` surface, so the fake-agent tests
+   * need nothing more). Production injects `(a) => void a.disposeGracefully()` so
+   * eviction best-effort closes hosted sessions THEN terminates — asynchronously,
+   * AFTER the pool's maps are already updated below, so consistency + re-warm are
+   * unaffected. The pool never awaits this (fire-and-forget): lifecycle bookkeeping
+   * stays synchronous while the child's clean shutdown finishes in the background.
+   */
+  disposeAgent?: (agent: A) => void
 }
 
 /** Inputs to the pure idle-evict policy (TB5 #50). */
@@ -97,6 +107,7 @@ export class AgentPool<A extends PoolAgent = WorkspaceAgent> {
   private readonly createAgent: (workspaceDir: string) => A
   private readonly mintId: () => string
   private readonly now: () => number
+  private readonly disposeAgent: (agent: A) => void
   /** Warm agents keyed by the minted `agentId` (the renderer's handle). */
   private readonly byId = new Map<string, PoolEntry<A>>()
   /** Reverse index: Workspace dir -> `agentId`, for reuse + dir-scoped lookup. */
@@ -106,6 +117,7 @@ export class AgentPool<A extends PoolAgent = WorkspaceAgent> {
     this.createAgent = options.createAgent
     this.mintId = options.mintId ?? randomUUID
     this.now = options.now ?? Date.now
+    this.disposeAgent = options.disposeAgent ?? ((agent) => agent.stop())
   }
 
   /**
@@ -215,9 +227,13 @@ export class AgentPool<A extends PoolAgent = WorkspaceAgent> {
   dispose(agentId: string): void {
     const entry = this.byId.get(agentId)
     if (!entry) return
-    entry.agent.stop()
+    // Update the maps FIRST (synchronously) so the pool is consistent the instant
+    // dispose returns — `get`/`getByWorkspace` already miss this id, and a re-warm
+    // `acquire` spawns a fresh agent — THEN tear the old agent down (which may be
+    // async + best-effort `session/close` via the injected disposer, TB5 #50).
     this.byId.delete(agentId)
     this.byWorkspace.delete(entry.workspaceDir)
+    this.disposeAgent(entry.agent)
   }
 
   /** Stop + drop every warm agent (app quit). */

--- a/src/main/agent-pool.ts
+++ b/src/main/agent-pool.ts
@@ -14,10 +14,13 @@ import type { WorkspaceAgent } from './workspace-agent'
  * the renderer-facing `agentId` handle, holds the agent, and is the only place an
  * agent is stopped (`dispose`/`disposeAll`).
  *
- * Bounded only by spawn-once-and-reuse-per-Workspace here (unbounded warm count is
- * fine for this slice). Idle-eviction and a warm-count cap are TB5 (#50): they hook
- * in HERE — the pool owning lifecycle is the seam, so eviction will just call this
- * pool's own `dispose` on an LRU/idle policy without scattering teardown elsewhere.
+ * BOUNDED (TB5 #50): beyond spawn-once-and-reuse-per-Workspace, the pool tracks
+ * per-agent activity (`lastActiveAt`, set on acquire/reuse + `touch`) and exposes
+ * two pure policies — `evictIdle` (dispose agents idle past a timeout) and
+ * `enforceCap` (LRU-trim the warm count) — that just call this pool's own `dispose`,
+ * so all teardown stays here. Both honor an injected `isProtected` predicate so the
+ * on-screen / mid-turn Workspace is never evicted (main supplies the real one), and
+ * return the disposed agentIds so the caller re-warms the renderer transparently.
  *
  * The agent factory is injected (Seam B) so tests pool a fake — never a live
  * `vibe-acp`. Generic over the agent type for that reason; production wires
@@ -49,6 +52,12 @@ interface PoolEntry<A extends PoolAgent> {
   agentId: string
   workspaceDir: string
   agent: A
+  /**
+   * Epoch-ms of this agent's last real activity (TB5 #50): set on `acquire`
+   * (spawn AND reuse) and refreshed by `touch`. The idle-evict + LRU-cap policy
+   * read it, so an in-use Workspace is always most-recently-active.
+   */
+  lastActiveAt: number
 }
 
 export interface AgentPoolOptions<A extends PoolAgent> {
@@ -56,11 +65,38 @@ export interface AgentPoolOptions<A extends PoolAgent> {
   createAgent: (workspaceDir: string) => A
   /** Mint the renderer-facing agent id (testing). Defaults to a random uuid. */
   mintId?: () => string
+  /**
+   * Clock for activity timestamps (TB5 #50), mirroring `MetadataStore`'s `now`
+   * seam. Defaults to `Date.now` (available in main — only Workflow scripts lack
+   * it). Tests inject a fake clock so eviction is exercised with NO real timers.
+   */
+  now?: () => number
+}
+
+/** Inputs to the pure idle-evict policy (TB5 #50). */
+export interface EvictIdleOptions {
+  /** Dispose an agent idle (no activity) for at least this many ms. */
+  idleMs: number
+  /**
+   * Protection predicate: an agent is NEVER evicted while this returns true —
+   * main supplies the real one (the on-screen Workspace + any mid-turn agent),
+   * keeping the pure logic testable. See the protection contract in #50.
+   */
+  isProtected: (agentId: string) => boolean
+}
+
+/** Inputs to the pure warm-count-cap policy (TB5 #50). */
+export interface EnforceCapOptions {
+  /** The maximum number of simultaneously-warm agents to keep. */
+  maxWarm: number
+  /** Protection predicate — see `EvictIdleOptions.isProtected`. */
+  isProtected: (agentId: string) => boolean
 }
 
 export class AgentPool<A extends PoolAgent = WorkspaceAgent> {
   private readonly createAgent: (workspaceDir: string) => A
   private readonly mintId: () => string
+  private readonly now: () => number
   /** Warm agents keyed by the minted `agentId` (the renderer's handle). */
   private readonly byId = new Map<string, PoolEntry<A>>()
   /** Reverse index: Workspace dir -> `agentId`, for reuse + dir-scoped lookup. */
@@ -69,6 +105,7 @@ export class AgentPool<A extends PoolAgent = WorkspaceAgent> {
   constructor(options: AgentPoolOptions<A>) {
     this.createAgent = options.createAgent
     this.mintId = options.mintId ?? randomUUID
+    this.now = options.now ?? Date.now
   }
 
   /**
@@ -81,13 +118,74 @@ export class AgentPool<A extends PoolAgent = WorkspaceAgent> {
     const existingId = this.byWorkspace.get(workspaceDir)
     if (existingId) {
       const entry = this.byId.get(existingId)
-      if (entry) return { agentId: entry.agentId, agent: entry.agent, created: false }
+      if (entry) {
+        // A reuse IS activity — refresh so a re-selected Workspace can't be
+        // mistaken for idle and evicted out from under the user (TB5 #50).
+        entry.lastActiveAt = this.now()
+        return { agentId: entry.agentId, agent: entry.agent, created: false }
+      }
     }
     const agentId = this.mintId()
     const agent = this.createAgent(workspaceDir)
-    this.byId.set(agentId, { agentId, workspaceDir, agent })
+    this.byId.set(agentId, { agentId, workspaceDir, agent, lastActiveAt: this.now() })
     this.byWorkspace.set(workspaceDir, agentId)
     return { agentId, agent, created: true }
+  }
+
+  /**
+   * Mark an agent active NOW (TB5 #50) — main calls this on real activity beyond
+   * acquire (a prompt, an open) so an in-use Workspace stays most-recently-active
+   * and outranks idle ones under both the idle-evict and the LRU cap. An unknown
+   * id is a no-op (the agent may have just been evicted/disposed).
+   */
+  touch(agentId: string): void {
+    const entry = this.byId.get(agentId)
+    if (entry) entry.lastActiveAt = this.now()
+  }
+
+  /**
+   * Dispose every warm agent idle for at least `idleMs`, EXCEPT protected ones
+   * (the on-screen / mid-turn agents — `isProtected`). Returns the disposed
+   * agentIds so the caller can notify the renderer to drop the now-dead handles
+   * (re-warm transparently on next select). A pure policy over the injected clock
+   * — no real timers — so it's unit-testable without Electron.
+   */
+  evictIdle(opts: EvictIdleOptions): string[] {
+    const cutoff = this.now() - opts.idleMs
+    const stale: string[] = []
+    for (const entry of this.byId.values()) {
+      if (entry.lastActiveAt <= cutoff && !opts.isProtected(entry.agentId)) {
+        stale.push(entry.agentId)
+      }
+    }
+    for (const agentId of stale) this.dispose(agentId)
+    return stale
+  }
+
+  /**
+   * Bound the warm count to `maxWarm` (TB5 #50): while over the cap, dispose the
+   * least-recently-active NON-protected agent. Returns the disposed agentIds.
+   * Protection WINS — if the only over-cap candidates are protected (on-screen or
+   * mid-turn), we stop and stay over cap rather than kill an in-use agent; the
+   * next acquire (or the next sweep, once it's unprotected) trims it. Called after
+   * each `acquire`, so the just-warmed agent — most-recently-active — is never the
+   * one trimmed.
+   */
+  enforceCap(opts: EnforceCapOptions): string[] {
+    const evicted: string[] = []
+    while (this.byId.size > opts.maxWarm) {
+      let victim: PoolEntry<A> | null = null
+      for (const entry of this.byId.values()) {
+        if (opts.isProtected(entry.agentId)) continue
+        if (!victim || entry.lastActiveAt < victim.lastActiveAt) victim = entry
+      }
+      // No unprotected candidate: every over-cap agent is in use — protection
+      // wins, leave them warm (the caller logs/notes the over-cap, see #50).
+      if (!victim) break
+      this.dispose(victim.agentId)
+      evicted.push(victim.agentId)
+    }
+    return evicted
   }
 
   /** The warm agent for a renderer `agentId` handle, or null when none. */

--- a/src/main/agent-protection.test.ts
+++ b/src/main/agent-protection.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { isProtected, type ProtectionState } from './agent-protection'
+
+/**
+ * The warm-pool eviction-protection predicate (TB5 #50) — the safety-critical
+ * guarantee that the on-screen / streaming / signing-in Workspace can NEVER be
+ * evicted. Exercised here as a pure function over the three protection signals
+ * (no Electron, no timers), so the rule itself is verified in isolation.
+ */
+
+/** Build a protection state, overriding only the fields a case cares about. */
+function state(over: Partial<ProtectionState> = {}): ProtectionState {
+  return {
+    activeAgentId: null,
+    inFlightTurns: new Map(),
+    signingInAgents: new Set(),
+    ...over,
+  }
+}
+
+describe('isProtected (TB5 #50)', () => {
+  it('protects the on-screen (active) agent', () => {
+    expect(isProtected('a1', state({ activeAgentId: 'a1' }))).toBe(true)
+  })
+
+  it('protects an agent with a prompt turn in flight (>0)', () => {
+    expect(isProtected('a1', state({ inFlightTurns: new Map([['a1', 1]]) }))).toBe(true)
+    // Overlapping turns (count 2) stay protected.
+    expect(isProtected('a1', state({ inFlightTurns: new Map([['a1', 2]]) }))).toBe(true)
+  })
+
+  it('protects an agent with a sign-in flow in progress', () => {
+    expect(isProtected('a1', state({ signingInAgents: new Set(['a1']) }))).toBe(true)
+  })
+
+  it('does NOT protect an agent that is idle, not selected, and not signing in', () => {
+    const s = state({
+      activeAgentId: 'other',
+      inFlightTurns: new Map([['other', 1]]),
+      signingInAgents: new Set(['another']),
+    })
+    expect(isProtected('a1', s)).toBe(false)
+  })
+
+  it('treats a zero / settled turn count as unprotected (the count is removed at zero)', () => {
+    // Defensive: even a lingering 0 entry must not protect (mirrors `endTurn`'s delete).
+    expect(isProtected('a1', state({ inFlightTurns: new Map([['a1', 0]]) }))).toBe(false)
+  })
+
+  it('protects nobody when there is no on-screen agent (activeAgentId null)', () => {
+    expect(isProtected('a1', state({ activeAgentId: null }))).toBe(false)
+  })
+})

--- a/src/main/agent-protection.ts
+++ b/src/main/agent-protection.ts
@@ -1,0 +1,32 @@
+/**
+ * The warm-pool eviction-protection predicate (TB5 #50), as a PURE function over
+ * the three protection signals main tracks. This is the safety-critical guarantee
+ * of the hardening slice — an agent that is protected is NEVER evicted by the idle
+ * sweep OR the warm-count cap — so it lives here, decoupled from Electron/IPC, to
+ * be unit-tested directly. `index.ts`'s `isAgentProtected` is a thin wrapper that
+ * feeds it the live state; the pool calls that wrapper via its `isProtected` input.
+ *
+ * An agent is protected when it is ANY of:
+ *   - the on-screen Workspace's agent (`activeAgentId`, reported by the renderer) —
+ *     the Workspace the user is looking at is never evicted out from under them;
+ *   - mid-turn (`inFlightTurns[agentId] > 0`) — a streaming Workspace is never
+ *     disposed while a prompt is running;
+ *   - mid-sign-in (`signingInAgents`) — a backgrounded delegated browser OAuth can
+ *     pend longer than the idle timeout, so the agent is shielded for the flow's
+ *     duration (a one-shot touch wouldn't outlast `IDLE_EVICT_MS`).
+ */
+export interface ProtectionState {
+  /** The agentId of the currently selected (on-screen) Workspace, or null. */
+  activeAgentId: string | null
+  /** Per-agent count of in-flight prompt turns (absent / 0 = none). */
+  inFlightTurns: ReadonlyMap<string, number>
+  /** Agents with a sign-in flow in progress. */
+  signingInAgents: ReadonlySet<string>
+}
+
+export function isProtected(agentId: string, state: ProtectionState): boolean {
+  if (agentId === state.activeAgentId) return true
+  if ((state.inFlightTurns.get(agentId) ?? 0) > 0) return true
+  if (state.signingInAgents.has(agentId)) return true
+  return false
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -37,6 +37,7 @@ import {
 } from './persistence/transcript'
 import { WorkspaceAgent, WorkspaceAgentError } from './workspace-agent'
 import { AgentPool } from './agent-pool'
+import { isProtected } from './agent-protection'
 import { ensureBoundSession, resolveContinueTarget } from './thread-binding'
 import { createThreadDraft } from './persistence/drafts'
 import { deleteThread } from './persistence/delete-thread'
@@ -56,6 +57,11 @@ const pool = new AgentPool({
       // Delegated sign-in (#12): open the returned signInUrl in the system browser.
       openUrl: (url) => void shell.openExternal(url),
     }),
+  // Graceful teardown on dispose/evict/stopAgent (TB5 #50, acceptance #3): best-
+  // effort `session/close` each hosted session THEN terminate. Fire-and-forget —
+  // the pool updates its maps synchronously and the child shuts down in the
+  // background, so the renderer re-warms transparently without awaiting close.
+  disposeAgent: (agent) => void agent.disposeGracefully(),
 })
 
 /**
@@ -70,7 +76,7 @@ const pool = new AgentPool({
  *    also bounds the live `acp:event` listener fan-out (the #53 prerequisite).
  *  - `SWEEP_INTERVAL_MS` (1 min): coarse enough to be near-free, fine enough that
  *    eviction lands within a minute of crossing the idle line.
- * Protection (the selected + any mid-turn agent) overrides BOTH bounds (#50).
+ * Protection (the selected, mid-turn, or mid-sign-in agent) overrides BOTH (#50).
  */
 const IDLE_EVICT_MS = 15 * 60 * 1000
 const MAX_WARM_AGENTS = 4
@@ -81,6 +87,12 @@ const SWEEP_INTERVAL_MS = 60 * 1000
  * renderer via `setActiveAgent`. Protected from eviction so the Workspace the user
  * is looking at is never trimmed by the idle/cap policy. Null when the selection
  * has no warm agent (idle/connecting/error) — nothing to protect.
+ *
+ * Single-window assumption: this is an app-GLOBAL protecting the one window's
+ * on-screen agent (the pool itself is process-global today — see
+ * `window-all-closed`). If a multi-window slice ever lands, protection must become
+ * per-window (a set/map of active agents, one per window) or one window's eviction
+ * sweep could evict another window's on-screen agent.
  */
 let activeAgentId: string | null = null
 
@@ -103,13 +115,32 @@ function endTurn(agentId: string): void {
 }
 
 /**
+ * Agents with a sign-in flow IN PROGRESS (TB5 #50). A backgrounded delegated
+ * browser OAuth can pend longer than `IDLE_EVICT_MS` while the user is on another
+ * Workspace (so the agent is neither `activeAgentId` nor mid-turn) — without this
+ * the sweep would evict it mid-`signIn`, rejecting the call with "AcpClient
+ * stopped". Mirrors the turn protection: `beginAuth` at the top of the sign-in
+ * handler, `endAuth` in its `finally`. A one-shot `touch` wouldn't suffice — the
+ * flow can outlast the idle window — so we protect for its whole duration.
+ */
+const signingInAgents = new Set<string>()
+
+function beginAuth(agentId: string): void {
+  signingInAgents.add(agentId)
+}
+
+function endAuth(agentId: string): void {
+  signingInAgents.delete(agentId)
+}
+
+/**
  * The eviction-protection predicate (TB5 #50) handed to the pool's pure policies:
- * NEVER evict the on-screen Workspace's agent, nor one with a prompt turn in
- * flight. This is the load-bearing guarantee — proof that idle/cap can't dispose
- * the selected or streaming Workspace lives entirely here.
+ * NEVER evict the on-screen Workspace's agent, one mid-turn, or one mid-sign-in. A
+ * thin wrapper over the PURE `isProtected` (agent-protection.ts) — the load-bearing
+ * safety logic is unit-tested there; this just feeds it the live main-process state.
  */
 function isAgentProtected(agentId: string): boolean {
-  return agentId === activeAgentId || (inFlightTurns.get(agentId) ?? 0) > 0
+  return isProtected(agentId, { activeAgentId, inFlightTurns, signingInAgents })
 }
 
 /** The periodic idle-evict sweep timer (cleared on quit). */
@@ -598,11 +629,19 @@ function registerIpc(): void {
     // state (ADR-0001). Credentials never touch us — Vibe owns the keyring (ADR-0003).
     const agent = pool.get(args.agentId)
     if (!agent) return { ok: false, error: `No active agent for id ${args.agentId}.` }
+    // Protect the agent for the WHOLE sign-in (TB5 #50): a delegated browser OAuth
+    // can pend past IDLE_EVICT_MS while the user is on another Workspace, so without
+    // this the sweep would evict it mid-flight and reject the call. `endAuth` always
+    // runs in `finally`, so the flag can't leak even on failure/early-exit.
+    pool.touch(args.agentId)
+    beginAuth(args.agentId)
     try {
       const authState = await agent.signIn(args.methodId)
       return { ok: true, authState }
     } catch (err) {
       return { ok: false, error: err instanceof Error ? err.message : String(err) }
+    } finally {
+      endAuth(args.agentId)
     }
   })
 
@@ -611,6 +650,7 @@ function registerIpc(): void {
     // stays alive so the user can sign a different account back in (ADR-0003).
     const agent = pool.get(args.agentId)
     if (!agent) return { ok: false, error: `No active agent for id ${args.agentId}.` }
+    pool.touch(args.agentId) // sign-out is quick activity; a touch suffices (TB5 #50)
     try {
       const authState = await agent.signOut()
       return { ok: true, authState, authMethods: agent.authMethods }
@@ -702,14 +742,18 @@ app.whenReady().then(async () => {
   registerIpc()
   createWindow()
 
-  // The periodic idle-evict sweep (TB5 #50): release any agent untouched past
-  // IDLE_EVICT_MS, except the protected (on-screen / mid-turn) ones, and notify
-  // the renderer to re-warm them lazily on next select. Started once here; the
-  // interval is `unref`'d so it never keeps the process alive on its own, and is
-  // cleared on quit. Resilient across the macOS window-close/reopen cycle — after
-  // `disposeAll` the pool is empty, so the sweep simply no-ops until re-warmed.
+  // The periodic sweep (TB5 #50): release any agent untouched past IDLE_EVICT_MS,
+  // THEN re-run the cap, both skipping the protected (on-screen / mid-turn /
+  // mid-sign-in) agents, and notify the renderer to re-warm any evicted ones lazily
+  // on next select. Running `enforceCap` here too lets a temporarily over-cap state
+  // — one that persisted because every over-cap candidate was protected at acquire
+  // time — self-heal on a later sweep once a candidate becomes unprotected. Started
+  // once here; the interval is `unref`'d so it never keeps the process alive on its
+  // own, and is cleared on quit. Resilient across the macOS window-close/reopen
+  // cycle — after `disposeAll` the pool is empty, so the sweep no-ops until re-warmed.
   sweepTimer = setInterval(() => {
     notifyAgentsEvicted(pool.evictIdle({ idleMs: IDLE_EVICT_MS, isProtected: isAgentProtected }))
+    notifyAgentsEvicted(pool.enforceCap({ maxWarm: MAX_WARM_AGENTS, isProtected: isAgentProtected }))
   }, SWEEP_INTERVAL_MS)
   sweepTimer.unref?.()
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -59,6 +59,80 @@ const pool = new AgentPool({
 })
 
 /**
+ * Warm-pool bounds (ADR-0006 decision 3, TB5 #50). Defaults chosen for a desktop
+ * orchestrator where a Workspace's child is cheap to re-warm (history is in our
+ * store, ADR-0005) but holding many idle `vibe-acp` processes leaks memory:
+ *  - `IDLE_EVICT_MS` (15 min): a Workspace untouched this long is almost certainly
+ *    abandoned for now; releasing its child reclaims memory and a re-select
+ *    re-warms in well under a second.
+ *  - `MAX_WARM_AGENTS` (4): a generous ceiling for how many Workspaces a user
+ *    actively juggles at once — past it the least-recently-used is trimmed. This
+ *    also bounds the live `acp:event` listener fan-out (the #53 prerequisite).
+ *  - `SWEEP_INTERVAL_MS` (1 min): coarse enough to be near-free, fine enough that
+ *    eviction lands within a minute of crossing the idle line.
+ * Protection (the selected + any mid-turn agent) overrides BOTH bounds (#50).
+ */
+const IDLE_EVICT_MS = 15 * 60 * 1000
+const MAX_WARM_AGENTS = 4
+const SWEEP_INTERVAL_MS = 60 * 1000
+
+/**
+ * The agentId of the Workspace currently ON SCREEN (TB5 #50), reported by the
+ * renderer via `setActiveAgent`. Protected from eviction so the Workspace the user
+ * is looking at is never trimmed by the idle/cap policy. Null when the selection
+ * has no warm agent (idle/connecting/error) — nothing to protect.
+ */
+let activeAgentId: string | null = null
+
+/**
+ * Agents with a prompt turn IN FLIGHT (TB5 #50), by agentId -> open-turn count.
+ * An agent mid-turn is protected from eviction so a streaming Workspace is never
+ * disposed under the user. A count (not a flag) tolerates overlapping prompts; the
+ * entry is removed when it hits zero so the map can't leak.
+ */
+const inFlightTurns = new Map<string, number>()
+
+function beginTurn(agentId: string): void {
+  inFlightTurns.set(agentId, (inFlightTurns.get(agentId) ?? 0) + 1)
+}
+
+function endTurn(agentId: string): void {
+  const next = (inFlightTurns.get(agentId) ?? 0) - 1
+  if (next > 0) inFlightTurns.set(agentId, next)
+  else inFlightTurns.delete(agentId)
+}
+
+/**
+ * The eviction-protection predicate (TB5 #50) handed to the pool's pure policies:
+ * NEVER evict the on-screen Workspace's agent, nor one with a prompt turn in
+ * flight. This is the load-bearing guarantee — proof that idle/cap can't dispose
+ * the selected or streaming Workspace lives entirely here.
+ */
+function isAgentProtected(agentId: string): boolean {
+  return agentId === activeAgentId || (inFlightTurns.get(agentId) ?? 0) > 0
+}
+
+/** The periodic idle-evict sweep timer (cleared on quit). */
+let sweepTimer: ReturnType<typeof setInterval> | null = null
+
+/**
+ * Push an eviction notice to every renderer (TB5 #50) so it drops the now-dead
+ * agents' Workspace connections and re-warms them lazily on next select. Also
+ * clears the agents' transcript-bridge entries so the `agentId -> threadId` map
+ * can't leak across evictions. A no-op when nothing was evicted.
+ */
+function notifyAgentsEvicted(agentIds: string[]): void {
+  if (agentIds.length === 0) return
+  for (const agentId of agentIds) {
+    inFlightTurns.delete(agentId)
+    transcriptThreads.delete(agentId)
+  }
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.webContents.isDestroyed()) win.webContents.send(IPC.agentEvicted, { agentIds })
+  }
+}
+
+/**
  * The single-writer metadata index (ADR-0005). Assigned at app-ready (needs
  * `userData`) and loaded before the first window so the renderer's cold list
  * fetch sees the persisted state. A failed load degrades to empty, never throws.
@@ -301,6 +375,77 @@ function wireAgentEvents(agentId: string, agent: WorkspaceAgent, sender: WebCont
   })
 }
 
+/**
+ * Run one prompt turn: bind-on-first-prompt, tee the input, send `session/prompt`,
+ * and map the outcome to a `SendPromptResult`. Extracted from the IPC handler so
+ * the handler stays a thin eviction-protection wrapper (TB5 #50) — the turn's
+ * lifecycle is unchanged from TB4/TB5 (#33/#46). `sender` is the request's
+ * webContents (for the up-front `thread:bound` signal).
+ */
+async function runPromptTurn(
+  sender: WebContents,
+  agent: WorkspaceAgent,
+  args: SendPromptArgs,
+): Promise<SendPromptResult> {
+  // Bind on first prompt (ADR-0005, TB5): a draft (sessionId null) mints its
+  // session via `session/new` NOW and binds it onto this Thread id; an
+  // already-bound Thread reuses its session — no second `session/new`. A
+  // binding failure surfaces WITHOUT teeing: nothing was logged yet, so a
+  // failed first prompt leaves no transcript residue.
+  let sessionId: string
+  let rebound: boolean
+  try {
+    const bound = await bindThreadSession(agent, args)
+    sessionId = bound.sessionId
+    rebound = bound.rebound
+    // Tell the renderer its draft is now bound, the INSTANT `session/new`
+    // returns and BEFORE `agent.prompt` streams any event below (same
+    // webContents, so ordered ahead of those `acp:event`s). This binds the
+    // draft's live view to its OWN session up front, so it never infers a
+    // session from an arbitrary (possibly sibling) event. `rebound` (TB4 #33)
+    // carries a NEW session for a reopened Thread whose resume failed — the
+    // renderer rebinds its live view to it AND renders the "context reset" notice.
+    if (bound.minted && !sender.isDestroyed()) {
+      sender.send(IPC.threadBound, { threadId: args.threadId, sessionId, rebound })
+    }
+  } catch (err) {
+    if (err instanceof WorkspaceAgentError && err.authState === 'not-signed-in') {
+      return { ok: false, kind: 'not-signed-in', agentId: args.agentId, authMethods: agent.authMethods }
+    }
+    return { ok: false, kind: 'error', error: err instanceof Error ? err.message : String(err) }
+  }
+
+  // Tee the user's prompt (the conversation INPUT) to THIS Thread's log before
+  // sending it, so it precedes the streamed events it triggers. We hold the
+  // Thread id, so no bridge lookup — a draft's first prompt can't misroute to
+  // another Thread. Main has no renderer item id, so mint an opaque replay key.
+  teeTranscript(args.threadId, userPromptEntry(randomUUID(), args.text))
+  // On a re-bind (TB4 #33), persist the "context reset" notice right AFTER the
+  // user's prompt and BEFORE the turn's events — so a later reopen replays it
+  // in the same position the live view rendered it (`thread:bound` -> notice).
+  if (rebound) teeTranscript(args.threadId, agentReboundEntry())
+  try {
+    const result = await agent.prompt(sessionId, args.text)
+    // Tee the clean turn end: this signal lives ONLY in this IPC response
+    // (never an `acp:event`), so without it a replay leaves `isProcessing`
+    // stuck true. Serialized after the turn's events (TranscriptStore chain).
+    teeTranscript(args.threadId, turnCompleteEntry())
+    return { ok: true, result, sessionId }
+  } catch (err) {
+    // Mid-session expiry (-32000): keep the agent alive so the renderer can
+    // re-auth in place on the same agent; don't stop it. This is a re-auth
+    // flow, NOT a conversation error — tee `turn-complete` (the renderer
+    // synthesizes no ErrorItem here either), so replay isn't left processing.
+    if (err instanceof WorkspaceAgentError && err.authState === 'not-signed-in') {
+      teeTranscript(args.threadId, turnCompleteEntry())
+      return { ok: false, kind: 'not-signed-in', agentId: args.agentId, authMethods: agent.authMethods }
+    }
+    const message = err instanceof Error ? err.message : String(err)
+    teeTranscript(args.threadId, turnErrorEntry(message))
+    return { ok: false, kind: 'error', error: message }
+  }
+}
+
 function createWindow(): void {
   const win = new BrowserWindow({
     width: 1280,
@@ -351,6 +496,12 @@ function registerIpc(): void {
     const { agentId, agent, created } = pool.acquire(args.workspaceDir)
     if (created) wireAgentEvents(agentId, agent, event.sender)
 
+    // Enforce the warm-count cap right after warming this Workspace (TB5 #50): if
+    // we're now over MAX_WARM_AGENTS, trim the least-recently-active UNPROTECTED
+    // agent and tell the renderer to re-warm it lazily on next select. The agent we
+    // just acquired is most-recently-active, so it's never the one trimmed.
+    notifyAgentsEvicted(pool.enforceCap({ maxWarm: MAX_WARM_AGENTS, isProtected: isAgentProtected }))
+
     // Persist the Workspace open up front (ADR-0005), so even a not-signed-in
     // Workspace shows in the cold list. Best-effort — must not reject connect.
     await recordWorkspaceOpen(args.workspaceDir)
@@ -389,6 +540,7 @@ function registerIpc(): void {
     // in-place re-auth). Reuses the retained agent — no re-spawn.
     const agent = pool.get(args.agentId)
     if (!agent) return { ok: false, kind: 'error', error: `No active agent for id ${args.agentId}.`, hint: null }
+    pool.touch(args.agentId) // opening a Thread is activity — outrank idle peers (TB5 #50)
     try {
       const thread = await agent.openThread()
       const ids = await recordThread(args.agentId, agent.workspaceDir, thread)
@@ -404,62 +556,17 @@ function registerIpc(): void {
       const agent = pool.get(args.agentId)
       if (!agent) return { ok: false, kind: 'error', error: `No active agent for id ${args.agentId}.` }
 
-      // Bind on first prompt (ADR-0005, TB5): a draft (sessionId null) mints its
-      // session via `session/new` NOW and binds it onto this Thread id; an
-      // already-bound Thread reuses its session — no second `session/new`. A
-      // binding failure surfaces WITHOUT teeing: nothing was logged yet, so a
-      // failed first prompt leaves no transcript residue.
-      let sessionId: string
-      let rebound: boolean
+      // Activity + eviction protection (TB5 #50): a prompt is real activity, so
+      // touch the agent (it outranks idle peers under the idle/cap policy), and
+      // mark a turn IN FLIGHT for the call's duration so the sweep/cap can't evict
+      // a streaming Workspace out from under the user. `endTurn` runs no matter how
+      // the turn settles (success, error, or a thrown bind), so the flag can't leak.
+      pool.touch(args.agentId)
+      beginTurn(args.agentId)
       try {
-        const bound = await bindThreadSession(agent, args)
-        sessionId = bound.sessionId
-        rebound = bound.rebound
-        // Tell the renderer its draft is now bound, the INSTANT `session/new`
-        // returns and BEFORE `agent.prompt` streams any event below (same
-        // webContents, so ordered ahead of those `acp:event`s). This binds the
-        // draft's live view to its OWN session up front, so it never infers a
-        // session from an arbitrary (possibly sibling) event. `rebound` (TB4 #33)
-        // carries a NEW session for a reopened Thread whose resume failed — the
-        // renderer rebinds its live view to it AND renders the "context reset" notice.
-        if (bound.minted && !event.sender.isDestroyed()) {
-          event.sender.send(IPC.threadBound, { threadId: args.threadId, sessionId, rebound })
-        }
-      } catch (err) {
-        if (err instanceof WorkspaceAgentError && err.authState === 'not-signed-in') {
-          return { ok: false, kind: 'not-signed-in', agentId: args.agentId, authMethods: agent.authMethods }
-        }
-        return { ok: false, kind: 'error', error: err instanceof Error ? err.message : String(err) }
-      }
-
-      // Tee the user's prompt (the conversation INPUT) to THIS Thread's log before
-      // sending it, so it precedes the streamed events it triggers. We hold the
-      // Thread id, so no bridge lookup — a draft's first prompt can't misroute to
-      // another Thread. Main has no renderer item id, so mint an opaque replay key.
-      teeTranscript(args.threadId, userPromptEntry(randomUUID(), args.text))
-      // On a re-bind (TB4 #33), persist the "context reset" notice right AFTER the
-      // user's prompt and BEFORE the turn's events — so a later reopen replays it
-      // in the same position the live view rendered it (`thread:bound` -> notice).
-      if (rebound) teeTranscript(args.threadId, agentReboundEntry())
-      try {
-        const result = await agent.prompt(sessionId, args.text)
-        // Tee the clean turn end: this signal lives ONLY in this IPC response
-        // (never an `acp:event`), so without it a replay leaves `isProcessing`
-        // stuck true. Serialized after the turn's events (TranscriptStore chain).
-        teeTranscript(args.threadId, turnCompleteEntry())
-        return { ok: true, result, sessionId }
-      } catch (err) {
-        // Mid-session expiry (-32000): keep the agent alive so the renderer can
-        // re-auth in place on the same agent; don't stop it. This is a re-auth
-        // flow, NOT a conversation error — tee `turn-complete` (the renderer
-        // synthesizes no ErrorItem here either), so replay isn't left processing.
-        if (err instanceof WorkspaceAgentError && err.authState === 'not-signed-in') {
-          teeTranscript(args.threadId, turnCompleteEntry())
-          return { ok: false, kind: 'not-signed-in', agentId: args.agentId, authMethods: agent.authMethods }
-        }
-        const message = err instanceof Error ? err.message : String(err)
-        teeTranscript(args.threadId, turnErrorEntry(message))
-        return { ok: false, kind: 'error', error: message }
+        return await runPromptTurn(event.sender, agent, args)
+      } finally {
+        endTurn(args.agentId)
       }
     },
   )
@@ -473,8 +580,16 @@ function registerIpc(): void {
     // last-prompted map: answering Thread A's permission after switching+prompting
     // a sibling B must land in A's log, not B's.
     const agent = pool.get(args.agentId)
+    pool.touch(args.agentId) // answering a permission is activity (TB5 #50)
     teeTranscript(args.threadId, resolvePermissionEntry(args.requestId, args.optionId))
     agent?.respondPermission(args.requestId, args.optionId)
+  })
+
+  ipcMain.handle(IPC.setActiveAgent, (_event, agentId: string | null) => {
+    // The renderer reports which Workspace agent is currently ON SCREEN (TB5 #50).
+    // Tracked so `isAgentProtected` shields it from idle/cap eviction — the
+    // Workspace the user is looking at is never trimmed out from under them.
+    activeAgentId = agentId
   })
 
   ipcMain.handle(IPC.signIn, async (_event, args: SignInArgs): Promise<SignInResult> => {
@@ -587,6 +702,17 @@ app.whenReady().then(async () => {
   registerIpc()
   createWindow()
 
+  // The periodic idle-evict sweep (TB5 #50): release any agent untouched past
+  // IDLE_EVICT_MS, except the protected (on-screen / mid-turn) ones, and notify
+  // the renderer to re-warm them lazily on next select. Started once here; the
+  // interval is `unref`'d so it never keeps the process alive on its own, and is
+  // cleared on quit. Resilient across the macOS window-close/reopen cycle — after
+  // `disposeAll` the pool is empty, so the sweep simply no-ops until re-warmed.
+  sweepTimer = setInterval(() => {
+    notifyAgentsEvicted(pool.evictIdle({ idleMs: IDLE_EVICT_MS, isProtected: isAgentProtected }))
+  }, SWEEP_INTERVAL_MS)
+  sweepTimer.unref?.()
+
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow()
   })
@@ -597,4 +723,13 @@ app.on('window-all-closed', () => {
   // A future multi-window slice should scope the pool per window.
   pool.disposeAll()
   if (process.platform !== 'darwin') app.quit()
+})
+
+app.on('will-quit', () => {
+  // Stop the idle-evict sweep so no timer outlives the app (TB5 #50). The pool's
+  // own teardown is `window-all-closed`'s `disposeAll`; this just clears the timer.
+  if (sweepTimer) {
+    clearInterval(sweepTimer)
+    sweepTimer = null
+  }
 })

--- a/src/main/workspace-agent.test.ts
+++ b/src/main/workspace-agent.test.ts
@@ -808,6 +808,52 @@ describe('WorkspaceAgent.closeSession() (TB6 #35)', () => {
   })
 })
 
+// --- TB5: graceful disposal on eviction (#50) -------------------------------
+
+describe('WorkspaceAgent.disposeGracefully() (TB5 #50)', () => {
+  it('best-effort closes EACH hosted session (where advertised) THEN terminates', async () => {
+    const fake = makeCapturingFake()
+    const agent = await connectWithCaps(fake, true) // hosts SESSION_ID, close advertised
+
+    const disposing = agent.disposeGracefully()
+    await new Promise((r) => setTimeout(r, 0))
+    const closeReq = sent(fake).find((m) => m.method === 'session/close')
+    expect(closeReq?.params?.sessionId).toBe(SESSION_ID) // close attempted first
+    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: closeReq?.id, result: {} }) + '\n')
+
+    await expect(disposing).resolves.toBeUndefined()
+    // THEN terminated: the session is no longer hosted and the agent is stopped
+    // (an uninitialized agent rejects further work).
+    expect(agent.hasSession(SESSION_ID)).toBe(false)
+    await expect(agent.prompt(SESSION_ID, 'x')).rejects.toThrow(/not initialized/i)
+  })
+
+  it('terminates WITHOUT sending session/close when the capability is not advertised', async () => {
+    const fake = makeCapturingFake()
+    const agent = await connectWithCaps(fake, false) // hosts SESSION_ID, NO close capability
+
+    await expect(agent.disposeGracefully()).resolves.toBeUndefined()
+
+    expect(sent(fake).some((m) => m.method === 'session/close')).toBe(false)
+    expect(agent.hasSession(SESSION_ID)).toBe(false) // still terminated
+  })
+
+  it('never rejects, and still terminates, when a session/close errors', async () => {
+    const fake = makeCapturingFake()
+    const agent = await connectWithCaps(fake, true)
+
+    const disposing = agent.disposeGracefully()
+    await new Promise((r) => setTimeout(r, 0))
+    const closeReq = sent(fake).find((m) => m.method === 'session/close')
+    fake.feed(
+      JSON.stringify({ jsonrpc: '2.0', id: closeReq?.id, error: { code: -32603, message: 'boom' } }) + '\n',
+    )
+
+    await expect(disposing).resolves.toBeUndefined() // swallowed — terminate runs in finally
+    expect(agent.hasSession(SESSION_ID)).toBe(false)
+  })
+})
+
 // --- TB3: fs/write serving + permission responder ---------------------------
 
 /** Drive a ready agent over the capturing fake, with an injected writer. */

--- a/src/main/workspace-agent.ts
+++ b/src/main/workspace-agent.ts
@@ -583,6 +583,25 @@ export class WorkspaceAgent extends EventEmitter {
     this.initialized = false
   }
 
+  /**
+   * Graceful teardown for eviction (TB5 #50): best-effort `session/close` EVERY
+   * hosted session (where the capability is advertised — `closeSession` already
+   * gates that and swallows failures), THEN terminate via `stop()`. Mirrors the
+   * TB6 delete close-then-drop order. The close fan-out is wrapped so a hung/erroring
+   * close can never skip the `stop()` — terminate ALWAYS runs in the `finally`, so
+   * disposal never wedges and never rejects. Snapshots the session ids up front
+   * because `closeSession` mutates the `threads` map as it goes.
+   */
+  async disposeGracefully(): Promise<void> {
+    try {
+      for (const sessionId of [...this.threads.keys()]) {
+        await this.closeSession(sessionId)
+      }
+    } finally {
+      this.stop()
+    }
+  }
+
   private detachStartGuards(
     onError: (err: Error) => void,
     onExit: (info: { code: number | null; signal: NodeJS.Signals | null }) => void,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer } from 'electron'
 import {
   IPC,
   type AcpEvent,
+  type AgentEvictedEvent,
   type CreateDraftArgs,
   type CreateDraftResult,
   type ListMetadataResult,
@@ -34,6 +35,8 @@ const api = {
   signIn: (args: SignInArgs): Promise<SignInResult> => ipcRenderer.invoke(IPC.signIn, args),
   signOut: (args: SignOutArgs): Promise<SignOutResult> => ipcRenderer.invoke(IPC.signOut, args),
   stopAgent: (agentId: string): Promise<void> => ipcRenderer.invoke(IPC.stopAgent, agentId),
+  setActiveAgent: (agentId: string | null): Promise<void> =>
+    ipcRenderer.invoke(IPC.setActiveAgent, agentId),
   listMetadata: (): Promise<ListMetadataResult> => ipcRenderer.invoke(IPC.listMetadata),
   createDraft: (args: CreateDraftArgs): Promise<CreateDraftResult> =>
     ipcRenderer.invoke(IPC.createDraft, args),
@@ -50,6 +53,11 @@ const api = {
     const handler = (_e: unknown, payload: ThreadBoundEvent): void => listener(payload)
     ipcRenderer.on(IPC.threadBound, handler)
     return () => ipcRenderer.removeListener(IPC.threadBound, handler)
+  },
+  onAgentEvicted: (listener: (event: AgentEvictedEvent) => void): (() => void) => {
+    const handler = (_e: unknown, payload: AgentEvictedEvent): void => listener(payload)
+    ipcRenderer.on(IPC.agentEvicted, handler)
+    return () => ipcRenderer.removeListener(IPC.agentEvicted, handler)
   },
 }
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -15,6 +15,7 @@ import {
 } from './auth/auth-view'
 import { routeThreadResult, type ConnectState } from './connection/routing'
 import {
+  agentIdOf,
   connectedWorkspaceIds,
   connectionsReducer,
   initialConnections,
@@ -205,6 +206,19 @@ export function App(): JSX.Element {
     void refreshRecents()
   }, [])
 
+  // Pool eviction (TB5 #50): when main evicts a warm agent (idle timeout or the
+  // warm-count cap), drop the Workspaces holding those now-dead agentIds so the
+  // next select re-warms lazily (a normal re-connect; history from the store, no
+  // user-visible error). By contract the evicted agent is never the selected or
+  // mid-turn one, so nothing the user is looking at vanishes. This also caps the
+  // `acp:event` listener fan-out (bounded by MAX_WARM_AGENTS) — the prerequisite
+  // #53 was waiting on; #53 itself (mounting all live siblings) is NOT done here.
+  useEffect(() => {
+    return window.api.onAgentEvicted((e) => {
+      connDispatch({ type: 'evict', agentIds: new Set(e.agentIds) })
+    })
+  }, [])
+
   /**
    * Select a Workspace from the sidebar: pin it in the nav reducer and
    * connect-OR-REUSE its warm agent. A never-connected (or errored) Workspace
@@ -335,6 +349,15 @@ export function App(): JSX.Element {
   const connectedIds = connectedWorkspaceIds(connections)
   const selectedWs = nav.selectedWorkspaceId
   const selected = selectedConnection(connections, selectedWs)
+
+  // Tell main which agent backs the ON-SCREEN Workspace (TB5 #50) so the pool
+  // protects it from idle/cap eviction — the Workspace the user is looking at is
+  // never evicted out from under them. Null when the selection has no warm agent
+  // (idle/connecting/error); main also protects any mid-turn agent independently.
+  const selectedAgentId = agentIdOf(selected)
+  useEffect(() => {
+    void window.api.setActiveAgent(selectedAgentId)
+  }, [selectedAgentId])
 
   // Per-Workspace rolled-up live status for the switcher badges — what flags a
   // BACKGROUND Workspace blocked on a permission prompt (the deferred TB2 finding).

--- a/src/renderer/src/connection/connections.test.ts
+++ b/src/renderer/src/connection/connections.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
+  agentIdOf,
   connectedWorkspaceIds,
   connectionsReducer,
   initialConnections,
@@ -62,6 +63,36 @@ describe('connectionsReducer', () => {
 
     const same = connectionsReducer(a, { type: 'clear', workspaceId: 'absent' })
     expect(same).toBe(a) // unchanged reference: no spurious re-render
+  })
+
+  it('evict drops the Workspaces holding pool-evicted agents (re-warm on next select), TB5 #50', () => {
+    const map: ConnectionMap = {
+      w1: connected('w1', 'a1'),
+      w2: connected('w2', 'a2'),
+      w3: { status: 'not-signed-in', agentId: 'a3', workspaceDir: '/proj/w3', authMethods: AUTH_METHODS },
+    }
+    // The pool evicted a1 (connected) and a3 (not-signed-in) — both Workspaces drop.
+    const next = connectionsReducer(map, { type: 'evict', agentIds: new Set(['a1', 'a3']) })
+    expect(Object.keys(next)).toEqual(['w2']) // w2 (a2) untouched
+  })
+
+  it('evict is a no-op (same ref) when no connection holds an evicted agent', () => {
+    const map: ConnectionMap = { w1: connected('w1', 'a1') }
+    // a connecting/idle Workspace has no agent yet, so an unrelated eviction is inert.
+    const same = connectionsReducer(map, { type: 'evict', agentIds: new Set(['a-unknown']) })
+    expect(same).toBe(map)
+  })
+})
+
+describe('agentIdOf', () => {
+  it('extracts the pool agentId from a connected / not-signed-in state, null otherwise', () => {
+    expect(agentIdOf(connected('w1', 'a1'))).toBe('a1')
+    expect(
+      agentIdOf({ status: 'not-signed-in', agentId: 'a4', workspaceDir: '/proj/w4', authMethods: AUTH_METHODS }),
+    ).toBe('a4')
+    expect(agentIdOf({ status: 'idle' })).toBeNull()
+    expect(agentIdOf({ status: 'connecting', workspaceDir: '/proj/w1' })).toBeNull()
+    expect(agentIdOf({ status: 'error', message: 'boom', hint: null })).toBeNull()
   })
 })
 

--- a/src/renderer/src/connection/connections.ts
+++ b/src/renderer/src/connection/connections.ts
@@ -14,6 +14,7 @@ export type ConnectionMap = Readonly<Record<string, ConnectState>>
 export type ConnectionAction =
   | { type: 'set'; workspaceId: string; state: ConnectState }
   | { type: 'clear'; workspaceId: string }
+  | { type: 'evict'; agentIds: ReadonlySet<string> }
 
 export const initialConnections: ConnectionMap = {}
 
@@ -27,7 +28,33 @@ export function connectionsReducer(state: ConnectionMap, action: ConnectionActio
       delete next[action.workspaceId]
       return next
     }
+    case 'evict': {
+      // The pool evicted these agents (TB5 #50): drop the Workspaces holding them
+      // so the next select re-warms lazily (a re-connect, history from the store).
+      // Returns the SAME ref when no connection referenced an evicted agent, so a
+      // sweep that evicted nothing the renderer tracks drives no re-render.
+      const doomed = Object.keys(state).filter((id) => {
+        const agentId = agentIdOf(state[id])
+        return agentId !== null && action.agentIds.has(agentId)
+      })
+      if (doomed.length === 0) return state
+      const next = { ...state }
+      for (const id of doomed) delete next[id]
+      return next
+    }
   }
+}
+
+/**
+ * The pool agentId a ConnectState holds, when any (TB5 #50): a connected state
+ * carries it on its `thread`, a not-signed-in state inline; the transient
+ * idle/connecting/error states have no agent yet. Used to map a pool eviction
+ * (by agentId) back to the Workspace connection to drop.
+ */
+export function agentIdOf(state: ConnectState): string | null {
+  if (state.status === 'connected') return state.thread.agentId
+  if (state.status === 'not-signed-in') return state.agentId
+  return null
 }
 
 /**

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -25,6 +25,20 @@ export const IPC = {
   /** Main -> renderer: streamed ACP event tagged by the owning agent. */
   acpEvent: 'acp:event',
   /**
+   * Renderer -> main: the agentId of the currently SELECTED (on-screen) Workspace,
+   * or null when none is connected/selected (TB5 #50). Main protects this agent
+   * from idle/cap eviction so the Workspace the user is looking at is never
+   * evicted out from under them.
+   */
+  setActiveAgent: 'agent:set-active',
+  /**
+   * Main -> renderer: agents the pool just EVICTED (TB5 #50, idle/cap policy). The
+   * renderer drops their now-dead connections so the next select re-warms lazily
+   * (history intact from the store, no user-visible error). By contract these are
+   * never the selected/streaming Workspace, so nothing vanishes mid-use.
+   */
+  agentEvicted: 'agent:evicted',
+  /**
    * Main -> renderer: a draft's session was just minted (`session/new`) and bound
    * to its Thread (TB5). Emitted BEFORE that session streams any event, so a draft
    * is bound before its own events arrive — it never infers its session from one.
@@ -168,6 +182,17 @@ export interface AcpEvent {
   agentId: string
   /** Raw ACP / JSON-RPC payload (or a serialized child lifecycle event). */
   payload: unknown
+}
+
+/**
+ * Main -> renderer notice that the pool evicted one or more warm agents (TB5 #50):
+ * the renderer resets each agent's Workspace connection to a re-warmable state so
+ * the next select lazily re-connects. Carries the agentIds (the renderer keys its
+ * connections by Workspace but each connection holds its agentId) so it can drop
+ * exactly the dead ones.
+ */
+export interface AgentEvictedEvent {
+  agentIds: string[]
 }
 
 /**


### PR DESCRIPTION
## What this is

TB5 (closes #50) — the **FINAL slice** of the UI/layout-shell epic (PRD #45, ADR-0006). Bounds the warm-agent pool from TB2 with an **idle-evict** + **LRU warm-count cap**, disposing cleanly and re-warming transparently — closing the epic.

## Behavior

- **Eviction logic (pure, clock-injected, in `agent-pool.ts`):** `touch`/`lastActiveAt`; `evictIdle({idleMs, isProtected})` disposes agents idle past the timeout; `enforceCap({maxWarm, isProtected})` LRU-trims the warm count. Both honor the protection predicate and return disposed ids.
- **Protection contract (`agent-protection.ts`, pure + unit-tested):** an agent is NEVER evicted while it's the **on-screen** Workspace (`activeAgentId`, renderer-reported), **mid-turn** (`inFlightTurns>0`), or **mid-sign-in** (`signingInAgents`). The safety-critical guarantee — the Workspace you're looking at or streaming is never disposed out from under you.
- **Wiring (`index.ts`):** named constants (`IDLE_EVICT_MS`=15min, `MAX_WARM_AGENTS`=4, `SWEEP_INTERVAL_MS`=1min); a periodic sweep running `evictIdle`+`enforceCap`; `enforceCap` after each acquire; `touch` on real activity; `beginTurn`/`endTurn` + `beginAuth`/`endAuth` for protection; sweep `unref`'d and cleared on `will-quit`.
- **Re-warm transparency / pool↔renderer consistency:** eviction → `agentEvicted` push IPC → renderer drops that Workspace's connection (by agentId) → next select lazily re-warms (new agentId, fresh tee) with history intact from the store; no user-visible error. Capping warm count also bounds the `acp:event` listener fan-out — the prerequisite #53 was waiting on.
- **Graceful dispose:** `WorkspaceAgent.disposeGracefully()` best-effort `session/close`es hosted sessions (gated on the advertised capability), then terminates; the pool uses an injected disposer so this runs while the maps stay consistent.

## Review

Team loop: independent verification + adversarial review. The safety-critical properties were **proven clean** — the on-screen/streaming agent can never be evicted (recency + protection cover the `setActiveAgent` IPC lag), `inFlightTurns` is balanced (`endTurn` in `finally`), re-warm is self-healing, and the `runPromptTurn` extraction is regression-free. **No MUST-FIX.** Folded 5 review items: best-effort `session/close` on evict (acceptance #3), protect in-progress sign-in (slow-OAuth gap), extract+test the pure `isProtected` predicate, sweep also runs `enforceCap` (self-healing over-cap), single-window guard note.

## Gates

`lint` ✓ · `typecheck` ✓ · `build` ✓ · `test` ✓ — **271 tests** (24 files; +12 vs TB4's 248).

🤖 Generated with [Claude Code](https://claude.com/claude-code)