### PR TITLE
#75: pre-select agent controls on a draft (before first prompt)

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -28,6 +28,7 @@ import {
   boundConfigValue,
   configFor,
   currentConfigValue,
+  draftControls,
   initialWorkspaceThreads,
   reassertions,
   selectedFor,
@@ -264,6 +265,25 @@ export function App(): JSX.Element {
         if (prev !== null) wtDispatch({ type: 'set-config', workspaceId, threadId, axis, value: prev })
       })
     }
+  }
+
+  /**
+   * Pre-select an agent control on a New-thread DRAFT (#75), before its first prompt
+   * binds a session. A draft has no live session, so there's NO IPC — we only cache
+   * the pick into the in-memory `selected` map (keyed by `threadId`). The display
+   * updates because the draft's picker reads `draftControls(connection, selected)`, and
+   * because this writes the SAME cache `changeThreadConfig` writes on a bound Thread,
+   * the EXISTING `reassertAfterResume` (#72) applies the pre-pick to the session the
+   * instant the first prompt mints it — no second apply path, and no residue (the cache
+   * evaporates with the draft / on restart, ADR-0007).
+   */
+  function preselectDraftConfig(
+    workspaceId: string,
+    threadId: string,
+    axis: ThreadConfigAxis,
+    value: string,
+  ): void {
+    wtDispatch({ type: 'cache-selection', workspaceId, threadId, axis, value })
   }
 
   /**
@@ -536,10 +556,19 @@ export function App(): JSX.Element {
           activeThread={activeThread}
           isLive={isLive}
           seedSessionId={seed}
-          controls={configFor(workspaceThreads, conn.workspaceId, activeThread.id)}
-          onSetConfig={(axis, value, sessionId) =>
-            changeThreadConfig(conn.workspaceId, conn.agentId, activeThread.id, axis, value, sessionId)
+          controls={
+            // A bound Thread sources its OWN live config (#70); a draft (no config
+            // seeded) shows the connection's option lists + defaults, overlaid with any
+            // cached pre-pick (#75).
+            configFor(workspaceThreads, conn.workspaceId, activeThread.id) ??
+            draftControls(connectionControlsOf(conn), selectedFor(workspaceThreads, conn.workspaceId, activeThread.id))
           }
+          onSetConfig={(axis, value, sessionId) => {
+            // A real session => the bound IPC path (#70); a null session => a draft
+            // pre-pick that only caches (#75), applied to the session on first bind.
+            if (sessionId) changeThreadConfig(conn.workspaceId, conn.agentId, activeThread.id, axis, value, sessionId)
+            else preselectDraftConfig(conn.workspaceId, activeThread.id, axis, value)
+          }}
           onBound={(sessionId, controls) => {
             // Seed the displayed config from the bound session's reported values, then
             // re-assert the user's cached selection over them (#72) — a resume reports
@@ -671,6 +700,16 @@ function synthConnectionMeta(conn: ThreadConnection): ThreadMeta {
     createdAt: 0,
     lastActiveAt: 0,
   }
+}
+
+/**
+ * Project a connection's advertised agent-controls (#75): the connect-time option
+ * lists + DEFAULT current values, never optimistically mutated (a pick lands in
+ * `workspace-threads.config`, not here — #70). Used to seed a draft's picker so it
+ * shows the agent defaults a default-mint would produce.
+ */
+function connectionControlsOf(conn: ThreadConnection): ThreadAgentControls {
+  return { modes: conn.modes, models: conn.models, reasoningEffort: conn.reasoningEffort }
 }
 
 /**

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -559,7 +559,14 @@ export function App(): JSX.Element {
           controls={
             // A bound Thread sources its OWN live config (#70); a draft (no config
             // seeded) shows the connection's option lists + defaults, overlaid with any
-            // cached pre-pick (#75).
+            // cached pre-pick (#75). CAVEAT: a CONTINUED (reopened, not-yet-bound) Thread
+            // also has no config, so it shows the connection DEFAULTS too — honest for
+            // Mode (session/load resets it to default) but the MODEL can persist across
+            // a resume (acp-capture §10), so a reopened Thread may briefly show the
+            // default model until its first prompt's bind reports the real one and
+            // self-corrects. We don't eagerly resume to learn it (#33 defers load to the
+            // first prompt); Model isn't trust-relevant (it doesn't gate writes), so the
+            // transient pre-prompt mismatch is accepted.
             configFor(workspaceThreads, conn.workspaceId, activeThread.id) ??
             draftControls(connectionControlsOf(conn), selectedFor(workspaceThreads, conn.workspaceId, activeThread.id))
           }

--- a/src/renderer/src/connection/ConnectedWorkspace.tsx
+++ b/src/renderer/src/connection/ConnectedWorkspace.tsx
@@ -51,8 +51,9 @@ export function ConnectedWorkspace({
   seedSessionId: string | null
   /** The active Thread's OWN agent-controls (#70), or null when none are seeded yet. */
   controls: ThreadAgentControls | null
