### PR TITLE
#76: preserve sign-in/out failure reason + RPC code (part A)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -709,7 +709,12 @@ function registerIpc(): void {
       const authState = await agent.signIn(args.methodId)
       return { ok: true, authState }
     } catch (err) {
-      return { ok: false, error: err instanceof Error ? err.message : String(err) }
+      const error = err instanceof Error ? err.message : String(err)
+      // Diagnostic breadcrumb to main-process stderr (NOT the renderer transcript):
+      // the formatted message already carries Vibe's reason + the JSON-RPC code, so
+      // an intermittent failure (e.g. a timed-out delegated `complete`) is traceable.
+      console.error(`[vibe-mistro:auth] sign-in failed (agent ${args.agentId}): ${error}`)
+      return { ok: false, error }
     } finally {
       endAuth(args.agentId)
     }
@@ -725,7 +730,9 @@ function registerIpc(): void {
       const authState = await agent.signOut()
       return { ok: true, authState, authMethods: agent.authMethods }
     } catch (err) {
-      return { ok: false, error: err instanceof Error ? err.message : String(err) }
+      const error = err instanceof Error ? err.message : String(err)
+      console.error(`[vibe-mistro:auth] sign-out failed (agent ${args.agentId}): ${error}`)
+      return { ok: false, error }
     }
   })
 

--- a/src/main/workspace-agent.test.ts
+++ b/src/main/workspace-agent.test.ts
@@ -340,11 +340,19 @@ describe('WorkspaceAgent — sign in (browser-auth-delegated)', () => {
       JSON.stringify({
         jsonrpc: '2.0',
         id: completeReq?.id,
-        error: { code: -32602, message: 'Invalid request' },
+        // Vibe's real reason for a lapsed poll window (browser_sign_in.py: TIMED_OUT),
+        // surfaced as InvalidRequestError(-32602).
+        error: { code: -32602, message: 'Browser sign-in timed out.' },
       }) + '\n',
     )
 
-    await expect(signingIn).rejects.toBeInstanceOf(WorkspaceAgentError)
+    const err = await signingIn.catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(WorkspaceAgentError)
+    // Vibe's specific reason AND the JSON-RPC code are preserved (not collapsed into
+    // a generic "Sign-in failed") — the whole point of #76 part A.
+    expect((err as WorkspaceAgentError).message).toMatch(/Browser sign-in timed out\./)
+    expect((err as WorkspaceAgentError).message).toContain('(code -32602)')
+    expect((err as WorkspaceAgentError).code).toBe(-32602)
     // The failure leaves auth state untouched (still signed-out) — never wedged.
     expect(agent.authState).toBe('not-signed-in')
   })
@@ -601,6 +609,10 @@ describe('WorkspaceAgent — sign out (_auth/signOut)', () => {
     const err = await settled
     expect(err).toBeInstanceOf(WorkspaceAgentError)
     expect((err as WorkspaceAgentError).message).toMatch(/sign-out failed/i)
+    // Preserves the keyring reason + code (#76 part A), not a bare "Sign-out failed".
+    expect((err as WorkspaceAgentError).message).toContain('keyring error')
+    expect((err as WorkspaceAgentError).message).toContain('(code -32603)')
+    expect((err as WorkspaceAgentError).code).toBe(-32603)
     // Failed sign-out leaves the session signed-in — never wedged.
     expect(agent.authState).toBe('signed-in')
   })

--- a/src/main/workspace-agent.ts
+++ b/src/main/workspace-agent.ts
@@ -42,11 +42,24 @@ export class WorkspaceAgentError extends Error {
    * sign-in panel and keep the agent alive instead of treating it as generic.
    */
   readonly authState: AuthState | null
-  constructor(message: string, hint: string | null = null, authState: AuthState | null = null) {
+  /**
+   * The originating JSON-RPC error `code` when this wraps an ACP request failure
+   * (e.g. `-32602` for a timed-out/denied/expired delegated `complete`). Preserved
+   * so the specific reason reaches the renderer and the diagnostic log instead of
+   * collapsing into a generic message. `null` when the failure carried no code.
+   */
+  readonly code: number | null
+  constructor(
+    message: string,
+    hint: string | null = null,
+    authState: AuthState | null = null,
+    code: number | null = null,
+  ) {
     super(message)
     this.name = 'WorkspaceAgentError'
     this.hint = hint
     this.authState = authState
+    this.code = code
   }
 }
 
@@ -400,18 +413,23 @@ export class WorkspaceAgent extends EventEmitter {
     }
   }
 
-  /** Map a sign-out failure to a clear message (not a bare RPC string). */
+  /** Map a sign-out failure to a clear message (Vibe's reason + the RPC code). */
   private toSignOutError(err: unknown): WorkspaceAgentError {
     if (err instanceof WorkspaceAgentError) return err
-    const detail = (err as { message?: string })?.message ?? (err instanceof Error ? err.message : String(err))
-    return new WorkspaceAgentError(`Sign-out failed: ${detail}`, AUTH_HINT)
+    const { code, detail } = rpcErrorParts(err)
+    return new WorkspaceAgentError(formatAuthFailure('Sign-out', detail, code), AUTH_HINT, null, code)
   }
 
