### PR TITLE
#66: Agent controls (Mode / Model / Reasoning effort) picker in the composer

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,6 +11,8 @@ import {
   type RespondPermissionArgs,
   type SendPromptArgs,
   type SendPromptResult,
+  type SetThreadConfigArgs,
+  type SetThreadConfigResult,
   type SignInArgs,
   type SignInResult,
   type SignOutArgs,
@@ -395,6 +397,7 @@ function continueConnection(
     title: target.title,
     modes: null,
     models: null,
+    reasoningEffort: null,
     threadId: target.threadId,
     workspaceId: target.workspaceId,
     signOutAvailable: agent.signOutAvailable,
@@ -757,6 +760,28 @@ function registerIpc(): void {
     })
     return { ok: true }
   })
+
+  ipcMain.handle(
+    IPC.setThreadConfig,
+    async (_event, args: SetThreadConfigArgs): Promise<SetThreadConfigResult> => {
+      // Change one agent control (#66) on a Thread's bound session: resolve the
+      // agent, map the axis to its verified setter (acp-capture §10), and return
+      // ok/err. The renderer already reflected the change optimistically, so an
+      // `{ok:false}` here is its cue to revert. Touch the agent — a config change is
+      // activity, like a prompt/permission answer (TB5 #50).
+      const agent = pool.get(args.agentId)
+      if (!agent) return { ok: false, error: `No active agent for id ${args.agentId}.` }
+      pool.touch(args.agentId)
+      try {
+        if (args.axis === 'mode') await agent.setMode(args.sessionId, args.value)
+        else if (args.axis === 'model') await agent.setModel(args.sessionId, args.value)
+        else await agent.setReasoningEffort(args.sessionId, args.value)
+        return { ok: true }
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) }
+      }
+    },
+  )
 
   ipcMain.handle(IPC.getThreadStatuses, (): ThreadStatusEvent[] => {
     // One-shot re-seed for a renderer that mounts MID-turn (#53): main pushes

--- a/src/main/thread-binding.test.ts
+++ b/src/main/thread-binding.test.ts
@@ -42,7 +42,7 @@ function fakeOpener(prefix = 'sess'): SessionBinder & { calls: number } {
       n++
       const sessionId = `${prefix}-${n}`
       hosted.add(sessionId)
-      return { sessionId, title: null, modes: null, models: null }
+      return { sessionId, title: null, modes: null, models: null, reasoningEffort: null }
     },
   }
 }
@@ -69,12 +69,12 @@ function fakeBinder(opts: {
       const outcome = opts.loadOutcome ?? 'resume'
       if (outcome !== 'resume') throw outcome
       // Resume keeps the SAME id (the session/load result carries none, §9).
-      return { sessionId, title: null, modes: null, models: null }
+      return { sessionId, title: null, modes: null, models: null, reasoningEffort: null }
     },
     async openThread(): Promise<ThreadInfo> {
       this.newCalls++
       n++
-      return { sessionId: `fresh-${n}`, title: 'Fresh', modes: null, models: null }
+      return { sessionId: `fresh-${n}`, title: 'Fresh', modes: null, models: null, reasoningEffort: null }
     },
   }
 }

