### PR TITLE
#70: per-Thread agent-controls sourcing (remove the #66 primary-Thread gate)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -19,6 +19,7 @@ import {
   type SignOutResult,
   type StartThreadArgs,
   type StartThreadResult,
+  type ThreadAgentControls,
   type ThreadConnection,
   type ThreadInfo,
   type ThreadStatusEvent,
@@ -40,7 +41,7 @@ import {
 import { WorkspaceAgent, WorkspaceAgentError } from './workspace-agent'
 import { AgentPool } from './agent-pool'
 import { isProtected } from './agent-protection'
-import { ensureBoundSession, resolveContinueTarget } from './thread-binding'
+import { controlsOf, ensureBoundSession, resolveContinueTarget } from './thread-binding'
 import { deleteThread } from './persistence/delete-thread'
 import { permissionRequestIdOf, ThreadStatusTracker, type ThreadStatusChange } from './thread-status'
 
@@ -314,7 +315,7 @@ async function recordThread(agentId: string, workspaceDir: string, thread: Threa
 async function bindThreadSession(
   agent: WorkspaceAgent,
   args: SendPromptArgs,
-): Promise<{ sessionId: string; minted: boolean; rebound: boolean }> {
+): Promise<{ sessionId: string; minted: boolean; rebound: boolean; controls: ThreadAgentControls | null }> {
   // Point the bridge at the Thread being prompted, so a session-less lifecycle
   // event tees to the ACTIVE Thread when several share an agent — refreshed every
   // prompt (last-write-wins, and only the active Thread prompts at a time).
@@ -327,13 +328,15 @@ async function bindThreadSession(
       workspaceId: args.workspaceId,
       sessionId: args.sessionId,
     })
-    return { sessionId: bound.sessionId, minted: bound.minted, rebound: bound.rebound }
+    return { sessionId: bound.sessionId, minted: bound.minted, rebound: bound.rebound, controls: bound.controls }
   }
+  // Degraded (no store): a reused session brings no fresh result (null controls);
+  // a freshly opened one carries its `session/new` controls (#70).
   if (args.sessionId && agent.hasSession(args.sessionId)) {
-    return { sessionId: args.sessionId, minted: false, rebound: false }
+    return { sessionId: args.sessionId, minted: false, rebound: false, controls: null }
   }
   const thread = await agent.openThread()
-  return { sessionId: thread.sessionId, minted: true, rebound: false }
+  return { sessionId: thread.sessionId, minted: true, rebound: false, controls: controlsOf(thread) }
 }
 
 /**
@@ -473,15 +476,25 @@ async function runPromptTurn(
     const bound = await bindThreadSession(agent, args)
     sessionId = bound.sessionId
     rebound = bound.rebound
-    // Tell the renderer its draft is now bound, the INSTANT `session/new`
-    // returns and BEFORE `agent.prompt` streams any event below (same
-    // webContents, so ordered ahead of those `acp:event`s). This binds the
-    // draft's live view to its OWN session up front, so it never infers a
+    // Tell the renderer this Thread is now bound, the INSTANT `session/new` /
+    // `session/load` returns and BEFORE `agent.prompt` streams any event below
+    // (same webContents, so ordered ahead of those `acp:event`s). This binds the
+    // Thread's live view to its OWN session up front, so it never infers a
     // session from an arbitrary (possibly sibling) event. `rebound` (TB4 #33)
     // carries a NEW session for a reopened Thread whose resume failed — the
     // renderer rebinds its live view to it AND renders the "context reset" notice.
-    if (bound.minted && !sender.isDestroyed()) {
-      sender.send(IPC.threadBound, { threadId: args.threadId, sessionId, rebound })
+    //
+    // We emit whenever the bind produced a fresh result with `controls` (#70) — a
+    // mint, a re-bind, OR a successful resume — so the Thread's picker sources its
+    // OWN Mode/Model/effort from THIS session (the #66 single-Thread limitation this
+    // removes). A plain reuse of an already-hosted session brings null controls and
+    // no re-emit (the renderer keeps what it holds). NOTE (deferred follow-up): we
+    // hand the renderer the session's REPORTED controls only; caching a user's prior
+    // non-default selection and re-asserting it after a `session/load` resume
+    // (ADR-0007) is a separate slice — today a reopened Thread shows its resumed
+    // (default) config, not the choice it last carried.
+    if (bound.controls && !sender.isDestroyed()) {
+      sender.send(IPC.threadBound, { threadId: args.threadId, sessionId, rebound, controls: bound.controls })
     }
   } catch (err) {
     if (err instanceof WorkspaceAgentError && err.authState === 'not-signed-in') {

--- a/src/main/thread-binding.ts
+++ b/src/main/thread-binding.ts
@@ -1,6 +1,15 @@
-import type { ThreadInfo } from '../shared/ipc'
+import type { ThreadAgentControls, ThreadInfo } from '../shared/ipc'
 import { WorkspaceAgentError } from './workspace-agent'
 import type { ThreadRecord } from './persistence/metadata-store'
+
+/**
+ * Project a `session/new` / `session/load` `ThreadInfo` onto its agent-controls
+ * bundle (#70) — the per-Thread Mode/Model/Reasoning-effort the renderer sources
+ * its picker from. Each axis stays null when the agent advertises none.
+ */
+export function controlsOf(thread: ThreadInfo): ThreadAgentControls {
+  return { modes: thread.modes, models: thread.models, reasoningEffort: thread.reasoningEffort }
+}
 
 /**
  * The minimal agent surface for binding: open a new ACP session (`session/new`).
@@ -86,6 +95,13 @@ export interface BoundSession {
    * and re-emits `thread:bound` with the NEW sessionId; `minted` is also true.
    */
   rebound: boolean
