### PR TITLE
#84: streamed git status + changed-files Changes panel (slice 1a)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@base-ui/react": "^1.4.1",
     "@tailwindcss/vite": "^4",
+    "chokidar": "^5.0.0",
     "clsx": "^2.1.1",
     "lucide-react": "^0.564",
     "react": "^19.1.0",

--- a/src/main/git/runtime.ts
+++ b/src/main/git/runtime.ts
@@ -1,0 +1,41 @@
+import { watch as chokidarWatch } from 'chokidar'
+import type { Clock, WatchFactory } from './status-stream'
+
+/**
+ * Production wiring for the git status manager (#84) — the real clock + the chokidar
+ * fs watcher. Kept out of `status-stream.ts` so that module stays dep-free and fully
+ * unit-testable (fakes for both), mirroring how the ACP transport injects its spawn.
+ */
+
+/** The real timers as a `Clock` (handles are opaque to the manager). */
+export const realClock: Clock = {
+  setTimeout: (fn, ms) => setTimeout(fn, ms),
+  clearTimeout: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+  setInterval: (fn, ms) => setInterval(fn, ms),
+  clearInterval: (handle) => clearInterval(handle as ReturnType<typeof setInterval>),
+}
+
+/**
+ * Churn dirs the working-tree watcher must IGNORE (#84): `.git/` (so our own status
+ * reads + the agent's commits don't self-trigger — the turn-end refresh covers those
+ * deliberately), plus heavy build/dep dirs whose writes aren't user changes. Matched
+ * anywhere in the path (segment-bounded) on both `/` and `\` separators.
+ */
+const IGNORED = /(^|[/\\])(\.git|node_modules|out|dist)([/\\]|$)/
+
+/**
+ * chokidar-backed `WatchFactory`. Node's recursive `fs.watch` isn't portable, so we
+ * use chokidar with `ignoreInitial` (no snapshot burst — `subscribe` emits that) and
+ * the ignore matcher above. Any add/change/unlink calls `onChange`; the manager
+ * debounces the burst into one re-read.
+ */
+export const chokidarWatchFactory: WatchFactory = (workspaceDir, onChange) => {
+  const watcher = chokidarWatch(workspaceDir, {
+    ignoreInitial: true,
+    ignored: (path: string) => IGNORED.test(path),
+  })
+  watcher.on('all', () => onChange())
+  // Swallow watcher errors (a removed dir, an EMFILE) — they must never crash main.
+  watcher.on('error', () => {})
+  return { close: () => watcher.close() }
+}

--- a/src/main/git/status-stream.test.ts
+++ b/src/main/git/status-stream.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi } from 'vitest'
+import { GitStatusManager, type Clock, type WatchFactory } from './status-stream'
+import type { GitStatus, GitStatusEvent } from '../../shared/ipc'
+
+/**
+ * The manager's lifecycle is the load-bearing seam: ref-count start/stop, the single
+ * watcher + fetch per dir, debounce, fetch TTL, and teardown. Driven entirely by
+ * injected fakes (clock / watch / read / fetch / emit) — no real git, fs, or timers.
+ */
+
+const sampleStatus: GitStatus = {
+  isRepo: true,
+  branch: 'main',
+  upstream: null,
+  ahead: 0,
+  behind: 0,
+  files: [],
+}
+
+/** Let any pending microtasks + a few macrotasks settle (real timers; the manager's are faked). */
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+    .then(() => new Promise((resolve) => setTimeout(resolve, 0)))
+    .then(() => new Promise((resolve) => setTimeout(resolve, 0)))
+}
+
+function makeClock(): {
+  clock: Clock
+  timeouts: Map<number, () => void>
+  intervals: Map<number, () => void>
+  fireTimeouts: () => void
+  fireIntervals: () => void
+} {
+  let nextId = 1
+  const timeouts = new Map<number, () => void>()
+  const intervals = new Map<number, () => void>()
+  const clock: Clock = {
+    setTimeout: (fn) => {
+      const id = nextId++
+      timeouts.set(id, fn)
+      return id
+    },
+    clearTimeout: (h) => void timeouts.delete(h as number),
+    setInterval: (fn) => {
+      const id = nextId++
+      intervals.set(id, fn)
+      return id
+    },
+    clearInterval: (h) => void intervals.delete(h as number),
+  }
+  return {
+    clock,
+    timeouts,
+    intervals,
+    fireTimeouts: () => [...timeouts.values()].forEach((fn) => fn()),
+    fireIntervals: () => [...intervals.values()].forEach((fn) => fn()),
+  }
+}
+
+function makeWatch(): {
+  factory: WatchFactory
+  watchers: { dir: string; onChange: () => void; closed: boolean }[]
+} {
+  const watchers: { dir: string; onChange: () => void; closed: boolean }[] = []
+  const factory: WatchFactory = (dir, onChange) => {
+    const w = { dir, onChange, closed: false }
+    watchers.push(w)
+    return { close: () => void (w.closed = true) }
+  }
+  return { factory, watchers }
+}
+
+function setup() {
+  const clock = makeClock()
+  const watch = makeWatch()
+  const emitted: GitStatusEvent[] = []
+  const read = vi.fn().mockResolvedValue(sampleStatus)
+  const fetch = vi.fn().mockResolvedValue(undefined)
+  const manager = new GitStatusManager({
+    read,
+    fetch,
+    watch: watch.factory,
+    clock: clock.clock,
+    emit: (event) => emitted.push(event),
+  })
+  return { manager, clock, watch, emitted, read, fetch }
+}
+
+describe('GitStatusManager', () => {
+  it('emits a snapshot on subscribe', async () => {
+    const { manager, emitted } = setup()
+    manager.subscribe('/a')
+    await flush()
+    expect(emitted).toHaveLength(1)
+    expect(emitted[0]).toMatchObject({ workspaceDir: '/a', kind: 'snapshot', status: sampleStatus })
+  })
+
+  it('ref-counts: a 2nd subscribe does not start a 2nd watcher', async () => {
+    const { manager, watch, clock } = setup()
+    manager.subscribe('/a')
+    manager.subscribe('/a')
+    await flush()
+    expect(watch.watchers).toHaveLength(1)
+    expect(clock.intervals.size).toBe(1)
+  })
+
+  it('tears down only on the LAST unsubscribe', async () => {
+    const { manager, watch, clock } = setup()
+    manager.subscribe('/a')
+    manager.subscribe('/a')
+    manager.unsubscribe('/a')
+    expect(watch.watchers[0].closed).toBe(false)
+    expect(clock.intervals.size).toBe(1)
+    manager.unsubscribe('/a')
+    expect(watch.watchers[0].closed).toBe(true)
+    expect(clock.intervals.size).toBe(0)
+    expect(manager.isSubscribed('/a')).toBe(false)
+  })
+
+  it('debounces an fs-watcher burst into one localUpdated re-read', async () => {
+    const { manager, watch, clock, emitted } = setup()
+    manager.subscribe('/a')
+    await flush()
+    emitted.length = 0
+    watch.watchers[0].onChange()
+    watch.watchers[0].onChange() // burst: the first timer is cleared, one remains
+    expect(clock.timeouts.size).toBe(1)
+    clock.fireTimeouts()
+    await flush()
+    expect(emitted.filter((e) => e.kind === 'localUpdated')).toHaveLength(1)
+  })
+
+  it('fetches then emits remoteUpdated on a fetch tick', async () => {
+    const { manager, clock, emitted, fetch } = setup()
+    manager.subscribe('/a')
+    await flush()
+    emitted.length = 0
+    fetch.mockClear()
+    clock.fireIntervals()
+    await flush()
+    expect(fetch).toHaveBeenCalledWith('/a')
+    expect(emitted.filter((e) => e.kind === 'remoteUpdated')).toHaveLength(1)
+  })
+
+  it('refresh re-reads (localUpdated) when subscribed, no-ops otherwise', async () => {
+    const { manager, emitted } = setup()
+    manager.refresh('/x') // not subscribed
+    await flush()
+    expect(emitted).toHaveLength(0)
+    manager.subscribe('/a')
+    await flush()
+    emitted.length = 0
+    manager.refresh('/a')
+    await flush()
+    expect(emitted.filter((e) => e.kind === 'localUpdated')).toHaveLength(1)
+  })
+
+  it('disposeAll tears down every subscription', () => {
+    const { manager, watch, clock } = setup()
+    manager.subscribe('/a')
+    manager.subscribe('/b')
+    expect(watch.watchers).toHaveLength(2)
+    manager.disposeAll()
+    expect(watch.watchers.every((w) => w.closed)).toBe(true)
+    expect(clock.intervals.size).toBe(0)
+    expect(manager.isSubscribed('/a')).toBe(false)
+    expect(manager.isSubscribed('/b')).toBe(false)
+  })
+})

