### PR TITLE
#61: adopt t3code UI stack (Tailwind v4 + base-ui + lucide + react-markdown)

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'node:path'
 import { defineConfig, externalizeDepsPlugin } from 'electron-vite'
 import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
 
 export default defineConfig({
   main: {
@@ -31,6 +32,6 @@ export default defineConfig({
         input: { index: resolve(__dirname, 'src/renderer/index.html') },
       },
     },
-    plugins: [react()],
+    plugins: [react(), tailwindcss()],
   },
 })

--- a/package.json
+++ b/package.json
@@ -18,8 +18,17 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@base-ui/react": "^1.4.1",
+    "@tailwindcss/vite": "^4",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.564",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-markdown": "^10",
+    "remark-breaks": "^4",
+    "remark-gfm": "^4",
+    "tailwind-merge": "^3",
+    "tailwindcss": "^4"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",

--- a/src/renderer/src/conversation/ChatMarkdown.tsx
+++ b/src/renderer/src/conversation/ChatMarkdown.tsx
@@ -1,0 +1,32 @@
+import type { JSX } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import remarkBreaks from 'remark-breaks'
+import { cn } from '../lib/utils'
+
+/**
+ * Renders agent-authored text as GitHub-flavoured Markdown (tables, task lists,
+ * autolinks via `remark-gfm`; single newlines as `<br>` via `remark-breaks`, to
+ * match how chat output is typed).
+ *
+ * SECURITY: agent output is UNTRUSTED. We deliberately do NOT enable `rehype-raw`
+ * or any raw-HTML pass — react-markdown's default escapes embedded HTML, so a
+ * model echoing `<script>`/`<img onerror=…>` renders as inert text. Do not add a
+ * raw-HTML rehype plugin here.
+ *
+ * Visuals come from the scoped `.chat-md` rules in styles.css (brand tokens, square
+ * code blocks, accent-text links) so this stays a thin wrapper.
+ */
+export function ChatMarkdown({
+  text,
+  className,
+}: {
+  text: string
+  className?: string
+}): JSX.Element {
+  return (
+    <div className={cn('chat-md', className)}>
+      <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>{text}</ReactMarkdown>
+    </div>
+  )
+}

--- a/src/renderer/src/conversation/Conversation.tsx
+++ b/src/renderer/src/conversation/Conversation.tsx
@@ -16,6 +16,7 @@ import {
 } from './reducer'
 import { eventBelongsToThread } from './event-routing'
 import { replayTranscript } from './replay'
+import { ChatMarkdown } from './ChatMarkdown'
 
 /** Process-local counter for unique echoed-prompt ids. */
 let promptSeq = 0
@@ -326,7 +327,7 @@ function AssistantRow({ item }: { item: AssistantItem }): JSX.Element {
   return (
     <div className="msg msg--assistant">
       <div className="msg__role">Vibe</div>
-      <div className="msg__body">{item.text}</div>
+      <ChatMarkdown className="msg__body" text={item.text} />
     </div>
   )
 }
@@ -335,7 +336,7 @@ function ReasoningRow({ item }: { item: ReasoningItem }): JSX.Element {
   return (
     <details className="reasoning" open>
       <summary className="reasoning__summary">Reasoning</summary>
-      <div className="reasoning__body">{item.text}</div>
+      <ChatMarkdown className="reasoning__body" text={item.text} />
     </details>
   )
 }

--- a/src/renderer/src/lib/utils.test.ts
+++ b/src/renderer/src/lib/utils.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { cn } from './utils'
+
+/**
+ * `cn` is the className composer used across the new UI layer. Its contract: drop
+ * falsy inputs (so `condition && 'cls'` is safe), and resolve conflicting Tailwind
+ * utilities last-wins via tailwind-merge — this is what guarantees a caller's
+ * override actually wins instead of producing two fighting classes.
+ */
+describe('cn', () => {
+  it('resolves conflicting utilities last-wins (radius cannot regress to square→round silently)', () => {
+    expect(cn('rounded-none', 'rounded-lg')).toBe('rounded-lg')
+    expect(cn('rounded-lg', 'rounded-none')).toBe('rounded-none')
+  })
+
+  it('keeps the conditional class when the condition is true', () => {
+    const active = true
+    expect(cn('text-muted', active && 'text-accent-text')).toBe('text-accent-text')
+  })
+
+  it('drops the conditional class (and the base wins) when the condition is false', () => {
+    const active = false
+    expect(cn('text-muted', active && 'text-accent-text')).toBe('text-muted')
+  })
+
+  it('drops falsy inputs (false / null / undefined / empty)', () => {
+    expect(cn('p-2', false, null, undefined, '', 'm-2')).toBe('p-2 m-2')
+  })
+
+  it('flattens arrays and merges conflicts across them', () => {
+    expect(cn(['px-2', 'px-4'], 'py-1')).toBe('px-4 py-1')
+  })
+
+  it('returns an empty string when given nothing actionable', () => {
+    expect(cn(false, null, undefined)).toBe('')
+  })
+})

