### PR TITLE
#60: persist composer drafts per-Thread in localStorage

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/abdullahatrash/mistral/vibe-mistro/node_modules

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -36,6 +36,7 @@ import {
   setThreadStatus,
   type ThreadStatusMap,
 } from './conversation/thread-status'
+import { clearDraft } from './conversation/composer-draft-store'
 import { Shell, type WorkspaceFlags } from './shell/Shell'
 import { firstRunState, type FirstRunState } from './shell/first-run'
 import { findSelectedThread, initialNavState, navReducer } from './shell/nav-reducer'
@@ -141,6 +142,8 @@ export function App(): JSX.Element {
       selectThreadInWorkspace(thread.workspaceId, conn.thread.threadId)
     }
     setStatuses((prev) => clearThreadStatus(prev, thread.id))
+    // Drop the deleted Thread's persisted composer draft (#60) — no orphaned text.
+    clearDraft(window.localStorage, thread.id)
     await refreshRecents()
   }
 

--- a/src/renderer/src/conversation/Conversation.tsx
+++ b/src/renderer/src/conversation/Conversation.tsx
@@ -17,6 +17,7 @@ import {
 import { eventBelongsToThread } from './event-routing'
 import { replayTranscript } from './replay'
 import { ChatMarkdown } from './ChatMarkdown'
+import { getDraft, setDraft as persistDraft, clearDraft } from './composer-draft-store'
 
 /** Process-local counter for unique echoed-prompt ids. */
 let promptSeq = 0
@@ -62,7 +63,13 @@ export function Conversation({
   onBound?: (sessionId: string) => void
 }): JSX.Element {
   const [state, dispatch] = useReducer(conversationReducer, initialConversationState)
-  const [draft, setDraft] = useState('')
+  // The composer's unsent text, persisted per-Thread to localStorage (#60) so it
+  // survives any unmount (cold↔live, agent eviction/re-warm, app restart, switching
+  // to a cold Thread). This view is keyed by `thread.threadId` in the outlet, so it
+  // REMOUNTS on a Thread switch — the lazy initializer seeds THAT Thread's stored
+  // draft fresh, with no stale carry-over (no re-seed effect needed). Reading here
+  // must not write, so we only persist on change/send below.
+  const [draft, setDraft] = useState(() => getDraft(window.localStorage, thread.threadId))
   // The session this Thread is bound to — null until a draft's first prompt binds
   // it (via main's `thread:bound`). Seeded from the record; mirrored into a ref so
   // the event subscription reads the LATEST value without re-subscribing (a stale
@@ -139,6 +146,8 @@ export function Conversation({
     const text = draft.trim()
     if (!text || state.isProcessing) return
     setDraft('')
+    // The text is now in the transcript — drop the persisted draft (#60).
+    clearDraft(window.localStorage, thread.threadId)
     dispatch({ type: 'send-prompt', id: `user:${promptSeq++}`, text })
     try {
       const result = await window.api.sendPrompt({
@@ -252,7 +261,11 @@ export function Conversation({
           className="composer__input"
           placeholder="Ask Vibe… (Enter to send, Shift+Enter for a newline)"
           value={draft}
-          onChange={(e) => setDraft(e.target.value)}
+          onChange={(e) => {
+            // Write-through: keep React state and the persisted draft (#60) in lockstep.
+            setDraft(e.target.value)
+            persistDraft(window.localStorage, thread.threadId, e.target.value)
+          }}
           onKeyDown={onKeyDown}
           rows={2}
         />

--- a/src/renderer/src/conversation/composer-draft-store.test.ts
+++ b/src/renderer/src/conversation/composer-draft-store.test.ts
@@ -65,6 +65,20 @@ describe('prune on empty / whitespace-only', () => {
     expect(getDraft(storage, 't1')).toBe('')
     expect(JSON.parse(storage.map.get(COMPOSER_DRAFT_STORAGE_KEY) ?? '{}')).toEqual({})
   })
+
+  it('removes the whole storage key once the last draft is pruned (no dangling blob)', () => {
+    const storage = fakeStorage()
+    setDraft(storage, 't1', 'something')
+    setDraft(storage, 't1', '')
+    expect(storage.map.has(COMPOSER_DRAFT_STORAGE_KEY)).toBe(false)
+  })
+
+  it('removes the whole storage key once the last draft is cleared', () => {
+    const storage = fakeStorage()
+    setDraft(storage, 't1', 'queued')
+    clearDraft(storage, 't1')
+    expect(storage.map.has(COMPOSER_DRAFT_STORAGE_KEY)).toBe(false)
+  })
 })
 
 describe('raw text fidelity (only the prune decision trims)', () => {

--- a/src/renderer/src/conversation/composer-draft-store.test.ts
+++ b/src/renderer/src/conversation/composer-draft-store.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest'
+import {
+  COMPOSER_DRAFT_STORAGE_KEY,
+  clearDraft,
+  getDraft,
+  setDraft,
+  type DraftStorage,
+} from './composer-draft-store'
+
+/**
+ * Per-Thread composer drafts (#60): unsent composer text persisted to localStorage
+ * so it survives any unmount. The module is pure over an injected storage seam, so
+ * here we feed it a Map-backed fake — round-trip, prune, raw-text fidelity, send
+ * clear, per-Thread isolation, and the never-throw tolerance paths.
+ */
+
+/** A Map-backed fake satisfying the injected `DraftStorage` seam. */
+function fakeStorage(): DraftStorage & { map: Map<string, string> } {
+  const map = new Map<string, string>()
+  return {
+    map,
+    getItem: (k) => (map.has(k) ? (map.get(k) as string) : null),
+    setItem: (k, v) => {
+      map.set(k, v)
+    },
+    removeItem: (k) => {
+      map.delete(k)
+    },
+  }
+}
+
+describe('getDraft / setDraft round-trip', () => {
+  it('stores and reads back a draft keyed by threadId', () => {
+    const storage = fakeStorage()
+    setDraft(storage, 't1', 'hello world')
+    expect(getDraft(storage, 't1')).toBe('hello world')
+  })
+
+  it('returns "" for an absent thread', () => {
+    expect(getDraft(fakeStorage(), 'never')).toBe('')
+  })
+
+  it('overwrites an existing draft', () => {
+    const storage = fakeStorage()
+    setDraft(storage, 't1', 'first')
+    setDraft(storage, 't1', 'second')
+    expect(getDraft(storage, 't1')).toBe('second')
+  })
+})
+
+describe('prune on empty / whitespace-only', () => {
+  it('removes the entry when set to an empty string', () => {
+    const storage = fakeStorage()
+    setDraft(storage, 't1', 'something')
+    setDraft(storage, 't1', '')
+    expect(getDraft(storage, 't1')).toBe('')
+    // The entry is gone from the underlying map, not stored as ''.
+    expect(JSON.parse(storage.map.get(COMPOSER_DRAFT_STORAGE_KEY) ?? '{}')).toEqual({})
+  })
+
+  it('removes the entry when set to whitespace-only text', () => {
+    const storage = fakeStorage()
+    setDraft(storage, 't1', 'something')
+    setDraft(storage, 't1', '   \n\t  ')
+    expect(getDraft(storage, 't1')).toBe('')
+    expect(JSON.parse(storage.map.get(COMPOSER_DRAFT_STORAGE_KEY) ?? '{}')).toEqual({})
+  })
+})
+
+describe('raw text fidelity (only the prune decision trims)', () => {
+  it('preserves leading/trailing spaces and newlines verbatim', () => {
+    const storage = fakeStorage()
+    const raw = '  hello \n  world  \n'
+    setDraft(storage, 't1', raw)
+    expect(getDraft(storage, 't1')).toBe(raw)
+  })
+
+  it('keeps a non-empty draft that has trailing whitespace', () => {
+    const storage = fakeStorage()
+    setDraft(storage, 't1', 'typing ')
+    expect(getDraft(storage, 't1')).toBe('typing ')
+  })
+})
+
+describe('clearDraft (send / delete)', () => {
+  it('removes the entry', () => {
+    const storage = fakeStorage()
+    setDraft(storage, 't1', 'queued prompt')
+    clearDraft(storage, 't1')
+    expect(getDraft(storage, 't1')).toBe('')
+  })
+
+  it('is a no-op for an absent entry', () => {
+    const storage = fakeStorage()
+    expect(() => clearDraft(storage, 'gone')).not.toThrow()
+    expect(getDraft(storage, 'gone')).toBe('')
+  })
+})
+
+describe('per-Thread isolation', () => {
+  it('keeps two threads independent', () => {
+    const storage = fakeStorage()
+    setDraft(storage, 't1', 'one')
+    setDraft(storage, 't2', 'two')
+    expect(getDraft(storage, 't1')).toBe('one')
+    expect(getDraft(storage, 't2')).toBe('two')
+  })
+
+  it('clearing one thread leaves the other intact (delete cascade)', () => {
+    const storage = fakeStorage()
+    setDraft(storage, 't1', 'one')
+    setDraft(storage, 't2', 'two')
+    clearDraft(storage, 't1')
+    expect(getDraft(storage, 't1')).toBe('')
+    expect(getDraft(storage, 't2')).toBe('two')
+  })
+
+  it('pruning one thread leaves the other intact', () => {
+    const storage = fakeStorage()
+    setDraft(storage, 't1', 'one')
+    setDraft(storage, 't2', 'two')
+    setDraft(storage, 't1', '')
+    expect(getDraft(storage, 't1')).toBe('')
+    expect(getDraft(storage, 't2')).toBe('two')
+  })
+})
+
+describe('malformed / missing tolerance (never throws into render)', () => {
+  it('treats malformed JSON as empty', () => {
+    const storage = fakeStorage()
+    storage.map.set(COMPOSER_DRAFT_STORAGE_KEY, '{not json')
+    expect(getDraft(storage, 't1')).toBe('')
+  })
+
+  it('treats a non-object blob as empty', () => {
+    const storage = fakeStorage()
+    storage.map.set(COMPOSER_DRAFT_STORAGE_KEY, '"a string"')
+    expect(getDraft(storage, 't1')).toBe('')
+  })
+
+  it('treats an array blob as empty', () => {
+    const storage = fakeStorage()
+    storage.map.set(COMPOSER_DRAFT_STORAGE_KEY, '[1,2,3]')
+    expect(getDraft(storage, 't1')).toBe('')
+  })
+
+  it('treats a non-string entry value as ""', () => {
+    const storage = fakeStorage()
+    storage.map.set(COMPOSER_DRAFT_STORAGE_KEY, JSON.stringify({ t1: 42 }))
+    expect(getDraft(storage, 't1')).toBe('')
+  })
+
+  it('returns "" for an absent key', () => {
+    expect(getDraft(fakeStorage(), 't1')).toBe('')
+  })
+
+  it('overwrites a malformed blob on the next set', () => {
+    const storage = fakeStorage()
+    storage.map.set(COMPOSER_DRAFT_STORAGE_KEY, '{not json')
+    setDraft(storage, 't1', 'recovered')
+    expect(getDraft(storage, 't1')).toBe('recovered')
+  })
+})
+
+describe('best-effort writes (a throwing storage does not propagate)', () => {
+  it('swallows a setItem exception on set', () => {
+    const throwing: DraftStorage = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error('quota exceeded')
+      },
+      removeItem: () => {},
+    }
+    expect(() => setDraft(throwing, 't1', 'text')).not.toThrow()
+  })
+
+  it('swallows a getItem exception on read', () => {
+    const throwing: DraftStorage = {
+      getItem: () => {
+        throw new Error('SecurityError')
+      },
+      setItem: () => {},
+      removeItem: () => {},
+    }
+    expect(getDraft(throwing, 't1')).toBe('')
+    expect(() => clearDraft(throwing, 't1')).not.toThrow()
+  })
+})
+
+describe('absent storage guard', () => {
+  it('getDraft returns "" when storage is null/undefined', () => {
+    expect(getDraft(null, 't1')).toBe('')
+    expect(getDraft(undefined, 't1')).toBe('')
+  })
+
+  it('setDraft / clearDraft are no-ops when storage is null/undefined', () => {
+    expect(() => setDraft(null, 't1', 'x')).not.toThrow()
+    expect(() => clearDraft(undefined, 't1')).not.toThrow()
+  })
+})

--- a/src/renderer/src/conversation/composer-draft-store.ts
+++ b/src/renderer/src/conversation/composer-draft-store.ts
@@ -50,9 +50,17 @@ function readMap(storage: DraftStorage | null | undefined): DraftMap {
   }
 }
 
-/** Persist the draft map best-effort: a quota/security exception is swallowed. */
+/**
+ * Persist the draft map best-effort: a quota/security exception is swallowed. When
+ * the last draft is pruned the whole key is REMOVED (not stored as `'{}'`), so an
+ * emptied store leaves no dangling blob behind.
+ */
 function writeMap(storage: DraftStorage, map: DraftMap): void {
   try {
+    if (Object.keys(map).length === 0) {
+      storage.removeItem(COMPOSER_DRAFT_STORAGE_KEY)
+      return
+    }
     storage.setItem(COMPOSER_DRAFT_STORAGE_KEY, JSON.stringify(map))
   } catch {
     // Best-effort: a full/blocked storage must never throw from a keystroke.

--- a/src/renderer/src/conversation/composer-draft-store.ts
+++ b/src/renderer/src/conversation/composer-draft-store.ts
@@ -1,0 +1,103 @@
+/**
+ * Per-Thread composer drafts (#60): the unsent text in a Thread's composer, kept
+ * so it survives any unmount — a cold↔live transition, an agent eviction/re-warm
+ * (TB5 #56), an app restart, or switching to a non-mounted cold Thread. The draft
+ * is EPHEMERAL UI state, so it lives in localStorage ONLY: no IPC, no main, no
+ * JSONL (those persist the transcript, not the half-typed prompt). Keyed by the
+ * durable renderer-minted Thread id (#58 hands us one up front), so a single key
+ * space covers both unsent-draft Threads and persisted ones.
+ *
+ * A pure module over an INJECTED storage seam (like `thread-status.ts` /
+ * `workspace-threads.ts`): every function takes the storage, so tests pass a fake
+ * and render code passes `window.localStorage`. Reading must never throw into a
+ * render and writing must never throw from a keystroke, so both paths swallow a
+ * malformed blob, an absent key, and a quota/security exception.
+ */
+
+/** The single localStorage key holding the `threadId -> text` map. */
+export const COMPOSER_DRAFT_STORAGE_KEY = 'vibe-mistro:composer-drafts:v1'
+
+/** The slice of the Web Storage API we depend on — `window.localStorage` satisfies it. */
+export interface DraftStorage {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+  removeItem(key: string): void
+}
+
+/** The persisted shape: a thread id -> unsent text map. */
+type DraftMap = Record<string, string>
+
+/**
+ * Read + parse the draft map, tolerating everything: an unavailable storage, an
+ * absent key, a parse error, or a non-object blob all yield an empty map. Never
+ * throws — a corrupt entry must not break the composer's render.
+ */
+function readMap(storage: DraftStorage | null | undefined): DraftMap {
+  if (!storage) return {}
+  let raw: string | null
+  try {
+    raw = storage.getItem(COMPOSER_DRAFT_STORAGE_KEY)
+  } catch {
+    return {}
+  }
+  if (raw === null) return {}
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {}
+    return parsed as DraftMap
+  } catch {
+    return {}
+  }
+}
+
+/** Persist the draft map best-effort: a quota/security exception is swallowed. */
+function writeMap(storage: DraftStorage, map: DraftMap): void {
+  try {
+    storage.setItem(COMPOSER_DRAFT_STORAGE_KEY, JSON.stringify(map))
+  } catch {
+    // Best-effort: a full/blocked storage must never throw from a keystroke.
+  }
+}
+
+/** The stored draft for a Thread, or '' when absent/malformed. Never throws. */
+export function getDraft(storage: DraftStorage | null | undefined, threadId: string): string {
+  const text = readMap(storage)[threadId]
+  return typeof text === 'string' ? text : ''
+}
+
+/**
+ * Write a Thread's unsent text. The RAW text is stored verbatim (a trailing space
+ * the user is mid-typing is preserved), but an effectively-empty draft is PRUNED
+ * rather than stored as '' so blank entries never accumulate — the prune DECISION
+ * is the only place we trim. A no-op (already-stored value, or pruning an absent
+ * entry) skips the write.
+ */
+export function setDraft(
+  storage: DraftStorage | null | undefined,
+  threadId: string,
+  text: string,
+): void {
+  if (!storage) return
+  const map = readMap(storage)
+  if (text.trim().length === 0) {
+    if (!(threadId in map)) return
+    delete map[threadId]
+    writeMap(storage, map)
+    return
+  }
+  if (map[threadId] === text) return
+  map[threadId] = text
+  writeMap(storage, map)
+}
+
+/**
+ * Drop a Thread's draft entry — used on send (the text is now in the transcript)
+ * and on delete (no orphaned composer text). Skips the write when absent.
+ */
+export function clearDraft(storage: DraftStorage | null | undefined, threadId: string): void {
+  if (!storage) return
+  const map = readMap(storage)
+  if (!(threadId in map)) return
+  delete map[threadId]
+  writeMap(storage, map)
+}


### PR DESCRIPTION
## What

Persists the composer's unsent text per-Thread so it survives navigation, unmount, agent eviction/re-warm, and app restart (closes #60). Follow-up to #58 (which made an unsent *thread* renderer-only) — this is the *message-level* draft t3code also has. Renderer-only; **localStorage only**, no IPC/main/JSONL — composer drafts are ephemeral UI state, not conversation history.

- New pure store `src/renderer/src/conversation/composer-draft-store.ts` — `threadId → text` map under `vibe-mistro:composer-drafts:v1`, over an **injected `DraftStorage` seam** (matches `thread-status.ts` / `workspace-threads.ts`). `getDraft` / `setDraft` / `clearDraft`.
- **Stores raw text verbatim** (a trailing space mid-typing is kept); only the **prune decision** trims — an empty/whitespace draft removes its entry, never accumulating blanks. Emptying the last draft **removes the whole key** (no dangling `{}`).
- **Tolerates everything**: absent/malformed/non-object/array/non-string blob → `''`; a quota/security exception on read or write is swallowed. Never throws into a render or a keystroke.
- Wired into `Conversation.tsx`: lazy-seed on mount (`useState(() => getDraft(...))`), write-through on textarea change, **clear on send**. The view is keyed `key={activeThread.id}` so it **remounts** on thread switch → the initializer re-seeds the right thread's draft (no cross-thread bleed).
- **Delete cascade** in `App.tsx` `deleteThread` — a deleted Thread drops its composer-draft entry.

## Three-way verification

Implementer → my independent re-run → separate adversarial reviewer. Reviewer verdict **SHIP** (no MUST/SHOULD-FIX). All checked: no cross-thread bleed (remount key confirmed), id spaces match across #58 bind + delete, store never throws, malformed tolerance, per-thread isolation, TB2 hidden-view no-clobber.

The one NIT (dangling `'{}'` + unused `removeItem`) is **folded** in this PR (commit 2): `writeMap` now `removeItem`s the key when the map empties, with two tests asserting it.

## Gates (run by all three parties)

`bun run lint && bun run typecheck && bun run build && bun run test` — all green. **318 tests** (26 files).

## Notes / scope

- Send-failure behavior is unchanged from pre-#60: the composer clears before the IPC (the user's text also survives as the echoed `send-prompt` item). "Restore draft on a failed send" would be a separate follow-up.
- Keystroke write-through is synchronous per change — fine for a desktop app over one small map; not debounced.
- Out of scope (per issue): attachments/model in the draft, any main/JSONL persistence, cross-device sync.
- Couldn't observe a live Electron restart headless; the logic is straightforward (localStorage survives restart; lazy init re-reads) and is unit-covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