--- a/src/main/workspace-agent.test.ts
+++ b/src/main/workspace-agent.test.ts
@@ -649,7 +649,15 @@ function makeCapturingFake(): CapturingFake {
 interface SentRpc {
   id?: number
   method?: string
-  params?: { sessionId?: string; prompt?: Array<{ type: string; text: string }> }
+  params?: {
+    sessionId?: string
+    prompt?: Array<{ type: string; text: string }>
+    // Agent-control setters (#66): the per-axis params.
+    modeId?: string
+    modelId?: string
+    configId?: string
+    value?: string
+  }
   result?: { content?: string; outcome?: { outcome?: string; optionId?: string } } | Record<string, never>
   error?: { code?: number; message?: string }
 }
@@ -1179,5 +1187,107 @@ describe('WorkspaceAgent.start() — concurrent + idempotent (TB2 #47)', () => {
     await agent.start()
     expect(spawns).toBe(1)
     expect(sent(fake).filter((m) => m.method === 'initialize')).toHaveLength(1)
+  })
+})
+
+describe('WorkspaceAgent agent controls (#66, acp-capture §10)', () => {
+  it('setMode sends session/set_mode {sessionId, modeId} and resolves on the {} result', async () => {
+    const fake = makeCapturingFake()
+    const agent = await connect(fake)
+
+    const change = agent.setMode(SESSION_ID, 'plan')
+    const req = sent(fake).find((m) => m.method === 'session/set_mode')
+    expect(req?.params).toEqual({ sessionId: SESSION_ID, modeId: 'plan' })
+
+    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: req?.id, result: {} }) + '\n')
+    await expect(change).resolves.toBeUndefined()
+  })
+
+  it('setModel sends session/set_model {sessionId, modelId} (dedicated method, not set_config_option)', async () => {
+    const fake = makeCapturingFake()
+    const agent = await connect(fake)
+
+    const change = agent.setModel(SESSION_ID, 'devstral-small')
+    const req = sent(fake).find((m) => m.method === 'session/set_model')
+    expect(req?.params).toEqual({ sessionId: SESSION_ID, modelId: 'devstral-small' })
+    // Model has its OWN method — it does NOT flow through set_config_option.
+    expect(sent(fake).some((m) => m.method === 'session/set_config_option')).toBe(false)
+
+    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: req?.id, result: {} }) + '\n')
+    await expect(change).resolves.toBeUndefined()
+  })
+
+  it('setReasoningEffort sends session/set_config_option with configId:"thinking" (NOT id)', async () => {
+    const fake = makeCapturingFake()
+    const agent = await connect(fake)
+
+    const change = agent.setReasoningEffort(SESSION_ID, 'high')
+    const req = sent(fake).find((m) => m.method === 'session/set_config_option')
+    // The gotcha that cost real guesses: the key is `configId`, NOT `id`.
+    expect(req?.params).toEqual({ sessionId: SESSION_ID, configId: 'thinking', value: 'high' })
+
+    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: req?.id, result: {} }) + '\n')
+    await expect(change).resolves.toBeUndefined()
+  })
+
+  it('a setter rejects (mapped) when the agent errors, so the caller can revert', async () => {
+    const fake = makeCapturingFake()
+    const agent = await connect(fake)
+
+    const change = agent.setMode(SESSION_ID, 'plan')
+    const req = sent(fake).find((m) => m.method === 'session/set_mode')
+    fake.feed(
+      JSON.stringify({ jsonrpc: '2.0', id: req?.id, error: { code: -32602, message: 'Invalid params' } }) + '\n',
+    )
+    await expect(change).rejects.toThrow(/Invalid params/)
+  })
+
+  it('openThread surfaces the reasoning-effort axis from the thinking configOption', async () => {
+    const fake = makeCapturingFake()
+    const agent = new WorkspaceAgent({ workspaceDir: '/abs/workspace', spawn: () => fake.child })
+    const started = agent.start()
+    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: 1, result: { protocolVersion: 1 } }) + '\n')
+    await new Promise((r) => setTimeout(r, 0))
+    fake.feed(
+      JSON.stringify({ jsonrpc: '2.0', id: 2, result: { authenticated: true, authState: 'os_keyring' } }) + '\n',
+    )
+    await started
+
+    const opened = agent.openThread()
+    fake.feed(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 3,
+        result: {
+          sessionId: SESSION_ID,
+          configOptions: [
+            { id: 'mode' },
+            { id: 'model' },
+            {
+              id: 'thinking',
+              currentValue: 'high',
+              options: [{ value: 'off' }, { value: 'low' }, { value: 'high' }, { value: 'max' }],
+            },
+          ],
+        },
+      }) + '\n',
+    )
+    const info = await opened
+    expect(info.reasoningEffort).toEqual({
+      current: 'high',
+      options: [{ value: 'off' }, { value: 'low' }, { value: 'high' }, { value: 'max' }],
+    })
+  })
+
+  it('openThread leaves reasoningEffort null when no thinking configOption is advertised', async () => {
+    const fake = makeCapturingFake()
+    const agent = await connect(fake)
+
+    // Open a second Thread over the same agent whose result omits configOptions.
+    const opened = agent.openThread()
+    const req = sent(fake).filter((m) => m.method === 'session/new').at(-1)
+    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: req?.id, result: { sessionId: 'second' } }) + '\n')
+    const info = await opened
+    expect(info.reasoningEffort).toBeNull()
   })
 })

--- a/src/main/workspace-agent.ts
+++ b/src/main/workspace-agent.ts
@@ -11,6 +11,7 @@ import type {
   ThreadInfo,
   ThreadModes,
   ThreadModels,
+  ThreadReasoningEffort,
 } from '../shared/ipc'
 
 /**
@@ -75,7 +76,12 @@ interface SessionNewResult {
   title?: string | null
   modes?: ThreadModes
   models?: ThreadModels
+  /** The agent-control selects, including the `thinking` reasoning-effort axis (#66). */
+  configOptions?: unknown
 }