-  /** Map a sign-in failure to a clear message (not a bare RPC string). */
+  /**
+   * Map a sign-in failure to a clear message. Preserves Vibe's specific reason
+   * (e.g. "Browser sign-in timed out." / "denied" / "expired" from a delegated
+   * `complete`) and the JSON-RPC `code`, so the renderer surfaces the actual cause
+   * instead of a generic "Sign-in failed" — and so the main-process log records it.
+   */
   private toSignInError(err: unknown): WorkspaceAgentError {
     if (err instanceof WorkspaceAgentError) return err
-    const detail = (err as { message?: string })?.message ?? (err instanceof Error ? err.message : String(err))
-    return new WorkspaceAgentError(`Sign-in failed: ${detail}`, AUTH_HINT)
+    const { code, detail } = rpcErrorParts(err)
+    return new WorkspaceAgentError(formatAuthFailure('Sign-in', detail, code), AUTH_HINT, null, code)
   }
 
   /**
@@ -738,6 +756,28 @@ export class WorkspaceAgent extends EventEmitter {
     }
     return new WorkspaceAgentError(message)
   }
+}
+
+/**
+ * Pull a JSON-RPC error's `{code, message}` off an ACP request rejection.
+ * `AcpClient` rejects a failed request with the wire `error` object
+ * (`{code, message, data}`); a process-exit/stop rejection is a plain `Error`
+ * (no `code`). Falls back to a non-empty detail string so the surfaced message
+ * is never blank.
+ */
+function rpcErrorParts(err: unknown): { code: number | null; detail: string } {
+  const rawCode = (err as { code?: unknown } | null)?.code
+  const code = typeof rawCode === 'number' ? rawCode : null
+  const rawMessage = (err as { message?: unknown } | null)?.message
+  const detail =
+    (typeof rawMessage === 'string' ? rawMessage : err instanceof Error ? err.message : String(err)) ||
+    'unknown error'
+  return { code, detail }
+}
+
+/** Format an auth failure as the reason plus the JSON-RPC code (when present). */
+function formatAuthFailure(action: string, detail: string, code: number | null): string {
+  return code !== null ? `${action} failed: ${detail} (code ${code})` : `${action} failed: ${detail}`
 }
 
 interface DelegatedMeta {


### PR DESCRIPTION
Closes part A of #76.

## Problem

Intermittent **delegated browser sign-in** failures (a timed-out / denied / expired `complete`, surfaced by Vibe as `-32602`) were collapsed into a generic `Sign-in failed: <msg>` with the JSON-RPC **code dropped**, and **nothing was logged**. So the failure was undiagnosable after the fact, and the user couldn't tell a timeout from a denial from a network blip — they just saw a vague error and had to retry blind.

Root cause is detailed in #76: the flow is correct on both sides (Vibe's `complete` long-polls; our `AcpClient.request` has no timeout; `persist_api_key` sets `os.environ` synchronously so the follow-up `_auth/status` is race-proof). An intermittent failure that a retry clears is therefore the `complete` long-poll itself failing → `-32602` → our `signIn` rejects → recoverable error → retry succeeds.

## Change (part A — diagnosability + clear errors)

- **`src/main/workspace-agent.ts`** — `WorkspaceAgentError` gains a `code: number | null`. New shared helper `rpcErrorParts()` pulls `{code, message}` off an ACP request rejection (handles both wire `error` objects and plain process-exit `Error`s); `formatAuthFailure()` renders `"<action> failed: <reason> (code <n>)"`. `toSignInError`/`toSignOutError` now preserve **Vibe's specific reason + the JSON-RPC code** (e.g. `Sign-in failed: Browser sign-in timed out. (code -32602)`).
- **`src/main/index.ts`** — both auth IPC handlers log a tagged `[vibe-mistro:auth]` breadcrumb to **main-process stderr** on failure. Deliberately *not* routed through the agent event channel: every `agent.on('event')` payload is tee'd into the transcript and forwarded to the renderer (`index.ts:438`), so logging there would pollute the conversation and mis-attribute (auth runs before any Thread exists).
- **`src/main/workspace-agent.test.ts`** — the delegated `-32602` test now feeds Vibe's real "Browser sign-in timed out." reason and asserts the reason, the `(code -32602)` suffix, and `err.code`; the sign-out `-32603` keyring test asserts the same.

## Out of scope (part B, tracked in #76)

A t3code-style "re-check / observe" recovery affordance (re-query `_auth/status` without restarting the flow). t3code never drives OAuth in-app — it observes auth state by re-probing on a poll + on-demand refresh — which structurally avoids this class of bug; that resilience pattern is the follow-up.

## Gates

`bun run lint` ✓ · `bun run typecheck` ✓ · `bun run build` ✓ · `bun run test` ✓ (353 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