--- a/src/renderer/src/lib/utils.ts
+++ b/src/renderer/src/lib/utils.ts
@@ -1,0 +1,12 @@
+import { clsx, type ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+/**
+ * Compose Tailwind class strings: `clsx` flattens conditionals/arrays/objects and
+ * drops falsy values, then `tailwind-merge` resolves conflicts last-wins (so a
+ * later `rounded-lg` overrides an earlier `rounded-none`). Use this anywhere a
+ * component takes a `className` override or toggles utilities conditionally.
+ */
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs))
+}

--- a/src/renderer/src/shell/Shell.tsx
+++ b/src/renderer/src/shell/Shell.tsx
@@ -1,7 +1,9 @@
-import { useState, type JSX, type ReactNode } from 'react'
+import { type JSX, type ReactNode } from 'react'
+import { Loader2, MoreVertical, Trash2 } from 'lucide-react'
 import type { ListMetadataResult, ThreadMeta } from '../../../shared/ipc'
 import type { NavState } from './nav-reducer'
 import { isThreadDeletable, type UnifiedThreadRow } from './unified-threads'
+import { Menu, MenuContent, MenuItem, MenuTrigger } from '../ui/menu'
 
 /** A Workspace's rolled-up live status, for its switcher row. */
 export interface WorkspaceFlags {
@@ -183,8 +185,10 @@ function WorkspaceNav({
 /**
  * One unified Thread row: its label, a live (●) vs `history` badge, a streaming
  * indicator and a needs-attention badge driven by the status registry, and a
- * two-step inline delete (TB6) shown only when `deletable`. Clicking selects it →
- * the outlet routes live `Conversation` vs cold `ColdThread`.
+ * kebab actions menu (base-ui) holding Delete — shown only when `deletable`.
+ * Clicking the row selects it → the outlet routes live `Conversation` vs cold
+ * `ColdThread`. The Menu is keyboard-accessible (base-ui owns focus + roving), and
+ * the delete contract is unchanged: it still calls `onDelete(row.thread)`.
  */
 function NavThread({
   row,
@@ -199,7 +203,6 @@ function NavThread({
   onOpen: () => void
   onDelete: (thread: ThreadMeta) => Promise<void>
 }): JSX.Element {
-  const [confirming, setConfirming] = useState(false)
   return (
     <li className="recents__thread">
       <button
@@ -208,7 +211,11 @@ function NavThread({
       >
         <span className={row.live ? 'dot dot--ok' : 'dot dot--idle'} aria-hidden />
         <span className="recents__thread-label">{threadLabel(row)}</span>
-        {row.streaming && <span className="recents__thread-streaming" title="Streaming">⟳</span>}
+        {row.streaming && (
+          <span className="recents__thread-streaming" title="Streaming" role="img" aria-label="Streaming">
+            <Loader2 size={14} aria-hidden />
+          </span>
+        )}
         {!row.live && <span className="badge badge--history">history</span>}
         {row.needsAttention && (
           <span className="badge badge--attention" title="Awaiting your response">
@@ -216,30 +223,22 @@ function NavThread({
           </span>
         )}
       </button>
-      {!deletable ? null : confirming ? (
-        <span className="recents__thread-confirm">
-          <button
-            className="btn btn--ghost btn--danger"
-            onClick={() => {
-              setConfirming(false)
-              void onDelete(row.thread)
-            }}
+      {deletable && (
+        <Menu>
+          <MenuTrigger
+            className="recents__thread-actions"
+            aria-label="Thread actions"
+            title="Thread actions"
           >
-            Delete
-          </button>
-          <button className="btn btn--ghost" onClick={() => setConfirming(false)}>
-            Cancel
-          </button>
-        </span>
-      ) : (
-        <button
-          className="recents__thread-delete"
-          aria-label="Delete thread"
-          title="Delete thread"
-          onClick={() => setConfirming(true)}
-        >
-          ✕
-        </button>
+            <MoreVertical size={14} aria-hidden />
+          </MenuTrigger>
+          <MenuContent>
+            <MenuItem className="text-bad" onClick={() => void onDelete(row.thread)}>
+              <Trash2 size={14} aria-hidden />
+              Delete
+            </MenuItem>
+          </MenuContent>
+        </Menu>
       )}
     </li>
   )

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1,3 +1,5 @@
+@import 'tailwindcss';
+
 :root {
   /* Mistral light-mode brand tokens.
      Orange = fills / borders / gradients. --accent-text = orange TEXT (AA-safe). */
@@ -27,6 +29,34 @@
   --radius: 0;
 
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* Bridge the brand tokens into Tailwind v4's theme so utilities resolve to the
+   SAME variables (the tokens above stay the single source of truth — `@theme
+   inline` emits `var(--…)` references rather than copying values). This makes
+   `bg-accent`, `text-accent-text`, `border-border`, `text-muted`, etc. paint in
+   brand colours, and the radius scale is pinned to 0 so even `rounded-lg` /
+   `rounded-2xl` stay square — sharp edges can't regress through a utility. */
+@theme inline {
+  --color-bg: var(--bg);
+  --color-panel: var(--panel);
+  --color-surface: var(--surface);
+  --color-border: var(--border);
+  --color-text: var(--text);
+  --color-muted: var(--muted);
+  --color-accent: var(--accent);
+  --color-accent-text: var(--accent-text);
+  --color-on-accent: var(--on-accent);
+  --color-ok: var(--ok);
+  --color-bad: var(--bad);
+
+  --radius-xs: 0;
+  --radius-sm: 0;
+  --radius-md: 0;
+  --radius-lg: 0;
+  --radius-xl: 0;
+  --radius-2xl: 0;
+  --radius-3xl: 0;
 }
 
 * {
@@ -355,20 +385,23 @@ body {
   padding: 2px 0;
 }
 
-/* Thread row: the open button flexes, the delete control sits at the trailing edge. */
+/* Thread row: the open button flexes, the actions kebab sits at the trailing edge. */
 .recents__thread {
   display: flex;
   align-items: center;
   gap: 6px;
 }
 
-/* Delete affordance (TB6): muted until hovered, then the danger token. */
-.recents__thread-delete {
+/* Actions affordance (#61): a base-ui Menu kebab trigger. Muted and hidden until
+   the row is hovered/focused or the menu is open (base-ui sets data-popup-open). */
+.recents__thread-actions {
   flex: none;
+  display: inline-flex;
+  align-items: center;
   background: none;
   border: none;
   border-radius: var(--radius);
-  padding: 2px 6px;
+  padding: 2px 4px;
   font: inherit;
   line-height: 1;
   color: var(--muted);
@@ -376,35 +409,16 @@ body {
   opacity: 0;
 }
 
-.recents__thread:hover .recents__thread-delete,
-.recents__thread-delete:focus-visible {
+.recents__thread:hover .recents__thread-actions,
+.recents__thread-actions:focus-visible,
+.recents__thread-actions[data-popup-open] {
   opacity: 1;
 }
 
-.recents__thread-delete:hover {
-  color: var(--bad);
-  background: var(--bad-tint);
-}
-
-/* Inline confirm (TB6): two small buttons, no blocking native dialog. */
-.recents__thread-confirm {
-  display: inline-flex;
-  flex: none;
-  gap: 6px;
-}
-
-.recents__thread-confirm .btn {
-  padding: 2px 8px;
-  font-size: 11px;
-}
-
-.btn--danger {
-  color: var(--bad);
-  border-color: var(--bad-tint-border);
-}
-
-.btn--danger:hover {
-  background: var(--bad-tint);
+.recents__thread-actions:hover,
+.recents__thread-actions[data-popup-open] {
+  color: var(--text);
+  background: var(--accent-tint);
 }
 
 /* Clickable Thread in the unified list (TB3 #48): a live/cold dot, the label, and
@@ -442,9 +456,12 @@ body {
   background: var(--border);
 }
 
-/* The per-row streaming indicator (a turn in flight on a live Thread). */
+/* The per-row streaming indicator (a turn in flight on a live Thread) — a lucide
+   spinner glyph (#61); the wrapper carries the colour + pulse, the icon inherits. */
 .recents__thread-streaming {
   flex: none;
+  display: inline-flex;
+  align-items: center;
   color: var(--accent-text);
   animation: pulse 1.2s ease-in-out infinite;
 }
@@ -957,4 +974,95 @@ body {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/* --- Rendered Markdown (#61): agent/reasoning text via ChatMarkdown ---
+   Scoped so it only styles react-markdown output, not plain rows. Block elements
+   replace the old raw-text node, so we tame margins and keep brand tokens (links
+   = --accent-text, code blocks square per the zero-radius rule). The wrapper still
+   carries .msg__body / .reasoning__body for its font/colour; we just override the
+   pre-wrap meant for raw text, since markdown now owns its own block flow. */
+.chat-md {
+  white-space: normal;
+}
+
+.chat-md > :first-child {
+  margin-top: 0;
+}
+
+.chat-md > :last-child {
+  margin-bottom: 0;
+}
+
+.chat-md p {
+  margin: 0 0 8px;
+}
+
+.chat-md ul,
+.chat-md ol {
+  margin: 0 0 8px;
+  padding-left: 20px;
+}
+
+.chat-md li {
+  margin: 2px 0;
+}
+
+.chat-md a {
+  color: var(--accent-text);
+  text-decoration: underline;
+}
+
+.chat-md code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.9em;
+  background: var(--accent-tint);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.1em 0.3em;
+}
+
+.chat-md pre {
+  margin: 0 0 8px;
+  padding: 10px 12px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow-x: auto;
+}
+
+/* A fenced block's <code> sheds the inline chip styling — the <pre> owns the box. */
+.chat-md pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 0.85em;
+}
+
+.chat-md blockquote {
+  margin: 0 0 8px;
+  padding-left: 10px;
+  border-left: 2px solid var(--border);
+  color: var(--muted);
+}
+
+.chat-md h1,
+.chat-md h2,
+.chat-md h3,
+.chat-md h4 {
+  margin: 12px 0 6px;
+  font-size: 1em;
+  font-weight: 600;
+}
+
+.chat-md table {
+  border-collapse: collapse;
+  margin: 0 0 8px;
+}
+
+.chat-md th,
+.chat-md td {
+  border: 1px solid var(--border);
+  padding: 4px 8px;
+  text-align: left;
 }

--- a/src/renderer/src/ui/menu.tsx
+++ b/src/renderer/src/ui/menu.tsx
@@ -1,0 +1,67 @@
+import type { ComponentProps, JSX } from 'react'
+import { Menu as BaseMenu } from '@base-ui/react/menu'
+import { cn } from '../lib/utils'
+
+/**
+ * A small brand-styled wrapper over base-ui's Menu primitive. base-ui owns the
+ * hard parts — focus management, roving keyboard nav, type-ahead, portalling,
+ * outside-click/ESC dismissal — so these components only layer on the Mistral look
+ * (square corners via the zero radius scale, `--panel` surface, `--border`, an
+ * accent hover tint). Compose them like the base parts:
+ *
+ *   <Menu>
+ *     <MenuTrigger render={<button …/>} />
+ *     <MenuContent>
+ *       <MenuItem onClick={…}>Delete</MenuItem>
+ *     </MenuContent>
+ *   </Menu>
+ */
+export const Menu = BaseMenu.Root
+export const MenuTrigger = BaseMenu.Trigger
+
+/**
+ * The popup surface, already wrapped in Portal + Positioner (portals to <body>,
+ * which is correct under Electron). `sideOffset` keeps it off the trigger.
+ */
+export function MenuContent({
+  className,
+  sideOffset = 4,
+  align = 'end',
+  ...props
+}: ComponentProps<typeof BaseMenu.Popup> & {
+  sideOffset?: number
+  align?: ComponentProps<typeof BaseMenu.Positioner>['align']
+}): JSX.Element {
+  return (
+    <BaseMenu.Portal>
+      <BaseMenu.Positioner sideOffset={sideOffset} align={align}>
+        <BaseMenu.Popup
+          className={cn(
+            'min-w-32 rounded-none border border-border bg-panel py-1 text-sm text-text shadow-md outline-none',
+            className,
+          )}
+          {...props}
+        />
+      </BaseMenu.Positioner>
+    </BaseMenu.Portal>
+  )
+}
+
+/** A single command row. Highlight state is driven by base-ui's `data-highlighted`. */
+export function MenuItem({
+  className,
+  ...props
+}: ComponentProps<typeof BaseMenu.Item>): JSX.Element {
+  return (
+    <BaseMenu.Item
+      className={cn(
+        'flex cursor-default select-none items-center gap-2 px-3 py-1.5 outline-none',
+        'data-[highlighted]:bg-accent data-[highlighted]:text-on-accent',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export const MenuSeparator = BaseMenu.Separator


### PR DESCRIPTION
## What

Foundational wiring for the t3code UI stack (closes #61). Renderer-only; plain CSS continues to coexist for everything not yet migrated. This is the base future UI slices build on — not a rewrite.

- **Tailwind v4** via `@tailwindcss/vite`, added to the **renderer** plugins only (`electron.vite.config.ts`); `@import "tailwindcss"` at the top of `styles.css`.
- **Brand tokens drive Tailwind** through `@theme inline` — utilities resolve to `var(--accent)` / `var(--border)` / etc., so `:root` stays the single source of truth. The radius scale is pinned to `0`, so even `rounded-lg` compiles to a square corner — sharp edges can't regress through a utility.
- **`ChatMarkdown`** (react-markdown + remark-gfm + remark-breaks) renders assistant + reasoning text. **No `rehype-raw`** — agent output is untrusted; react-markdown's default escaping + `defaultUrlTransform` (drops `javascript:` etc.) are relied on. User input stays plain text.
- **`cn()`** util (clsx + tailwind-merge) + focused last-wins/falsy tests.
- **base-ui `Menu`** primitive (`ui/menu.tsx`) wired into the thread-row delete affordance in `Shell.tsx` `NavThread`, keyboard-accessible.
- **lucide** icons: `MoreVertical` (kebab), `Trash2` (delete item), `Loader2` (streaming).

## Decision to sign off on (delete safety)

The old thread-row delete was a two-step inline **Delete / Cancel** confirm. Per the issue spec ("convert the two-step confirm to a base-ui Dialog/Menu"), it's now a kebab **Menu → Delete** — two interactions, but the final Delete is a single click with no second confirm/undo. base-ui does not auto-activate the first item, and the main-process streaming guard still blocks deleting an in-flight thread. If you'd prefer a confirm/undo back, say so and I'll add `closeOnClick={false}` + a "Confirm delete?" item (cheap) before/after merge.

## Gates (run by implementer, by me independently, and by the adversarial reviewer)

`bun run lint && bun run typecheck && bun run build && bun run test` — all green. **294 tests** (25 files). Tailwind confirmed absent from `out/main` / `out/preload`.

## Verified by hand / by review

- XSS: `rehype-raw` not installed; `[x](javascript:…)` and gfm autolinks render with empty href via react-markdown's `defaultUrlTransform`.
- `@base-ui/react` resolved 1.6.0 (req ^1.4.1) — every used API surface unchanged; `data-popup-open` / `data-highlighted` selectors match.
- Kebab trigger is a **sibling** of the row button (valid DOM, no nested interactives, no event-bubble conflict with row select).
- `--on-accent` on flat `--accent` fill ≈ 6:1 (AA pass); no orange used as text.
- `.chat-md { white-space: normal }` correctly overrides the inherited `pre-wrap`.

## Still worth a manual `bun run dev` glance (couldn't run Electron headless)

Tailwind HMR, markdown render quality inside the message bodies, and menu keyboard nav / portal positioning under Electron.

## Follow-ups (NITs, not blocking)

- Renderer JS bundle grew to ~1.41 MB (react-markdown + base-ui + lucide); no lazy-split — fine for a local Electron app, revisit if tracked.
- Pin `@base-ui/react` if reproducibility is wanted.
- Per-area component migration to base-ui/Tailwind is the intended follow-up (composer, sidebar, conversation, auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