+  /**
+   * The bound session's agent-controls (#70), so the renderer's `thread:bound`
+   * handler can seed THIS Thread's picker with its OWN Mode/Model/effort. Carried
+   * from the fresh `session/new` (mint/re-bind) or `session/load` (resume) result;
+   * null on a plain reuse of an already-hosted session (case iii — no fresh result).
+   */
+  controls: ThreadAgentControls | null
 }
 
 /**
@@ -118,16 +134,17 @@ export async function ensureBoundSession(args: {
   // (i) draft: mint a fresh session and bind it.
   if (!args.sessionId) return mintAndBind(args)
 
-  // (iii) already hosted this run: reuse with no load/new.
+  // (iii) already hosted this run: reuse with no load/new — no fresh result, so no
+  // controls to hand the renderer (it keeps whatever it already holds for this Thread).
   if (args.agent.hasSession(args.sessionId)) {
-    return { sessionId: args.sessionId, minted: false, title: null, resumed: false, rebound: false }
+    return { sessionId: args.sessionId, minted: false, title: null, resumed: false, rebound: false, controls: null }
   }
 
   // (ii) reopened: resume via session/load if advertised, else re-bind.
   if (args.agent.loadSessionAvailable) {
     try {
       const resumed = await args.agent.loadThread(args.sessionId)
-      return { sessionId: resumed.sessionId, minted: false, title: null, resumed: true, rebound: false }
+      return { sessionId: resumed.sessionId, minted: false, title: null, resumed: true, rebound: false, controls: controlsOf(resumed) }
     } catch (err) {
       // A mid-session auth expiry (-32000) isn't a resume failure — let the caller
       // route to sign-in rather than re-binding (which would just fail the same way).
@@ -152,5 +169,5 @@ async function mintAndBind(args: {
     workspaceId: args.workspaceId,
     sessionId: thread.sessionId,
   })
-  return { sessionId: thread.sessionId, minted: true, title: thread.title, resumed: false, rebound: false }
+  return { sessionId: thread.sessionId, minted: true, title: thread.title, resumed: false, rebound: false, controls: controlsOf(thread) }
 }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -19,12 +19,13 @@ import {
   agentIdOf,
   connectedWorkspaceIds,
   connectionsReducer,
-  currentConfigValue,
   initialConnections,
   selectedConnection,
   shouldConnect,
 } from './connection/connections'
 import {
+  configFor,
+  currentConfigValue,
   initialWorkspaceThreads,
   workspaceThreadsReducer,
   workspaceThreadStateFor,
@@ -160,11 +161,21 @@ export function App(): JSX.Element {
   function applyConnectResult(workspaceId: string, state: ConnectState, focus: boolean): void {
     connDispatch({ type: 'set', workspaceId, state })
     if (state.status !== 'connected') return
+    // Seed the connect-time (primary) Thread's controls per-Thread (#70) from the
+    // connection's `session/new` values — every sibling Thread later seeds its own on
+    // `bind`. NOTE (deferred follow-up): caching a non-default selection across a
+    // session loss + re-asserting it after `session/load` (ADR-0007) is a separate
+    // slice; today a reopened/continued Thread shows its resumed (default) config.
     wtDispatch({
       type: 'connect',
       workspaceId,
       threadId: state.thread.threadId,
       sessionId: state.thread.sessionId,
+      controls: {
+        modes: state.thread.modes,
+        models: state.thread.models,
+        reasoningEffort: state.thread.reasoningEffort,
+      },
     })
     if (focus || selectionRef.current === workspaceId) {
       navDispatch({ type: 'select-thread', workspaceId, threadId: state.thread.threadId })
@@ -184,27 +195,29 @@ export function App(): JSX.Element {
   }
 
   /**
-   * Change an agent control (#66, ADR-0007): reflect the pick OPTIMISTICALLY on the
-   * connection (a change emits no notification, so the `{}` result is the only
-   * signal), fire the IPC, and on an `{ok:false}` REVERT to the value shown before —
-   * leaving the control displaying the agent's real state — and surface the error.
-   * Reads the prior value from the connection up front so the revert is exact.
+   * Change an agent control for ONE Thread (#66/#70, ADR-0007): reflect the pick
+   * OPTIMISTICALLY on THAT Thread's per-Thread config (keyed by `threadId` in the
+   * workspace-threads store — a change emits no notification, so the `{}` result is
+   * the only signal), fire the IPC, and on an `{ok:false}` REVERT to the value shown
+   * before — leaving the control displaying the agent's real state — and surface the
+   * error. Reads the prior value from the per-Thread config up front so the revert is
+   * exact; a sibling Thread's controls are never touched.
    */
   function changeThreadConfig(
     workspaceId: string,
     agentId: string,
+    threadId: string,
     axis: ThreadConfigAxis,
     value: string,
     sessionId: string,
   ): void {
-    const conn = connections[workspaceId]
-    const prev = conn?.status === 'connected' ? currentConfigValue(conn.thread, axis) : null
+    const prev = currentConfigValue(workspaceThreads, workspaceId, threadId, axis)
     if (prev === value) return // already current — no optimistic churn, no IPC round-trip
-    connDispatch({ type: 'set-config', workspaceId, axis, value })
+    wtDispatch({ type: 'set-config', workspaceId, threadId, axis, value })
     void window.api.setThreadConfig({ agentId, sessionId, axis, value }).then((res) => {
       if (res.ok) return
       console.error(`Failed to set ${axis} to "${value}": ${res.error}`)
-      if (prev !== null) connDispatch({ type: 'set-config', workspaceId, axis, value: prev })
+      if (prev !== null) wtDispatch({ type: 'set-config', workspaceId, threadId, axis, value: prev })
     })
   }
 
