### PR TITLE
#85: working-tree diff viewer via @pierre/diffs (slice 1b)

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -27,6 +27,13 @@ export default defineConfig({
         '@renderer': resolve(__dirname, 'src/renderer/src'),
       },
     },
+    // `@pierre/diffs`' worker (#85, imported via `?worker`) code-splits its shiki engine
+    // + language grammars with dynamic imports, so it must bundle as an ES-module worker.
+    // Vite defaults workers to `iife`, which rollup rejects for a code-splitting build
+    // ("UMD and IIFE output formats are not supported for code-splitting builds").
+    worker: {
+      format: 'es',
+    },
     build: {
       rollupOptions: {
         input: { index: resolve(__dirname, 'src/renderer/index.html') },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
+    "@pierre/diffs": "^1.2.12",
     "@tailwindcss/vite": "^4",
     "chokidar": "^5.0.0",
     "clsx": "^2.1.1",

--- a/src/main/git/diff.test.ts
+++ b/src/main/git/diff.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest'
+import { createHash } from 'node:crypto'
+import { finalizeDiff, readGitDiff } from './diff'
+import type { GitRun } from './status'
+
+/**
+ * The pure `finalizeDiff` (hash + cap) is the testable seam; `readGitDiff` is the thin
+ * impure shell driven by a fake `GitRun` so no test shells real git. The fixtures below
+ * are shaped like real `git diff` stdout (a tracked unified diff, an untracked
+ * new-file `--no-index` diff). The `--no-index` exit-code-1-is-success behaviour and
+ * the swallow-to-empty failure path are the two non-obvious bits worth pinning.
+ */
+
+const trackedPatch = `diff --git a/tracked.txt b/tracked.txt
+index c0d0fb4..ed51eca 100644
+--- a/tracked.txt
++++ b/tracked.txt
+@@ -1,2 +1,3 @@
+ line1
+-line2
++CHANGED
++line3
+`
+
+const untrackedPatch = `diff --git a/untracked.txt b/untracked.txt
+new file mode 100644
+index 0000000..d82766f
+--- /dev/null
++++ b/untracked.txt
+@@ -0,0 +1,2 @@
++new file
++content
+`
+
+describe('finalizeDiff', () => {
+  it('hashes the patch with sha256 and reports not-truncated for a small diff', () => {
+    const res = finalizeDiff(trackedPatch)
+    expect(res.patch).toBe(trackedPatch)
+    expect(res.truncated).toBe(false)
+    expect(res.diffHash).toBe(createHash('sha256').update(trackedPatch).digest('hex'))
+  })
+
+  it('is a stable hash: same input → same diffHash', () => {
+    expect(finalizeDiff(trackedPatch).diffHash).toBe(finalizeDiff(trackedPatch).diffHash)
+  })
+
+  it('different patches hash differently', () => {
+    expect(finalizeDiff(trackedPatch).diffHash).not.toBe(finalizeDiff(untrackedPatch).diffHash)
+  })
+
+  it('returns the empty result for an empty patch (no diff)', () => {
+    expect(finalizeDiff('')).toEqual({ patch: '', diffHash: '', truncated: false })
+  })
+
+  it('caps the patch at the ~120 KB byte limit and flags truncated, hashing the CAPPED text', () => {
+    const CAP = 120 * 1024
+    const huge = 'x'.repeat(CAP + 5000)
+    const res = finalizeDiff(huge)
+    expect(res.truncated).toBe(true)
+    expect(Buffer.byteLength(res.patch, 'utf8')).toBe(CAP)
+    // The hash is of the CAPPED patch (what the renderer receives), not the full input.
+    expect(res.diffHash).toBe(createHash('sha256').update(res.patch).digest('hex'))
+    expect(res.diffHash).not.toBe(createHash('sha256').update(huge).digest('hex'))
+  })
+
+  it('caps BY BYTES, not chars (a multibyte file cannot smuggle past the cap)', () => {
+    const CAP = 120 * 1024
+    // '€' is 3 bytes in UTF-8 — a char-length cap would let ~3x the bytes through.
+    const huge = '€'.repeat(CAP) // 3 * CAP bytes
+    const res = finalizeDiff(huge)
+    expect(res.truncated).toBe(true)
+    expect(Buffer.byteLength(res.patch, 'utf8')).toBeLessThanOrEqual(CAP)
+  })
+})
+
+describe('readGitDiff', () => {
+  /** A fake runner that returns one canned response for any invocation, recording args. */
+  function fakeRun(response: { stdout: string; code: number }, seen?: string[][]): GitRun {
+    return (args) => {
+      seen?.push(args)
+      return Promise.resolve(response)
+    }
+  }
+
+  it('reads a tracked file diff (exit 0) and returns the finalized patch', async () => {
+    const seen: string[][] = []
+    const res = await readGitDiff('/repo', 'tracked.txt', false, false, fakeRun({ stdout: trackedPatch, code: 0 }, seen))
+    expect(res.patch).toBe(trackedPatch)
+    expect(res.diffHash).toBe(createHash('sha256').update(trackedPatch).digest('hex'))
+    // tracked form: `diff --no-color -- <path>`, no `--no-index`, no `-w`.
+    const args = seen[0]
+    expect(args).toContain('--no-color')
+    expect(args).not.toContain('--no-index')
+    expect(args).not.toContain('-w')
+    expect(args.slice(0, 2)).toEqual(['-c', 'core.quotePath=false'])
+    expect(args.slice(-2)).toEqual(['--', 'tracked.txt'])
+  })
+
+  it('treats an untracked --no-index diff (exit 1) as SUCCESS, capturing stdout', async () => {
+    const seen: string[][] = []
+    const res = await readGitDiff('/repo', 'untracked.txt', true, false, fakeRun({ stdout: untrackedPatch, code: 1 }, seen))
+    expect(res.patch).toBe(untrackedPatch)
+    expect(res.truncated).toBe(false)
+    // untracked form: `diff --no-color --no-index -- /dev/null <path>`.
+    const args = seen[0]
+    expect(args).toContain('--no-index')
+    expect(args.slice(-3)).toEqual(['--', '/dev/null', 'untracked.txt'])
+  })
+
+  it('treats an untracked --no-index with NO diff (exit 0) as the empty result', async () => {
+    const res = await readGitDiff('/repo', 'untracked.txt', true, false, fakeRun({ stdout: '', code: 0 }))
+    expect(res).toEqual({ patch: '', diffHash: '', truncated: false })
+  })
+
+  it('swallows a real --no-index failure (exit > 1) into the empty result', async () => {
+    const res = await readGitDiff('/repo', 'gone.txt', true, false, fakeRun({ stdout: 'fatal: bad', code: 128 }))
+    expect(res).toEqual({ patch: '', diffHash: '', truncated: false })
+  })
+
+  it('swallows a tracked-diff failure (exit != 0) into the empty result', async () => {
+    const res = await readGitDiff('/repo', 'tracked.txt', false, false, fakeRun({ stdout: 'fatal: bad', code: 128 }))
+    expect(res).toEqual({ patch: '', diffHash: '', truncated: false })
+  })
+
+  it('adds -w when ignoreWhitespace is set (both tracked and untracked forms)', async () => {
+    const seenTracked: string[][] = []
+    await readGitDiff('/repo', 'tracked.txt', false, true, fakeRun({ stdout: trackedPatch, code: 0 }, seenTracked))
+    expect(seenTracked[0]).toContain('-w')
+
+    const seenUntracked: string[][] = []
+    await readGitDiff('/repo', 'untracked.txt', true, true, fakeRun({ stdout: untrackedPatch, code: 1 }, seenUntracked))
+    expect(seenUntracked[0]).toContain('-w')
+    expect(seenUntracked[0]).toContain('--no-index')
+  })
+
+  it('never throws — a runner that rejects degrades to the empty result', async () => {
+    const throwingRun: GitRun = () => Promise.reject(new Error('spawn failed'))
+    const res = await readGitDiff('/repo', 'tracked.txt', false, false, throwingRun)
+    expect(res).toEqual({ patch: '', diffHash: '', truncated: false })
+  })
+})

--- a/src/main/git/diff.test.ts
+++ b/src/main/git/diff.test.ts
@@ -87,9 +87,11 @@ describe('readGitDiff', () => {
     const res = await readGitDiff('/repo', 'tracked.txt', false, false, fakeRun({ stdout: trackedPatch, code: 0 }, seen))
     expect(res.patch).toBe(trackedPatch)
     expect(res.diffHash).toBe(createHash('sha256').update(trackedPatch).digest('hex'))
-    // tracked form: `diff --no-color -- <path>`, no `--no-index`, no `-w`.
+    // tracked form: `diff --no-color HEAD -- <path>`, no `--no-index`, no `-w`.
+    // `HEAD` so a fully-staged file still diffs (vs the bare worktree-vs-index form).
     const args = seen[0]
     expect(args).toContain('--no-color')
+    expect(args).toContain('HEAD')
     expect(args).not.toContain('--no-index')
     expect(args).not.toContain('-w')
     expect(args.slice(0, 2)).toEqual(['-c', 'core.quotePath=false'])

--- a/src/main/git/diff.ts
+++ b/src/main/git/diff.ts
@@ -1,0 +1,77 @@
+import { createHash } from 'node:crypto'
+import { defaultGitRun, type GitRun } from './status'
+import type { GitDiffResult } from '../../shared/ipc'
+
+/**
+ * Read a single changed path's WORKING-TREE unified diff (#85, ADR-0008). Like #84's
+ * status read, git runs in MAIN via `child_process` through the injectable `GitRun`
+ * seam (reused from `status.ts`) — no git2 / isomorphic-git. The renderer parses +
+ * renders the raw patch with `@pierre/diffs`; this side only produces the raw text.
+ *
+ * The data contract is deliberately thin: main returns the RAW unified-diff text plus
+ * a content `diffHash` (so the renderer can memoize an unchanged file and skip a
+ * re-parse), and a `truncated` flag when the patch is capped. Working-tree source
+ * only (no branch-range). Read-only. Any git failure is swallowed into the empty
+ * result — it NEVER throws, mirroring `readGitStatus`.
+ */
+
+/**
+ * Cap on the raw patch size handed to the renderer (~120 KB). A huge diff (a vendored
+ * lockfile, a generated bundle) would otherwise bloat the IPC payload and stall the
+ * worker render; past the cap we hand back a `truncated` prefix the viewer flags.
+ */
+const MAX_PATCH_BYTES = 120 * 1024
+
+/**
+ * PURE seam: turn a raw `git diff` stdout into the renderer payload. Caps the patch at
+ * `MAX_PATCH_BYTES` (BY BYTES, so a multibyte UTF-8 file can't smuggle past the cap),
+ * flags `truncated`, and hashes the FINAL (post-cap) patch with sha256 — the hash keys
+ * the renderer's memo, so it must reflect exactly the text the renderer receives. An
+ * empty input yields the empty result (`patch:''`, `diffHash:''`) — also the
+ * swallow-all-errors fallback shape, so a no-diff and a failed-diff read look alike.
+ */
+export function finalizeDiff(raw: string): GitDiffResult {
+  if (!raw) return { patch: '', diffHash: '', truncated: false }
+  const bytes = Buffer.from(raw, 'utf8')
+  const truncated = bytes.byteLength > MAX_PATCH_BYTES
+  const patch = truncated ? bytes.subarray(0, MAX_PATCH_BYTES).toString('utf8') : raw
+  const diffHash = createHash('sha256').update(patch).digest('hex')
+  return { patch, diffHash, truncated }
+}
+
+/**
+ * Impure read (#85): run `git diff` for one path in `cwd` and finalize it. Two shapes:
+ *  - TRACKED: `git -c core.quotePath=false diff --no-color [-w] -- <path>` (exit 0 OK).
+ *  - UNTRACKED: `git ... diff --no-color [-w] --no-index -- /dev/null <path>`. `--no-index`
+ *    exits **1 when there IS a diff** (verified against real git) — so 0 AND 1 are both
+ *    success (capture stdout); only a LARGER code (a real error) degrades to empty.
+ * `core.quotePath=false` so non-ASCII paths come back as plain UTF-8 (matching #84's
+ * status read). `ignoreWhitespace` adds `-w` (`--ignore-all-space`) — @pierre can't
+ * ignore whitespace on a pre-parsed patch, so the toggle re-reads the diff here.
+ * All git failure is swallowed into the empty result — this NEVER throws.
+ */
+export async function readGitDiff(
+  cwd: string,
+  path: string,
+  untracked: boolean,
+  ignoreWhitespace = false,
+  run: GitRun = defaultGitRun,
+): Promise<GitDiffResult> {
+  try {
+    const ws = ignoreWhitespace ? ['-w'] : []
+    if (untracked) {
+      const res = await run(
+        ['-c', 'core.quotePath=false', 'diff', '--no-color', ...ws, '--no-index', '--', '/dev/null', path],
+        cwd,
+      )
+      // `--no-index`: 0 = no diff, 1 = diff present, >1 = a real failure.
+      if (res.code !== 0 && res.code !== 1) return finalizeDiff('')
+      return finalizeDiff(res.stdout)
+    }
+    const res = await run(['-c', 'core.quotePath=false', 'diff', '--no-color', ...ws, '--', path], cwd)
+    if (res.code !== 0) return finalizeDiff('')
+    return finalizeDiff(res.stdout)
+  } catch {
+    return finalizeDiff('')
+  }
+}

--- a/src/main/git/diff.ts
+++ b/src/main/git/diff.ts
@@ -68,7 +68,11 @@ export async function readGitDiff(
       if (res.code !== 0 && res.code !== 1) return finalizeDiff('')
       return finalizeDiff(res.stdout)
     }
-    const res = await run(['-c', 'core.quotePath=false', 'diff', '--no-color', ...ws, '--', path], cwd)
+    // `HEAD` (not the bare worktree-vs-index `git diff`) so a fully-STAGED file still
+    // shows its diff: the Changes panel lists a file's churn as staged+unstaged (vs
+    // HEAD), so the viewer must match — a bare `git diff` is empty for an `M.`/`A.`
+    // file and would dead-click. (A zero-commit repo has no HEAD → empty; rare edge.)
+    const res = await run(['-c', 'core.quotePath=false', 'diff', '--no-color', ...ws, 'HEAD', '--', path], cwd)
     if (res.code !== 0) return finalizeDiff('')
     return finalizeDiff(res.stdout)
   } catch {

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -200,7 +200,10 @@ export async function readGitStatus(cwd: string, run: GitRun = defaultGitRun): P
     // would render `src/héllo.txt` as the literal `"src/h\303\251llo.txt"` in the
     // panel). Applied to BOTH status and the numstats so their path keys still match.
     const [porcelain, numstat, cachedNumstat] = await Promise.all([
-      run(['-c', 'core.quotePath=false', 'status', '--porcelain=2', '--branch'], cwd),
+      // `--untracked-files=all` expands an untracked DIRECTORY into its individual
+      // files (the default `normal` mode collapses it to one `? dir/` entry, which
+      // the diff viewer can't `--no-index` against — it'd dead-click on `dir/`).
+      run(['-c', 'core.quotePath=false', 'status', '--porcelain=2', '--branch', '--untracked-files=all'], cwd),
       run(['-c', 'core.quotePath=false', 'diff', '--numstat'], cwd),
       run(['-c', 'core.quotePath=false', 'diff', '--cached', '--numstat'], cwd),
     ])

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -22,7 +22,7 @@ import type { GitFile, GitStatus } from '../../shared/ipc'
  */
 export type GitRun = (args: string[], cwd: string) => Promise<{ stdout: string; code: number }>
 
-const defaultRun: GitRun = (args, cwd) =>
+export const defaultGitRun: GitRun = (args, cwd) =>
   new Promise((resolve) => {
     execFile(
       'git',
@@ -191,7 +191,7 @@ function splitLeading(line: string, n: number): { fields: string[]; rest: string
  * empty `isRepo:false` status. All git errors are swallowed into that fallback — this
  * NEVER throws, so a watcher tick or background fetch can't crash the status manager.
  */
-export async function readGitStatus(cwd: string, run: GitRun = defaultRun): Promise<GitStatus> {
+export async function readGitStatus(cwd: string, run: GitRun = defaultGitRun): Promise<GitStatus> {
   try {
     const inside = await run(['rev-parse', '--is-inside-work-tree'], cwd)
     if (inside.code !== 0 || inside.stdout.trim() !== 'true') return notARepo()
@@ -216,7 +216,7 @@ export async function readGitStatus(cwd: string, run: GitRun = defaultRun): Prom
  * swallow-all: an offline / no-upstream / auth-failed fetch just resolves (the caller
  * re-reads status either way, so ahead/behind simply stays as it was). Never throws.
  */
-export async function gitFetch(cwd: string, run: GitRun = defaultRun): Promise<void> {
+export async function gitFetch(cwd: string, run: GitRun = defaultGitRun): Promise<void> {
   try {
     await run(['fetch', '--quiet'], cwd)
   } catch {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,6 +5,8 @@ import { basename, join } from 'node:path'
 import {
   IPC,
   type DeleteThreadResult,
+  type GitDiffArgs,
+  type GitDiffResult,
   type GitStatusEvent,
   type GitStatusSubscriptionArgs,
   type ListMetadataResult,
@@ -49,6 +51,7 @@ import { controlsOf, ensureBoundSession, resolveContinueTarget } from './thread-
 import { deleteThread } from './persistence/delete-thread'
 import { permissionRequestIdOf, ThreadStatusTracker, type ThreadStatusChange } from './thread-status'
 import { gitFetch, readGitStatus } from './git/status'
+import { readGitDiff } from './git/diff'
 import { GitStatusManager } from './git/status-stream'
 import { chokidarWatchFactory, realClock } from './git/runtime'
 
@@ -889,6 +892,15 @@ function registerIpc(): void {
     // Panel unmount / Workspace switch-away (#84): the last unsubscribe tears the
     // watcher + fetch timer down (active-Workspace-only streaming, ADR-0008).
     gitStatus.unsubscribe(args.workspaceDir)
+  })
+
+  ipcMain.handle(IPC.gitDiff, (_event, args: GitDiffArgs): Promise<GitDiffResult> => {
+    // Read one changed path's working-tree diff for the viewer (#85). Resolve cwd from
+    // the Workspace dir (where #84's status ran, so the path keys match). This is NOT
+    // agent activity, so it does NOT `pool.touch` — opening a diff must not keep a warm
+    // agent alive past its idle window (TB5 #50). Swallows git failure into the empty
+    // result inside `readGitDiff` (never throws).
+    return readGitDiff(args.workspaceDir, args.path, args.untracked, args.ignoreWhitespace ?? false)
   })
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4,6 +4,8 @@ import {
   type AcpEvent,
   type AgentEvictedEvent,
   type DeleteThreadResult,
+  type GitDiffArgs,
+  type GitDiffResult,
   type GitStatusEvent,
   type GitStatusSubscriptionArgs,
   type ListMetadataResult,
@@ -57,6 +59,7 @@ const api = {
     ipcRenderer.invoke(IPC.gitSubscribeStatus, args),
   gitUnsubscribeStatus: (args: GitStatusSubscriptionArgs): Promise<void> =>
     ipcRenderer.invoke(IPC.gitUnsubscribeStatus, args),
+  gitDiff: (args: GitDiffArgs): Promise<GitDiffResult> => ipcRenderer.invoke(IPC.gitDiff, args),
   onAcpEvent: (listener: (event: AcpEvent) => void): (() => void) => {
     const handler = (_e: unknown, payload: AcpEvent): void => listener(payload)
     ipcRenderer.on(IPC.acpEvent, handler)

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="vite/client" />
+
+// Pulls in Vite's client ambient types — notably the `*?worker` module shape used by
+// `@pierre/diffs/worker/worker.js?worker` (#85). Vite/electron-vite compile that import
+// to a worker-constructor default export; without this reference the renderer tsconfig
+// (`types: ["node"]`) has no declaration for the `?worker` query suffix.

--- a/src/renderer/src/git/ChangesPanel.tsx
+++ b/src/renderer/src/git/ChangesPanel.tsx
@@ -64,17 +64,25 @@ export function ChangesPanel({
 
   const view = buildChangesView(status)
 
-  // DIFF mode: only while the selected file is STILL in the changed set — a streamed
-  // status update that drops it (revert / commit) falls the panel back to the list,
-  // and re-derives `selected` from the live view so its untracked/glyph stay current.
-  const selected = selectedPath ? view.files.find((f) => f.path === selectedPath) : undefined
+  // DIFF mode, gated on `isActive` so a backgrounded (mounted-hidden) Workspace left
+  // in DIFF doesn't keep the `@pierre/diffs` worker pool alive while off-screen — and
+  // only while the selected file is STILL in the changed set, so a streamed status
+  // update that drops it (revert / commit) falls the panel back to the list. `selected`
+  // is re-derived from the LIVE view each render, so its `untracked` + churn stay
+  // current — and feeding the churn to `DiffView` re-fetches the open diff on an edit.
+  const selected = isActive && selectedPath ? view.files.find((f) => f.path === selectedPath) : undefined
   if (selected) {
     return (
       <aside className="flex min-h-0 flex-1 shrink-0 flex-col self-stretch border-l border-border bg-panel text-text">
         <DiffWorkerProvider>
           <DiffView
             workspaceDir={workspaceDir}
-            file={{ path: selected.path, untracked: selected.untracked, glyphLabel: selected.glyphLabel }}
+            file={{
+              path: selected.path,
+              untracked: selected.untracked,
+              insertions: selected.insertions,
+              deletions: selected.deletions,
+            }}
             onBack={() => setSelectedPath(null)}
           />
         </DiffWorkerProvider>

--- a/src/renderer/src/git/ChangesPanel.tsx
+++ b/src/renderer/src/git/ChangesPanel.tsx
@@ -3,13 +3,21 @@ import { ChevronDown, ChevronRight, GitBranch, RefreshCw } from 'lucide-react'
 import type { GitStatus } from '../../../shared/ipc'
 import { cn } from '../lib/utils'
 import { buildChangesView, type GitFileView } from './status-view'
+import { DiffWorkerProvider } from './DiffWorkerProvider'
+import { DiffView } from './DiffView'
 
 /**
- * The collapsible right "Changes" panel for a connected Workspace (#84, ADR-0008).
- * It subscribes to the Workspace's STREAMED git status while it is the ACTIVE one
- * (`isActive`), holds the latest snapshot, and renders the branch header + the
- * changed-files list. v1 is purely observational — a file row is a no-op stub (the
- * diff view is slice #85).
+ * The right "Changes" panel for a connected Workspace (#84, ADR-0008). It subscribes to
+ * the Workspace's STREAMED git status while it is the ACTIVE one (`isActive`), holds the
+ * latest snapshot, and renders the branch header + changed-files list. Clicking a file
+ * opens its working-tree diff (#85): the panel has two modes —
+ *  - LIST: the narrow (`w-72`) file list + branch header (the #84 view).
+ *  - DIFF: a WIDER (`flex-1`) view of the selected file's diff (`DiffView`), with a
+ *    "← Changes" back button. A diff needs width, so the panel widens rather than
+ *    cramming a side-by-side into 72px.
+ * The status subscription runs in BOTH modes (the effect is render-mode-independent), so
+ * the panel keeps streaming while a diff is open — and if the selected file drops out of
+ * the changed set (reverted / committed), the panel falls back to the list.
  *
  * Subscription lifecycle (active-Workspace-only, ADR-0008): the effect runs only when
  * active, registering `onGitStatus` (filtered by `workspaceDir`) and calling
@@ -29,6 +37,7 @@ export function ChangesPanel({
 }): JSX.Element | null {
   const [status, setStatus] = useState<GitStatus | null>(null)
   const [collapsed, setCollapsed] = useState(false)
+  const [selectedPath, setSelectedPath] = useState<string | null>(null)
 
   useEffect(() => {
     if (!isActive) return
@@ -54,6 +63,24 @@ export function ChangesPanel({
   if (!status || !status.isRepo) return null
 
   const view = buildChangesView(status)
+
+  // DIFF mode: only while the selected file is STILL in the changed set — a streamed
+  // status update that drops it (revert / commit) falls the panel back to the list,
+  // and re-derives `selected` from the live view so its untracked/glyph stay current.
+  const selected = selectedPath ? view.files.find((f) => f.path === selectedPath) : undefined
+  if (selected) {
+    return (
+      <aside className="flex min-h-0 flex-1 shrink-0 flex-col self-stretch border-l border-border bg-panel text-text">
+        <DiffWorkerProvider>
+          <DiffView
+            workspaceDir={workspaceDir}
+            file={{ path: selected.path, untracked: selected.untracked, glyphLabel: selected.glyphLabel }}
+            onBack={() => setSelectedPath(null)}
+          />
+        </DiffWorkerProvider>
+      </aside>
+    )
+  }
 
   return (
     <aside className="w-72 shrink-0 border-l border-border bg-panel text-text">
@@ -105,7 +132,7 @@ export function ChangesPanel({
           ) : (
             <ul className="flex flex-col py-1">
               {view.files.map((file) => (
-                <FileRow key={file.path} file={file} />
+                <FileRow key={file.path} file={file} onSelect={() => setSelectedPath(file.path)} />
               ))}
             </ul>
           )}
@@ -122,14 +149,13 @@ function glyphClass(glyph: string): string {
   return 'text-accent-text'
 }
 
-/** One changed-file row. Clicking is a no-op stub — the diff view is slice #85. */
-function FileRow({ file }: { file: GitFileView }): JSX.Element {
+/** One changed-file row. Clicking opens the file's working-tree diff (#85, DIFF mode). */
+function FileRow({ file, onSelect }: { file: GitFileView; onSelect: () => void }): JSX.Element {
   return (
     <li>
       <button
         type="button"
-        // diff view — slice #85 (no-op for now).
-        onClick={() => {}}
+        onClick={onSelect}
         title={file.path}
         className="flex w-full items-center gap-2 px-3 py-1 text-left text-xs hover:bg-accent/10"
       >

--- a/src/renderer/src/git/DiffView.tsx
+++ b/src/renderer/src/git/DiffView.tsx
@@ -27,7 +27,7 @@ export function DiffView({
   onBack,
 }: {
   workspaceDir: string
-  file: { path: string; untracked: boolean; glyphLabel: string }
+  file: { path: string; untracked: boolean; insertions: number; deletions: number }
   onBack: () => void
 }): JSX.Element {
   const [diffStyle, setDiffStyle] = useState<'unified' | 'split'>('unified')
@@ -37,6 +37,12 @@ export function DiffView({
 
   useEffect(() => {
     let cancelled = false
+    // CLEAR the prior patch up front so a re-fetch (whitespace toggle, or the file
+    // changing on disk) shows the Loading state instead of the stale diff under the
+    // already-updated header. The churn (`insertions`/`deletions`) is in the deps so
+    // an open diff RE-FETCHES when the agent (or the user) edits the file — the
+    // streamed status update bumps the churn → fresh diff, no manual refresh needed.
+    setResult(null)
     setLoading(true)
     void window.api
       .gitDiff({ workspaceDir, path: file.path, untracked: file.untracked, ignoreWhitespace })
@@ -48,7 +54,7 @@ export function DiffView({
     return () => {
       cancelled = true
     }
-  }, [workspaceDir, file.path, file.untracked, ignoreWhitespace])
+  }, [workspaceDir, file.path, file.untracked, ignoreWhitespace, file.insertions, file.deletions])
 
   const patch = result?.patch ?? ''
   const diffHash = result?.diffHash ?? ''

--- a/src/renderer/src/git/DiffView.tsx
+++ b/src/renderer/src/git/DiffView.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useMemo, useState, type JSX } from 'react'
+import { ArrowLeft } from 'lucide-react'
+import { PatchDiff } from '@pierre/diffs/react'
+import type { GitDiffResult } from '../../../shared/ipc'
+import { cn } from '../lib/utils'
+
+/**
+ * The working-tree diff viewer for ONE changed file (#85, ADR-0008). Fetches the raw
+ * unified-diff for `file` via `window.api.gitDiff`, then renders it with `@pierre/diffs`'
+ * `PatchDiff` (parsing happens in the lib's worker, off the main thread). Read-only —
+ * no review-comment annotations. Mounted by `ChangesPanel` inside `DiffWorkerProvider`
+ * when the panel is in DIFF mode; `onBack` returns to the file list.
+ *
+ * Two toggles, both light-touch:
+ *  - STACKED ↔ SPLIT: a pure render option (`diffStyle`), no re-fetch — the same patch
+ *    re-lays-out unified vs side-by-side.
+ *  - WHITESPACE: @pierre can't ignore whitespace on a pre-parsed patch, so this drives a
+ *    fresh `gitDiff` read with `-w` (a new `diffHash`); the effect re-runs on the flag.
+ *
+ * The rendered `PatchDiff` is memoized on `diffHash` (+ `diffStyle`) so unrelated panel
+ * re-renders (status stream ticks, a sibling toggle) don't churn the diff subtree.
+ * Degrades to a quiet "No changes to show" for an empty patch (clean / failed read).
+ */
+export function DiffView({
+  workspaceDir,
+  file,
+  onBack,
+}: {
+  workspaceDir: string
+  file: { path: string; untracked: boolean; glyphLabel: string }
+  onBack: () => void
+}): JSX.Element {
+  const [diffStyle, setDiffStyle] = useState<'unified' | 'split'>('unified')
+  const [ignoreWhitespace, setIgnoreWhitespace] = useState(false)
+  const [result, setResult] = useState<GitDiffResult | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    void window.api
+      .gitDiff({ workspaceDir, path: file.path, untracked: file.untracked, ignoreWhitespace })
+      .then((res) => {
+        if (cancelled) return
+        setResult(res)
+        setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [workspaceDir, file.path, file.untracked, ignoreWhitespace])
+
+  const patch = result?.patch ?? ''
+  const diffHash = result?.diffHash ?? ''
+
+  // Memoize the rendered diff on its content hash + render style: an unchanged file
+  // skips re-creating the (worker-backed) PatchDiff subtree on unrelated re-renders.
+  const rendered = useMemo(() => {
+    if (!patch) return null
+    return (
+      <PatchDiff
+        patch={patch}
+        options={{ diffStyle, theme: 'pierre-light', themeType: 'light', overflow: 'scroll' }}
+      />
+    )
+    // diffHash is a 1:1 proxy for `patch`; depend on it (not the long string) + style.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [diffHash, diffStyle])
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex items-center gap-1.5 border-b border-border px-3 py-2">
+        <button
+          type="button"
+          onClick={onBack}
+          className="flex shrink-0 items-center gap-1 text-xs font-medium text-muted hover:text-accent-text"
+        >
+          <ArrowLeft size={14} aria-hidden />
+          <span>Changes</span>
+        </button>
+        <span className="min-w-0 flex-1 truncate text-xs text-text" dir="rtl" title={file.path}>
+          {file.path}
+        </span>
+        {result?.truncated && (
+          <span className="shrink-0 text-[11px] text-muted" title="Diff truncated — file too large">
+            truncated
+          </span>
+        )}
+      </div>
+
+      <div className="flex items-center gap-1 border-b border-border px-3 py-1.5 text-xs">
+        <div className="flex border border-border">
+          <ToggleButton active={diffStyle === 'unified'} onClick={() => setDiffStyle('unified')}>
+            Stacked
+          </ToggleButton>
+          <ToggleButton active={diffStyle === 'split'} onClick={() => setDiffStyle('split')}>
+            Split
+          </ToggleButton>
+        </div>
+        <button
+          type="button"
+          onClick={() => setIgnoreWhitespace((w) => !w)}
+          aria-pressed={ignoreWhitespace}
+          title={ignoreWhitespace ? 'Show whitespace changes' : 'Hide whitespace changes'}
+          className={cn(
+            'ml-auto shrink-0 border border-border px-2 py-0.5',
+            ignoreWhitespace ? 'bg-accent/10 text-accent-text' : 'text-muted hover:text-accent-text',
+          )}
+        >
+          Ignore whitespace
+        </button>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto">
+        {loading && !result ? (
+          <p className="px-3 py-3 text-xs text-muted">Loading diff…</p>
+        ) : rendered ? (
+          rendered
+        ) : (
+          <p className="px-3 py-3 text-xs text-muted">
+            No changes to show{ignoreWhitespace ? ' (whitespace-only changes hidden).' : '.'}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/** A segmented-control button (Stacked / Split) in the brand's zero-radius idiom. */
+function ToggleButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean
+  onClick: () => void
+  children: React.ReactNode
+}): JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={cn(
+        'px-2 py-0.5',
+        active ? 'bg-accent/10 text-accent-text' : 'text-muted hover:text-accent-text',
+      )}
+    >
+      {children}
+    </button>
+  )
+}

--- a/src/renderer/src/git/DiffWorkerProvider.tsx
+++ b/src/renderer/src/git/DiffWorkerProvider.tsx
@@ -1,0 +1,39 @@
+import { useMemo, type JSX, type ReactNode } from 'react'
+import { WorkerPoolContextProvider } from '@pierre/diffs/react'
+import DiffsWorker from '@pierre/diffs/worker/worker.js?worker'
+
+/**
+ * Mounts `@pierre/diffs`' web-worker pool around the diff viewer (#85, ADR-0008). The
+ * lib offloads syntax-highlighting + diff layout to workers; `WorkerPoolContextProvider`
+ * owns a process-wide singleton pool (created on first mount, torn down when the last
+ * provider unmounts), so this is mounted ONCE around the diff area — not per file.
+ *
+ * The worker is a Vite `?worker` import (`@pierre/diffs/worker/worker.js?worker`), which
+ * electron-vite's renderer bundles to a worker-constructor; we hand the pool a factory
+ * that news one up. Pool size is derived from `hardwareConcurrency`, clamped to 2-6 so a
+ * many-core machine doesn't spawn a wasteful fleet and a single-core one still gets two.
+ *
+ * Brand is light-mode (CONTEXT.md), so we pin @pierre's `pierre-light` highlighter theme
+ * and skip t3code's theme-sync effect entirely — there is no dark mode to follow.
+ */
+
+/** @pierre's bundled light theme — matches the brand's light-mode surfaces. */
+const DIFF_THEME = 'pierre-light'
+
+export function DiffWorkerProvider({ children }: { children?: ReactNode }): JSX.Element {
+  // Clamp pool size to 2-6 from half the core count (mirrors t3code's heuristic): a
+  // diff render is bursty, so a couple of workers suffice and a big box gains little.
+  const poolSize = useMemo(() => {
+    const cores = typeof navigator === 'undefined' ? 4 : Math.max(1, navigator.hardwareConcurrency || 4)
+    return Math.max(2, Math.min(6, Math.floor(cores / 2)))
+  }, [])
+
+  return (
+    <WorkerPoolContextProvider
+      poolOptions={{ workerFactory: () => new DiffsWorker(), poolSize }}
+      highlighterOptions={{ theme: DIFF_THEME }}
+    >
+      {children}
+    </WorkerPoolContextProvider>
+  )
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -104,6 +104,15 @@ export const IPC = {
    * ahead/behind). The renderer filters by `workspaceDir` and holds the latest status.
    */
   gitStatus: 'git:status',
+  /**
+   * Renderer -> main: read ONE changed path's working-tree unified diff (#85,
+   * ADR-0008). Invoke, `{ workspaceDir, path, untracked, ignoreWhitespace? }` ->
+   * `GitDiffResult` (raw patch text + a content `diffHash` + a `truncated` flag). The
+   * renderer parses + renders the patch with `@pierre/diffs`; main only shells `git
+   * diff`. Working-tree source only, read-only. Not agent activity, so it does NOT
+   * touch the warm-agent pool. A git failure (or no diff) returns the empty result.
+   */
+  gitDiff: 'git:diff',
 } as const
 
 /**
@@ -566,4 +575,33 @@ export interface GitStatusEvent {
 /** Args for `gitSubscribeStatus` / `gitUnsubscribeStatus` (#84). */
 export interface GitStatusSubscriptionArgs {
   workspaceDir: string
+}
+
+/**
+ * Args for `gitDiff` (#85): read one changed path's working-tree diff. `path` is the
+ * `GitFile.path` (relative to the Workspace root, as `git status` reported it).
+ * `untracked` routes to the `git diff --no-index -- /dev/null <path>` form (a new file
+ * has no index entry to diff against). `ignoreWhitespace` re-reads the diff with `-w`
+ * for the panel's whitespace toggle — @pierre can't ignore whitespace on a pre-parsed
+ * patch, so the toggle drives a fresh read (a new `diffHash`) here.
+ */
+export interface GitDiffArgs {
+  workspaceDir: string
+  path: string
+  untracked: boolean
+  ignoreWhitespace?: boolean
+}
+
+/**
+ * The `gitDiff` reply (#85): a changed path's RAW working-tree unified diff plus a
+ * content `diffHash` (sha256 of `patch`) the renderer memoizes on, so an unchanged
+ * file skips a re-parse / re-render. `truncated` is true when the patch was capped
+ * (~120 KB) — the viewer flags it. The empty result (`patch:''`, `diffHash:''`,
+ * `truncated:false`) covers BOTH a clean path (no diff) and a swallowed git failure;
+ * the renderer renders nothing for it (degrade quietly, like #84's non-repo panel).
+ */
+export interface GitDiffResult {
+  patch: string
+  diffHash: string
+  truncated: boolean
 }


### PR DESCRIPTION
Closes #85. Git slice 1b (ADR-0008): clicking a file in the #84 Changes panel opens its **working-tree diff**, rendered by `@pierre/diffs`.

## What

- **main `src/main/git/diff.ts`:** `readGitDiff` → `{ patch, diffHash, truncated }` (raw unified-diff text + sha256 hash + a 120 KB byte-cap). Tracked = `git -c core.quotePath=false diff HEAD -- <path>` (vs HEAD, so staged changes show); untracked = `--no-index -- /dev/null <path>` (exit-1-with-diff handled). Swallow-to-empty, never throws. IPC `git:diff` invoke (not agent activity → no `pool.touch`).
- **renderer:** `DiffWorkerProvider` mounts `@pierre/diffs`' `WorkerPoolContextProvider` + `?worker` (lazy singleton pool, `pierre-light`); `DiffView` renders the high-level `PatchDiff` with **stacked/split** (render-option) + **whitespace** (re-fetch with `-w`) toggles, memoized on `diffHash`. `ChangesPanel` gains a wider **DIFF mode** (LIST `w-72` ↔ DIFF `flex-1`) with a "← Changes" back button; a reverted/committed file auto-falls-back to the list, and an open diff **auto-refreshes** when the file changes (churn in the fetch deps).
- **electron-vite:** `worker: { format: 'es' }` so the `?worker` bundles (@pierre code-splits shiki). `env.d.ts` adds `vite/client` types for the `?worker` import.

## Review + verification

Implementer → my independent gate re-run + full diff read → adversarial reviewer (verdict **SHIP-WITH-FIXES**, no MUST-FIX; verified the worker is scoped to the renderer, the @pierre 1.2.12 API, that the strict CSP doesn't block it (JS-regex engine, no WASM), and no #84 regression). Gates green: lint / typecheck / build (worker chunk emitted) / **391 tests**.

**Folded the SHOULD-FIXes:** the two dead-clicks (staged-only files via `git diff HEAD`; untracked dirs via `--untracked-files=all`), the stale-diff freshness (clear-on-refetch + auto-refresh-on-edit), the hidden-panel worker pool (gate DIFF on `isActive`), and a dead prop.

## ⚠️ Residual: live render NOT driven

`bun run build` bundles the worker and the app launches clean, but the live `PatchDiff` render was **not** executed (needs a connected git Workspace + a click in the real window). **Worth a 2-min manual smoke before relying on it:** open a repo Workspace → click a changed file → confirm the diff renders under the `script-src 'self'` CSP, toggle split/stacked + whitespace, and check a staged file + an untracked file now show diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)