### PR TITLE
#79: re-check auth status without re-running sign-in (part B)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,6 +11,8 @@ import {
   type RespondPermissionArgs,
   type SendPromptArgs,
   type SendPromptResult,
+  type CheckAuthStatusArgs,
+  type CheckAuthStatusResult,
   type SetThreadConfigArgs,
   type SetThreadConfigResult,
   type SignInArgs,
@@ -735,6 +737,27 @@ function registerIpc(): void {
       return { ok: false, error }
     }
   })
+
+  ipcMain.handle(
+    IPC.checkAuthStatus,
+    async (_event, args: CheckAuthStatusArgs): Promise<CheckAuthStatusResult> => {
+      // Re-query `_auth/status` to OBSERVE current auth state without re-running
+      // the sign-in flow (#79) — recovers an out-of-band `vibe` CLI sign-in, the
+      // blocking fallback, or a delegated `complete` whose result we lost. A quick
+      // round-trip, so a `touch` suffices (no eviction protection like signIn).
+      const agent = pool.get(args.agentId)
+      if (!agent) return { ok: false, error: `No active agent for id ${args.agentId}.` }
+      pool.touch(args.agentId)
+      try {
+        const authState = await agent.refreshAuthStatus()
+        return { ok: true, authState, signOutAvailable: agent.signOutAvailable }
+      } catch (err) {
+        const error = err instanceof Error ? err.message : String(err)
+        console.error(`[vibe-mistro:auth] status check failed (agent ${args.agentId}): ${error}`)
+        return { ok: false, error }
+      }
+    },
+  )
 
   ipcMain.handle(IPC.stopAgent, (_event, agentId: string) => {
     // Explicit close: the pool stops the child and drops it; the Workspace

--- a/src/main/workspace-agent.test.ts
+++ b/src/main/workspace-agent.test.ts
@@ -225,6 +225,63 @@ describe('WorkspaceAgent — auth detection (_auth/status)', () => {
   })
 })
 