-  /** Change an agent control on the active Thread's bound session (#66/#70, ADR-0007). */
-  onSetConfig: (axis: ThreadConfigAxis, value: string, sessionId: string) => void
+  /** Change an agent control on the active Thread (#66/#70, ADR-0007): a bound session
+   *  fires the IPC; a null session is a draft pre-pick App caches to apply on bind (#75). */
+  onSetConfig: (axis: ThreadConfigAxis, value: string, sessionId: string | null) => void
   /** A draft's first prompt bound its session — lift it (and its controls) to App. */
   onBound: (sessionId: string, controls: ThreadAgentControls | null) => void
   /** Promote the (cold) active Thread to live (Continue) — App hosts + reselects it. */

--- a/src/renderer/src/connection/workspace-threads.test.ts
+++ b/src/renderer/src/connection/workspace-threads.test.ts
@@ -3,6 +3,7 @@ import {
   boundConfigValue,
   configFor,
   currentConfigValue,
+  draftControls,
   initialWorkspaceThreads,
   reassertions,
   selectedFor,
@@ -512,5 +513,50 @@ describe('selection cache + re-assert (#72)', () => {
     expect(boundConfigValue(controls('plan', 'devstral-small', 'max'), 'model')).toBe('devstral-small')
     expect(boundConfigValue(controls('plan', 'devstral-small', 'max'), 'reasoningEffort')).toBe('max')
     expect(boundConfigValue({ modes: null, models: null, reasoningEffort: null }, 'mode')).toBeNull()
+  })
+})
+
+describe('draftControls (#75)', () => {
+  it('shows the connection defaults when there is no pre-pick (no lie)', () => {
+    // A fresh draft (empty selected) must display the agent's connect-time current
+    // values, so the default session the first prompt mints matches the display.
+    const out = draftControls(controls('default', 'mistral-medium-3.5', 'high'), {})
+    expect(out.modes?.currentModeId).toBe('default')
+    expect(out.models?.currentModelId).toBe('mistral-medium-3.5')
+    expect(out.reasoningEffort?.current).toBe('high')
+  })
+
+  it('overlays each axis with the cached pre-pick when present', () => {
+    const out = draftControls(controls('default', 'mistral-medium-3.5', 'high'), {
+      mode: 'plan',
+      model: 'devstral-small',
+      reasoningEffort: 'max',
+    })
+    expect(out.modes?.currentModeId).toBe('plan')
+    expect(out.models?.currentModelId).toBe('devstral-small')
+    expect(out.reasoningEffort?.current).toBe('max')
+  })
+
+  it('falls back per axis to the connection current when only some axes are pre-picked', () => {
+    const out = draftControls(controls('default', 'mistral-medium-3.5', 'high'), { mode: 'plan' })
+    expect(out.modes?.currentModeId).toBe('plan') // overlaid
+    expect(out.models?.currentModelId).toBe('mistral-medium-3.5') // connection default
+    expect(out.reasoningEffort?.current).toBe('high') // connection default
+  })
+
+  it('carries the connection option lists through unchanged', () => {
+    const conn = controls('default', 'mistral-medium-3.5', 'high')
+    const out = draftControls(conn, { mode: 'plan' })
+    expect(out.modes?.availableModes).toEqual(conn.modes?.availableModes)
+    expect(out.models?.availableModels).toEqual(conn.models?.availableModels)
+    expect(out.reasoningEffort?.options).toEqual(conn.reasoningEffort?.options)
+  })
+
+  it('keeps an axis null when the agent advertises none (even with a stray pick)', () => {
+    const none: ThreadAgentControls = { modes: null, models: null, reasoningEffort: null }
+    const out = draftControls(none, { mode: 'plan', model: 'x', reasoningEffort: 'max' })
+    expect(out.modes).toBeNull()
+    expect(out.models).toBeNull()
+    expect(out.reasoningEffort).toBeNull()
   })
 })