--- a/src/main/git/status-stream.ts
+++ b/src/main/git/status-stream.ts
@@ -1,0 +1,151 @@
+import type { GitStatus, GitStatusEvent, GitStatusKind } from '../../shared/ipc'
+
+/**
+ * The streamed git-status manager (#84, ADR-0008). Per `workspaceDir` it ref-counts
+ * subscribers and, while at least one is held, runs ONE debounced fs watcher (local
+ * edits) + ONE background `git fetch` interval (remote ahead/behind) — the same
+ * resource discipline as the warm-agent cap (ADR-0006): active-Workspace-only, one
+ * watcher + one fetch. The renderer's mounted Changes panel is the only subscriber,
+ * so subscribe-on-mount / unsubscribe-on-switch keeps it bounded by construction.
+ *
+ * All side-effecting deps are INJECTED (read / fetch / watch / clock / emit) so the
+ * load-bearing lifecycle — ref-count start/stop, debounce, fetch TTL, teardown — is
+ * unit-testable without shelling git or touching the real fs / electron. The index.ts
+ * glue wires `emit` to `webContents.send` (this module never imports electron),
+ * mirroring `emitThreadStatus`.
+ */
+
+/** Opaque timer handle — the real clock returns Node timers; tests return fakes. */
+export type TimerHandle = unknown
+
+/** The clock seam (setTimeout for debounce, setInterval for the fetch TTL). */
+export interface Clock {
+  setTimeout(fn: () => void, ms: number): TimerHandle
+  clearTimeout(handle: TimerHandle): void
+  setInterval(fn: () => void, ms: number): TimerHandle
+  clearInterval(handle: TimerHandle): void
+}
+
+/** A started fs watcher this manager can later close (the chokidar surface it uses). */
+export interface WatcherLike {
+  close(): void | Promise<void>
+}
+
+/** Start watching `workspaceDir`, calling `onChange` on each (non-ignored) fs event. */
+export type WatchFactory = (workspaceDir: string, onChange: () => void) => WatcherLike
+
+/** Push one status event to the renderer(s). Wired to `webContents.send` in index.ts. */
+export type EmitStatus = (event: GitStatusEvent) => void
+
+export interface GitStatusManagerDeps {
+  read: (workspaceDir: string) => Promise<GitStatus>
+  fetch: (workspaceDir: string) => Promise<void>
+  watch: WatchFactory
+  clock: Clock
+  emit: EmitStatus
+  /** fs-watcher debounce before a re-read (default 250ms). */
+  debounceMs?: number
+  /** Background fetch TTL — re-fetch + re-read this often while subscribed (default 15s). */
+  fetchIntervalMs?: number
+}
+
+interface Entry {
+  count: number
+  watcher: WatcherLike
+  fetchTimer: TimerHandle
+  debounceTimer: TimerHandle | null
+}
+
+const DEFAULT_DEBOUNCE_MS = 250
+const DEFAULT_FETCH_INTERVAL_MS = 15_000
+
+export class GitStatusManager {
+  private readonly entries = new Map<string, Entry>()
+  private readonly debounceMs: number
+  private readonly fetchIntervalMs: number
+
+  constructor(private readonly deps: GitStatusManagerDeps) {
+    this.debounceMs = deps.debounceMs ?? DEFAULT_DEBOUNCE_MS
+    this.fetchIntervalMs = deps.fetchIntervalMs ?? DEFAULT_FETCH_INTERVAL_MS
+  }
+
+  /**
+   * Add a subscriber for `workspaceDir`. The FIRST starts the fs watcher + the fetch
+   * interval; later ones only bump the ref-count (no 2nd watcher). Every subscribe
+   * emits a fresh `snapshot` so the newly-mounted panel renders current state.
+   */
+  subscribe(workspaceDir: string): void {
+    let entry = this.entries.get(workspaceDir)
+    if (!entry) {
+      const watcher = this.deps.watch(workspaceDir, () => this.onLocalChange(workspaceDir))
+      const fetchTimer = this.deps.clock.setInterval(() => void this.onFetch(workspaceDir), this.fetchIntervalMs)
+      entry = { count: 0, watcher, fetchTimer, debounceTimer: null }
+      this.entries.set(workspaceDir, entry)
+    }
+    entry.count++
+    void this.emitRead(workspaceDir, 'snapshot')
+  }
+
+  /** Drop one subscriber. The LAST tears the watcher + fetch timer down; else no-op. */
+  unsubscribe(workspaceDir: string): void {
+    const entry = this.entries.get(workspaceDir)
+    if (!entry) return
+    entry.count--
+    if (entry.count > 0) return
+    this.teardown(workspaceDir, entry)
+  }
+
+  /**
+   * Force a `localUpdated` re-read for a SUBSCRIBED Workspace (the turn-end trigger +
+   * the panel's manual Refresh). No-op when not subscribed — there's no panel to push
+   * to. The turn-end case catches the agent's OWN git commands (a commit changes
+   * `.git/`, which the working-tree watcher ignores).
+   */
+  refresh(workspaceDir: string): void {
+    if (!this.entries.has(workspaceDir)) return
+    void this.emitRead(workspaceDir, 'localUpdated')
+  }
+
+  /** Tear every subscription down (app quit) — no watcher or timer outlives the app. */
+  disposeAll(): void {
+    for (const [workspaceDir, entry] of [...this.entries]) this.teardown(workspaceDir, entry)
+  }
+
+  /** Whether a Workspace currently has any subscriber (test/diagnostic helper). */
+  isSubscribed(workspaceDir: string): boolean {
+    return this.entries.has(workspaceDir)
+  }
+
+  /** Debounce an fs-watcher burst into a single `localUpdated` re-read. */
+  private onLocalChange(workspaceDir: string): void {
+    const entry = this.entries.get(workspaceDir)
+    if (!entry) return
+    if (entry.debounceTimer != null) this.deps.clock.clearTimeout(entry.debounceTimer)
+    entry.debounceTimer = this.deps.clock.setTimeout(() => {
+      entry.debounceTimer = null
+      void this.emitRead(workspaceDir, 'localUpdated')
+    }, this.debounceMs)
+  }
+
+  /** Background fetch tick: best-effort `git fetch`, then a `remoteUpdated` re-read. */
+  private async onFetch(workspaceDir: string): Promise<void> {
+    if (!this.entries.has(workspaceDir)) return
+    await this.deps.fetch(workspaceDir)
+    if (!this.entries.has(workspaceDir)) return // unsubscribed during the fetch
+    await this.emitRead(workspaceDir, 'remoteUpdated')
+  }
+
+  /** Read status and emit it, unless the Workspace was unsubscribed during the read. */
+  private async emitRead(workspaceDir: string, kind: GitStatusKind): Promise<void> {
+    const status = await this.deps.read(workspaceDir)
+    if (!this.entries.has(workspaceDir)) return
+    this.deps.emit({ workspaceDir, kind, status })
+  }
+
+  private teardown(workspaceDir: string, entry: Entry): void {
+    if (entry.debounceTimer != null) this.deps.clock.clearTimeout(entry.debounceTimer)
+    this.deps.clock.clearInterval(entry.fetchTimer)
+    void entry.watcher.close()
+    this.entries.delete(workspaceDir)
+  }
+}