+
+/** The reasoning-effort configId — the only `configOption` we surface (#66, §10). */
+const REASONING_EFFORT_CONFIG_ID = 'thinking'
 
 export interface WorkspaceAgentOptions {
   /** Absolute path to the Workspace directory. */
@@ -432,6 +438,7 @@ export class WorkspaceAgent extends EventEmitter {
       title: result.title ?? null,
       modes: result.modes ?? null,
       models: result.models ?? null,
+      reasoningEffort: extractReasoningEffort(result.configOptions),
     }
     this.threads.set(thread.sessionId, thread)
     return thread
@@ -473,6 +480,7 @@ export class WorkspaceAgent extends EventEmitter {
         title: result.title ?? null,
         modes: result.modes ?? null,
         models: result.models ?? null,
+        reasoningEffort: extractReasoningEffort(result.configOptions),
       }
       this.threads.set(sessionId, thread)
       return thread
@@ -503,6 +511,55 @@ export class WorkspaceAgent extends EventEmitter {
       return await this.client.request<PromptResult>('session/prompt', {
         sessionId,
         prompt: [{ type: 'text', text }],
+      })
+    } catch (err) {
+      throw this.mapErrorAndCacheAuth(err)
+    }
+  }
+
+  /**
+   * Change a Thread's Mode (`session/set_mode`, acp-capture §10). A successful
+   * change returns `{}` and emits NO notification — the caller reflects it
+   * optimistically (ADR-0007). Rejects (mapped + auth-cached) on failure so the
+   * IPC handler can surface the error and the renderer can revert.
+   */
+  async setMode(sessionId: string, modeId: string): Promise<void> {
+    if (!this.initialized) throw new WorkspaceAgentError('Agent is not initialized; call start() first.')
+    try {
+      await this.client.request('session/set_mode', { sessionId, modeId })
+    } catch (err) {
+      throw this.mapErrorAndCacheAuth(err)
+    }
+  }
+
+  /**
+   * Change a Thread's Model (`session/set_model`, acp-capture §10). The agent
+   * FALSE-ACCEPTS any string as `modelId` (returns `{}` without validating against
+   * `availableModels`), so the renderer must only ever pass an id from
+   * `models.availableModels` — a `{}` is not proof the value was valid.
+   */
+  async setModel(sessionId: string, modelId: string): Promise<void> {
+    if (!this.initialized) throw new WorkspaceAgentError('Agent is not initialized; call start() first.')
+    try {
+      await this.client.request('session/set_model', { sessionId, modelId })
+    } catch (err) {
+      throw this.mapErrorAndCacheAuth(err)
+    }
+  }
+
+  /**
+   * Change a Thread's reasoning effort via the GENERIC config setter
+   * (`session/set_config_option`, acp-capture §10). The param key is `configId`
+   * (NOT `id` — `{id, value}` returns -32602), pinned to `thinking`; `value` is one
+   * of the `thinking` option values (`off`/`low`/`medium`/`high`/`max`).
+   */
+  async setReasoningEffort(sessionId: string, value: string): Promise<void> {
+    if (!this.initialized) throw new WorkspaceAgentError('Agent is not initialized; call start() first.')
+    try {
+      await this.client.request('session/set_config_option', {
+        sessionId,
+        configId: REASONING_EFFORT_CONFIG_ID,
+        value,
       })
     } catch (err) {
       throw this.mapErrorAndCacheAuth(err)
@@ -721,6 +778,32 @@ function extractSessionCloseCapability(init: InitializeResult): boolean {
  */
 function extractLoadSessionCapability(init: InitializeResult): boolean {
   return (init.agentCapabilities as { loadSession?: unknown } | null)?.loadSession === true
+}
+
+/**
+ * Surface the reasoning-effort axis from `session/new`/`session/load`'s
+ * `configOptions` (#66, acp-capture §10): find the `thinking` select and map its
+ * `currentValue` + `options[{value, name?}]` to a `ThreadReasoningEffort`. Defaults
+ * to null on any absent/malformed shape (no array, no `thinking`, non-string
+ * `currentValue`) — so the picker simply omits the control rather than rendering a
+ * broken one. Mode/Model come back as their own dedicated fields, not here.
+ */
+function extractReasoningEffort(configOptions: unknown): ThreadReasoningEffort | null {
+  if (!Array.isArray(configOptions)) return null
+  const thinking = configOptions.find(
+    (o): o is { id: string; currentValue?: unknown; options?: unknown } =>
+      !!o && typeof o === 'object' && (o as { id?: unknown }).id === REASONING_EFFORT_CONFIG_ID,
+  )
+  if (!thinking || typeof thinking.currentValue !== 'string') return null
+  const options = Array.isArray(thinking.options)
+    ? thinking.options
+        .filter(
+          (opt): opt is { value: string; name?: unknown } =>
+            !!opt && typeof opt === 'object' && typeof (opt as { value?: unknown }).value === 'string',
+        )
+        .map((opt) => ({ value: opt.value, name: typeof opt.name === 'string' ? opt.name : undefined }))
+    : []
+  return { current: thinking.currentValue, options }
 }
 
 /** Pull the well-formed `authMethods` out of an `initialize` result. */

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -10,6 +10,8 @@ import {
   type OpenThreadArgs,
   type SendPromptArgs,
   type SendPromptResult,
+  type SetThreadConfigArgs,
+  type SetThreadConfigResult,
   type SignInArgs,
   type SignInResult,
   type SignOutArgs,
@@ -41,6 +43,8 @@ const api = {
   deleteThread: (threadId: string): Promise<DeleteThreadResult> =>
     ipcRenderer.invoke(IPC.deleteThread, threadId),
   getThreadStatuses: (): Promise<ThreadStatusEvent[]> => ipcRenderer.invoke(IPC.getThreadStatuses),
+  setThreadConfig: (args: SetThreadConfigArgs): Promise<SetThreadConfigResult> =>
+    ipcRenderer.invoke(IPC.setThreadConfig, args),
   readTranscript: (threadId: string): Promise<ReadTranscriptResult> =>
     ipcRenderer.invoke(IPC.readTranscript, threadId),
   onAcpEvent: (listener: (event: AcpEvent) => void): (() => void) => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -3,6 +3,7 @@ import type {
   AuthMethod,
   ListMetadataResult,
   StartThreadResult,
+  ThreadConfigAxis,
   ThreadConnection,
   ThreadMeta,
   VibeDetectResult,
@@ -18,6 +19,7 @@ import {
   agentIdOf,
   connectedWorkspaceIds,
   connectionsReducer,
+  currentConfigValue,
   initialConnections,
   selectedConnection,
   shouldConnect,
@@ -179,6 +181,31 @@ export function App(): JSX.Element {
     if (workspaceThreadStateFor(workspaceThreads, workspaceId)) {
       wtDispatch({ type: 'select', workspaceId, threadId })
     }
+  }
+
+  /**
+   * Change an agent control (#66, ADR-0007): reflect the pick OPTIMISTICALLY on the
+   * connection (a change emits no notification, so the `{}` result is the only
+   * signal), fire the IPC, and on an `{ok:false}` REVERT to the value shown before —
+   * leaving the control displaying the agent's real state — and surface the error.
+   * Reads the prior value from the connection up front so the revert is exact.
+   */
+  function changeThreadConfig(
+    workspaceId: string,
+    agentId: string,
+    axis: ThreadConfigAxis,
+    value: string,
+    sessionId: string,
+  ): void {
+    const conn = connections[workspaceId]
+    const prev = conn?.status === 'connected' ? currentConfigValue(conn.thread, axis) : null
+    if (prev === value) return // already current — no optimistic churn, no IPC round-trip
+    connDispatch({ type: 'set-config', workspaceId, axis, value })
+    void window.api.setThreadConfig({ agentId, sessionId, axis, value }).then((res) => {
+      if (res.ok) return
+      console.error(`Failed to set ${axis} to "${value}": ${res.error}`)
+      if (prev !== null) connDispatch({ type: 'set-config', workspaceId, axis, value: prev })
+    })
   }
 
   /**
@@ -451,6 +478,9 @@ export function App(): JSX.Element {
           activeThread={activeThread}
           isLive={isLive}
           seedSessionId={seed}
+          onSetConfig={(axis, value, sessionId) =>
+            changeThreadConfig(conn.workspaceId, conn.agentId, axis, value, sessionId)
+          }
           onBound={(sessionId) =>
             wtDispatch({ type: 'bind', workspaceId: conn.workspaceId, threadId: activeThread.id, sessionId })
           }

--- a/src/renderer/src/connection/ConnectedWorkspace.tsx
+++ b/src/renderer/src/connection/ConnectedWorkspace.tsx
@@ -47,6 +47,14 @@ export function ConnectedWorkspace({
   /** Mid-session expiry (-32000): route to in-place re-auth with these methods. */
   onAuthExpired: (authMethods: AuthMethod[]) => void
 }): JSX.Element {
+  // The connection carries exactly ONE Thread's Agent-controls values — the
+  // connect-time `session/new` Thread (`connection.threadId`). Show the picker ONLY
+  // when the active Thread IS that primary one, so a sibling live Thread (New-thread
+  // / Continue) never displays the primary's Mode/Model as if they were its own (a
+  // trust-relevant lie, since Mode gates write-approval). Per-Thread sourcing +
+  // post-`session/load` population (so every live Thread gets its own correct
+  // controls) is the tracked follow-up; until then a non-primary Thread shows none.
+  const showControls = activeThread.id === connection.threadId
   return (
     <div className="workspace">
       {isLive ? (
@@ -59,9 +67,9 @@ export function ConnectedWorkspace({
             sessionId: seedSessionId,
             title: activeThread.title,
           }}
-          modes={connection.modes}
-          models={connection.models}
-          reasoningEffort={connection.reasoningEffort}
+          modes={showControls ? connection.modes : null}
+          models={showControls ? connection.models : null}
+          reasoningEffort={showControls ? connection.reasoningEffort : null}
           onSetConfig={onSetConfig}
           onAuthExpired={onAuthExpired}
           onBound={onBound}

--- a/src/renderer/src/connection/ConnectedWorkspace.tsx
+++ b/src/renderer/src/connection/ConnectedWorkspace.tsx
@@ -1,5 +1,5 @@
 import { type JSX } from 'react'
-import type { AuthMethod, ThreadConnection, ThreadMeta } from '../../../shared/ipc'
+import type { AuthMethod, ThreadConfigAxis, ThreadConnection, ThreadMeta } from '../../../shared/ipc'
 import { ColdThread } from '../conversation/ColdThread'
 import { Conversation } from '../conversation/Conversation'
 
@@ -23,6 +23,7 @@ export function ConnectedWorkspace({
   activeThread,
   isLive,
   seedSessionId,
+  onSetConfig,
   onBound,
   onContinue,
   onCloseCold,
@@ -35,6 +36,8 @@ export function ConnectedWorkspace({
   isLive: boolean
   /** The session to seed a live view with (bound-this-session wins over the cursor). */
   seedSessionId: string | null
+  /** Change an agent control on the active Thread's bound session (#66, ADR-0007). */
+  onSetConfig: (axis: ThreadConfigAxis, value: string, sessionId: string) => void
   /** A draft's first prompt bound its session — lift it to App's live-state. */
   onBound: (sessionId: string) => void
   /** Promote the (cold) active Thread to live (Continue) — App hosts + reselects it. */
@@ -56,6 +59,10 @@ export function ConnectedWorkspace({
             sessionId: seedSessionId,
             title: activeThread.title,
           }}
+          modes={connection.modes}
+          models={connection.models}
+          reasoningEffort={connection.reasoningEffort}
+          onSetConfig={onSetConfig}
           onAuthExpired={onAuthExpired}
           onBound={onBound}
         />

--- a/src/renderer/src/connection/connections.test.ts
+++ b/src/renderer/src/connection/connections.test.ts
@@ -3,6 +3,7 @@ import {
   agentIdOf,
   connectedWorkspaceIds,
   connectionsReducer,
+  currentConfigValue,
   initialConnections,
   selectedConnection,
   shouldConnect,
@@ -29,10 +30,41 @@ function connected(workspaceId: string, agentId: string): ConnectState {
     title: null,
     modes: null,
     models: null,
+    reasoningEffort: null,
     signOutAvailable: true,
     authMethods: AUTH_METHODS,
   }
   return { status: 'connected', thread }
+}
+
+/** A connected state carrying all three agent-control axes (#66), for set-config tests. */
+function connectedWithControls(workspaceId: string, agentId: string): ConnectState {
+  const base = connected(workspaceId, agentId)
+  if (base.status !== 'connected') throw new Error('unreachable')
+  return {
+    status: 'connected',
+    thread: {
+      ...base.thread,
+      modes: {
+        currentModeId: 'default',
+        availableModes: [
+          { id: 'default', name: 'Default' },
+          { id: 'plan', name: 'Plan' },
+        ],
+      },
+      models: {
+        currentModelId: 'mistral-medium-3.5',
+        availableModels: [
+          { modelId: 'mistral-medium-3.5', name: 'mistral-medium-3.5' },
+          { modelId: 'devstral-small', name: 'devstral-small' },
+        ],
+      },
+      reasoningEffort: {
+        current: 'high',
+        options: [{ value: 'low' }, { value: 'high' }, { value: 'max' }],
+      },
+    },
+  }
 }
 
 describe('connectionsReducer', () => {
@@ -81,6 +113,80 @@ describe('connectionsReducer', () => {
     // a connecting/idle Workspace has no agent yet, so an unrelated eviction is inert.
     const same = connectionsReducer(map, { type: 'evict', agentIds: new Set(['a-unknown']) })
     expect(same).toBe(map)
+  })
+})
+
+describe('connectionsReducer set-config (#66 optimistic agent-control change)', () => {
+  it('updates the current value for each axis, leaving the others untouched', () => {
+    const map: ConnectionMap = { w1: connectedWithControls('w1', 'a1') }
+
+    const mode = connectionsReducer(map, { type: 'set-config', workspaceId: 'w1', axis: 'mode', value: 'plan' })
+    const s1 = mode.w1
+    if (s1.status !== 'connected') throw new Error('expected connected')
+    expect(s1.thread.modes?.currentModeId).toBe('plan')
+    expect(s1.thread.models?.currentModelId).toBe('mistral-medium-3.5') // model untouched
+    expect(s1.thread.reasoningEffort?.current).toBe('high') // effort untouched
+
+    const model = connectionsReducer(map, { type: 'set-config', workspaceId: 'w1', axis: 'model', value: 'devstral-small' })
+    const s2 = model.w1
+    if (s2.status !== 'connected') throw new Error('expected connected')
+    expect(s2.thread.models?.currentModelId).toBe('devstral-small')
+
+    const effort = connectionsReducer(map, { type: 'set-config', workspaceId: 'w1', axis: 'reasoningEffort', value: 'max' })
+    const s3 = effort.w1
+    if (s3.status !== 'connected') throw new Error('expected connected')
+    expect(s3.thread.reasoningEffort?.current).toBe('max')
+  })
+
+  it('reverts cleanly by re-dispatching the prior value (ADR-0007 revert)', () => {
+    const map: ConnectionMap = { w1: connectedWithControls('w1', 'a1') }
+    const optimistic = connectionsReducer(map, { type: 'set-config', workspaceId: 'w1', axis: 'mode', value: 'plan' })
+    const reverted = connectionsReducer(optimistic, { type: 'set-config', workspaceId: 'w1', axis: 'mode', value: 'default' })
+    const s = reverted.w1
+    if (s.status !== 'connected') throw new Error('expected connected')
+    expect(s.thread.modes?.currentModeId).toBe('default')
+  })
+
+  it('does not mutate the input state', () => {
+    const before = connectedWithControls('w1', 'a1')
+    const map: ConnectionMap = { w1: before }
+    connectionsReducer(map, { type: 'set-config', workspaceId: 'w1', axis: 'mode', value: 'plan' })
+    if (before.status !== 'connected') throw new Error('expected connected')
+    expect(before.thread.modes?.currentModeId).toBe('default') // original object unchanged
+  })
+
+  it('is a no-op (same ref) when the value is already current', () => {
+    const map: ConnectionMap = { w1: connectedWithControls('w1', 'a1') }
+    const same = connectionsReducer(map, { type: 'set-config', workspaceId: 'w1', axis: 'mode', value: 'default' })
+    expect(same).toBe(map)
+  })
+
+  it('is a no-op (same ref) when the Workspace is not connected or absent', () => {
+    const map: ConnectionMap = {
+      w1: { status: 'connecting', workspaceDir: '/proj/w1' },
+    }
+    expect(connectionsReducer(map, { type: 'set-config', workspaceId: 'w1', axis: 'mode', value: 'plan' })).toBe(map)
+    expect(connectionsReducer(map, { type: 'set-config', workspaceId: 'absent', axis: 'mode', value: 'plan' })).toBe(map)
+  })
+
+  it('is a no-op (same ref) when the axis is not advertised (null modes/models/effort)', () => {
+    const map: ConnectionMap = { w1: connected('w1', 'a1') } // all axes null
+    expect(connectionsReducer(map, { type: 'set-config', workspaceId: 'w1', axis: 'model', value: 'x' })).toBe(map)
+  })
+})
+
+describe('currentConfigValue (#66)', () => {
+  it('reads the current value per axis, null when unadvertised', () => {
+    const withControls = connectedWithControls('w1', 'a1')
+    if (withControls.status !== 'connected') throw new Error('expected connected')
+    expect(currentConfigValue(withControls.thread, 'mode')).toBe('default')
+    expect(currentConfigValue(withControls.thread, 'model')).toBe('mistral-medium-3.5')
+    expect(currentConfigValue(withControls.thread, 'reasoningEffort')).toBe('high')
+
+    const bare = connected('w1', 'a1')
+    if (bare.status !== 'connected') throw new Error('expected connected')
+    expect(currentConfigValue(bare.thread, 'mode')).toBeNull()
+    expect(currentConfigValue(bare.thread, 'reasoningEffort')).toBeNull()
   })
 })
 

--- a/src/renderer/src/connection/connections.ts
+++ b/src/renderer/src/connection/connections.ts
@@ -1,3 +1,4 @@
+import type { ThreadConfigAxis, ThreadConnection } from '../../../shared/ipc'
 import type { ConnectState } from './routing'
 
 /**
@@ -15,6 +16,10 @@ export type ConnectionAction =
   | { type: 'set'; workspaceId: string; state: ConnectState }
   | { type: 'clear'; workspaceId: string }
   | { type: 'evict'; agentIds: ReadonlySet<string> }
+  // Optimistically reflect an agent-control change (#66, ADR-0007): a change emits
+  // no notification, so the renderer updates the displayed current value the instant
+  // the user picks, then reverts (re-dispatching the prior value) on an IPC failure.
+  | { type: 'set-config'; workspaceId: string; axis: ThreadConfigAxis; value: string }
 
 export const initialConnections: ConnectionMap = {}
 
@@ -42,6 +47,54 @@ export function connectionsReducer(state: ConnectionMap, action: ConnectionActio
       for (const id of doomed) delete next[id]
       return next
     }
+    case 'set-config': {
+      // Only a connected Workspace carries the live current values; a transient
+      // (connecting / not-signed-in / error / absent) one has no controls to update,
+      // so the action is inert (same ref). `applyConfig` also returns the SAME thread
+      // ref when the axis has no options or the value is unchanged — so a redundant
+      // pick (or a revert to the value already shown) drives no re-render.
+      const current = state[action.workspaceId]
+      if (!current || current.status !== 'connected') return state
+      const nextThread = applyConfig(current.thread, action.axis, action.value)
+      if (nextThread === current.thread) return state
+      return { ...state, [action.workspaceId]: { status: 'connected', thread: nextThread } }
+    }
+  }
+}
+
+/**
+ * Return a connection's CURRENT value for an agent-control axis (#66), or null when
+ * the axis isn't advertised. App reads this BEFORE an optimistic `set-config` so it
+ * can revert to the prior value if the IPC change fails (ADR-0007).
+ */
+export function currentConfigValue(thread: ThreadConnection, axis: ThreadConfigAxis): string | null {
+  switch (axis) {
+    case 'mode':
+      return thread.modes?.currentModeId ?? null
+    case 'model':
+      return thread.models?.currentModelId ?? null
+    case 'reasoningEffort':
+      return thread.reasoningEffort?.current ?? null
+  }
+}
+
+/**
+ * Apply an agent-control change to a connection's current value (#66), returning a
+ * NEW `ThreadConnection` with only the targeted nested current updated — or the SAME
+ * ref when the axis isn't advertised (null) or the value is already current, so a
+ * no-op pick can't churn the reducer.
+ */
+function applyConfig(thread: ThreadConnection, axis: ThreadConfigAxis, value: string): ThreadConnection {
+  switch (axis) {
+    case 'mode':
+      if (!thread.modes || thread.modes.currentModeId === value) return thread
+      return { ...thread, modes: { ...thread.modes, currentModeId: value } }
+    case 'model':
+      if (!thread.models || thread.models.currentModelId === value) return thread
+      return { ...thread, models: { ...thread.models, currentModelId: value } }
+    case 'reasoningEffort':
+      if (!thread.reasoningEffort || thread.reasoningEffort.current === value) return thread
+      return { ...thread, reasoningEffort: { ...thread.reasoningEffort, current: value } }
   }
 }
 

--- a/src/renderer/src/connection/routing.test.ts
+++ b/src/renderer/src/connection/routing.test.ts
@@ -20,6 +20,7 @@ const THREAD: ThreadConnection = {
   title: null,
   modes: null,
   models: null,
+  reasoningEffort: null,
   signOutAvailable: true,
   authMethods: AUTH_METHODS,
 }

--- a/src/renderer/src/conversation/AgentControls.tsx
+++ b/src/renderer/src/conversation/AgentControls.tsx
@@ -1,0 +1,124 @@
+import { type JSX } from 'react'
+import { Check, ChevronDown } from 'lucide-react'
+import type {
+  ThreadConfigAxis,
+  ThreadModes,
+  ThreadModels,
+  ThreadReasoningEffort,
+} from '../../../shared/ipc'
+import { Menu, MenuContent, MenuItem, MenuTrigger } from '../ui/menu'
+import { cn } from '../lib/utils'
+
+/**
+ * The composer's agent-controls row (#66): Mode / Model / Reasoning-effort pickers,
+ * each showing the Thread's current value and a base-ui menu of its options. Vibe-
+ * owned, display-from-session-state (ADR-0007): the current values come from the
+ * connection (sourced from `session/new`), and a pick fires `onSetConfig` which App
+ * reflects OPTIMISTICALLY and reverts on failure — a change emits no notification.
+ *
+ * `disabled` is the between-turns + bound-session gate (a turn streaming OR no bound
+ * session yet) — the controls grey out rather than letting a mid-turn / pre-session
+ * change through. The row renders nothing when the agent advertises no axes at all.
+ */
+export function AgentControls({
+  modes,
+  models,
+  reasoningEffort,
+  disabled,
+  onSetConfig,
+}: {
+  modes: ThreadModes | null
+  models: ThreadModels | null
+  reasoningEffort: ThreadReasoningEffort | null
+  disabled: boolean
+  onSetConfig: (axis: ThreadConfigAxis, value: string) => void
+}): JSX.Element | null {
+  if (!modes && !models && !reasoningEffort) return null
+  return (
+    <div className="composer__controls flex flex-wrap items-center gap-2">
+      {modes && (
+        <AgentControl
+          label="Mode"
+          current={modes.currentModeId}
+          options={modes.availableModes.map((m) => ({ value: m.id, label: m.name }))}
+          disabled={disabled}
+          onSelect={(value) => onSetConfig('mode', value)}
+        />
+      )}
+      {models && (
+        <AgentControl
+          label="Model"
+          current={models.currentModelId}
+          options={models.availableModels.map((m) => ({ value: m.modelId, label: m.name }))}
+          disabled={disabled}
+          onSelect={(value) => onSetConfig('model', value)}
+        />
+      )}
+      {reasoningEffort && (
+        <AgentControl
+          label="Reasoning effort"
+          current={reasoningEffort.current}
+          options={reasoningEffort.options.map((o) => ({ value: o.value, label: o.name ?? titleCase(o.value) }))}
+          disabled={disabled}
+          onSelect={(value) => onSetConfig('reasoningEffort', value)}
+        />
+      )}
+    </div>
+  )
+}
+
+interface ControlOption {
+  value: string
+  label: string
+}
+
+/**
+ * One labelled picker. base-ui owns focus / keyboard nav / dismissal; this layers
+ * on the brand look (square corners, surface + border, accent hover) and a leading
+ * check on the active option. `disabled` greys the trigger and stops it opening.
+ */
+function AgentControl({
+  label,
+  current,
+  options,
+  disabled,
+  onSelect,
+}: {
+  label: string
+  current: string | null
+  options: ControlOption[]
+  disabled: boolean
+  onSelect: (value: string) => void
+}): JSX.Element {
+  const currentLabel = options.find((o) => o.value === current)?.label ?? current ?? '—'
+  return (
+    <Menu>
+      <MenuTrigger
+        disabled={disabled}
+        title={label}
+        className={cn(
+          'flex items-center gap-1.5 border border-border bg-surface px-2 py-1 text-xs text-text',
+          'hover:bg-accent hover:text-on-accent',
+          'disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-surface disabled:hover:text-text',
+        )}
+      >
+        <span className="text-muted">{label}</span>
+        <span className="font-medium">{currentLabel}</span>
+        <ChevronDown size={12} aria-hidden />
+      </MenuTrigger>
+      <MenuContent align="start">
+        {options.map((o) => (
+          <MenuItem key={o.value} onClick={() => onSelect(o.value)}>
+            <Check size={12} aria-hidden className={o.value === current ? 'opacity-100' : 'opacity-0'} />
+            {o.label}
+          </MenuItem>
+        ))}
+      </MenuContent>
+    </Menu>
+  )
+}
+
+/** Title-case a bare effort value (`off` -> `Off`) when the agent gives no `name`. */
+function titleCase(value: string): string {
+  return value.length === 0 ? value : value[0].toUpperCase() + value.slice(1)
+}

--- a/src/renderer/src/conversation/Conversation.tsx
+++ b/src/renderer/src/conversation/Conversation.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useReducer, useRef, useState, type JSX, type KeyboardEvent } from 'react'
-import type { AuthMethod } from '../../../shared/ipc'
+import type {
+  AuthMethod,
+  ThreadConfigAxis,
+  ThreadModes,
+  ThreadModels,
+  ThreadReasoningEffort,
+} from '../../../shared/ipc'
+import { AgentControls } from './AgentControls'
 import {
   conversationReducer,
   initialConversationState,
@@ -52,10 +59,23 @@ export interface LiveThread {
  */
 export function Conversation({
   thread,
+  modes,
+  models,
+  reasoningEffort,
+  onSetConfig,
   onAuthExpired,
   onBound,
 }: {
   thread: LiveThread
+  /** The connection's current Mode + options (#66) — display-from-session-state. */
+  modes: ThreadModes | null
+  /** The connection's current Model + options (#66). */
+  models: ThreadModels | null
+  /** The connection's current Reasoning effort + options (#66). */
+  reasoningEffort: ThreadReasoningEffort | null
+  /** Change an agent control (#66): App reflects it optimistically + reverts on error.
+   *  Carries the Thread's bound `sessionId` (non-null once bound) for the IPC call. */
+  onSetConfig?: (axis: ThreadConfigAxis, value: string, sessionId: string) => void
   /** Mid-session expiry (-32000): route to in-place re-auth with these methods. */
   onAuthExpired: (authMethods: AuthMethod[]) => void
   /** The Thread's session once bound (TB5) — lifts it so a switch-away-and-back
@@ -256,26 +276,43 @@ export function Conversation({
         </button>
       )}
 
-      <div className="composer">
-        <textarea
-          className="composer__input"
-          placeholder="Ask Vibe… (Enter to send, Shift+Enter for a newline)"
-          value={draft}
-          onChange={(e) => {
-            // Write-through: keep React state and the persisted draft (#60) in lockstep.
-            setDraft(e.target.value)
-            persistDraft(window.localStorage, thread.threadId, e.target.value)
+      <div className="composer-area">
+        {/* Agent controls (#66): Mode / Model / Reasoning effort. Vibe-owned,
+            between-turns only — disabled while a turn streams OR before this Thread
+            has a bound session (a draft binds on its first prompt). */}
+        <AgentControls
+          modes={modes}
+          models={models}
+          reasoningEffort={reasoningEffort}
+          disabled={state.isProcessing || boundSessionId === null}
+          onSetConfig={(axis, value) => {
+            // The disabled gate guarantees a bound session here, but guard anyway so
+            // a stray call can never send a config change with a null sessionId.
+            if (boundSessionId) onSetConfig?.(axis, value, boundSessionId)
           }}
-          onKeyDown={onKeyDown}
-          rows={2}
         />
-        <button
-          className="btn"
-          onClick={() => void send()}
-          disabled={state.isProcessing || draft.trim().length === 0}
-        >
-          {state.isProcessing ? 'Sending…' : 'Send'}
-        </button>
+
+        <div className="composer">
+          <textarea
+            className="composer__input"
+            placeholder="Ask Vibe… (Enter to send, Shift+Enter for a newline)"
+            value={draft}
+            onChange={(e) => {
+              // Write-through: keep React state and the persisted draft (#60) in lockstep.
+              setDraft(e.target.value)
+              persistDraft(window.localStorage, thread.threadId, e.target.value)
+            }}
+            onKeyDown={onKeyDown}
+            rows={2}
+          />
+          <button
+            className="btn"
+            onClick={() => void send()}
+            disabled={state.isProcessing || draft.trim().length === 0}
+          >
+            {state.isProcessing ? 'Sending…' : 'Send'}
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -883,6 +883,12 @@ body {
   border-color: var(--accent);
 }
 
+.composer-area {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 .composer {
   display: flex;
   gap: 8px;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -71,6 +71,15 @@ export const IPC = {
    * change (`thread:status`), so without this a fresh window misses in-flight state.
    */
   getThreadStatuses: 'thread:statuses',
+  /**
+   * Renderer -> main: change one of a Thread's agent controls (#66) — Mode, Model,
+   * or Reasoning effort — on its bound ACP session. Main maps the axis to the
+   * verified setter (`session/set_mode` / `session/set_model` /
+   * `session/set_config_option`, acp-capture §10) and returns ok/err. A change emits
+   * NO notification (the `{}` result is the only signal), so the renderer updates the
+   * displayed value OPTIMISTICALLY and reverts on an `{ok:false}` (ADR-0007).
+   */
+  setThreadConfig: 'thread:set-config',
 } as const
 
 /**
@@ -133,6 +142,18 @@ export interface ThreadModels {
   availableModels: AcpModel[]
 }
 
+/**
+ * The reasoning-effort axis (#66), surfaced from `session/new`'s `thinking`
+ * configOption (acp-capture §10) — a select of `off`/`low`/`medium`/`high`/`max`.
+ * Distinct from Mode/Model: it has no dedicated method, so a change goes through
+ * the generic `session/set_config_option` with `configId: 'thinking'`. Each option
+ * carries a `value`; `name` is the display label when the agent provides one.
+ */
+export interface ThreadReasoningEffort {
+  current: string
+  options: { value: string; name?: string }[]
+}
+
 /** A connected Thread, mapped onto the ACP `sessionId` from `session/new`. */
 export interface ThreadInfo {
   /** The ACP session id this Thread is bound to (debug-visible only). */
@@ -141,6 +162,8 @@ export interface ThreadInfo {
   title: string | null
   modes: ThreadModes | null
   models: ThreadModels | null
+  /** The `thinking` configOption (#66) — null when the agent advertises none. */
+  reasoningEffort: ThreadReasoningEffort | null
 }
 
 export interface StartThreadArgs {
@@ -338,6 +361,32 @@ export interface SignOutArgs {
 export type SignOutResult =
   | { ok: true; authState: AuthState; authMethods: AuthMethod[] }
   | { ok: false; error: string }
+
+/** Which agent control a `setThreadConfig` change targets (#66). */
+export type ThreadConfigAxis = 'mode' | 'model' | 'reasoningEffort'
+
+/**
+ * Change one agent control on a Thread's bound ACP session (#66). `value` is the
+ * new id for the axis — a `modeId` from `availableModes`, a `modelId` from
+ * `availableModels` (NEVER an arbitrary string: `session/set_model` false-accepts
+ * any string, acp-capture §10), or a reasoning-effort `value` from the `thinking`
+ * options.
+ */
+export interface SetThreadConfigArgs {
+  /** Id of the Workspace agent (one `vibe-acp` process) hosting the Thread. */
+  agentId: string
+  /** The Thread's bound ACP session — the change is between-turns, so it's never null. */
+  sessionId: string
+  axis: ThreadConfigAxis
+  value: string
+}
+
+/**
+ * The `setThreadConfig` reply (#66). `ok` once the setter's `{}` result lands; on
+ * `{ok:false}` the renderer reverts the optimistic display to the prior value and
+ * surfaces the error (ADR-0007).
+ */
+export type SetThreadConfigResult = { ok: true } | { ok: false; error: string }
 
 /**
  * Persisted Workspace metadata (ADR-0005): a project dir the user has opened.


### PR DESCRIPTION
Closes #66. A per-Thread picker for **Mode / Model / Reasoning effort** in the composer, on the #61 base-ui/Tailwind/lucide stack, using the change methods verified by the #65 spike.

## What

- **IPC** `thread:set-config {agentId, sessionId, axis, value}` → main maps the axis to the verified setter (acp-capture §10): Mode → `session/set_mode {modeId}`, Model → `session/set_model {modelId}`, Reasoning effort → `session/set_config_option {configId:'thinking', value}`.
- **Reasoning effort surfaced** from `session/new`'s `thinking` configOption (`workspace-agent.ts extractReasoningEffort`); Mode/Model already came from `session/new`.
- **Optimistic update** of the connection's current value (connection reducer `set-config`, same-ref discipline), **reverting** on an IPC `{ok:false}` (ADR-0007: a change emits no notification, so optimistic is the only path).
- **Picker UI** (`AgentControls.tsx`): base-ui menus, on-brand, lucide; renders only advertised axes; active-option check; **disabled while a turn streams or before the Thread has a bound session** (between-turns + pre-session, ADR-0007). A Mode change is forward-acting — it never resolves a pending Permission request.
- `set_model` false-accepts any string → the UI only ever offers ids from `availableModels`.

## Review + verification

Implementer → my independent gate re-run + diff read → adversarial reviewer (verdict **SHIP-WITH-FIXES**, no MUST-FIX). All gates green: lint / typecheck / build / **331 tests**. Reviewer confirmed: setter params correct, no cross-workspace leak, disabled gating + optional-callback handled, #60 composer-draft + #61 markdown intact, no scope creep.

**Folded S1 (the trust issue):** the picker showed the connect-time Thread's values for *sibling* live Threads (a change could display `auto-approve` while that Thread's session was `default`). Now **gated to the primary Thread** (`activeThread === connection.threadId`) — a non-primary Thread shows no controls rather than wrong ones.

## Deferred to follow-up (tracked)

Full **per-Thread sourcing + post-`session/load` population** (so New-thread / Continue / reopened Threads each get their own correct controls), plus ADR-0007's **cache-and-re-assert after resume** (Vibe resets Mode to `default` on `session/load`). Today the picker is correct where it appears (the connect-time Thread) and simply absent elsewhere — honest, never wrong. Follow-up issue filed.

## Manual smoke still worth doing

Changing a live session's Mode/Model/effort in `bun run dev` and seeing the optimistic value hold / revert on error (couldn't drive a live agent headless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)