@@ -478,11 +491,12 @@ export function App(): JSX.Element {
           activeThread={activeThread}
           isLive={isLive}
           seedSessionId={seed}
+          controls={configFor(workspaceThreads, conn.workspaceId, activeThread.id)}
           onSetConfig={(axis, value, sessionId) =>
-            changeThreadConfig(conn.workspaceId, conn.agentId, axis, value, sessionId)
+            changeThreadConfig(conn.workspaceId, conn.agentId, activeThread.id, axis, value, sessionId)
           }
-          onBound={(sessionId) =>
-            wtDispatch({ type: 'bind', workspaceId: conn.workspaceId, threadId: activeThread.id, sessionId })
+          onBound={(sessionId, controls) =>
+            wtDispatch({ type: 'bind', workspaceId: conn.workspaceId, threadId: activeThread.id, sessionId, controls })
           }
           onContinue={() => {
             wtDispatch({ type: 'open', workspaceId: conn.workspaceId, threadId: activeThread.id })

--- a/src/renderer/src/connection/ConnectedWorkspace.tsx
+++ b/src/renderer/src/connection/ConnectedWorkspace.tsx
@@ -1,5 +1,11 @@
 import { type JSX } from 'react'
-import type { AuthMethod, ThreadConfigAxis, ThreadConnection, ThreadMeta } from '../../../shared/ipc'
+import type {
+  AuthMethod,
+  ThreadAgentControls,
+  ThreadConfigAxis,
+  ThreadConnection,
+  ThreadMeta,
+} from '../../../shared/ipc'
 import { ColdThread } from '../conversation/ColdThread'
 import { Conversation } from '../conversation/Conversation'
 
@@ -17,12 +23,19 @@ import { Conversation } from '../conversation/Conversation'
  * The sidebar's per-Thread streaming / needs-attention indicators no longer depend
  * on this view reporting up: main pushes per-Thread status for ALL live Threads
  * (#53), so a background Workspace's blocked permission surfaces without it.
+ *
+ * Agent controls (#70): the active Thread's OWN Mode/Model/Reasoning-effort come in
+ * as `controls`, sourced PER Thread from `workspace-threads` (seeded on connect/bind,
+ * keyed by `threadId`). This removes the #66 primary-Thread gate — EVERY live Thread
+ * (the auto-opened one, a New-thread draft #58, a continued Thread #33) now shows and
+ * changes its own controls, with no risk of a sibling displaying the primary's values.
  */
 export function ConnectedWorkspace({
   connection,
   activeThread,
   isLive,
   seedSessionId,
+  controls,
   onSetConfig,
   onBound,
   onContinue,
@@ -36,10 +49,12 @@ export function ConnectedWorkspace({
   isLive: boolean
   /** The session to seed a live view with (bound-this-session wins over the cursor). */
   seedSessionId: string | null
-  /** Change an agent control on the active Thread's bound session (#66, ADR-0007). */
+  /** The active Thread's OWN agent-controls (#70), or null when none are seeded yet. */
+  controls: ThreadAgentControls | null
+  /** Change an agent control on the active Thread's bound session (#66/#70, ADR-0007). */
   onSetConfig: (axis: ThreadConfigAxis, value: string, sessionId: string) => void
-  /** A draft's first prompt bound its session — lift it to App's live-state. */
-  onBound: (sessionId: string) => void
+  /** A draft's first prompt bound its session — lift it (and its controls) to App. */
+  onBound: (sessionId: string, controls: ThreadAgentControls | null) => void
   /** Promote the (cold) active Thread to live (Continue) — App hosts + reselects it. */
   onContinue: () => void
   /** Back out of a cold view to the connection's primary live Thread. */
@@ -47,14 +62,6 @@ export function ConnectedWorkspace({
   /** Mid-session expiry (-32000): route to in-place re-auth with these methods. */
   onAuthExpired: (authMethods: AuthMethod[]) => void
 }): JSX.Element {
-  // The connection carries exactly ONE Thread's Agent-controls values — the
-  // connect-time `session/new` Thread (`connection.threadId`). Show the picker ONLY
-  // when the active Thread IS that primary one, so a sibling live Thread (New-thread
-  // / Continue) never displays the primary's Mode/Model as if they were its own (a
-  // trust-relevant lie, since Mode gates write-approval). Per-Thread sourcing +
-  // post-`session/load` population (so every live Thread gets its own correct
-  // controls) is the tracked follow-up; until then a non-primary Thread shows none.
-  const showControls = activeThread.id === connection.threadId
   return (
     <div className="workspace">
       {isLive ? (
@@ -67,9 +74,9 @@ export function ConnectedWorkspace({
             sessionId: seedSessionId,
             title: activeThread.title,
           }}
-          modes={showControls ? connection.modes : null}
-          models={showControls ? connection.models : null}
-          reasoningEffort={showControls ? connection.reasoningEffort : null}
+          modes={controls?.modes ?? null}
+          models={controls?.models ?? null}
+          reasoningEffort={controls?.reasoningEffort ?? null}
           onSetConfig={onSetConfig}
           onAuthExpired={onAuthExpired}
           onBound={onBound}

--- a/src/renderer/src/connection/connections.test.ts
+++ b/src/renderer/src/connection/connections.test.ts
@@ -3,7 +3,6 @@ import {
   agentIdOf,
   connectedWorkspaceIds,
   connectionsReducer,
-  currentConfigValue,
   initialConnections,
   selectedConnection,
   shouldConnect,
@@ -35,36 +34,6 @@ function connected(workspaceId: string, agentId: string): ConnectState {
     authMethods: AUTH_METHODS,
   }
   return { status: 'connected', thread }
-}
-
-/** A connected state carrying all three agent-control axes (#66), for set-config tests. */
-function connectedWithControls(workspaceId: string, agentId: string): ConnectState {
-  const base = connected(workspaceId, agentId)
-  if (base.status !== 'connected') throw new Error('unreachable')
-  return {
-    status: 'connected',
-    thread: {
-      ...base.thread,
-      modes: {
-        currentModeId: 'default',
-        availableModes: [
-          { id: 'default', name: 'Default' },
-          { id: 'plan', name: 'Plan' },
-        ],
-      },
-      models: {
-        currentModelId: 'mistral-medium-3.5',
-        availableModels: [
-          { modelId: 'mistral-medium-3.5', name: 'mistral-medium-3.5' },
-          { modelId: 'devstral-small', name: 'devstral-small' },
-        ],
-      },
-      reasoningEffort: {
-        current: 'high',
-        options: [{ value: 'low' }, { value: 'high' }, { value: 'max' }],
-      },
-    },
-  }
 }
 
 describe('connectionsReducer', () => {
@@ -113,80 +82,6 @@ describe('connectionsReducer', () => {
     // a connecting/idle Workspace has no agent yet, so an unrelated eviction is inert.
     const same = connectionsReducer(map, { type: 'evict', agentIds: new Set(['a-unknown']) })
     expect(same).toBe(map)
-  })
-})
-
-describe('connectionsReducer set-config (#66 optimistic agent-control change)', () => {
-  it('updates the current value for each axis, leaving the others untouched', () => {
-    const map: ConnectionMap = { w1: connectedWithControls('w1', 'a1') }
-
-    const mode = connectionsReducer(map, { type: 'set-config', workspaceId: 'w1', axis: 'mode', value: 'plan' })
-    const s1 = mode.w1
-    if (s1.status !== 'connected') throw new Error('expected connected')
-    expect(s1.thread.modes?.currentModeId).toBe('plan')
-    expect(s1.thread.models?.currentModelId).toBe('mistral-medium-3.5') // model untouched
-    expect(s1.thread.reasoningEffort?.current).toBe('high') // effort untouched
-
-    const model = connectionsReducer(map, { type: 'set-config', workspaceId: 'w1', axis: 'model', value: 'devstral-small' })
-    const s2 = model.w1
-    if (s2.status !== 'connected') throw new Error('expected connected')
-    expect(s2.thread.models?.currentModelId).toBe('devstral-small')
-
-    const effort = connectionsReducer(map, { type: 'set-config', workspaceId: 'w1', axis: 'reasoningEffort', value: 'max' })
-    const s3 = effort.w1
-    if (s3.status !== 'connected') throw new Error('expected connected')
-    expect(s3.thread.reasoningEffort?.current).toBe('max')
-  })
-
-  it('reverts cleanly by re-dispatching the prior value (ADR-0007 revert)', () => {
-    const map: ConnectionMap = { w1: connectedWithControls('w1', 'a1') }
-    const optimistic = connectionsReducer(map, { type: 'set-config', workspaceId: 'w1', axis: 'mode', value: 'plan' })
-    const reverted = connectionsReducer(optimistic, { type: 'set-config', workspaceId: 'w1', axis: 'mode', value: 'default' })
-    const s = reverted.w1
-    if (s.status !== 'connected') throw new Error('expected connected')
-    expect(s.thread.modes?.currentModeId).toBe('default')
-  })
-
-  it('does not mutate the input state', () => {
-    const before = connectedWithControls('w1', 'a1')
-    const map: ConnectionMap = { w1: before }
-    connectionsReducer(map, { type: 'set-config', workspaceId: 'w1', axis: 'mode', value: 'plan' })
-    if (before.status !== 'connected') throw new Error('expected connected')
-    expect(before.thread.modes?.currentModeId).toBe('default') // original object unchanged
-  })
-
-  it('is a no-op (same ref) when the value is already current', () => {
-    const map: ConnectionMap = { w1: connectedWithControls('w1', 'a1') }
-    const same = connectionsReducer(map, { type: 'set-config', workspaceId: 'w1', axis: 'mode', value: 'default' })
-    expect(same).toBe(map)
-  })
-
-  it('is a no-op (same ref) when the Workspace is not connected or absent', () => {
-    const map: ConnectionMap = {
-      w1: { status: 'connecting', workspaceDir: '/proj/w1' },
-    }
-    expect(connectionsReducer(map, { type: 'set-config', workspaceId: 'w1', axis: 'mode', value: 'plan' })).toBe(map)
-    expect(connectionsReducer(map, { type: 'set-config', workspaceId: 'absent', axis: 'mode', value: 'plan' })).toBe(map)
-  })
-
-  it('is a no-op (same ref) when the axis is not advertised (null modes/models/effort)', () => {
-    const map: ConnectionMap = { w1: connected('w1', 'a1') } // all axes null
-    expect(connectionsReducer(map, { type: 'set-config', workspaceId: 'w1', axis: 'model', value: 'x' })).toBe(map)
-  })
-})
-
-describe('currentConfigValue (#66)', () => {
-  it('reads the current value per axis, null when unadvertised', () => {
-    const withControls = connectedWithControls('w1', 'a1')
-    if (withControls.status !== 'connected') throw new Error('expected connected')
-    expect(currentConfigValue(withControls.thread, 'mode')).toBe('default')
-    expect(currentConfigValue(withControls.thread, 'model')).toBe('mistral-medium-3.5')
-    expect(currentConfigValue(withControls.thread, 'reasoningEffort')).toBe('high')
-
-    const bare = connected('w1', 'a1')
-    if (bare.status !== 'connected') throw new Error('expected connected')
-    expect(currentConfigValue(bare.thread, 'mode')).toBeNull()
-    expect(currentConfigValue(bare.thread, 'reasoningEffort')).toBeNull()
   })
 })
 

--- a/src/renderer/src/connection/connections.ts
+++ b/src/renderer/src/connection/connections.ts
@@ -1,4 +1,3 @@
-import type { ThreadConfigAxis, ThreadConnection } from '../../../shared/ipc'
 import type { ConnectState } from './routing'
 
 /**
@@ -16,10 +15,6 @@ export type ConnectionAction =
   | { type: 'set'; workspaceId: string; state: ConnectState }
   | { type: 'clear'; workspaceId: string }
   | { type: 'evict'; agentIds: ReadonlySet<string> }
-  // Optimistically reflect an agent-control change (#66, ADR-0007): a change emits
-  // no notification, so the renderer updates the displayed current value the instant
-  // the user picks, then reverts (re-dispatching the prior value) on an IPC failure.
-  | { type: 'set-config'; workspaceId: string; axis: ThreadConfigAxis; value: string }
 
 export const initialConnections: ConnectionMap = {}
 
@@ -47,54 +42,6 @@ export function connectionsReducer(state: ConnectionMap, action: ConnectionActio
       for (const id of doomed) delete next[id]
       return next
     }
-    case 'set-config': {
-      // Only a connected Workspace carries the live current values; a transient
-      // (connecting / not-signed-in / error / absent) one has no controls to update,
-      // so the action is inert (same ref). `applyConfig` also returns the SAME thread
-      // ref when the axis has no options or the value is unchanged — so a redundant
-      // pick (or a revert to the value already shown) drives no re-render.
-      const current = state[action.workspaceId]
-      if (!current || current.status !== 'connected') return state
-      const nextThread = applyConfig(current.thread, action.axis, action.value)
-      if (nextThread === current.thread) return state
-      return { ...state, [action.workspaceId]: { status: 'connected', thread: nextThread } }
-    }
-  }
-}
-
-/**
- * Return a connection's CURRENT value for an agent-control axis (#66), or null when
- * the axis isn't advertised. App reads this BEFORE an optimistic `set-config` so it
- * can revert to the prior value if the IPC change fails (ADR-0007).
- */
-export function currentConfigValue(thread: ThreadConnection, axis: ThreadConfigAxis): string | null {
-  switch (axis) {
-    case 'mode':
-      return thread.modes?.currentModeId ?? null
-    case 'model':
-      return thread.models?.currentModelId ?? null
-    case 'reasoningEffort':
-      return thread.reasoningEffort?.current ?? null
-  }
-}
-
-/**
- * Apply an agent-control change to a connection's current value (#66), returning a
- * NEW `ThreadConnection` with only the targeted nested current updated — or the SAME
- * ref when the axis isn't advertised (null) or the value is already current, so a
- * no-op pick can't churn the reducer.
- */
-function applyConfig(thread: ThreadConnection, axis: ThreadConfigAxis, value: string): ThreadConnection {
-  switch (axis) {
-    case 'mode':
-      if (!thread.modes || thread.modes.currentModeId === value) return thread
-      return { ...thread, modes: { ...thread.modes, currentModeId: value } }
-    case 'model':
-      if (!thread.models || thread.models.currentModelId === value) return thread
-      return { ...thread, models: { ...thread.models, currentModelId: value } }
-    case 'reasoningEffort':
-      if (!thread.reasoningEffort || thread.reasoningEffort.current === value) return thread
-      return { ...thread, reasoningEffort: { ...thread.reasoningEffort, current: value } }
   }
 }
 

--- a/src/renderer/src/connection/workspace-threads.test.ts
+++ b/src/renderer/src/connection/workspace-threads.test.ts
@@ -1,16 +1,44 @@
 import { describe, it, expect } from 'vitest'
 import {
+  configFor,
+  currentConfigValue,
   initialWorkspaceThreads,
   workspaceThreadsReducer,
   workspaceThreadStateFor,
   type WorkspaceThreadsState,
 } from './workspace-threads'
+import type { ThreadAgentControls } from '../../../shared/ipc'
 
 /**
  * Per-Workspace, per-session Thread state lifted out of ConnectedWorkspace (TB3
- * #48): the live set, bound sessions, and the active (kept-mounted) Thread, keyed
- * by Workspace so several warm Workspaces coexist. Pure reducer + derivation.
+ * #48): the live set, bound sessions, the active (kept-mounted) Thread, and (TB #70)
+ * each live Thread's OWN agent-controls — keyed by Workspace so several warm
+ * Workspaces coexist. Pure reducer + derivations.
  */
+
+/** A full agent-controls bundle for the per-Thread config tests (#70). */
+function controls(modeId = 'default', modelId = 'mistral-medium-3.5', effort = 'high'): ThreadAgentControls {
+  return {
+    modes: {
+      currentModeId: modeId,
+      availableModes: [
+        { id: 'default', name: 'Default' },
+        { id: 'plan', name: 'Plan' },
+      ],
+    },
+    models: {
+      currentModelId: modelId,
+      availableModels: [
+        { modelId: 'mistral-medium-3.5', name: 'mistral-medium-3.5' },
+        { modelId: 'devstral-small', name: 'devstral-small' },
+      ],
+    },
+    reasoningEffort: {
+      current: effort,
+      options: [{ value: 'low' }, { value: 'high' }, { value: 'max' }],
+    },
+  }
+}
 
 describe('workspaceThreadsReducer', () => {
   it('connect seeds the live set + active with the auto-opened Thread', () => {
@@ -19,6 +47,7 @@ describe('workspaceThreadsReducer', () => {
       workspaceId: 'w1',
       threadId: 't-open',
       sessionId: 's1',
+      controls: null,
     })
     expect([...s.w1.live]).toEqual(['t-open'])
     expect(s.w1.bound).toEqual({ 't-open': 's1' })
@@ -31,6 +60,7 @@ describe('workspaceThreadsReducer', () => {
       workspaceId: 'w1',
       threadId: 't-cont',
       sessionId: null,
+      controls: null,
     })
     expect(s.w1.bound).toEqual({})
     expect([...s.w1.live]).toEqual(['t-cont'])
@@ -42,9 +72,10 @@ describe('workspaceThreadsReducer', () => {
       workspaceId: 'w1',
       threadId: 't-open',
       sessionId: 's1',
+      controls: null,
     })
     s = workspaceThreadsReducer(s, { type: 'open', workspaceId: 'w1', threadId: 'draft' })
-    s = workspaceThreadsReducer(s, { type: 'connect', workspaceId: 'w1', threadId: 't-new', sessionId: 's2' })
+    s = workspaceThreadsReducer(s, { type: 'connect', workspaceId: 'w1', threadId: 't-new', sessionId: 's2', controls: null })
     expect([...s.w1.live]).toEqual(['t-new']) // 'draft' gone with the old agent
     expect(s.w1.active).toBe('t-new')
   })
@@ -55,6 +86,7 @@ describe('workspaceThreadsReducer', () => {
       workspaceId: 'w1',
       threadId: 't-open',
       sessionId: null,
+      controls: null,
     })
     s = workspaceThreadsReducer(s, { type: 'open', workspaceId: 'w1', threadId: 'draft' })
     expect([...s.w1.live].sort()).toEqual(['draft', 't-open'])
@@ -76,6 +108,7 @@ describe('workspaceThreadsReducer', () => {
       workspaceId: 'w1',
       threadId: 't-open',
       sessionId: null,
+      controls: null,
     })
     s = workspaceThreadsReducer(s, { type: 'open', workspaceId: 'w1', threadId: 'draft' })
     s = workspaceThreadsReducer(s, { type: 'select', workspaceId: 'w1', threadId: 't-open' })
@@ -89,6 +122,7 @@ describe('workspaceThreadsReducer', () => {
       workspaceId: 'w1',
       threadId: 't-open',
       sessionId: null,
+      controls: null,
     })
     expect(workspaceThreadsReducer(s, { type: 'select', workspaceId: 'w1', threadId: 't-open' })).toBe(s)
   })
@@ -99,20 +133,24 @@ describe('workspaceThreadsReducer', () => {
       workspaceId: 'w1',
       threadId: 't-open',
       sessionId: null,
+      controls: null,
     })
     s = workspaceThreadsReducer(s, { type: 'open', workspaceId: 'w1', threadId: 'draft' })
-    s = workspaceThreadsReducer(s, { type: 'bind', workspaceId: 'w1', threadId: 'draft', sessionId: 'sD' })
+    s = workspaceThreadsReducer(s, { type: 'bind', workspaceId: 'w1', threadId: 'draft', sessionId: 'sD', controls: null })
     expect(s.w1.bound).toEqual({ draft: 'sD' })
   })
 
-  it('bind with an unchanged session returns the same state reference', () => {
+  it('bind with an unchanged session AND null controls returns the same state reference', () => {
     const s = workspaceThreadsReducer(initialWorkspaceThreads, {
       type: 'connect',
       workspaceId: 'w1',
       threadId: 't-open',
       sessionId: 's1',
+      controls: null,
     })
-    expect(workspaceThreadsReducer(s, { type: 'bind', workspaceId: 'w1', threadId: 't-open', sessionId: 's1' })).toBe(s)
+    expect(
+      workspaceThreadsReducer(s, { type: 'bind', workspaceId: 'w1', threadId: 't-open', sessionId: 's1', controls: null }),
+    ).toBe(s)
   })
 
   it('remove drops a live Thread + its bound session (delete teardown)', () => {
@@ -121,9 +159,10 @@ describe('workspaceThreadsReducer', () => {
       workspaceId: 'w1',
       threadId: 't-open',
       sessionId: 's1',
+      controls: null,
     })
     s = workspaceThreadsReducer(s, { type: 'open', workspaceId: 'w1', threadId: 'draft' })
-    s = workspaceThreadsReducer(s, { type: 'bind', workspaceId: 'w1', threadId: 'draft', sessionId: 'sD' })
+    s = workspaceThreadsReducer(s, { type: 'bind', workspaceId: 'w1', threadId: 'draft', sessionId: 'sD', controls: null })
     s = workspaceThreadsReducer(s, { type: 'remove', workspaceId: 'w1', threadId: 'draft' })
     expect([...s.w1.live]).toEqual(['t-open'])
     expect(s.w1.bound).toEqual({ 't-open': 's1' })
@@ -135,6 +174,7 @@ describe('workspaceThreadsReducer', () => {
       workspaceId: 'w1',
       threadId: 't-open',
       sessionId: null,
+      controls: null,
     })
     expect(workspaceThreadsReducer(s, { type: 'remove', workspaceId: 'w1', threadId: 'cold' })).toBe(s)
   })
@@ -145,16 +185,184 @@ describe('workspaceThreadsReducer', () => {
       workspaceId: 'w1',
       threadId: 't1',
       sessionId: null,
+      controls: null,
     })
-    s = workspaceThreadsReducer(s, { type: 'connect', workspaceId: 'w2', threadId: 't2', sessionId: null })
+    s = workspaceThreadsReducer(s, { type: 'connect', workspaceId: 'w2', threadId: 't2', sessionId: null, controls: null })
     expect(Object.keys(s).sort()).toEqual(['w1', 'w2'])
     expect(s.w1.active).toBe('t1')
   })
 })
 
+describe('per-Thread agent-controls config (#70)', () => {
+  it('connect seeds config for the primary Thread (none when controls are null)', () => {
+    const withControls = workspaceThreadsReducer(initialWorkspaceThreads, {
+      type: 'connect',
+      workspaceId: 'w1',
+      threadId: 't-open',
+      sessionId: 's1',
+      controls: controls('plan'),
+    })
+    expect(withControls.w1.config['t-open']?.modes?.currentModeId).toBe('plan')
+
+    const without = workspaceThreadsReducer(initialWorkspaceThreads, {
+      type: 'connect',
+      workspaceId: 'w1',
+      threadId: 't-open',
+      sessionId: 's1',
+      controls: null,
+    })
+    expect(without.w1.config).toEqual({})
+  })
+
+  it('bind seeds the bound Thread its OWN config without touching the primary', () => {
+    let s = workspaceThreadsReducer(initialWorkspaceThreads, {
+      type: 'connect',
+      workspaceId: 'w1',
+      threadId: 't-open',
+      sessionId: 's1',
+      controls: controls('default'),
+    })
+    s = workspaceThreadsReducer(s, { type: 'open', workspaceId: 'w1', threadId: 'draft' })
+    s = workspaceThreadsReducer(s, {
+      type: 'bind',
+      workspaceId: 'w1',
+      threadId: 'draft',
+      sessionId: 'sD',
+      controls: controls('plan', 'devstral-small'),
+    })
+    expect(s.w1.config['draft']?.modes?.currentModeId).toBe('plan')
+    expect(s.w1.config['draft']?.models?.currentModelId).toBe('devstral-small')
+    // The primary Thread's controls are untouched — per-Thread isolation.
+    expect(s.w1.config['t-open']?.modes?.currentModeId).toBe('default')
+    expect(s.w1.config['t-open']?.models?.currentModelId).toBe('mistral-medium-3.5')
+  })
+
+  it('bind with null controls leaves an existing entry (no clobber), updating only the session', () => {
+    let s = workspaceThreadsReducer(initialWorkspaceThreads, {
+      type: 'connect',
+      workspaceId: 'w1',
+      threadId: 't-open',
+      sessionId: null,
+      controls: controls('plan'),
+    })
+    s = workspaceThreadsReducer(s, { type: 'bind', workspaceId: 'w1', threadId: 't-open', sessionId: 's1', controls: null })
+    expect(s.w1.bound['t-open']).toBe('s1')
+    expect(s.w1.config['t-open']?.modes?.currentModeId).toBe('plan') // kept
+  })
+
+  it('bind delivers controls even when the session is unchanged (resumed Thread)', () => {
+    // A continued Thread: connect seeds the cursor; its first prompt resumes the
+    // SAME session and `thread:bound` brings the resumed config — the same-session
+    // path must still seed config (it no longer short-circuits before that).
+    let s = workspaceThreadsReducer(initialWorkspaceThreads, {
+      type: 'connect',
+      workspaceId: 'w1',
+      threadId: 't-cont',
+      sessionId: 'cursor',
+      controls: null,
+    })
+    s = workspaceThreadsReducer(s, {
+      type: 'bind',
+      workspaceId: 'w1',
+      threadId: 't-cont',
+      sessionId: 'cursor',
+      controls: controls('default'),
+    })
+    expect(s.w1.config['t-cont']?.modes?.currentModeId).toBe('default')
+  })
+
+  it('set-config optimistically updates one axis for one Thread, leaving siblings + axes untouched', () => {
+    let s = workspaceThreadsReducer(initialWorkspaceThreads, {
+      type: 'connect',
+      workspaceId: 'w1',
+      threadId: 't-open',
+      sessionId: 's1',
+      controls: controls('default'),
+    })
+    s = workspaceThreadsReducer(s, { type: 'open', workspaceId: 'w1', threadId: 'draft' })
+    s = workspaceThreadsReducer(s, {
+      type: 'bind',
+      workspaceId: 'w1',
+      threadId: 'draft',
+      sessionId: 'sD',
+      controls: controls('default'),
+    })
+    s = workspaceThreadsReducer(s, { type: 'set-config', workspaceId: 'w1', threadId: 'draft', axis: 'mode', value: 'plan' })
+    expect(s.w1.config['draft']?.modes?.currentModeId).toBe('plan')
+    expect(s.w1.config['draft']?.models?.currentModelId).toBe('mistral-medium-3.5') // axis untouched
+    expect(s.w1.config['t-open']?.modes?.currentModeId).toBe('default') // sibling untouched
+  })
+
+  it('set-config reverts cleanly by re-dispatching the prior value (ADR-0007 revert)', () => {
+    const s = workspaceThreadsReducer(initialWorkspaceThreads, {
+      type: 'connect',
+      workspaceId: 'w1',
+      threadId: 't-open',
+      sessionId: 's1',
+      controls: controls('default'),
+    })
+    const optimistic = workspaceThreadsReducer(s, { type: 'set-config', workspaceId: 'w1', threadId: 't-open', axis: 'mode', value: 'plan' })
+    const reverted = workspaceThreadsReducer(optimistic, { type: 'set-config', workspaceId: 'w1', threadId: 't-open', axis: 'mode', value: 'default' })
+    expect(reverted.w1.config['t-open']?.modes?.currentModeId).toBe('default')
+  })
+
+  it('set-config does not mutate the input state', () => {
+    const before = workspaceThreadsReducer(initialWorkspaceThreads, {
+      type: 'connect',
+      workspaceId: 'w1',
+      threadId: 't-open',
+      sessionId: 's1',
+      controls: controls('default'),
+    })
+    workspaceThreadsReducer(before, { type: 'set-config', workspaceId: 'w1', threadId: 't-open', axis: 'mode', value: 'plan' })
+    expect(before.w1.config['t-open']?.modes?.currentModeId).toBe('default')
+  })
+
+  it('set-config is a no-op (same ref) for an unchanged value, missing axis, missing Thread, or missing Workspace', () => {
+    const s = workspaceThreadsReducer(initialWorkspaceThreads, {
+      type: 'connect',
+      workspaceId: 'w1',
+      threadId: 't-open',
+      sessionId: 's1',
+      controls: controls('default'),
+    })
+    // unchanged value
+    expect(workspaceThreadsReducer(s, { type: 'set-config', workspaceId: 'w1', threadId: 't-open', axis: 'mode', value: 'default' })).toBe(s)
+    // a Thread with no seeded config
+    expect(workspaceThreadsReducer(s, { type: 'set-config', workspaceId: 'w1', threadId: 'no-config', axis: 'mode', value: 'plan' })).toBe(s)
+    // an absent Workspace
+    expect(workspaceThreadsReducer(s, { type: 'set-config', workspaceId: 'absent', threadId: 't-open', axis: 'mode', value: 'plan' })).toBe(s)
+
+    // an unadvertised axis (null modes/models/effort)
+    const bare = workspaceThreadsReducer(initialWorkspaceThreads, {
+      type: 'connect',
+      workspaceId: 'w1',
+      threadId: 't-open',
+      sessionId: 's1',
+      controls: { modes: null, models: null, reasoningEffort: null },
+    })
+    expect(workspaceThreadsReducer(bare, { type: 'set-config', workspaceId: 'w1', threadId: 't-open', axis: 'model', value: 'x' })).toBe(bare)
+  })
+
+  it('remove drops a Thread config entry too', () => {
+    let s = workspaceThreadsReducer(initialWorkspaceThreads, {
+      type: 'connect',
+      workspaceId: 'w1',
+      threadId: 't-open',
+      sessionId: 's1',
+      controls: controls('default'),
+    })
+    s = workspaceThreadsReducer(s, { type: 'open', workspaceId: 'w1', threadId: 'draft' })
+    s = workspaceThreadsReducer(s, { type: 'bind', workspaceId: 'w1', threadId: 'draft', sessionId: 'sD', controls: controls('plan') })
+    s = workspaceThreadsReducer(s, { type: 'remove', workspaceId: 'w1', threadId: 'draft' })
+    expect(s.w1.config['draft']).toBeUndefined()
+    expect(s.w1.config['t-open']?.modes?.currentModeId).toBe('default') // primary kept
+  })
+})
+
 describe('workspaceThreadStateFor', () => {
   const state: WorkspaceThreadsState = {
-    w1: { live: new Set(['t1']), bound: {}, active: 't1' },
+    w1: { live: new Set(['t1']), bound: {}, active: 't1', config: {} },
   }
   it('returns a Workspace live-state', () => {
     expect(workspaceThreadStateFor(state, 'w1')?.active).toBe('t1')
@@ -162,5 +370,49 @@ describe('workspaceThreadStateFor', () => {
   it('returns null for an unconnected or unselected Workspace', () => {
     expect(workspaceThreadStateFor(state, 'w2')).toBeNull()
     expect(workspaceThreadStateFor(state, null)).toBeNull()
+  })
+})
+
+describe('configFor (#70)', () => {
+  const state = workspaceThreadsReducer(initialWorkspaceThreads, {
+    type: 'connect',
+    workspaceId: 'w1',
+    threadId: 't-open',
+    sessionId: 's1',
+    controls: controls('plan'),
+  })
+  it('returns a Thread its own controls', () => {
+    expect(configFor(state, 'w1', 't-open')?.modes?.currentModeId).toBe('plan')
+  })
+  it('returns null for a Thread with no seeded config, an absent Workspace, or null workspaceId', () => {
+    expect(configFor(state, 'w1', 'no-config')).toBeNull()
+    expect(configFor(state, 'absent', 't-open')).toBeNull()
+    expect(configFor(state, null, 't-open')).toBeNull()
+  })
+})
+
+describe('currentConfigValue (#70)', () => {
+  const state = workspaceThreadsReducer(initialWorkspaceThreads, {
+    type: 'connect',
+    workspaceId: 'w1',
+    threadId: 't-open',
+    sessionId: 's1',
+    controls: controls('default', 'devstral-small', 'max'),
+  })
+  it('reads the current value per axis', () => {
+    expect(currentConfigValue(state, 'w1', 't-open', 'mode')).toBe('default')
+    expect(currentConfigValue(state, 'w1', 't-open', 'model')).toBe('devstral-small')
+    expect(currentConfigValue(state, 'w1', 't-open', 'reasoningEffort')).toBe('max')
+  })
+  it('returns null when no controls are seeded, or the axis is unadvertised', () => {
+    expect(currentConfigValue(state, 'w1', 'no-config', 'mode')).toBeNull()
+    const bare = workspaceThreadsReducer(initialWorkspaceThreads, {
+      type: 'connect',
+      workspaceId: 'w1',
+      threadId: 't-open',
+      sessionId: 's1',
+      controls: { modes: null, models: null, reasoningEffort: null },
+    })
+    expect(currentConfigValue(bare, 'w1', 't-open', 'mode')).toBeNull()
   })
 })

--- a/src/renderer/src/connection/workspace-threads.ts
+++ b/src/renderer/src/connection/workspace-threads.ts
@@ -1,3 +1,5 @@
+import type { ThreadAgentControls, ThreadConfigAxis } from '../../../shared/ipc'
+
 /**
  * Per-Workspace, per-session Thread state (ADR-0006, TB3 #48) — lifted OUT of
  * `ConnectedWorkspace` so the sidebar (and the nav reducer) is the single source
@@ -14,6 +16,12 @@
  * - `active`: the Thread this Workspace is currently showing. Lifted so a
  *   BACKGROUND (hidden) Workspace keeps its in-flight Thread mounted/streaming
  *   while the user looks elsewhere — the keep-mounted outlet renders `active`.
+ * - `config`: each live Thread's OWN agent-controls (#70), keyed by `threadId`.
+ *   The home migrated here from the single connect-time `ThreadConnection` (#66
+ *   sourced ALL Threads' picker from one Thread's values) — seeded per Thread on
+ *   `connect` (the primary) and `bind` (drafts/continued), and updated
+ *   OPTIMISTICALLY per Thread on a `set-config` (a change emits no notification,
+ *   ADR-0007). So EVERY live Thread shows + changes its own Mode/Model/effort.
  *
  * A pure reducer + derivation (no React, no IPC), like the nav/connection reducers.
  */
@@ -21,6 +29,7 @@ export interface WorkspaceThreadState {
   live: ReadonlySet<string>
   bound: Readonly<Record<string, string>>
   active: string
+  config: Readonly<Record<string, ThreadAgentControls>>
 }
 
 export type WorkspaceThreadsState = Readonly<Record<string, WorkspaceThreadState>>
@@ -28,16 +37,37 @@ export type WorkspaceThreadsState = Readonly<Record<string, WorkspaceThreadState
 export type WorkspaceThreadsAction =
   // A Workspace (re)connected: reset its live-state to the agent's auto-opened
   // Thread. Fired once per connection — a reconnect (new agent) deliberately drops
-  // the prior session's drafts (their sessions died with the old process).
-  | { type: 'connect'; workspaceId: string; threadId: string; sessionId: string | null }
+  // the prior session's drafts (their sessions died with the old process). Carries
+  // the connect-time Thread's controls (#70) so its picker is seeded up front.
+  | {
+      type: 'connect'
+      workspaceId: string
+      threadId: string
+      sessionId: string | null
+      controls: ThreadAgentControls | null
+    }
   // A draft was minted or a cold Thread continued: host it live and make it active.
   | { type: 'open'; workspaceId: string; threadId: string }
   // Switch which Thread the Workspace is showing (kept mounted when backgrounded).
   | { type: 'select'; workspaceId: string; threadId: string }
-  // A draft's first prompt bound its session (`thread:bound`) — record it.
-  | { type: 'bind'; workspaceId: string; threadId: string; sessionId: string }
-  // A live Thread was deleted (TB6): drop it from the live set + its bound session.
+  // A draft's first prompt bound its session (`thread:bound`) — record it, and seed
+  // THIS Thread's controls (#70) from the bind payload (null on a reuse — keep what's
+  // there, don't clobber with null).
+  | {
+      type: 'bind'
+      workspaceId: string
+      threadId: string
+      sessionId: string
+      controls: ThreadAgentControls | null
+    }
+  // A live Thread was deleted (TB6): drop it from the live set + its bound session
+  // + its config entry.
   | { type: 'remove'; workspaceId: string; threadId: string }
+  // Optimistically reflect a per-Thread agent-control change (#70, ADR-0007): a
+  // change emits no notification, so the renderer updates THIS Thread's displayed
+  // current value the instant the user picks, then reverts (re-dispatching the prior
+  // value) on an IPC failure. Keyed by `threadId` so a sibling Thread is untouched.
+  | { type: 'set-config'; workspaceId: string; threadId: string; axis: ThreadConfigAxis; value: string }
 
 export const initialWorkspaceThreads: WorkspaceThreadsState = {}
 
@@ -53,6 +83,7 @@ export function workspaceThreadsReducer(
           live: new Set([action.threadId]),
           bound: action.sessionId ? { [action.threadId]: action.sessionId } : {},
           active: action.threadId,
+          config: action.controls ? { [action.threadId]: action.controls } : {},
         },
       }
     case 'open': {
@@ -69,12 +100,20 @@ export function workspaceThreadsReducer(
     }
     case 'bind': {
       const cur = state[action.workspaceId]
-      if (!cur || cur.bound[action.threadId] === action.sessionId) return state
+      if (!cur) return state
+      const boundUnchanged = cur.bound[action.threadId] === action.sessionId
+      // Seed this Thread's controls (#70) from the bind payload; a null payload
+      // (reuse — no fresh result) leaves any existing entry untouched (no clobber).
+      const config = action.controls
+        ? { ...cur.config, [action.threadId]: action.controls }
+        : cur.config
+      if (boundUnchanged && config === cur.config) return state
       return {
         ...state,
         [action.workspaceId]: {
           ...cur,
-          bound: { ...cur.bound, [action.threadId]: action.sessionId },
+          bound: boundUnchanged ? cur.bound : { ...cur.bound, [action.threadId]: action.sessionId },
+          config,
         },
       }
     }
@@ -85,10 +124,52 @@ export function workspaceThreadsReducer(
       live.delete(action.threadId)
       const bound = { ...cur.bound }
       delete bound[action.threadId]
+      const config = { ...cur.config }
+      delete config[action.threadId]
       // `active` is left to the caller: deleting the active Thread is paired with a
       // `select` back to the connection's primary Thread (which is never deletable).
-      return { ...state, [action.workspaceId]: { ...cur, live, bound } }
+      return { ...state, [action.workspaceId]: { ...cur, live, bound, config } }
     }
+    case 'set-config': {
+      // Optimistic per-Thread update (#70, ADR-0007). Same-ref-on-noop discipline:
+      // no Workspace, no config entry for the Thread, an unadvertised axis, or an
+      // unchanged value all return the SAME ref so a redundant pick (or a revert to
+      // the value already shown) drives no re-render. Sibling Threads are untouched.
+      const cur = state[action.workspaceId]
+      const controls = cur?.config[action.threadId]
+      if (!cur || !controls) return state
+      const next = applyConfig(controls, action.axis, action.value)
+      if (next === controls) return state
+      return {
+        ...state,
+        [action.workspaceId]: { ...cur, config: { ...cur.config, [action.threadId]: next } },
+      }
+    }
+  }
+}
+
+/**
+ * Apply an agent-control change to a Thread's controls bundle (#70), returning a
+ * NEW `ThreadAgentControls` with only the targeted nested current updated — or the
+ * SAME ref when the axis isn't advertised (null) or the value is already current, so
+ * a no-op pick can't churn the reducer. (Migrated from the per-Workspace #66 home in
+ * `connections.ts`, now keyed per Thread.)
+ */
+function applyConfig(
+  controls: ThreadAgentControls,
+  axis: ThreadConfigAxis,
+  value: string,
+): ThreadAgentControls {
+  switch (axis) {
+    case 'mode':
+      if (!controls.modes || controls.modes.currentModeId === value) return controls
+      return { ...controls, modes: { ...controls.modes, currentModeId: value } }
+    case 'model':
+      if (!controls.models || controls.models.currentModelId === value) return controls
+      return { ...controls, models: { ...controls.models, currentModelId: value } }
+    case 'reasoningEffort':
+      if (!controls.reasoningEffort || controls.reasoningEffort.current === value) return controls
+      return { ...controls, reasoningEffort: { ...controls.reasoningEffort, current: value } }
   }
 }
 
@@ -99,4 +180,42 @@ export function workspaceThreadStateFor(
 ): WorkspaceThreadState | null {
   if (!workspaceId) return null
   return state[workspaceId] ?? null
+}
+
+/**
+ * One live Thread's agent-controls (#70), or null when none are seeded for it yet —
+ * a Thread whose session hasn't bound (a never-prompted draft), or a reopened Thread
+ * before its first prompt resumes. App feeds this to the active Thread's picker so it
+ * sources its OWN Mode/Model/effort.
+ */
+export function configFor(
+  state: WorkspaceThreadsState,
+  workspaceId: string | null,
+  threadId: string,
+): ThreadAgentControls | null {
+  if (!workspaceId) return null
+  return state[workspaceId]?.config[threadId] ?? null
+}
+
+/**
+ * A Thread's CURRENT value for an agent-control axis (#70), or null when the axis
+ * isn't advertised (or no controls are seeded). App reads this BEFORE an optimistic
+ * `set-config` so it can revert to the prior value if the IPC change fails (ADR-0007).
+ */
+export function currentConfigValue(
+  state: WorkspaceThreadsState,
+  workspaceId: string,
+  threadId: string,
+  axis: ThreadConfigAxis,
+): string | null {
+  const controls = state[workspaceId]?.config[threadId]
+  if (!controls) return null
+  switch (axis) {
+    case 'mode':
+      return controls.modes?.currentModeId ?? null
+    case 'model':
+      return controls.models?.currentModelId ?? null
+    case 'reasoningEffort':
+      return controls.reasoningEffort?.current ?? null
+  }
 }

--- a/src/renderer/src/conversation/Conversation.tsx
+++ b/src/renderer/src/conversation/Conversation.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useReducer, useRef, useState, type JSX, type KeyboardEvent } from 'react'
 import type {
   AuthMethod,
+  ThreadAgentControls,
   ThreadConfigAxis,
   ThreadModes,
   ThreadModels,
@@ -79,8 +80,11 @@ export function Conversation({
   /** Mid-session expiry (-32000): route to in-place re-auth with these methods. */
   onAuthExpired: (authMethods: AuthMethod[]) => void
   /** The Thread's session once bound (TB5) — lifts it so a switch-away-and-back
-   *  re-seeds the bound session instead of re-minting it. */
-  onBound?: (sessionId: string) => void
+   *  re-seeds the bound session instead of re-minting it. Carries the session's
+   *  agent-controls (#70) from `thread:bound` so App seeds THIS Thread's picker;
+   *  null on the `sendPrompt`-result path (the result carries no controls — the
+   *  `thread:bound` that fired ahead of the stream already delivered them). */
+  onBound?: (sessionId: string, controls: ThreadAgentControls | null) => void
 }): JSX.Element {
   const [state, dispatch] = useReducer(conversationReducer, initialConversationState)
   // The composer's unsent text, persisted per-Thread to localStorage (#60) so it
@@ -134,7 +138,7 @@ export function Conversation({
       if (e.threadId !== thread.threadId) return
       boundRef.current = e.sessionId
       setBoundSessionId(e.sessionId)
-      onBoundRef.current?.(e.sessionId)
+      onBoundRef.current?.(e.sessionId, e.controls)
       // A re-bind (TB4 #33): the agent couldn't resume this reopened Thread, so
       // main minted a fresh session. Weave the honest "context reset" notice in
       // NOW — main emits `thread:bound` before the prompt streams, so it lands
@@ -183,7 +187,9 @@ export function Conversation({
         // already set this for a fresh draft; this also covers the no-store path.
         boundRef.current = result.sessionId
         setBoundSessionId(result.sessionId)
-        onBound?.(result.sessionId)
+        // The result carries no controls — `thread:bound` (emitted ahead of the
+        // stream) already delivered them for a fresh mint/resume; pass null here.
+        onBound?.(result.sessionId, null)
       } else if (result.kind === 'not-signed-in') {
         // Mid-session expiry: route to in-place re-auth (the agent stays alive).
         onAuthExpired(result.authMethods)

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -154,6 +154,20 @@ export interface ThreadReasoningEffort {
   options: { value: string; name?: string }[]
 }
 
+/**
+ * A Thread's full agent-controls bundle (#66 axes, #70 per-Thread): the current
+ * values + options for Mode / Model / Reasoning effort, as a session reports them
+ * from `session/new` (a fresh mint) or `session/load` (a resume). Each axis is null
+ * when the agent advertises none. Carried to the renderer on `thread:bound` so EVERY
+ * live Thread sources its OWN controls, keyed by its `threadId` — not the single
+ * connect-time Thread's values (the #66 limitation this removes).
+ */
+export interface ThreadAgentControls {
+  modes: ThreadModes | null
+  models: ThreadModels | null
+  reasoningEffort: ThreadReasoningEffort | null
+}
+
 /** A connected Thread, mapped onto the ACP `sessionId` from `session/new`. */
 export interface ThreadInfo {
   /** The ACP session id this Thread is bound to (debug-visible only). */
@@ -248,6 +262,14 @@ export interface ThreadBoundEvent {
    * one-time "agent context reset" notice; absent/false on a normal draft mint.
    */
   rebound?: boolean
+  /**
+   * The just-bound session's agent-controls (#70), so THIS Thread's picker sources
+   * its OWN Mode/Model/Reasoning effort rather than inheriting the connect-time
+   * Thread's. Non-null whenever the bind produced a fresh `session/new`/`session/load`
+   * result (mint, re-bind, or resume); null on a plain reuse of an already-hosted
+   * session (no fresh result — the renderer keeps whatever it already holds).
+   */
+  controls: ThreadAgentControls | null
 }
 
 /**


### PR DESCRIPTION
Closes #70 (the per-Thread sourcing part). Completes the #66 Agent-controls picker so **every live Thread shows + changes its OWN Mode / Model / Reasoning effort**, removing the #66 primary-Thread gate.

## What

- **Config home migrated** from the single per-Workspace `ThreadConnection` (#66 — one Thread's values for all, gated to the connect-time Thread) to **per-Thread state** in `connection/workspace-threads.ts`, keyed by `threadId`.
- **Plumbing**: a new `ThreadAgentControls {modes, models, reasoningEffort}` bundle flows `session/new`/`session/load` → `ensureBoundSession.controls` (`BoundSession`) → the `thread:bound` event → the renderer, which seeds per-Thread config on `connect` (the primary Thread) and `bind` (drafts / continued Threads).
- **Optimistic change** now keyed by `threadId` (revert on `{ok:false}`); a sibling Thread is never touched.
- **#66 gate removed** in `ConnectedWorkspace`; the picker reads the ACTIVE Thread's own config (`configFor`).
- `set-config`/`applyConfig`/`currentConfigValue` moved from `connections.ts` to `workspace-threads.ts`.

## One intentional behavioral change

`thread:bound` now also fires on a successful **resume** (`session/load`), not just mint/re-bind — so a reopened Thread's picker gets its own controls. `rebound` stays `false` on resume (no spurious context-reset notice), and the double-`onBound` (thread:bound carries controls; the sendPrompt result passes null) is absorbed by the `bind` reducer's **null-no-clobber**.

## Review + verification

Implementer → my independent gate re-run + full diff read → adversarial reviewer (verdict **SHIP**, no MUST/SHOULD-FIX). Gates green: lint / typecheck / build / **337 tests** (new per-Thread seeding/isolation/no-op-discipline suites; old connections set-config suites removed). Reviewer confirmed: resume-emit safe, double-onBound idempotent, strict per-Thread isolation, clean connections.ts removal, no regression to #33/#58/#60/#61.

## Deferred (tracked follow-up)

ADR-0007's **cache a non-default selection across a session loss + re-assert after `session/load`** — only mentioned in comments here, not implemented. Today a reopened Thread shows its resumed (default) config. The re-assert needs a cache that survives both agent eviction and the `connect`-reset, a narrow within-session edge; separate slice.

## Manual smoke still worth doing

Two live Threads with different Modes; switch between them and confirm each shows its own; change one and confirm the other is unaffected (couldn't drive a live agent headless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)