### PR TITLE
fix: untrack node_modules symlink committed in #63

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-node_modules/
+# Match the dir AND a `node_modules` symlink (e.g. a worktree symlinking to the
+# main checkout) — a trailing-slash pattern alone misses the symlink and let one
+# get committed (#63), pointing at itself on checkout and breaking installs.
+node_modules
 out/
 dist/
 *.log

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/abdullahatrash/mistral/vibe-mistro/node_modules


### PR DESCRIPTION
## Problem

PR #63's squash merge (`0136b0a`) accidentally committed a **`node_modules` symlink** — the per-slice worktree's link back to the main checkout's `node_modules`. Root cause: `.gitignore` had `node_modules/` (trailing slash), which ignores the *directory's contents* but **not a symlink named `node_modules`**, so a `git add -A` during the review-fold staged it. The stored target is an absolute path to the repo's own `node_modules`, so on any checkout it resolves to **itself** — a self-referential symlink that breaks `bun install` / `tsc` / `vitest` ("Too many levels of symbolic links", exit 127).

Only the one symlink entry was affected; all real source files in #63 are fine.

## Fix

- `git rm --cached node_modules` — untrack the symlink (working-tree real `node_modules` stays, gitignored).
- `.gitignore`: `node_modules/` → `node_modules` so the directory **and** a `node_modules` symlink are both ignored, preventing a recurrence.

## Verified

- `git check-ignore node_modules` now matches; `git status` no longer surfaces it.
- Gates green (`lint`/`typecheck`/`build`/`test`, 318 tests) — code is unchanged from `main`, this only touches `.gitignore` + the index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)