--- a/src/renderer/src/connection/workspace-threads.ts
+++ b/src/renderer/src/connection/workspace-threads.ts
@@ -239,6 +239,32 @@ export function configFor(
 }
 
 /**
+ * A draft's agent-controls bundle (#75): a New-thread draft has no `config` seeded
+ * (its session binds only on the first prompt), so it can't read `configFor`. Instead
+ * we project the CONNECTION's advertised option lists with each axis's current value
+ * overlaid by the user's cached pre-pick (`selected`) when present, else the
+ * connection's OWN connect-time current — the agent default (`default` / a model id /
+ * `high`). The connection's current is never optimistically mutated (#70 moved that to
+ * `config`), so a no-pick draft shows the TRUE defaults — display == the session the
+ * first prompt will mint. Each axis is null when the agent advertises none. The cached
+ * pick is the SAME `selected` cache `reassertAfterResume` re-asserts once the draft
+ * binds (#72), so the pre-pick applies exactly once on bind — no second apply path.
+ */
+export function draftControls(
+  connectionControls: ThreadAgentControls,
+  selected: Partial<Record<ThreadConfigAxis, string>>,
+): ThreadAgentControls {
+  const { modes, models, reasoningEffort } = connectionControls
+  return {
+    modes: modes ? { ...modes, currentModeId: selected.mode ?? modes.currentModeId } : null,
+    models: models ? { ...models, currentModelId: selected.model ?? models.currentModelId } : null,
+    reasoningEffort: reasoningEffort
+      ? { ...reasoningEffort, current: selected.reasoningEffort ?? reasoningEffort.current }
+      : null,
+  }
+}
+
+/**
  * A Thread's CURRENT value for an agent-control axis (#70), or null when the axis
  * isn't advertised (or no controls are seeded). App reads this BEFORE an optimistic
  * `set-config` so it can revert to the prior value if the IPC change fails (ADR-0007).

--- a/src/renderer/src/conversation/AgentControls.tsx
+++ b/src/renderer/src/conversation/AgentControls.tsx
@@ -16,9 +16,10 @@ import { cn } from '../lib/utils'
  * connection (sourced from `session/new`), and a pick fires `onSetConfig` which App
  * reflects OPTIMISTICALLY and reverts on failure — a change emits no notification.
  *
- * `disabled` is the between-turns + bound-session gate (a turn streaming OR no bound
- * session yet) — the controls grey out rather than letting a mid-turn / pre-session
- * change through. The row renders nothing when the agent advertises no axes at all.
+ * `disabled` is the between-turns gate — true only WHILE a turn streams (a pre-prompt
+ * draft is NOT processing, so its pickers are live: #75 lets the user pre-select before
+ * a session exists, and App caches the pick to apply on the first bind). The row
+ * renders nothing when the agent advertises no axes at all.
  */
 export function AgentControls({
   modes,

--- a/src/renderer/src/conversation/Conversation.tsx
+++ b/src/renderer/src/conversation/Conversation.tsx
@@ -75,8 +75,9 @@ export function Conversation({
   /** The connection's current Reasoning effort + options (#66). */
   reasoningEffort: ThreadReasoningEffort | null
   /** Change an agent control (#66): App reflects it optimistically + reverts on error.
-   *  Carries the Thread's bound `sessionId` (non-null once bound) for the IPC call. */
-  onSetConfig?: (axis: ThreadConfigAxis, value: string, sessionId: string) => void
+   *  Carries the Thread's `sessionId` — non-null once bound (App fires the IPC), or
+   *  null for a pre-prompt draft (#75: App caches the pre-pick, applied on bind). */
+  onSetConfig?: (axis: ThreadConfigAxis, value: string, sessionId: string | null) => void
   /** Mid-session expiry (-32000): route to in-place re-auth with these methods. */
   onAuthExpired: (authMethods: AuthMethod[]) => void
   /** The Thread's session once bound (TB5) — lifts it so a switch-away-and-back
@@ -284,18 +285,16 @@ export function Conversation({
 
       <div className="composer-area">
         {/* Agent controls (#66): Mode / Model / Reasoning effort. Vibe-owned,
-            between-turns only — disabled while a turn streams OR before this Thread
-            has a bound session (a draft binds on its first prompt). */}
+            between-turns only — disabled WHILE a turn streams. A pre-prompt draft
+            (#75) is NOT processing, so its pickers are live: a pick passes the null
+            `boundSessionId` up, and App caches it (no IPC — no session yet) to apply
+            on the first bind. A bound Thread passes its real session for the IPC. */}
         <AgentControls
           modes={modes}
           models={models}
           reasoningEffort={reasoningEffort}
-          disabled={state.isProcessing || boundSessionId === null}
-          onSetConfig={(axis, value) => {
-            // The disabled gate guarantees a bound session here, but guard anyway so
-            // a stray call can never send a config change with a null sessionId.
-            if (boundSessionId) onSetConfig?.(axis, value, boundSessionId)
-          }}
+          disabled={state.isProcessing}
+          onSetConfig={(axis, value) => onSetConfig?.(axis, value, boundSessionId)}
         />
 
         <div className="composer">


### PR DESCRIPTION
Closes #75. A New-thread draft can now pick **Mode / Model / Reasoning effort up front**, before its first prompt — meeting the "open a thread to start coding, set my model/mode first" intent. Renderer-only.

## What

- A draft has no session, so it can't read `configFor`. New pure **`draftControls(connectionControls, selected)`** projects the connection's advertised **option lists** + connect-time **default** current values, overlaid with any cached pre-pick. The connection's current is never optimistically mutated (#70 moved that to `workspace-threads.config`), so a no-pick draft shows the **true defaults** the first prompt's `session/new` will mint — no lie.
- App sources the active Thread's controls as `configFor(...) ?? draftControls(...)` (bound → real config; draft → synthesized), and enables the pickers for a draft (`disabled = state.isProcessing` only).
- A draft pick passes `sessionId = null` up; App's `preselectDraftConfig` **caches it only** (no IPC — no session). The **existing #72 `reassertAfterResume`** applies it to the session the instant the first prompt binds — no second apply path, and a never-prompted draft leaves **zero residue** (#58 intact).

## Review + verification

Implementer → my independent gate re-run + full diff read → adversarial reviewer (verdict **SHIP-WITH-FIXES**, no MUST-FIX). Gates green: lint / typecheck / build / **353 tests** (5-case `draftControls` suite added). Reviewer confirmed: true-defaults/no-lie, no double-apply, no residue, correct draft→cache vs bound→IPC routing, no mid-bind pick window, per-Thread isolation, no regression to #66/#70/#72/#58/#33.

**Folded (comment-only):** corrected the stale `AgentControls` disable-gate docstring, and annotated one accepted caveat → a **continued (reopened, not-yet-bound)** Thread shows the connection-default **model** until its first prompt's bind reports the resumed value and self-corrects (transient, pre-prompt only, Model isn't trust-relevant; Mode is always honest since `session/load` resets it).

## Manual smoke worth doing

New thread → pick **Mode → Plan** (no send) → confirm the picker shows Plan with no errors → send the first prompt → confirm the turn runs in `plan` (and the picker stays Plan). Also: a draft you never send leaves no sidebar/disk residue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)