+describe('WorkspaceAgent.refreshAuthStatus() (#79)', () => {
+  it('re-queries _auth/status and folds signed_out → signed-in (observe, no re-sign-in)', async () => {
+    const fake = makeCapturingFake()
+    const agent = await startWithAuthStatus(fake, {
+      authenticated: false,
+      authState: 'signed_out',
+      signOutAvailable: false,
+    })
+    expect(agent.authState).toBe('not-signed-in')
+
+    // Simulates an out-of-band `vibe` CLI sign-in: a fresh _auth/status now reports
+    // authenticated, with no `authenticate` round-trip in between.
+    const refreshed = agent.refreshAuthStatus()
+    await new Promise((r) => setTimeout(r, 0))
+    const statusReqs = sent(fake).filter((m) => m.method === '_auth/status')
+    // No sign-in flow was driven — only the start-time detect + this re-check.
+    expect(statusReqs.length).toBe(2)
+    expect(sent(fake).some((m) => m.method === 'authenticate')).toBe(false)
+    fake.feed(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: statusReqs[statusReqs.length - 1]?.id,
+        result: { authenticated: true, authState: 'os_keyring', signOutAvailable: true },
+      }) + '\n',
+    )
+
+    expect(await refreshed).toBe('signed-in')
+    expect(agent.authState).toBe('signed-in')
+    expect(agent.signOutAvailable).toBe(true)
+  })
+
+  it('rejects (no wedge) when the re-query fails', async () => {
+    const fake = makeCapturingFake()
+    const agent = await startWithAuthStatus(fake, {
+      authenticated: false,
+      authState: 'signed_out',
+      signOutAvailable: false,
+    })
+
+    const refreshed = agent.refreshAuthStatus()
+    const settled = refreshed.catch((e: unknown) => e)
+    await new Promise((r) => setTimeout(r, 0))
+    const statusReqs = sent(fake).filter((m) => m.method === '_auth/status')
+    fake.feed(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: statusReqs[statusReqs.length - 1]?.id,
+        error: { code: -32603, message: 'internal' },
+      }) + '\n',
+    )
+
+    await settled
+    // The failed re-check leaves the cached state untouched — never wedged.
+    expect(agent.authState).toBe('not-signed-in')
+  })
+})
+
 // --- TB3: browser-auth-delegated sign-in ------------------------------------
 
 interface InitParams {

--- a/src/main/workspace-agent.ts
+++ b/src/main/workspace-agent.ts
@@ -311,6 +311,22 @@ export class WorkspaceAgent extends EventEmitter {
   }
 
   /**
+   * Re-query `_auth/status` and fold it into the cached auth state + sign-out gate
+   * (#79). The renderer's "Check sign-in status" affordance calls this to OBSERVE
+   * auth state without re-running the sign-in flow — e.g. after an out-of-band
+   * `vibe` CLI sign-in, the blocking fallback, or a delegated `complete` whose
+   * result we lost. Resolves the fresh `AuthState`; rejects (no wedge — relies on
+   * `AcpClient.rejectAllPending` on exit/stop) on an RPC failure or early exit.
+   */
+  async refreshAuthStatus(): Promise<AuthState> {
+    if (!this.initialized) {
+      throw new WorkspaceAgentError('Agent is not initialized; call start() first.')
+    }
+    const status = await this.client.request('_auth/status')
+    return this.applyAuthStatus(status)
+  }
+
+  /**
    * Drive Vibe's browser sign-in, dispatching on the advertised `methodId`
    * (acp-capture §8). Two captured modes (ADR-0003):
    *   - `browser-auth-delegated` (primary): the client-driven two-step

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -10,6 +10,8 @@ import {
   type OpenThreadArgs,
   type SendPromptArgs,
   type SendPromptResult,
+  type CheckAuthStatusArgs,
+  type CheckAuthStatusResult,
   type SetThreadConfigArgs,
   type SetThreadConfigResult,
   type SignInArgs,
@@ -36,6 +38,8 @@ const api = {
     ipcRenderer.invoke(IPC.respondPermission, args),
   signIn: (args: SignInArgs): Promise<SignInResult> => ipcRenderer.invoke(IPC.signIn, args),
   signOut: (args: SignOutArgs): Promise<SignOutResult> => ipcRenderer.invoke(IPC.signOut, args),
+  checkAuthStatus: (args: CheckAuthStatusArgs): Promise<CheckAuthStatusResult> =>
+    ipcRenderer.invoke(IPC.checkAuthStatus, args),
   stopAgent: (agentId: string): Promise<void> => ipcRenderer.invoke(IPC.stopAgent, agentId),
   setActiveAgent: (agentId: string | null): Promise<void> =>
     ipcRenderer.invoke(IPC.setActiveAgent, agentId),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -934,6 +934,28 @@ function SignInPanel({
     dispatch({ type: 'sign-in-cancel' })
   }
 
+  // #79: OBSERVE current auth state without re-running the browser flow — recovers
+  // an out-of-band `vibe` CLI sign-in, the blocking fallback, or a delegated
+  // `complete` whose result we lost. Bumps the attempt generation so any stale
+  // in-flight sign-in result is dropped (same guard as `signIn`/`cancel`).
+  async function checkStatus(): Promise<void> {
+    const attempt = ++attemptRef.current
+    dispatch({ type: 'check-start' })
+    const result = await window.api.checkAuthStatus({ agentId })
+    if (attempt !== attemptRef.current) return // superseded — drop the stale result
+    if (result.ok && result.authState === 'signed-in') {
+      dispatch({ type: 'sign-in-success' })
+      onSignedIn() // continue to a connected Thread on the same agent
+    } else if (result.ok) {
+      dispatch({
+        type: 'sign-in-error',
+        message: 'Still not signed in. Finish signing in (in your browser or via `vibe`), then check again.',
+      })
+    } else {
+      dispatch({ type: 'sign-in-error', message: result.error })
+    }
+  }
+
   if (view.kind === 'signed-in') {
     return (
       <div className="signin signin--done">
@@ -962,8 +984,17 @@ function SignInPanel({
     )
   }
 
+  if (view.kind === 'checking') {
+    return (
+      <div className="signin">
+        <div className="signin__title">Checking sign-in status…</div>
+      </div>
+    )
+  }
+
   // sign-in or error: both render the (clickable) Sign-in button so the error
-  // state stays recoverable.
+  // state stays recoverable, plus a re-check that OBSERVES auth state without
+  // re-running the browser flow (#79) — for an out-of-band `vibe` CLI sign-in.
   return (
     <div className="signin">
       <div className="signin__title">Not signed in to Mistral Vibe</div>
@@ -973,6 +1004,9 @@ function SignInPanel({
       {view.kind === 'error' && <div className="signin__error">{view.message}</div>}
       <button className="btn signin__action" onClick={() => void signIn(view.methodId)}>
         {view.kind === 'error' ? `Retry — ${view.methodName}` : view.methodName}
+      </button>
+      <button className="btn btn--ghost signin__action" onClick={() => void checkStatus()}>
+        Already signed in? Check status
       </button>
     </div>
   )

--- a/src/renderer/src/auth/auth-view.test.ts
+++ b/src/renderer/src/auth/auth-view.test.ts
@@ -88,6 +88,33 @@ describe('authReducer', () => {
     expect(state.phase).toBe('signed-in')
     expect(state.error).toBe('Sign-out failed.')
   })
+
+  it('re-checks: not-signed-in → checking on check-start (#79)', () => {
+    const state = authReducer(initialAuthViewState([DELEGATED]), { type: 'check-start' })
+    expect(state.phase).toBe('checking')
+    expect(state.error).toBeNull()
+  })
+
+  it('re-check that finds signed-in folds to signed-in (#79)', () => {
+    let state = authReducer(initialAuthViewState([DELEGATED]), { type: 'check-start' })
+    state = authReducer(state, { type: 'sign-in-success' })
+    expect(state.phase).toBe('signed-in')
+  })
+
+  it('re-check that is still not signed in stays recoverable (error w/ note, #79)', () => {
+    let state = authReducer(initialAuthViewState([DELEGATED]), { type: 'check-start' })
+    state = authReducer(state, { type: 'sign-in-error', message: 'Still not signed in.' })
+    expect(state.phase).toBe('error')
+    expect(state.error).toBe('Still not signed in.')
+    // check-start adds no state fields — the credential-shape guard still holds.
+    expect(Object.keys(state).sort()).toEqual([
+      'authMethods',
+      'error',
+      'identity',
+      'phase',
+      'signOutAvailable',
+    ])
+  })
 })
 
 describe('selectAuthView', () => {
@@ -124,6 +151,11 @@ describe('selectAuthView', () => {
   it('shows a signing-in view during the browser step', () => {
     const state = authReducer(initialAuthViewState([DELEGATED]), { type: 'sign-in-start' })
     expect(selectAuthView(state)).toEqual({ kind: 'signing-in' })
+  })
+
+  it('shows a checking view during the re-check step (#79)', () => {
+    const state = authReducer(initialAuthViewState([DELEGATED]), { type: 'check-start' })
+    expect(selectAuthView(state)).toEqual({ kind: 'checking' })
   })
 
   it('shows a signed-in indicator with the sign-out control gated on signOutAvailable', () => {

--- a/src/renderer/src/auth/auth-view.ts
+++ b/src/renderer/src/auth/auth-view.ts
@@ -13,7 +13,13 @@ import { BLOCKING_AUTH_METHOD_ID, DELEGATED_AUTH_METHOD_ID, type AuthMethod } fr
  * signed in (shows the indicator + sign-out); `signing-out` is the in-flight
  * sign-out; `error` is a recoverable sign-in failure the user can retry from.
  */
-export type AuthPhase = 'not-signed-in' | 'signing-in' | 'signed-in' | 'signing-out' | 'error'
+export type AuthPhase =
+  | 'not-signed-in'
+  | 'signing-in'
+  | 'checking'
+  | 'signed-in'
+  | 'signing-out'
+  | 'error'
 
 /** Pure view state for the auth panel/indicator — folded by `authReducer`. */
 export interface AuthViewState {
@@ -50,6 +56,7 @@ export type AuthAction =
   | { type: 'sign-in-success' }
   | { type: 'sign-in-error'; message: string }
   | { type: 'sign-in-cancel' }
+  | { type: 'check-start' }
   | { type: 'sign-out-start' }
   | { type: 'sign-out-success' }
   | { type: 'sign-out-error'; message: string }
@@ -62,6 +69,9 @@ export type AuthAction =
  * (the browser long-poll can't be aborted — see SignInPanel). `sign-out-success`
  * returns to `not-signed-in` so the same panel can sign a different account back
  * in (account switch); `sign-out-error` keeps the user signed-in (recoverable).
+ * `check-start` is the in-flight re-check (#79): from `not-signed-in`/`error` it
+ * OBSERVES auth state without re-running sign-in — resolving to `sign-in-success`
+ * (signed in) or back to `sign-in-error` (still not, recoverable, with a note).
  */
 export function authReducer(state: AuthViewState, action: AuthAction): AuthViewState {
   switch (action.type) {
@@ -73,6 +83,8 @@ export function authReducer(state: AuthViewState, action: AuthAction): AuthViewS
       return { ...state, phase: 'error', error: action.message }
     case 'sign-in-cancel':
       return { ...state, phase: 'not-signed-in', error: null }
+    case 'check-start':
+      return { ...state, phase: 'checking', error: null }
     case 'sign-out-start':
       return { ...state, phase: 'signing-out', error: null }
     case 'sign-out-success':
@@ -93,6 +105,11 @@ export interface SignInView {
 /** Render the in-flight browser step (a spinner / progress, no button). */
 export interface SigningInView {
   kind: 'signing-in'
+}
+
+/** Render the in-flight re-check (`_auth/status` re-query) step (#79). */
+export interface CheckingView {
+  kind: 'checking'
 }
 
 /**
@@ -123,6 +140,7 @@ export interface SignInErrorView {
 export type AuthView =
   | SignInView
   | SigningInView
+  | CheckingView
   | SignedInView
   | SigningOutView
   | SignInErrorView
@@ -156,6 +174,8 @@ export function selectAuthView(state: AuthViewState): AuthView {
       return { kind: 'sign-in', methodId: method.id, methodName: method.name, description: method.description }
     case 'signing-in':
       return { kind: 'signing-in' }
+    case 'checking':
+      return { kind: 'checking' }
     case 'error':
       return { kind: 'error', message: state.error ?? 'Sign-in failed.', methodId: method.id, methodName: method.name }
     case 'signed-in':

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -22,6 +22,8 @@ export const IPC = {
   signIn: 'auth:sign-in',
   /** Sign out the agent's session (`_auth/signOut`). */
   signOut: 'auth:sign-out',
+  /** Re-query an agent's `_auth/status` without re-running sign-in (#79). */
+  checkAuthStatus: 'auth:check-status',
   /** Main -> renderer: streamed ACP event tagged by the owning agent. */
   acpEvent: 'acp:event',
   /**
@@ -382,6 +384,24 @@ export interface SignOutArgs {
  */
 export type SignOutResult =
   | { ok: true; authState: AuthState; authMethods: AuthMethod[] }
+  | { ok: false; error: string }
+
+/**
+ * Re-query an agent's current `_auth/status` without re-running sign-in (#79).
+ * Lets the panel OBSERVE auth state — picking up an out-of-band `vibe` CLI
+ * sign-in, the blocking fallback, or a delegated `complete` whose result we lost.
+ */
+export interface CheckAuthStatusArgs {
+  /** Id of the Workspace agent to re-query. */
+  agentId: string
+}
+
+/**
+ * Result of a re-check. `signOutAvailable` seeds the signed-in indicator when the
+ * check lands signed-in (mirrors `SignOutResult`'s gate). Failures are recoverable.
+ */
+export type CheckAuthStatusResult =
+  | { ok: true; authState: AuthState; signOutAvailable: boolean }
   | { ok: false; error: string }
 
 /** Which agent control a `setThreadConfig` change targets (#66). */


### PR DESCRIPTION
Closes #79.

## What

Adopts the resilient half of t3code's pattern — **observe auth state by re-query** — for vibe-mistro's sign-in panel. When the delegated `complete` fails (timed out / denied / its result dropped) or the user signs in **out-of-band via the `vibe` CLI**, they no longer have to re-run the whole browser flow: a one-click **"Already signed in? Check status"** re-queries `_auth/status` and lands them connected if Vibe now reports signed-in.

## Changes

- **`src/main/workspace-agent.ts`** — `refreshAuthStatus()`: a public re-query of `_auth/status` that reuses the existing `applyAuthStatus` classifier (no new logic), rejecting (no wedge) on RPC failure / early exit.
- **`src/shared/ipc.ts` + `src/preload/index.ts`** — one new typed `invoke` channel `auth:check-status` (`CheckAuthStatusArgs` / `CheckAuthStatusResult`); no stringly channels.
- **`src/main/index.ts`** — thin handler: `touch` (no eviction protection — quick round-trip, unlike the long `signIn`), logs failures to main stderr (`[vibe-mistro:auth]`, consistent with #78).
- **`src/renderer/src/auth/auth-view.ts`** — renderer stays a pure `authReducer` fold: a new `checking` phase + `check-start` action, **no new state fields** (the credential-shape guard in the tests still holds).
- **`src/renderer/src/App.tsx`** — `SignInPanel` gains the re-check button on the sign-in/error panel, reusing the existing attempt-generation guard so a stale in-flight sign-in result is dropped. Re-check is intentionally NOT offered during `signing-in` (the `complete` long-poll is already pending there).

## Scope notes

- **Part 2 (expiry messaging)** from the issue is largely covered by #78 — failures already surface Vibe's specific "Browser sign-in timed out." / "expired." reason + code.
- **Part 3 (background polling)** is deferred per the issue's own guidance ("decide whether manual re-check is enough before adding a timer"). Manual re-check is the cheaper first step.
- Caveat (flagged in #79): in the *delegated* flow Vibe persists the credential only inside `complete`, so a never-completed exchange has nothing to re-read — the re-check's main wins are the out-of-band CLI sign-in, the blocking fallback, and a `complete` whose result we lost.

## Tests

- `refreshAuthStatus` folds `signed_out → signed-in` with **no `authenticate` round-trip** in between, surfaces `signOutAvailable`, and a failed re-query leaves cached state untouched (no wedge).
- `authReducer` / `selectAuthView` cover the `checking` phase and `check-start`, including the key-shape guard.

## Gates

`bun run lint` ✓ · `bun run typecheck` ✓ · `bun run build` ✓ · `bun run test` ✓ (359 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