--- a/src/main/git/status.test.ts
+++ b/src/main/git/status.test.ts
@@ -110,13 +110,42 @@ describe('parseGitStatus', () => {
 })
 
 describe('readGitStatus', () => {
-  // A fake runner keyed off the first git arg — no real git, no real fs.
-  function fakeRun(responses: Record<string, { stdout: string; code: number }>): GitRun {
+  // A fake runner keyed off the git SUBCOMMAND — skips leading `-c <value>` config
+  // pairs (e.g. `-c core.quotePath=false`) so the key is `status`/`diff`, not `-c`.
+  function fakeRun(
+    responses: Record<string, { stdout: string; code: number }>,
+    seen?: string[][],
+  ): GitRun {
     return (args) => {
-      const key = args[0] === 'diff' && args.includes('--cached') ? 'diff:cached' : args[0]
+      seen?.push(args)
+      let i = 0
+      while (args[i] === '-c') i += 2
+      const sub = args[i]
+      const key = sub === 'diff' && args.includes('--cached') ? 'diff:cached' : sub
       return Promise.resolve(responses[key] ?? { stdout: '', code: 0 })
     }
   }
+
+  it('passes -c core.quotePath=false to the path-emitting commands (non-ASCII names)', async () => {
+    const seen: string[][] = []
+    await readGitStatus(
+      '/repo',
+      fakeRun(
+        {
+          'rev-parse': { stdout: 'true\n', code: 0 },
+          status: { stdout: mixPorcelain, code: 0 },
+          diff: { stdout: mixNumstat, code: 0 },
+          'diff:cached': { stdout: mixCachedNumstat, code: 0 },
+        },
+        seen,
+      ),
+    )
+    const pathCmds = seen.filter((a) => a.includes('status') || a.includes('diff'))
+    expect(pathCmds.length).toBe(3)
+    for (const a of pathCmds) {
+      expect(a.slice(0, 2)).toEqual(['-c', 'core.quotePath=false'])
+    }
+  })
 
   it('returns isRepo:false when rev-parse is non-zero (not a repo / no git)', async () => {
     const status = await readGitStatus('/nope', fakeRun({ 'rev-parse': { stdout: '', code: 128 } }))

--- a/src/main/git/status.test.ts
+++ b/src/main/git/status.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest'
+import { parseGitStatus, readGitStatus, type GitRun } from './status'
+
+/**
+ * The parser is the pure seam — fixtures are VERBATIM from real `git status
+ * --porcelain=2 --branch` / `git diff --numstat` on a dirty repo (the mix below was
+ * captured from an actual rename + binary + staged + untracked working tree).
+ * `readGitStatus` is driven by a fake `GitRun` so no test shells real git.
+ */
+
+// A clean repo: branch headers only, no entries (no upstream → no branch.ab).
+const cleanPorcelain = `# branch.oid a1288794444eca02ae7d00d2ae055d42b3c1d8ef
+# branch.head main
+`
+
+// modified-unstaged binary + staged-rename-then-modified + staged-add + untracked.
+const mixPorcelain = `# branch.oid a1288794444eca02ae7d00d2ae055d42b3c1d8ef
+# branch.head main
+1 .M N... 100644 100644 100644 13122a653aac3d3777f545403322976a77cc5b53 13122a653aac3d3777f545403322976a77cc5b53 image.bin
+2 RM N... 100644 100644 100644 83db48f84ec878fbfb30b46d16630e944e34f205 83db48f84ec878fbfb30b46d16630e944e34f205 R100 renamed.txt\ttracked.txt
+1 A. N... 000000 100644 100644 0000000000000000000000000000000000000000 393d6dd7190959cece20cd7d77278332fa592633 staged_new.txt
+? untracked.txt
+`
+const mixNumstat = `-\t-\timage.bin
+2\t1\trenamed.txt
+`
+const mixCachedNumstat = `0\t0\ttracked.txt => renamed.txt
+1\t0\tstaged_new.txt
+`
+
+describe('parseGitStatus', () => {
+  it('parses a clean repo: branch set, no files, no upstream', () => {
+    const status = parseGitStatus(cleanPorcelain, '', '')
+    expect(status).toEqual({
+      isRepo: true,
+      branch: 'main',
+      upstream: null,
+      ahead: 0,
+      behind: 0,
+      files: [],
+    })
+  })
+
+  it('parses a modified + staged + untracked + renamed mix with merged numstat', () => {
+    const status = parseGitStatus(mixPorcelain, mixNumstat, mixCachedNumstat)
+    expect(status.isRepo).toBe(true)
+    expect(status.branch).toBe('main')
+    const byPath = Object.fromEntries(status.files.map((f) => [f.path, f]))
+
+    // Worktree-modified binary: X='.', unstaged, churn 0/0 (binary `-` numstat).
+    expect(byPath['image.bin']).toEqual({
+      path: 'image.bin',
+      status: '.M',
+      insertions: 0,
+      deletions: 0,
+      staged: false,
+      untracked: false,
+    })
+    // Staged rename, further worktree-modified: X='R' => staged; churn sums the
+    // unstaged (2/1) + cached (0/0) numstat under the NEW path.
+    expect(byPath['renamed.txt']).toEqual({
+      path: 'renamed.txt',
+      status: 'RM',
+      insertions: 2,
+      deletions: 1,
+      staged: true,
+      untracked: false,
+    })
+    // Staged add: X='A' => staged; churn from cached numstat (1/0).
+    expect(byPath['staged_new.txt']).toEqual({
+      path: 'staged_new.txt',
+      status: 'A.',
+      insertions: 1,
+      deletions: 0,
+      staged: true,
+      untracked: false,
+    })
+    // Untracked: '?' line.
+    expect(byPath['untracked.txt']).toEqual({
+      path: 'untracked.txt',
+      status: '?',
+      insertions: 0,
+      deletions: 0,
+      staged: false,
+      untracked: true,
+    })
+  })
+
+  it('parses ahead/behind from branch.ab when an upstream is set', () => {
+    const porcelain = `# branch.head main
+# branch.upstream origin/main
+# branch.ab +2 -3
+`
+    const status = parseGitStatus(porcelain, '', '')
+    expect(status.upstream).toBe('origin/main')
+    expect(status.ahead).toBe(2)
+    expect(status.behind).toBe(3)
+  })
+
+  it('reports a null branch when HEAD is detached', () => {
+    const status = parseGitStatus('# branch.head (detached)\n', '', '')
+    expect(status.branch).toBeNull()
+  })
+
+  it('handles a path containing spaces (porcelain=2 leaves it unquoted)', () => {
+    const porcelain = '1 .M N... 100644 100644 100644 00 00 my file.txt\n'
+    const status = parseGitStatus(porcelain, '5\t2\tmy file.txt\n', '')
+    expect(status.files[0]).toMatchObject({ path: 'my file.txt', insertions: 5, deletions: 2 })
+  })
+})
+
+describe('readGitStatus', () => {
+  // A fake runner keyed off the first git arg — no real git, no real fs.
+  function fakeRun(responses: Record<string, { stdout: string; code: number }>): GitRun {
+    return (args) => {
+      const key = args[0] === 'diff' && args.includes('--cached') ? 'diff:cached' : args[0]
+      return Promise.resolve(responses[key] ?? { stdout: '', code: 0 })
+    }
+  }
+
+  it('returns isRepo:false when rev-parse is non-zero (not a repo / no git)', async () => {
+    const status = await readGitStatus('/nope', fakeRun({ 'rev-parse': { stdout: '', code: 128 } }))
+    expect(status).toEqual({ isRepo: false, branch: null, upstream: null, ahead: 0, behind: 0, files: [] })
+  })
+
+  it('reads + parses a repo via the injected runner', async () => {
+    const status = await readGitStatus(
+      '/repo',
+      fakeRun({
+        'rev-parse': { stdout: 'true\n', code: 0 },
+        status: { stdout: mixPorcelain, code: 0 },
+        diff: { stdout: mixNumstat, code: 0 },
+        'diff:cached': { stdout: mixCachedNumstat, code: 0 },
+      }),
+    )
+    expect(status.isRepo).toBe(true)
+    expect(status.branch).toBe('main')
+    expect(status.files).toHaveLength(4)
+  })
+
+  it('swallows a non-zero status command into isRepo:false (never throws)', async () => {
+    const status = await readGitStatus(
+      '/repo',
+      fakeRun({
+        'rev-parse': { stdout: 'true\n', code: 0 },
+        status: { stdout: '', code: 1 },
+      }),
+    )
+    expect(status.isRepo).toBe(false)
+  })
+})

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -195,10 +195,14 @@ export async function readGitStatus(cwd: string, run: GitRun = defaultRun): Prom
   try {
     const inside = await run(['rev-parse', '--is-inside-work-tree'], cwd)
     if (inside.code !== 0 || inside.stdout.trim() !== 'true') return notARepo()
+    // `-c core.quotePath=false` so paths with non-ASCII chars (accented / CJK /
+    // emoji) come back as plain UTF-8, not octal-escaped + quoted (git's default
+    // would render `src/héllo.txt` as the literal `"src/h\303\251llo.txt"` in the
+    // panel). Applied to BOTH status and the numstats so their path keys still match.
     const [porcelain, numstat, cachedNumstat] = await Promise.all([
-      run(['status', '--porcelain=2', '--branch'], cwd),
-      run(['diff', '--numstat'], cwd),
-      run(['diff', '--cached', '--numstat'], cwd),
+      run(['-c', 'core.quotePath=false', 'status', '--porcelain=2', '--branch'], cwd),
+      run(['-c', 'core.quotePath=false', 'diff', '--numstat'], cwd),
+      run(['-c', 'core.quotePath=false', 'diff', '--cached', '--numstat'], cwd),
     ])
     if (porcelain.code !== 0) return notARepo()
     return parseGitStatus(porcelain.stdout, numstat.stdout, cachedNumstat.stdout)

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -1,0 +1,221 @@
+import { execFile, type ExecFileException } from 'node:child_process'
+import { getShellEnv } from '../shell-env'
+import type { GitFile, GitStatus } from '../../shared/ipc'
+
+/**
+ * Read a Workspace working tree's git status (#84, ADR-0008). Git runs in MAIN via
+ * `child_process` (ADR-0002 thin orchestrator) — no git2 / isomorphic-git. The PURE
+ * `parseGitStatus` is the testable seam (it never shells out); `readGitStatus` is the
+ * thin impure shell that runs the git commands (through an injectable runner,
+ * mirroring `AcpClient`'s `spawn` injection) and feeds the parser.
+ *
+ * v1 is purely OBSERVATIONAL: status only, no writes. Any git failure (a non-repo
+ * Workspace, a missing `git`, a broken index) is swallowed into `isRepo:false` — it
+ * NEVER throws into the stream, so a watcher tick or a fetch can't crash the manager.
+ */
+
+/**
+ * Run a git command and capture its stdout + exit code. Injectable for tests so they
+ * never shell real git (Seam, mirroring `AcpClient.spawn`). The default resolves
+ * `git` via the shell-env PATH (so a Finder/Dock launch still finds it, like the
+ * agent spawn) and resolves — never rejects — with the exit code even on failure.
+ */
+export type GitRun = (args: string[], cwd: string) => Promise<{ stdout: string; code: number }>
+
+const defaultRun: GitRun = (args, cwd) =>
+  new Promise((resolve) => {
+    execFile(
+      'git',
+      args,
+      { cwd, env: getShellEnv(), encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 },
+      (err: ExecFileException | null, stdout: string) => {
+        // execFile's `err.code` is the numeric exit code on a non-zero exit, or a
+        // string (e.g. 'ENOENT' when git is missing) on a spawn failure — map both
+        // to a non-zero code so the caller degrades to `isRepo:false`.
+        const code = err == null ? 0 : typeof err.code === 'number' ? err.code : 1
+        resolve({ stdout: stdout ?? '', code })
+      },
+    )
+  })
+
+/** The empty, not-a-repo status — also the swallow-all-errors fallback. */
+function notARepo(): GitStatus {
+  return { isRepo: false, branch: null, upstream: null, ahead: 0, behind: 0, files: [] }
+}
+
+interface Numstat {
+  insertions: number
+  deletions: number
+}
+
+/**
+ * Parse one `git diff --numstat` / `git diff --cached --numstat` block into a
+ * path -> {insertions, deletions} map. Each line is `<ins>\t<del>\t<path>`; a binary
+ * file reports `-`/`-` (parsed as 0/0). A rename shows in the path as `old => new`
+ * (optionally with a `{old => new}` brace segment) — we normalize to the NEW path so
+ * it keys the same as the porcelain=2 entry's (new) path.
+ */
+function parseNumstat(numstat: string): Map<string, Numstat> {
+  const map = new Map<string, Numstat>()
+  for (const line of numstat.split('\n')) {
+    if (!line) continue
+    const tab = line.indexOf('\t')
+    if (tab < 0) continue
+    const secondTab = line.indexOf('\t', tab + 1)
+    if (secondTab < 0) continue
+    const insRaw = line.slice(0, tab)
+    const delRaw = line.slice(tab + 1, secondTab)
+    const rawPath = line.slice(secondTab + 1)
+    map.set(normalizeRenamePath(rawPath), {
+      insertions: insRaw === '-' ? 0 : Number(insRaw) || 0,
+      deletions: delRaw === '-' ? 0 : Number(delRaw) || 0,
+    })
+  }
+  return map
+}
+
+/** Resolve a numstat rename path (`old => new` or `pre/{old => new}/post`) to the new path. */
+function normalizeRenamePath(path: string): string {
+  if (path.includes('{') && path.includes(' => ')) {
+    // `pre/{old => new}/post` -> `pre/new/post`
+    return path.replace(/\{[^}]*? => ([^}]*?)\}/g, '$1').replace(/\/{2,}/g, '/')
+  }
+  const arrow = path.indexOf(' => ')
+  return arrow >= 0 ? path.slice(arrow + 4) : path
+}
+
+/**
+ * PURE parser (#84): turn `git status --porcelain=2 --branch` + the two numstat
+ * blocks into a `GitStatus`. The porcelain=2 grammar (verified against real git):
+ *  - `# branch.head <name>` (`(detached)` when detached), `# branch.upstream <name>`,
+ *    `# branch.ab +<ahead> -<behind>` (both header lines absent with no upstream).
+ *  - `1 <XY> <sub> <mH> <mI> <mW> <hH> <hI> <path>` — an ordinary changed entry.
+ *  - `2 <XY> <sub> <mH> <mI> <mW> <hH> <hI> <Xscore> <path>\t<orig>` — rename/copy.
+ *  - `u <XY> ... <path>` — unmerged; `? <path>` — untracked; `! <path>` — ignored.
+ * The XY code's X (index) half being non-`.`/`?` marks the path `staged`.
+ */
+export function parseGitStatus(porcelain: string, numstat: string, cachedNumstat: string): GitStatus {
+  const status: GitStatus = { isRepo: true, branch: null, upstream: null, ahead: 0, behind: 0, files: [] }
+  const unstaged = parseNumstat(numstat)
+  const staged = parseNumstat(cachedNumstat)
+
+  for (const line of porcelain.split('\n')) {
+    if (!line) continue
+    if (line.startsWith('# ')) {
+      parseHeader(line.slice(2), status)
+      continue
+    }
+    const kind = line[0]
+    if (kind === '1' || kind === '2') {
+      const file = parseChangedEntry(line, kind, unstaged, staged)
+      if (file) status.files.push(file)
+    } else if (kind === '?') {
+      const path = line.slice(2)
+      status.files.push({ path, status: '?', insertions: 0, deletions: 0, staged: false, untracked: true })
+    }
+    // `u` (unmerged) and `!` (ignored, not requested) are intentionally skipped in v1.
+  }
+  return status
+}
+
+/** Fold one `# branch.*` header line into the status (mutates). */
+function parseHeader(rest: string, status: GitStatus): void {
+  if (rest.startsWith('branch.head ')) {
+    const name = rest.slice('branch.head '.length)
+    status.branch = name === '(detached)' ? null : name
+  } else if (rest.startsWith('branch.upstream ')) {
+    status.upstream = rest.slice('branch.upstream '.length)
+  } else if (rest.startsWith('branch.ab ')) {
+    // `+<ahead> -<behind>`
+    const m = /\+(-?\d+) -(-?\d+)/.exec(rest.slice('branch.ab '.length))
+    if (m) {
+      status.ahead = Number(m[1]) || 0
+      status.behind = Number(m[2]) || 0
+    }
+  }
+}
+
+/**
+ * Parse a `1`/`2` changed entry into a `GitFile`, merging its numstat churn. The
+ * path is the remainder after the fixed leading fields (8 for `1`, 9 for `2`, the
+ * extra being the rename score); a `2` entry's path is `<new>\t<orig>` so we take the
+ * portion before the tab. Insertions/deletions sum the staged + unstaged numstat for
+ * the path (an `MM` file is dirty in both), so the panel shows total churn.
+ */
+function parseChangedEntry(
+  line: string,
+  kind: '1' | '2',
+  unstaged: Map<string, Numstat>,
+  staged: Map<string, Numstat>,
+): GitFile | null {
+  const leadingFields = kind === '1' ? 8 : 9
+  const { fields, rest } = splitLeading(line, leadingFields)
+  if (fields.length < leadingFields) return null
+  const xy = fields[1]
+  const path = kind === '2' ? rest.split('\t')[0] : rest
+  if (!path) return null
+  const churn = {
+    insertions: (unstaged.get(path)?.insertions ?? 0) + (staged.get(path)?.insertions ?? 0),
+    deletions: (unstaged.get(path)?.deletions ?? 0) + (staged.get(path)?.deletions ?? 0),
+  }
+  return {
+    path,
+    status: xy,
+    insertions: churn.insertions,
+    deletions: churn.deletions,
+    // X (index) half non-`.` => staged. (`?`/`!` never reach here.)
+    staged: xy[0] !== '.' && xy[0] !== '?',
+    untracked: false,
+  }
+}
+
+/** Split off the first `n` space-delimited fields, keeping the remainder (the path) intact. */
+function splitLeading(line: string, n: number): { fields: string[]; rest: string } {
+  const fields: string[] = []
+  let i = 0
+  for (let f = 0; f < n; f++) {
+    const sp = line.indexOf(' ', i)
+    if (sp < 0) {
+      fields.push(line.slice(i))
+      return { fields, rest: '' }
+    }
+    fields.push(line.slice(i, sp))
+    i = sp + 1
+  }
+  return { fields, rest: line.slice(i) }
+}
+
+/**
+ * Impure read (#84): run the git commands for `cwd` and parse them. First gate on
+ * `git rev-parse --is-inside-work-tree`; on non-zero (non-repo / no git) return the
+ * empty `isRepo:false` status. All git errors are swallowed into that fallback — this
+ * NEVER throws, so a watcher tick or background fetch can't crash the status manager.
+ */
+export async function readGitStatus(cwd: string, run: GitRun = defaultRun): Promise<GitStatus> {
+  try {
+    const inside = await run(['rev-parse', '--is-inside-work-tree'], cwd)
+    if (inside.code !== 0 || inside.stdout.trim() !== 'true') return notARepo()
+    const [porcelain, numstat, cachedNumstat] = await Promise.all([
+      run(['status', '--porcelain=2', '--branch'], cwd),
+      run(['diff', '--numstat'], cwd),
+      run(['diff', '--cached', '--numstat'], cwd),
+    ])
+    if (porcelain.code !== 0) return notARepo()
+    return parseGitStatus(porcelain.stdout, numstat.stdout, cachedNumstat.stdout)
+  } catch {
+    return notARepo()
+  }
+}
+
+/**
+ * Best-effort background `git fetch` for the remote-tracking refresh (#84). Quiet and
+ * swallow-all: an offline / no-upstream / auth-failed fetch just resolves (the caller
+ * re-reads status either way, so ahead/behind simply stays as it was). Never throws.
+ */
+export async function gitFetch(cwd: string, run: GitRun = defaultRun): Promise<void> {
+  try {
+    await run(['fetch', '--quiet'], cwd)
+  } catch {
+    // best-effort — a failed fetch is a no-op for the stream.
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,6 +5,8 @@ import { basename, join } from 'node:path'
 import {
   IPC,
   type DeleteThreadResult,
+  type GitStatusEvent,
+  type GitStatusSubscriptionArgs,
   type ListMetadataResult,
   type OpenThreadArgs,
   type ReadTranscriptResult,
@@ -46,6 +48,9 @@ import { isProtected } from './agent-protection'
 import { controlsOf, ensureBoundSession, resolveContinueTarget } from './thread-binding'
 import { deleteThread } from './persistence/delete-thread'
 import { permissionRequestIdOf, ThreadStatusTracker, type ThreadStatusChange } from './thread-status'
+import { gitFetch, readGitStatus } from './git/status'
+import { GitStatusManager } from './git/status-stream'
+import { chokidarWatchFactory, realClock } from './git/runtime'
 
 /**
  * The warm-agent pool (ADR-0006 decision 3, TB2 #47): one `vibe-acp` agent per
@@ -135,6 +140,26 @@ function emitThreadStatus(changes: ThreadStatusChange | ThreadStatusChange[] | n
     for (const change of list) win.webContents.send(IPC.threadStatus, change satisfies ThreadStatusEvent)
   }
 }
+
+/**
+ * The streamed git-status manager (#84, ADR-0008): per active Workspace it ref-counts
+ * subscribers and runs one debounced fs watcher + one background `git fetch`,
+ * emitting `snapshot`/`localUpdated`/`remoteUpdated`. Git runs in main via
+ * `child_process` (ADR-0002); the manager itself is electron-free (deps injected
+ * here), so its emit is wired to `webContents.send` below — mirroring
+ * `emitThreadStatus`. Torn down on quit so no watcher/timer outlives the app.
+ */
+const gitStatus = new GitStatusManager({
+  read: (workspaceDir) => readGitStatus(workspaceDir),
+  fetch: (workspaceDir) => gitFetch(workspaceDir),
+  watch: chokidarWatchFactory,
+  clock: realClock,
+  emit: (event: GitStatusEvent) => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (!win.webContents.isDestroyed()) win.webContents.send(IPC.gitStatus, event)
+    }
+  },
+})
 
 function beginTurn(agentId: string): void {
   inFlightTurns.set(agentId, (inFlightTurns.get(agentId) ?? 0) + 1)
@@ -668,6 +693,11 @@ function registerIpc(): void {
         // permission (see `ThreadStatusTracker.clearThread`).
         emitThreadStatus(threadStatus.endTurn(args.agentId, args.threadId))
         emitThreadStatus(threadStatus.clearThread(args.threadId))
+        // Re-read git status for THIS Workspace at turn end (#84): the working-tree
+        // watcher ignores `.git/`, so the agent's OWN git commands (e.g. a commit) are
+        // invisible to it — this trigger catches them. No-op unless the Workspace's
+        // Changes panel is subscribed.
+        gitStatus.refresh(agent.workspaceDir)
       }
     },
   )
@@ -847,6 +877,19 @@ function registerIpc(): void {
     if (!transcriptStore) return Promise.resolve([])
     return transcriptStore.read(threadId)
   })
+
+  ipcMain.handle(IPC.gitSubscribeStatus, (_event, args: GitStatusSubscriptionArgs) => {
+    // Subscribe the active Workspace's Changes panel to its streamed git status (#84).
+    // Ref-counted in the manager: the first subscribe starts the watcher + fetch and
+    // emits a snapshot, later ones just bump the count + re-emit the snapshot.
+    gitStatus.subscribe(args.workspaceDir)
+  })
+
+  ipcMain.handle(IPC.gitUnsubscribeStatus, (_event, args: GitStatusSubscriptionArgs) => {
+    // Panel unmount / Workspace switch-away (#84): the last unsubscribe tears the
+    // watcher + fetch timer down (active-Workspace-only streaming, ADR-0008).
+    gitStatus.unsubscribe(args.workspaceDir)
+  })
 }
 
 app.whenReady().then(async () => {
@@ -903,4 +946,7 @@ app.on('will-quit', () => {
     clearInterval(sweepTimer)
     sweepTimer = null
   }
+  // Tear down every git-status subscription (#84) so no fs watcher or fetch timer
+  // outlives the app — mirrors the sweep-timer cleanup above.
+  gitStatus.disposeAll()
 })

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4,6 +4,8 @@ import {
   type AcpEvent,
   type AgentEvictedEvent,
   type DeleteThreadResult,
+  type GitStatusEvent,
+  type GitStatusSubscriptionArgs,
   type ListMetadataResult,
   type ReadTranscriptResult,
   type RespondPermissionArgs,
@@ -51,6 +53,10 @@ const api = {
     ipcRenderer.invoke(IPC.setThreadConfig, args),
   readTranscript: (threadId: string): Promise<ReadTranscriptResult> =>
     ipcRenderer.invoke(IPC.readTranscript, threadId),
+  gitSubscribeStatus: (args: GitStatusSubscriptionArgs): Promise<void> =>
+    ipcRenderer.invoke(IPC.gitSubscribeStatus, args),
+  gitUnsubscribeStatus: (args: GitStatusSubscriptionArgs): Promise<void> =>
+    ipcRenderer.invoke(IPC.gitUnsubscribeStatus, args),
   onAcpEvent: (listener: (event: AcpEvent) => void): (() => void) => {
     const handler = (_e: unknown, payload: AcpEvent): void => listener(payload)
     ipcRenderer.on(IPC.acpEvent, handler)
@@ -70,6 +76,11 @@ const api = {
     const handler = (_e: unknown, payload: AgentEvictedEvent): void => listener(payload)
     ipcRenderer.on(IPC.agentEvicted, handler)
     return () => ipcRenderer.removeListener(IPC.agentEvicted, handler)
+  },
+  onGitStatus: (listener: (event: GitStatusEvent) => void): (() => void) => {
+    const handler = (_e: unknown, payload: GitStatusEvent): void => listener(payload)
+    ipcRenderer.on(IPC.gitStatus, handler)
+    return () => ipcRenderer.removeListener(IPC.gitStatus, handler)
   },
 }
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -525,7 +525,7 @@ export function App(): JSX.Element {
   }
 
   /** The connected view for a Workspace (SignedInBar + the controlled outlet). */
-  function renderConnected(conn: ThreadConnection): ReactNode {
+  function renderConnected(conn: ThreadConnection, isActive: boolean): ReactNode {
     const wts = workspaceThreadStateFor(workspaceThreads, conn.workspaceId)
     const cold = threadsForWorkspace(recents, conn.workspaceId)
     const activeId = wts?.active ?? conn.threadId
@@ -555,6 +555,7 @@ export function App(): JSX.Element {
           connection={conn}
           activeThread={activeThread}
           isLive={isLive}
+          isActive={isActive}
           seedSessionId={seed}
           controls={
             // A bound Thread sources its OWN live config (#70); a draft (no config
@@ -610,7 +611,7 @@ export function App(): JSX.Element {
         if (conn.status !== 'connected') return null
         return (
           <div key={wid} className="shell__connection" hidden={wid !== selectedWs}>
-            {renderConnected(conn.thread)}
+            {renderConnected(conn.thread, wid === selectedWs)}
           </div>
         )
       })}

--- a/src/renderer/src/connection/ConnectedWorkspace.tsx
+++ b/src/renderer/src/connection/ConnectedWorkspace.tsx
@@ -8,6 +8,7 @@ import type {
 } from '../../../shared/ipc'
 import { ColdThread } from '../conversation/ColdThread'
 import { Conversation } from '../conversation/Conversation'
+import { ChangesPanel } from '../git/ChangesPanel'
 
 /**
  * A connected Workspace's conversation OUTLET (ADR-0006, TB3 #48). It no longer
@@ -34,6 +35,7 @@ export function ConnectedWorkspace({
   connection,
   activeThread,
   isLive,
+  isActive,
   seedSessionId,
   controls,
   onSetConfig,
@@ -47,6 +49,12 @@ export function ConnectedWorkspace({
   activeThread: ThreadMeta
   /** Whether `activeThread` is hosted live on this session's agent (vs cold replay). */
   isLive: boolean
+  /**
+   * Whether this is the ON-SCREEN Workspace (#84). A background Workspace stays
+   * mounted (hidden), so the Changes panel gates its git-status subscription on this
+   * — not mere mount — to keep streaming active-Workspace-only (one watcher + fetch).
+   */
+  isActive: boolean
   /** The session to seed a live view with (bound-this-session wins over the cursor). */
   seedSessionId: string | null
   /** The active Thread's OWN agent-controls (#70), or null when none are seeded yet. */
@@ -64,27 +72,32 @@ export function ConnectedWorkspace({
   onAuthExpired: (authMethods: AuthMethod[]) => void
 }): JSX.Element {
   return (
-    <div className="workspace">
-      {isLive ? (
-        <Conversation
-          key={activeThread.id}
-          thread={{
-            agentId: connection.agentId,
-            threadId: activeThread.id,
-            workspaceId: connection.workspaceId,
-            sessionId: seedSessionId,
-            title: activeThread.title,
-          }}
-          modes={controls?.modes ?? null}
-          models={controls?.models ?? null}
-          reasoningEffort={controls?.reasoningEffort ?? null}
-          onSetConfig={onSetConfig}
-          onAuthExpired={onAuthExpired}
-          onBound={onBound}
-        />
-      ) : (
-        <ColdThread key={activeThread.id} thread={activeThread} onClose={onCloseCold} onContinue={onContinue} />
-      )}
+    <div className="flex min-h-0 flex-1 items-start gap-4">
+      <div className="workspace min-w-0 flex-1">
+        {isLive ? (
+          <Conversation
+            key={activeThread.id}
+            thread={{
+              agentId: connection.agentId,
+              threadId: activeThread.id,
+              workspaceId: connection.workspaceId,
+              sessionId: seedSessionId,
+              title: activeThread.title,
+            }}
+            modes={controls?.modes ?? null}
+            models={controls?.models ?? null}
+            reasoningEffort={controls?.reasoningEffort ?? null}
+            onSetConfig={onSetConfig}
+            onAuthExpired={onAuthExpired}
+            onBound={onBound}
+          />
+        ) : (
+          <ColdThread key={activeThread.id} thread={activeThread} onClose={onCloseCold} onContinue={onContinue} />
+        )}
+      </div>
+      {/* Streamed git status (#84) — observational only; renders nothing for a non-repo
+          Workspace and subscribes only while this is the active Workspace. */}
+      <ChangesPanel workspaceDir={connection.workspaceDir} isActive={isActive} />
     </div>
   )
 }

--- a/src/renderer/src/git/ChangesPanel.tsx
+++ b/src/renderer/src/git/ChangesPanel.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useState, type JSX } from 'react'
+import { ChevronDown, ChevronRight, GitBranch, RefreshCw } from 'lucide-react'
+import type { GitStatus } from '../../../shared/ipc'
+import { cn } from '../lib/utils'
+import { buildChangesView, type GitFileView } from './status-view'
+
+/**
+ * The collapsible right "Changes" panel for a connected Workspace (#84, ADR-0008).
+ * It subscribes to the Workspace's STREAMED git status while it is the ACTIVE one
+ * (`isActive`), holds the latest snapshot, and renders the branch header + the
+ * changed-files list. v1 is purely observational — a file row is a no-op stub (the
+ * diff view is slice #85).
+ *
+ * Subscription lifecycle (active-Workspace-only, ADR-0008): the effect runs only when
+ * active, registering `onGitStatus` (filtered by `workspaceDir`) and calling
+ * `gitSubscribeStatus`; its cleanup removes the listener and `gitUnsubscribeStatus`.
+ * ConnectedWorkspace stays MOUNTED (hidden) for background Workspaces, so gating on
+ * `isActive` — not mere mount — is what bounds streaming to one watcher + one fetch.
+ *
+ * Degrades to nothing for a non-repo Workspace (`isRepo:false`) or before the first
+ * snapshot — "a Workspace need not be a git repo" (CONTEXT.md): no panel, not an error.
+ */
+export function ChangesPanel({
+  workspaceDir,
+  isActive,
+}: {
+  workspaceDir: string
+  isActive: boolean
+}): JSX.Element | null {
+  const [status, setStatus] = useState<GitStatus | null>(null)
+  const [collapsed, setCollapsed] = useState(false)
+
+  useEffect(() => {
+    if (!isActive) return
+    const off = window.api.onGitStatus((event) => {
+      if (event.workspaceDir === workspaceDir) setStatus(event.status)
+    })
+    void window.api.gitSubscribeStatus({ workspaceDir })
+    return () => {
+      off()
+      void window.api.gitUnsubscribeStatus({ workspaceDir })
+    }
+  }, [workspaceDir, isActive])
+
+  // Manual refresh: a subscribe/unsubscribe pair re-emits a fresh snapshot without
+  // changing the net ref-count (the panel keeps its own hold across this).
+  function refresh(): void {
+    void window.api
+      .gitSubscribeStatus({ workspaceDir })
+      .then(() => window.api.gitUnsubscribeStatus({ workspaceDir }))
+  }
+
+  // No panel before the first snapshot, or for a non-repo Workspace (degrade quietly).
+  if (!status || !status.isRepo) return null
+
+  const view = buildChangesView(status)
+
+  return (
+    <aside className="w-72 shrink-0 border-l border-border bg-panel text-text">
+      <div className="flex items-center gap-1.5 border-b border-border px-3 py-2">
+        <button
+          type="button"
+          onClick={() => setCollapsed((c) => !c)}
+          title={collapsed ? 'Expand' : 'Collapse'}
+          aria-expanded={!collapsed}
+          className="flex min-w-0 flex-1 items-center gap-1.5 text-left text-xs font-medium"
+        >
+          {collapsed ? (
+            <ChevronRight size={14} aria-hidden className="shrink-0 text-muted" />
+          ) : (
+            <ChevronDown size={14} aria-hidden className="shrink-0 text-muted" />
+          )}
+          <span>Changes</span>
+          {view.fileCount > 0 && <span className="text-muted">{view.fileCount}</span>}
+        </button>
+        <button
+          type="button"
+          onClick={refresh}
+          title="Refresh"
+          aria-label="Refresh git status"
+          className="shrink-0 text-muted hover:text-accent-text"
+        >
+          <RefreshCw size={13} aria-hidden />
+        </button>
+      </div>
+
+      {!collapsed && (
+        <>
+          <div className="flex items-center gap-1.5 border-b border-border px-3 py-2 text-xs text-muted">
+            <GitBranch size={13} aria-hidden className="shrink-0" />
+            <span className="min-w-0 flex-1 truncate font-medium text-text" title={view.branch}>
+              {view.branch}
+            </span>
+            {(view.ahead > 0 || view.behind > 0) && (
+              <span className="shrink-0 tabular-nums" title={`${view.ahead} ahead, ${view.behind} behind`}>
+                {view.ahead > 0 && <>↑{view.ahead}</>}
+                {view.ahead > 0 && view.behind > 0 && ' '}
+                {view.behind > 0 && <>↓{view.behind}</>}
+              </span>
+            )}
+          </div>
+
+          {view.files.length === 0 ? (
+            <p className="px-3 py-3 text-xs text-muted">No changes — working tree clean.</p>
+          ) : (
+            <ul className="flex flex-col py-1">
+              {view.files.map((file) => (
+                <FileRow key={file.path} file={file} />
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+    </aside>
+  )
+}
+
+/** A glyph's accent: added/untracked read positive, deleted negative, else neutral. */
+function glyphClass(glyph: string): string {
+  if (glyph === 'A' || glyph === 'U') return 'text-ok'
+  if (glyph === 'D') return 'text-bad'
+  return 'text-accent-text'
+}
+
+/** One changed-file row. Clicking is a no-op stub — the diff view is slice #85. */
+function FileRow({ file }: { file: GitFileView }): JSX.Element {
+  return (
+    <li>
+      <button
+        type="button"
+        // diff view — slice #85 (no-op for now).
+        onClick={() => {}}
+        title={file.path}
+        className="flex w-full items-center gap-2 px-3 py-1 text-left text-xs hover:bg-accent/10"
+      >
+        <span
+          className={cn('w-3 shrink-0 text-center font-semibold tabular-nums', glyphClass(file.glyph))}
+          title={file.glyphLabel}
+          aria-label={file.glyphLabel}
+        >
+          {file.glyph}
+        </span>
+        <span className="min-w-0 flex-1 truncate" dir="rtl">
+          {file.path}
+        </span>
+        {(file.insertions > 0 || file.deletions > 0) && (
+          <span className="shrink-0 tabular-nums text-[11px]">
+            {file.insertions > 0 && <span className="text-ok">+{file.insertions}</span>}
+            {file.insertions > 0 && file.deletions > 0 && ' '}
+            {file.deletions > 0 && <span className="text-bad">−{file.deletions}</span>}
+          </span>
+        )}
+      </button>
+    </li>
+  )
+}

--- a/src/renderer/src/git/status-view.test.ts
+++ b/src/renderer/src/git/status-view.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { buildChangesView, fileGlyph } from './status-view'
+import type { GitFile, GitStatus } from '../../../shared/ipc'
+
+function file(partial: Partial<GitFile> & { path: string }): GitFile {
+  return {
+    status: '.M',
+    insertions: 0,
+    deletions: 0,
+    staged: false,
+    untracked: false,
+    ...partial,
+  }
+}
+
+describe('fileGlyph', () => {
+  it('maps each porcelain XY family to a glyph + label', () => {
+    expect(fileGlyph(file({ path: 'a', status: '?', untracked: true }))).toEqual({ glyph: 'U', label: 'Untracked' })
+    expect(fileGlyph(file({ path: 'a', status: '.M' }))).toEqual({ glyph: 'M', label: 'Modified' })
+    expect(fileGlyph(file({ path: 'a', status: 'A.' }))).toEqual({ glyph: 'A', label: 'Added' })
+    expect(fileGlyph(file({ path: 'a', status: '.D' }))).toEqual({ glyph: 'D', label: 'Deleted' })
+    expect(fileGlyph(file({ path: 'a', status: 'RM' }))).toEqual({ glyph: 'R', label: 'Renamed' })
+  })
+})
+
+describe('buildChangesView', () => {
+  const status: GitStatus = {
+    isRepo: true,
+    branch: 'main',
+    upstream: 'origin/main',
+    ahead: 2,
+    behind: 1,
+    files: [
+      file({ path: 'z.txt', status: '?', untracked: true }),
+      file({ path: 'a.txt', status: '.M', insertions: 3, deletions: 1 }),
+      file({ path: 'b.txt', status: 'A.', insertions: 5, deletions: 0, staged: true }),
+    ],
+  }
+
+  it('groups by glyph rank then path, and rolls up header + churn', () => {
+    const view = buildChangesView(status)
+    expect(view.branch).toBe('main')
+    expect(view.detached).toBe(false)
+    expect(view.ahead).toBe(2)
+    expect(view.behind).toBe(1)
+    expect(view.fileCount).toBe(3)
+    expect(view.totalInsertions).toBe(8)
+    expect(view.totalDeletions).toBe(1)
+    // Modified (a.txt) before Added (b.txt) before Untracked (z.txt).
+    expect(view.files.map((f) => f.path)).toEqual(['a.txt', 'b.txt', 'z.txt'])
+    expect(view.files.map((f) => f.glyph)).toEqual(['M', 'A', 'U'])
+  })
+
+  it('labels a detached HEAD', () => {
+    const view = buildChangesView({ ...status, branch: null, files: [] })
+    expect(view.branch).toBe('HEAD')
+    expect(view.detached).toBe(true)
+  })
+})

--- a/src/renderer/src/git/status-view.ts
+++ b/src/renderer/src/git/status-view.ts
@@ -1,0 +1,69 @@
+import type { GitFile, GitStatus } from '../../../shared/ipc'
+
+/**
+ * Pure view-model for the Changes panel (#84): turn a raw `GitStatus` into a
+ * render-ready shape — a per-file display glyph, a stable sort, and the header
+ * roll-ups (branch label, ahead/behind, total churn). Kept out of the component so
+ * the non-trivial mapping/sorting is unit-tested without rendering React.
+ */
+
+/** A changed file plus its single-letter display glyph + accessible label. */
+export interface GitFileView extends GitFile {
+  glyph: string
+  glyphLabel: string
+}
+
+/** The render-ready Changes view. */
+export interface ChangesView {
+  /** Branch name, or `'HEAD'` when detached (see `detached`). */
+  branch: string
+  detached: boolean
+  ahead: number
+  behind: number
+  files: GitFileView[]
+  fileCount: number
+  totalInsertions: number
+  totalDeletions: number
+}
+
+/**
+ * The single-letter glyph + label for a file, derived from its porcelain XY code.
+ * Untracked is `U`; otherwise the most salient change wins (rename > copy > add >
+ * delete > modify) looking at both the index (X) and worktree (Y) halves.
+ */
+export function fileGlyph(file: GitFile): { glyph: string; label: string } {
+  if (file.untracked) return { glyph: 'U', label: 'Untracked' }
+  const x = file.status[0] ?? ' '
+  const y = file.status[1] ?? ' '
+  if (x === 'R' || y === 'R') return { glyph: 'R', label: 'Renamed' }
+  if (x === 'C' || y === 'C') return { glyph: 'C', label: 'Copied' }
+  if (x === 'A') return { glyph: 'A', label: 'Added' }
+  if (x === 'D' || y === 'D') return { glyph: 'D', label: 'Deleted' }
+  return { glyph: 'M', label: 'Modified' }
+}
+
+/** Sort rank by glyph so like-changes group together; ties break on path. */
+const GLYPH_RANK: Record<string, number> = { M: 0, A: 1, D: 2, R: 3, C: 4, U: 5 }
+
+/** Build the render-ready view from a repo `GitStatus` (assumes `isRepo:true`). */
+export function buildChangesView(status: GitStatus): ChangesView {
+  const files: GitFileView[] = status.files
+    .map((file) => {
+      const { glyph, label } = fileGlyph(file)
+      return { ...file, glyph, glyphLabel: label }
+    })
+    .sort((a, b) => {
+      const rank = (GLYPH_RANK[a.glyph] ?? 99) - (GLYPH_RANK[b.glyph] ?? 99)
+      return rank !== 0 ? rank : a.path.localeCompare(b.path)
+    })
+  return {
+    branch: status.branch ?? 'HEAD',
+    detached: status.branch === null,
+    ahead: status.ahead,
+    behind: status.behind,
+    files,
+    fileCount: files.length,
+    totalInsertions: files.reduce((n, f) => n + f.insertions, 0),
+    totalDeletions: files.reduce((n, f) => n + f.deletions, 0),
+  }
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -82,6 +82,28 @@ export const IPC = {
    * displayed value OPTIMISTICALLY and reverts on an `{ok:false}` (ADR-0007).
    */
   setThreadConfig: 'thread:set-config',
+  /**
+   * Renderer -> main: subscribe to the active Workspace's STREAMED git status
+   * (#84, ADR-0008). Ref-counted per `workspaceDir` in main — the first subscribe
+   * starts one fs watcher + one background fetch and emits a `snapshot`; later
+   * subscribes only bump the count (and re-emit the current snapshot). Returns void;
+   * status arrives on the `gitStatus` push channel. Active-Workspace-only by
+   * construction: only the mounted Changes panel subscribes (ADR-0008).
+   */
+  gitSubscribeStatus: 'git:subscribe-status',
+  /**
+   * Renderer -> main: drop one subscriber's hold on a Workspace's status stream
+   * (#84). The last unsubscribe tears down the watcher + fetch timer; an over-count
+   * unsubscribe is a no-op. Paired with `gitSubscribeStatus` on panel mount/unmount.
+   */
+  gitUnsubscribeStatus: 'git:unsubscribe-status',
+  /**
+   * Main -> renderer: a streamed git-status update for a subscribed Workspace (#84).
+   * `kind` distinguishes the trigger — `snapshot` (on subscribe), `localUpdated` (fs
+   * watcher / turn-end / manual refresh), `remoteUpdated` (background fetch refreshed
+   * ahead/behind). The renderer filters by `workspaceDir` and holds the latest status.
+   */
+  gitStatus: 'git:status',
 } as const
 
 /**
@@ -493,3 +515,55 @@ export type TranscriptEntry =
 
 /** The `readTranscript` reply: a Thread's transcript entries (empty when none). */
 export type ReadTranscriptResult = TranscriptEntry[]
+
+/**
+ * One changed path in a Workspace's working tree (#84, ADR-0008). `status` is the
+ * raw `git status --porcelain=2` XY code (e.g. `.M`, `A.`, `RM`, `MM`) or `?` for an
+ * untracked path — the renderer maps it to a display glyph. `insertions`/`deletions`
+ * are the merged `git diff` + `git diff --cached` numstat for the path (0 for a
+ * binary `-`/`-` entry). `staged` is true when the index half (X) is non-clean; a
+ * path can be both staged and worktree-dirty (e.g. `MM`) — `staged` then still true.
+ */
+export interface GitFile {
+  path: string
+  status: string
+  insertions: number
+  deletions: number
+  staged: boolean
+  untracked: boolean
+}
+
+/**
+ * A Workspace working tree's git status (#84, ADR-0008) — the observational v1
+ * payload. `isRepo:false` (with the empty defaults) covers a non-repo Workspace OR
+ * any git failure swallowed into the stream (never a throw): the renderer then shows
+ * no Changes panel ("a Workspace need not be a git repo", CONTEXT.md). `ahead`/
+ * `behind` are 0 with no upstream; `branch`/`upstream` are null when detached / unset.
+ */
+export interface GitStatus {
+  isRepo: boolean
+  branch: string | null
+  upstream: string | null
+  ahead: number
+  behind: number
+  files: GitFile[]
+}
+
+/** Which trigger produced a `gitStatus` push (#84). */
+export type GitStatusKind = 'snapshot' | 'localUpdated' | 'remoteUpdated'
+
+/**
+ * Main -> renderer streamed git-status update (#84). Tagged by `workspaceDir` so a
+ * renderer with one mounted Changes panel ignores events for other Workspaces (the
+ * push fans out to every window, like `thread:status`).
+ */
+export interface GitStatusEvent {
+  workspaceDir: string
+  kind: GitStatusKind
+  status: GitStatus
+}
+
+/** Args for `gitSubscribeStatus` / `gitUnsubscribeStatus` (#84). */
+export interface GitStatusSubscriptionArgs {
+  workspaceDir: string
+}


### PR DESCRIPTION
First slice of the git/GitHub integration (ADR-0008). Read-only: a streamed git **status** + changed-files **Changes panel** for the active Workspace. The diff viewer is #85.

## What

- **main (`src/main/git/`):** git runs via `child_process` (resolved shell-env PATH). A **pure `parseGitStatus`** (`git status --porcelain=2 --branch` + unstaged/staged `--numstat`) over an **injected runner** — the testable seam; any git failure degrades to `{isRepo:false}` (never throws). A **`GitStatusManager`** ref-counts subscribers per `workspaceDir` and runs **one** chokidar fs watcher (debounced, ignoring `.git`/`node_modules`/`out`/`dist`) + **one** background `git fetch` (~15s TTL), emitting `snapshot` / `localUpdated` / `remoteUpdated` — all deps injected (electron-free, unit-tested).
- **IPC:** typed `git:subscribe-status` / `git:unsubscribe-status` + a `git:status` push channel (mirrors `thread:status`). A **turn-end trigger** re-reads status to catch the agent's own git commands (which the working-tree watcher ignores). `disposeAll()` on quit.
- **renderer (`ChangesPanel.tsx`):** a collapsible right panel that subscribes **only while its Workspace is active** (`isActive = wid === selectedWs`, so background mounted-but-hidden views hold no subscription — active-Workspace-only by construction). Shows branch + ahead/behind + the changed-files list with ±counts; file-click is a no-op stub (#85); renders nothing for a non-repo Workspace. On the #61 stack.

## Review + verification

Implementer → my independent gate re-run + full diff read → adversarial reviewer (verdict **SHIP-WITH-FIXES**, no MUST-FIX; verified the parser against **real git** output incl. spaces/renames/non-ASCII, traced the ref-count/teardown + manual-refresh race, confirmed chokidar's ignore prevents traversal, and the active-Workspace lifecycle). Gates green: lint / typecheck / build / **378 tests**.

**Folded the one SHOULD-FIX:** `-c core.quotePath=false` so non-ASCII filenames render as plain UTF-8 instead of octal-escaped quoted text.

## Known NITs (deferred)

Background `git fetch` doesn't guard against a >15s fetch overlapping the next tick (best-effort/swallowed); out-of-order reads self-correct (last-write-wins); a Workspace whose path itself contains an ignored segment (e.g. `…/out/repo`) wouldn't fs-watch (turn-end + manual Refresh still work). None block v1.

## Manual smoke worth doing

Open a git-repo Workspace → Changes panel shows branch + changed files; have the agent edit a file → list updates live; non-repo Workspace → no panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)