### PR TITLE
#72: cache + re-assert agent-control selection after session/load

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -488,11 +488,10 @@ async function runPromptTurn(
     // mint, a re-bind, OR a successful resume — so the Thread's picker sources its
     // OWN Mode/Model/effort from THIS session (the #66 single-Thread limitation this
     // removes). A plain reuse of an already-hosted session brings null controls and
-    // no re-emit (the renderer keeps what it holds). NOTE (deferred follow-up): we
-    // hand the renderer the session's REPORTED controls only; caching a user's prior
-    // non-default selection and re-asserting it after a `session/load` resume
-    // (ADR-0007) is a separate slice — today a reopened Thread shows its resumed
-    // (default) config, not the choice it last carried.
+    // no re-emit (the renderer keeps what it holds). We hand the renderer the
+    // session's REPORTED controls only; the renderer caches the user's prior
+    // non-default selection and RE-ASSERTS it after a `session/load` resume (#72,
+    // ADR-0007) — main stays oblivious to that within-session, renderer-only cache.
     if (bound.controls && !sender.isDestroyed()) {
       sender.send(IPC.threadBound, { threadId: args.threadId, sessionId, rebound, controls: bound.controls })
     }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -3,6 +3,7 @@ import type {
   AuthMethod,
   ListMetadataResult,
   StartThreadResult,
+  ThreadAgentControls,
   ThreadConfigAxis,
   ThreadConnection,
   ThreadMeta,
@@ -24,9 +25,12 @@ import {
   shouldConnect,
 } from './connection/connections'
 import {
+  boundConfigValue,
   configFor,
   currentConfigValue,
   initialWorkspaceThreads,
+  reassertions,
+  selectedFor,
   workspaceThreadsReducer,
   workspaceThreadStateFor,
   type WorkspaceThreadState,
@@ -102,6 +106,11 @@ export function App(): JSX.Element {
   // user has since switched away). Mirrors the latest rendered nav selection.
   const selectionRef = useRef<string | null>(nav.selectedWorkspaceId)
   selectionRef.current = nav.selectedWorkspaceId
+  // Latest workspace-threads, mirrored into a ref so the async `onBound` re-assert
+  // (#72) reads the CURRENT selection cache — its render-time closure is stale by the
+  // time a resume's `thread:bound` fires (mirrors `selectionRef` above).
+  const workspaceThreadsRef = useRef(workspaceThreads)
+  workspaceThreadsRef.current = workspaceThreads
 
   async function runDetect(): Promise<void> {
     setLoading(true)
@@ -163,9 +172,9 @@ export function App(): JSX.Element {
     if (state.status !== 'connected') return
     // Seed the connect-time (primary) Thread's controls per-Thread (#70) from the
     // connection's `session/new` values — every sibling Thread later seeds its own on
-    // `bind`. NOTE (deferred follow-up): caching a non-default selection across a
-    // session loss + re-asserting it after `session/load` (ADR-0007) is a separate
-    // slice; today a reopened/continued Thread shows its resumed (default) config.
+    // `bind`. A non-default selection lost to a session reset (re-warm / cold continue)
+    // is now re-asserted after the resume's `bind` via `reassertAfterResume` (#72), from
+    // the per-Thread `selected` cache that survives this `connect`-reset.
     wtDispatch({
       type: 'connect',
       workspaceId,
@@ -215,10 +224,46 @@ export function App(): JSX.Element {
     if (prev === value) return // already current — no optimistic churn, no IPC round-trip
     wtDispatch({ type: 'set-config', workspaceId, threadId, axis, value })
     void window.api.setThreadConfig({ agentId, sessionId, axis, value }).then((res) => {
-      if (res.ok) return
+      if (res.ok) {
+        // Remember the CONFIRMED pick (#72) so a later resume (re-warm / cold continue)
+        // re-asserts it — Vibe resets Mode to `default` on `session/load`. Cached only
+        // here, never on the optimistic update or the revert below.
+        wtDispatch({ type: 'cache-selection', workspaceId, threadId, axis, value })
+        return
+      }
       console.error(`Failed to set ${axis} to "${value}": ${res.error}`)
       if (prev !== null) wtDispatch({ type: 'set-config', workspaceId, threadId, axis, value: prev })
     })
+  }
+
+  /**
+   * Re-assert a Thread's cached selection after a resume (#72). Vibe resets Mode to
+   * `default` on `session/load`, so a Thread whose session was lost (idle-evicted +
+   * re-warmed per TB5, or a cold continue) and resumed reports its DEFAULT controls on
+   * `thread:bound`. For each axis whose cached `selected` differs from the resumed
+   * value, optimistically reflect it on the displayed config AND fire the IPC to put
+   * the live session back to the user's choice — reverting (to the resumed value) +
+   * logging on failure, mirroring `changeThreadConfig`. Reads the cache from the ref so
+   * an async resume sees the latest, not its stale render-time closure. No-ops for a
+   * fresh mint (no cache) and when the resumed value already matches.
+   */
+  function reassertAfterResume(
+    workspaceId: string,
+    agentId: string,
+    threadId: string,
+    sessionId: string,
+    controls: ThreadAgentControls,
+  ): void {
+    const selected = selectedFor(workspaceThreadsRef.current, workspaceId, threadId)
+    for (const { axis, value } of reassertions(selected, controls)) {
+      const prev = boundConfigValue(controls, axis) // the resumed value to revert to
+      wtDispatch({ type: 'set-config', workspaceId, threadId, axis, value })
+      void window.api.setThreadConfig({ agentId, sessionId, axis, value }).then((res) => {
+        if (res.ok) return
+        console.error(`Failed to re-assert ${axis} to "${value}": ${res.error}`)
+        if (prev !== null) wtDispatch({ type: 'set-config', workspaceId, threadId, axis, value: prev })
+      })
+    }
   }
 
   /**
@@ -495,9 +540,13 @@ export function App(): JSX.Element {
           onSetConfig={(axis, value, sessionId) =>
             changeThreadConfig(conn.workspaceId, conn.agentId, activeThread.id, axis, value, sessionId)
           }
-          onBound={(sessionId, controls) =>
+          onBound={(sessionId, controls) => {
+            // Seed the displayed config from the bound session's reported values, then
+            // re-assert the user's cached selection over them (#72) — a resume reports
+            // defaults, so this restores a prior non-default Mode/Model/effort.
             wtDispatch({ type: 'bind', workspaceId: conn.workspaceId, threadId: activeThread.id, sessionId, controls })
-          }
+            if (controls) reassertAfterResume(conn.workspaceId, conn.agentId, activeThread.id, sessionId, controls)
+          }}
           onContinue={() => {
             wtDispatch({ type: 'open', workspaceId: conn.workspaceId, threadId: activeThread.id })
             navDispatch({ type: 'select-thread', workspaceId: conn.workspaceId, threadId: activeThread.id })

--- a/src/renderer/src/connection/workspace-threads.test.ts
+++ b/src/renderer/src/connection/workspace-threads.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect } from 'vitest'
 import {
+  boundConfigValue,
   configFor,
   currentConfigValue,
   initialWorkspaceThreads,
+  reassertions,
+  selectedFor,
   workspaceThreadsReducer,
   workspaceThreadStateFor,
   type WorkspaceThreadsState,
@@ -362,7 +365,7 @@ describe('per-Thread agent-controls config (#70)', () => {
 
 describe('workspaceThreadStateFor', () => {
   const state: WorkspaceThreadsState = {
-    w1: { live: new Set(['t1']), bound: {}, active: 't1', config: {} },
+    w1: { live: new Set(['t1']), bound: {}, active: 't1', config: {}, selected: {} },
   }
   it('returns a Workspace live-state', () => {
     expect(workspaceThreadStateFor(state, 'w1')?.active).toBe('t1')
@@ -414,5 +417,100 @@ describe('currentConfigValue (#70)', () => {
       controls: { modes: null, models: null, reasoningEffort: null },
     })
     expect(currentConfigValue(bare, 'w1', 't-open', 'mode')).toBeNull()
+  })
+})
+
+describe('selection cache + re-assert (#72)', () => {
+  function connected(controls: ThreadAgentControls | null = null): WorkspaceThreadsState {
+    return workspaceThreadsReducer(initialWorkspaceThreads, {
+      type: 'connect',
+      workspaceId: 'w1',
+      threadId: 't-open',
+      sessionId: 's1',
+      controls,
+    })
+  }
+
+  it('cache-selection records, then overwrites, an axis pick (a confirmed change)', () => {
+    let s = connected()
+    s = workspaceThreadsReducer(s, { type: 'cache-selection', workspaceId: 'w1', threadId: 't-open', axis: 'mode', value: 'plan' })
+    expect(s.w1.selected['t-open']).toEqual({ mode: 'plan' })
+    s = workspaceThreadsReducer(s, { type: 'cache-selection', workspaceId: 'w1', threadId: 't-open', axis: 'model', value: 'devstral-small' })
+    expect(s.w1.selected['t-open']).toEqual({ mode: 'plan', model: 'devstral-small' })
+    s = workspaceThreadsReducer(s, { type: 'cache-selection', workspaceId: 'w1', threadId: 't-open', axis: 'mode', value: 'default' })
+    expect(s.w1.selected['t-open']).toEqual({ mode: 'default', model: 'devstral-small' })
+  })
+
+  it('cache-selection is a no-op (same ref) for an unchanged value or an absent Workspace', () => {
+    let s = connected()
+    s = workspaceThreadsReducer(s, { type: 'cache-selection', workspaceId: 'w1', threadId: 't-open', axis: 'mode', value: 'plan' })
+    expect(workspaceThreadsReducer(s, { type: 'cache-selection', workspaceId: 'w1', threadId: 't-open', axis: 'mode', value: 'plan' })).toBe(s)
+    expect(workspaceThreadsReducer(s, { type: 'cache-selection', workspaceId: 'absent', threadId: 't-open', axis: 'mode', value: 'x' })).toBe(s)
+  })
+
+  it('connect PRESERVES the selection cache while resetting live/bound/active/config (re-warm)', () => {
+    let s = connected(controls('default'))
+    s = workspaceThreadsReducer(s, { type: 'cache-selection', workspaceId: 'w1', threadId: 't-open', axis: 'mode', value: 'plan' })
+    // A re-warm after eviction: new agent, fresh primary Thread + session + config.
+    s = workspaceThreadsReducer(s, { type: 'connect', workspaceId: 'w1', threadId: 't-new', sessionId: 's2', controls: controls('default') })
+    expect([...s.w1.live]).toEqual(['t-new']) // live reset
+    expect(s.w1.bound).toEqual({ 't-new': 's2' }) // bound reset
+    expect(s.w1.config['t-open']).toBeUndefined() // config reset
+    expect(s.w1.selected['t-open']).toEqual({ mode: 'plan' }) // cache SURVIVES
+  })
+
+  it('remove drops a Thread selection cache entry too', () => {
+    let s = connected()
+    s = workspaceThreadsReducer(s, { type: 'open', workspaceId: 'w1', threadId: 'draft' })
+    s = workspaceThreadsReducer(s, { type: 'cache-selection', workspaceId: 'w1', threadId: 'draft', axis: 'mode', value: 'plan' })
+    s = workspaceThreadsReducer(s, { type: 'remove', workspaceId: 'w1', threadId: 'draft' })
+    expect(s.w1.selected['draft']).toBeUndefined()
+  })
+
+  it('selectedFor returns a Thread cache, or {} for none / absent Workspace / null workspaceId', () => {
+    let s = connected()
+    s = workspaceThreadsReducer(s, { type: 'cache-selection', workspaceId: 'w1', threadId: 't-open', axis: 'mode', value: 'plan' })
+    expect(selectedFor(s, 'w1', 't-open')).toEqual({ mode: 'plan' })
+    expect(selectedFor(s, 'w1', 'no-cache')).toEqual({})
+    expect(selectedFor(s, 'absent', 't-open')).toEqual({})
+    expect(selectedFor(s, null, 't-open')).toEqual({})
+  })
+
+  describe('reassertions', () => {
+    it('no cached selection → no re-assertions', () => {
+      expect(reassertions({}, controls('plan', 'devstral-small', 'max'))).toEqual([])
+    })
+
+    it('selection equal to the resumed value → no re-assertion', () => {
+      expect(reassertions({ mode: 'default' }, controls('default'))).toEqual([])
+    })
+
+    it('selection differing from the resumed value → re-asserted (the session/load reset case)', () => {
+      // Resume reports Mode=default; the user had picked plan.
+      expect(reassertions({ mode: 'plan' }, controls('default'))).toEqual([{ axis: 'mode', value: 'plan' }])
+    })
+
+    it('emits across multiple axes, skipping the ones that already match', () => {
+      const out = reassertions(
+        { mode: 'plan', model: 'mistral-medium-3.5', reasoningEffort: 'max' },
+        controls('default', 'mistral-medium-3.5', 'high'),
+      )
+      expect(out).toEqual([
+        { axis: 'mode', value: 'plan' }, // differs → re-assert
+        { axis: 'reasoningEffort', value: 'max' }, // differs → re-assert; model matched → skipped
+      ])
+    })
+
+    it('a cached axis the resumed session no longer advertises is re-asserted (differs from absent)', () => {
+      const bound: ThreadAgentControls = { modes: null, models: null, reasoningEffort: null }
+      expect(reassertions({ mode: 'plan' }, bound)).toEqual([{ axis: 'mode', value: 'plan' }])
+    })
+  })
+
+  it('boundConfigValue reads a controls payload per axis (null when unadvertised)', () => {
+    expect(boundConfigValue(controls('plan', 'devstral-small', 'max'), 'mode')).toBe('plan')
+    expect(boundConfigValue(controls('plan', 'devstral-small', 'max'), 'model')).toBe('devstral-small')
+    expect(boundConfigValue(controls('plan', 'devstral-small', 'max'), 'reasoningEffort')).toBe('max')
+    expect(boundConfigValue({ modes: null, models: null, reasoningEffort: null }, 'mode')).toBeNull()
   })
 })

--- a/src/renderer/src/connection/workspace-threads.test.ts
+++ b/src/renderer/src/connection/workspace-threads.test.ts
@@ -501,9 +501,9 @@ describe('selection cache + re-assert (#72)', () => {
       ])
     })
 
-    it('a cached axis the resumed session no longer advertises is re-asserted (differs from absent)', () => {
+    it('a cached axis the resumed session no longer advertises is NOT re-asserted (no setter target)', () => {
       const bound: ThreadAgentControls = { modes: null, models: null, reasoningEffort: null }
-      expect(reassertions({ mode: 'plan' }, bound)).toEqual([{ axis: 'mode', value: 'plan' }])
+      expect(reassertions({ mode: 'plan' }, bound)).toEqual([])
     })
   })
 

--- a/src/renderer/src/connection/workspace-threads.ts
+++ b/src/renderer/src/connection/workspace-threads.ts
@@ -287,11 +287,13 @@ export function selectedFor(
 
 /**
  * The re-assertions a just-resumed Thread needs (#72): for each axis the user has a
- * cached `selected` for, emit `{axis, value}` when it DIFFERS from the resumed
- * session's reported current (`bound`). A resume resets Mode to `default` (acp-capture
- * §10), so the user's prior non-default pick differs and is re-asserted; an axis with
- * no selection, or one whose resumed value already matches, yields nothing — so a
- * fresh mint (no cache) and a faithful resume both no-op. Pure (no React, no IPC).
+ * cached `selected` for AND that the resumed session still ADVERTISES, emit
+ * `{axis, value}` when it DIFFERS from the session's reported current (`bound`). A
+ * resume resets Mode to `default` (acp-capture §10), so the user's prior non-default
+ * pick differs and is re-asserted; an axis with no selection, one whose resumed value
+ * already matches, or one the resumed session no longer advertises (`boundConfigValue`
+ * null — there's no setter target) yields nothing. So a fresh mint (no cache) and a
+ * faithful resume both no-op, and we never fire a doomed setter. Pure (no React, no IPC).
  */
 export function reassertions(
   selected: Partial<Record<ThreadConfigAxis, string>>,
@@ -302,7 +304,10 @@ export function reassertions(
   for (const axis of axes) {
     const want = selected[axis]
     if (want === undefined) continue
-    if (boundConfigValue(bound, axis) !== want) out.push({ axis, value: want })
+    const have = boundConfigValue(bound, axis)
+    // Skip an unadvertised axis (have === null): the session has no setter target, so
+    // re-asserting would fire a request that just errors.
+    if (have !== null && have !== want) out.push({ axis, value: want })
   }
   return out
 }

--- a/src/renderer/src/connection/workspace-threads.ts
+++ b/src/renderer/src/connection/workspace-threads.ts
@@ -22,6 +22,14 @@ import type { ThreadAgentControls, ThreadConfigAxis } from '../../../shared/ipc'
  *   `connect` (the primary) and `bind` (drafts/continued), and updated
  *   OPTIMISTICALLY per Thread on a `set-config` (a change emits no notification,
  *   ADR-0007). So EVERY live Thread shows + changes its own Mode/Model/effort.
+ * - `selected`: the user's last EXPLICIT pick per Thread per axis (#72), recorded
+ *   only on a CONFIRMED change (IPC `{ok:true}`) — the in-memory cache that lets a
+ *   resumed Thread come back to the user's choice. Vibe resets Mode to `default` on
+ *   `session/load` (acp-capture §10), so a Thread whose session is lost (idle-evicted
+ *   + re-warmed per TB5, or a cold continue) and resumed would silently revert. We
+ *   re-assert `selected` after the resume's `bind`. CRITICAL: unlike `config`, this
+ *   SURVIVES a `connect`-reset, so a re-warm keeps the cache (ADR-0007 keeps it OUT of
+ *   the durable store, so a cold app-restart reopen has none — accepted/out of scope).
  *
  * A pure reducer + derivation (no React, no IPC), like the nav/connection reducers.
  */
@@ -30,6 +38,7 @@ export interface WorkspaceThreadState {
   bound: Readonly<Record<string, string>>
   active: string
   config: Readonly<Record<string, ThreadAgentControls>>
+  selected: Readonly<Record<string, Partial<Record<ThreadConfigAxis, string>>>>
 }
 
 export type WorkspaceThreadsState = Readonly<Record<string, WorkspaceThreadState>>
@@ -68,6 +77,11 @@ export type WorkspaceThreadsAction =
   // current value the instant the user picks, then reverts (re-dispatching the prior
   // value) on an IPC failure. Keyed by `threadId` so a sibling Thread is untouched.
   | { type: 'set-config'; workspaceId: string; threadId: string; axis: ThreadConfigAxis; value: string }
+  // Record the user's last EXPLICIT pick for a Thread's axis (#72), dispatched ONLY
+  // after the change's IPC confirms (`{ok:true}`) — never on the optimistic display
+  // update or a revert. This is the cache re-asserted after a resume; it survives a
+  // `connect`-reset (a re-warm keeps it), so it lives apart from `config`.
+  | { type: 'cache-selection'; workspaceId: string; threadId: string; axis: ThreadConfigAxis; value: string }
 
 export const initialWorkspaceThreads: WorkspaceThreadsState = {}
 
@@ -76,7 +90,13 @@ export function workspaceThreadsReducer(
   action: WorkspaceThreadsAction,
 ): WorkspaceThreadsState {
   switch (action.type) {
-    case 'connect':
+    case 'connect': {
+      // A reconnect (new agent) deliberately drops the prior session's live/bound/
+      // active/config — those died with the old process. But the per-Thread selection
+      // cache (#72) PERSISTS: a re-warm after eviction (TB5) must keep the user's last
+      // pick so it can be re-asserted once the resumed session reports its (default)
+      // values. `connect` is the only action that would otherwise wipe `selected`.
+      const cur = state[action.workspaceId]
       return {
         ...state,
         [action.workspaceId]: {
@@ -84,8 +104,10 @@ export function workspaceThreadsReducer(
           bound: action.sessionId ? { [action.threadId]: action.sessionId } : {},
           active: action.threadId,
           config: action.controls ? { [action.threadId]: action.controls } : {},
+          selected: cur?.selected ?? {},
         },
       }
+    }
     case 'open': {
       const cur = state[action.workspaceId]
       if (!cur) return state
@@ -126,9 +148,11 @@ export function workspaceThreadsReducer(
       delete bound[action.threadId]
       const config = { ...cur.config }
       delete config[action.threadId]
+      const selected = { ...cur.selected }
+      delete selected[action.threadId] // drop its cached picks too (#72)
       // `active` is left to the caller: deleting the active Thread is paired with a
       // `select` back to the connection's primary Thread (which is never deletable).
-      return { ...state, [action.workspaceId]: { ...cur, live, bound, config } }
+      return { ...state, [action.workspaceId]: { ...cur, live, bound, config, selected } }
     }
     case 'set-config': {
       // Optimistic per-Thread update (#70, ADR-0007). Same-ref-on-noop discipline:
@@ -143,6 +167,23 @@ export function workspaceThreadsReducer(
       return {
         ...state,
         [action.workspaceId]: { ...cur, config: { ...cur.config, [action.threadId]: next } },
+      }
+    }
+    case 'cache-selection': {
+      // Record a CONFIRMED pick (#72). Same-ref discipline: no Workspace, or the same
+      // value already cached for this axis, returns the SAME ref so a redundant cache
+      // can't churn the reducer. Unlike `set-config` this records even axes with no
+      // seeded `config` — the cache is keyed only by the pick the IPC confirmed.
+      const cur = state[action.workspaceId]
+      if (!cur) return state
+      const prev = cur.selected[action.threadId]
+      if (prev?.[action.axis] === action.value) return state
+      return {
+        ...state,
+        [action.workspaceId]: {
+          ...cur,
+          selected: { ...cur.selected, [action.threadId]: { ...prev, [action.axis]: action.value } },
+        },
       }
     }
   }
@@ -210,6 +251,16 @@ export function currentConfigValue(
 ): string | null {
   const controls = state[workspaceId]?.config[threadId]
   if (!controls) return null
+  return boundConfigValue(controls, axis)
+}
+
+/**
+ * A controls bundle's CURRENT value for an axis (#72) — the standalone read used both
+ * by `currentConfigValue` (over the store) and by `reassertions`/the App re-assert
+ * (over a freshly-`bound` payload, before it lands in the store). Null when the axis
+ * isn't advertised.
+ */
+export function boundConfigValue(controls: ThreadAgentControls, axis: ThreadConfigAxis): string | null {
   switch (axis) {
     case 'mode':
       return controls.modes?.currentModeId ?? null
@@ -218,4 +269,40 @@ export function currentConfigValue(
     case 'reasoningEffort':
       return controls.reasoningEffort?.current ?? null
   }
+}
+
+/**
+ * A Thread's cached EXPLICIT selections (#72), or an empty object when none — the
+ * user's last confirmed pick per axis, surviving a `connect`-reset (re-warm). App
+ * reads this after a resume's `bind` to decide what to re-assert.
+ */
+export function selectedFor(
+  state: WorkspaceThreadsState,
+  workspaceId: string | null,
+  threadId: string,
+): Partial<Record<ThreadConfigAxis, string>> {
+  if (!workspaceId) return {}
+  return state[workspaceId]?.selected[threadId] ?? {}
+}
+
+/**
+ * The re-assertions a just-resumed Thread needs (#72): for each axis the user has a
+ * cached `selected` for, emit `{axis, value}` when it DIFFERS from the resumed
+ * session's reported current (`bound`). A resume resets Mode to `default` (acp-capture
+ * §10), so the user's prior non-default pick differs and is re-asserted; an axis with
+ * no selection, or one whose resumed value already matches, yields nothing — so a
+ * fresh mint (no cache) and a faithful resume both no-op. Pure (no React, no IPC).
+ */
+export function reassertions(
+  selected: Partial<Record<ThreadConfigAxis, string>>,
+  bound: ThreadAgentControls,
+): Array<{ axis: ThreadConfigAxis; value: string }> {
+  const axes: ThreadConfigAxis[] = ['mode', 'model', 'reasoningEffort']
+  const out: Array<{ axis: ThreadConfigAxis; value: string }> = []
+  for (const axis of axes) {
+    const want = selected[axis]
+    if (want === undefined) continue
+    if (boundConfigValue(bound, axis) !== want) out.push({ axis, value: want })
+  }
+  return out
 }


### PR DESCRIPTION
Closes #72 — the final Agent-controls piece (ADR-0007). Renderer-only.

## Problem

The #65 spike found Vibe **resets Mode to `default` on `session/load`**. So a Thread set to a non-default Mode/Model/Reasoning effort, whose session is lost (agent idle-evicted + re-warmed per TB5, or a cold continue) and resumed, silently reverted. This restores the user's choice.

## What

- A per-Thread **`selected` cache** in `workspace-threads` (the user's last *confirmed* pick per axis). CRITICAL: the `connect` action **preserves** it while resetting `live`/`bound`/`config`, so a re-warm after eviction keeps it. Dropped on `remove`; same-ref discipline.
- **Cached only on a confirmed change** (`changeThreadConfig` IPC `{ok:true}`) — never on the optimistic display update or a revert.
- A pure **`reassertions(selected, bound)`** helper: for each axis whose cached pick differs from the resumed (default) value **and that the session still advertises**, emit `{axis, value}`. On `thread:bound` after a resume, App re-asserts each via the existing `thread:set-config` IPC + optimistic display (revert to the resumed value + log on failure). No-ops for fresh mints and faithful resumes.
- Stale-closure guarded via `workspaceThreadsRef` so the async resume reads the latest cache.
- `index.ts` change is comment-only (the cache is renderer-owned; main stays oblivious). It's a **within-session** cache — a cold app-restart reopen has none (accepted, ADR-0007).

## Review + verification

Implementer → my independent gate re-run + full diff read → adversarial reviewer (verdict **SHIP**, no MUST/SHOULD-FIX). All gates green: lint / typecheck / build / **348 tests**. Reviewer confirmed the evict→reselect→resume restore path, cache-only-on-ok + no re-assert loop, the stale-closure ref, correct Thread/session targeting, and no regression to #66/#70/#58/#33/#60/#61.

**Folded the one NIT:** `reassertions` no longer emits for an axis the resumed session stopped advertising (which would fire a doomed setter) — now guarded on `boundConfigValue !== null`, with the test flipped.

## Manual smoke still worth doing

Set a Thread to a non-default Mode, let its agent idle-evict (or force a re-warm), reselect + continue → confirm the Mode comes back (re-asserted), not `default`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)