### PR TITLE
#86: commit working-tree changes from the Changes panel (slice 2)

### DIFF
--- a/src/main/git/commit.test.ts
+++ b/src/main/git/commit.test.ts
@@ -22,18 +22,29 @@ function fakeRun(
 }
 
 describe('gitCommit', () => {
-  it('subset: reset -q → add -- <paths> → commit -m, then {ok:true}', async () => {
+  it('subset: status (rename scan) → reset -q → add -- <paths> → commit -m, then {ok:true}', async () => {
     const seen: string[][] = []
     const result = await gitCommit('/repo', 'msg', ['a.txt', 'b.txt'], fakeRun(seen))
     expect(result).toEqual({ ok: true })
     expect(seen).toEqual([
+      ['-c', 'core.quotePath=false', 'status', '--porcelain=2'],
       ['reset', '-q'],
       ['add', '--', 'a.txt', 'b.txt'],
       ['-c', 'core.quotePath=false', 'commit', '-m', 'msg'],
     ])
   })
 
-  it('all (empty paths): add -A → commit -m (NO reset), then {ok:true}', async () => {
+  it('subset with a selected staged RENAME stages BOTH the new path and its deleted origin', async () => {
+    const seen: string[][] = []
+    // porcelain-2 `2` rename entry: 9 leading fields then `<new>\t<orig>`.
+    const porcelain = '2 R. N... 100644 100644 100644 1111111 2222222 R100 moved.txt\torig.txt\n'
+    const result = await gitCommit('/repo', 'msg', ['moved.txt'], fakeRun(seen, [{ stdout: porcelain, code: 0 }]))
+    expect(result).toEqual({ ok: true })
+    // The add stages the new name AND the rename's deleted source — not just the add half.
+    expect(seen).toContainEqual(['add', '--', 'moved.txt', 'orig.txt'])
+  })
+
+  it('all (empty paths): add -A → commit -m (NO reset / NO status scan), then {ok:true}', async () => {
     const seen: string[][] = []
     const result = await gitCommit('/repo', 'msg', [], fakeRun(seen))
     expect(result).toEqual({ ok: true })
@@ -46,7 +57,8 @@ describe('gitCommit', () => {
   it('passes a path containing spaces as a SINGLE argv element', async () => {
     const seen: string[][] = []
     await gitCommit('/repo', 'msg', ['my file.txt'], fakeRun(seen))
-    expect(seen[1]).toEqual(['add', '--', 'my file.txt'])
+    // [0]=status scan, [1]=reset, [2]=add.
+    expect(seen[2]).toEqual(['add', '--', 'my file.txt'])
   })
 
   it('failing commit → {ok:false} carrying git’s reason (from stdout)', async () => {
@@ -67,8 +79,8 @@ describe('gitCommit', () => {
       '/repo',
       'msg',
       ['a.txt'],
-      // reset ok, add ok, commit fails with a hook error on STDERR.
-      fakeRun(seen, [{ code: 0 }, { code: 0 }, { stderr: 'pre-commit hook failed', code: 1 }]),
+      // status ok (no renames), reset ok, add ok, commit fails with a hook error on STDERR.
+      fakeRun(seen, [{ code: 0 }, { code: 0 }, { code: 0 }, { stderr: 'pre-commit hook failed', code: 1 }]),
     )
     expect(result).toEqual({ ok: false, error: 'pre-commit hook failed' })
   })
@@ -79,10 +91,10 @@ describe('gitCommit', () => {
       '/repo',
       'msg',
       ['a.txt'],
-      // reset fails — never reaches add / commit.
-      fakeRun(seen, [{ stderr: 'fatal: could not reset', code: 128 }]),
+      // status ok (rename scan), then reset fails — never reaches add / commit.
+      fakeRun(seen, [{ code: 0 }, { stderr: 'fatal: could not reset', code: 128 }]),
     )
     expect(result).toEqual({ ok: false, error: 'fatal: could not reset' })
-    expect(seen).toEqual([['reset', '-q']])
+    expect(seen).toEqual([['-c', 'core.quotePath=false', 'status', '--porcelain=2'], ['reset', '-q']])
   })
 })

--- a/src/main/git/commit.test.ts
+++ b/src/main/git/commit.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest'
+import { gitCommit } from './commit'
+import type { GitRun } from './status'
+
+/**
+ * `gitCommit` is the first git WRITE (#86). Its testable seam is the COMMAND SEQUENCE +
+ * args over an injected `GitRun` — no test shells real git. We assert the exact staging
+ * calls (subset vs all) and the failure mapping (git's reason, not a collapsed message).
+ */
+
+/** A fake runner: records every `args` and returns a per-call canned `{stdout,stderr,code}`. */
+function fakeRun(
+  seen: string[][],
+  responses: { stdout?: string; stderr?: string; code: number }[] = [],
+): GitRun {
+  let i = 0
+  return (args) => {
+    seen.push(args)
+    const r = responses[i++] ?? { code: 0 }
+    return Promise.resolve({ stdout: r.stdout ?? '', stderr: r.stderr ?? '', code: r.code })
+  }
+}
+
+describe('gitCommit', () => {
+  it('subset: reset -q → add -- <paths> → commit -m, then {ok:true}', async () => {
+    const seen: string[][] = []
+    const result = await gitCommit('/repo', 'msg', ['a.txt', 'b.txt'], fakeRun(seen))
+    expect(result).toEqual({ ok: true })
+    expect(seen).toEqual([
+      ['reset', '-q'],
+      ['add', '--', 'a.txt', 'b.txt'],
+      ['-c', 'core.quotePath=false', 'commit', '-m', 'msg'],
+    ])
+  })
+
+  it('all (empty paths): add -A → commit -m (NO reset), then {ok:true}', async () => {
+    const seen: string[][] = []
+    const result = await gitCommit('/repo', 'msg', [], fakeRun(seen))
+    expect(result).toEqual({ ok: true })
+    expect(seen).toEqual([
+      ['add', '-A'],
+      ['-c', 'core.quotePath=false', 'commit', '-m', 'msg'],
+    ])
+  })
+
+  it('passes a path containing spaces as a SINGLE argv element', async () => {
+    const seen: string[][] = []
+    await gitCommit('/repo', 'msg', ['my file.txt'], fakeRun(seen))
+    expect(seen[1]).toEqual(['add', '--', 'my file.txt'])
+  })
+
+  it('failing commit → {ok:false} carrying git’s reason (from stdout)', async () => {
+    const seen: string[][] = []
+    const result = await gitCommit(
+      '/repo',
+      'msg',
+      [],
+      // add ok, commit fails with "nothing to commit" on STDOUT (git puts it there).
+      fakeRun(seen, [{ code: 0 }, { stdout: 'nothing to commit, working tree clean', code: 1 }]),
+    )
+    expect(result).toEqual({ ok: false, error: 'nothing to commit, working tree clean' })
+  })
+
+  it('failing commit → surfaces a STDERR reason (e.g. a failed pre-commit hook)', async () => {
+    const seen: string[][] = []
+    const result = await gitCommit(
+      '/repo',
+      'msg',
+      ['a.txt'],
+      // reset ok, add ok, commit fails with a hook error on STDERR.
+      fakeRun(seen, [{ code: 0 }, { code: 0 }, { stderr: 'pre-commit hook failed', code: 1 }]),
+    )
+    expect(result).toEqual({ ok: false, error: 'pre-commit hook failed' })
+  })
+
+  it('a failing stage step short-circuits (no commit) and reports the reason', async () => {
+    const seen: string[][] = []
+    const result = await gitCommit(
+      '/repo',
+      'msg',
+      ['a.txt'],
+      // reset fails — never reaches add / commit.
+      fakeRun(seen, [{ stderr: 'fatal: could not reset', code: 128 }]),
+    )
+    expect(result).toEqual({ ok: false, error: 'fatal: could not reset' })
+    expect(seen).toEqual([['reset', '-q']])
+  })
+})

--- a/src/main/git/commit.ts
+++ b/src/main/git/commit.ts
@@ -1,0 +1,67 @@
+import { defaultGitRun, type GitRun } from './status'
+import type { GitCommitResult } from '../../shared/ipc'
+
+/**
+ * Commit working-tree changes from the Changes panel (#86, ADR-0008) — the FIRST git
+ * WRITE. Like #84's status read and #85's diff read, git runs in MAIN via
+ * `child_process` through the injectable `GitRun` seam (reused from `status.ts`) — no
+ * git2 / isomorphic-git. There is NO stage/unstage/discard UI: selection is decided at
+ * COMMIT time (like t3code's `prepareCommitContext`), so this stages exactly the
+ * caller's selection, then commits.
+ *
+ * Staging semantics (be precise — a wrong `add`/`reset` commits the wrong files):
+ *  - SUBSET (`paths.length > 0`): `git reset -q` first — a MIXED reset that unstages
+ *    everything but KEEPS the working tree — then `git add -- <paths…>`. Net effect:
+ *    ONLY the selected paths are staged, so a file the user previously staged out of
+ *    band but did NOT select is excluded from this commit.
+ *  - ALL (`paths` empty): `git add -A` — stage every change (modifications, untracked
+ *    adds, and deletions).
+ * Then `git -c core.quotePath=false commit -m <message>`. `core.quotePath=false` keeps
+ * us consistent with #84's status read (its paths are unquoted UTF-8). Each path is its
+ * own argv element (no shell), so a path with spaces is safe.
+ *
+ * Failure is SWALLOWED into the result — this NEVER throws (mirroring #84/#85 and the
+ * #78 auth-error style): a non-zero `reset`/`add`/`commit` returns `{ok:false, error}`
+ * carrying git's ACTUAL reason ("nothing to commit", a failed pre-commit hook, an
+ * index lock) rather than a collapsed "commit failed". `GitRun` resolves even on a
+ * non-zero exit, so we gate on `.code` after every step.
+ */
+export async function gitCommit(
+  cwd: string,
+  message: string,
+  paths: string[],
+  run: GitRun = defaultGitRun,
+): Promise<GitCommitResult> {
+  try {
+    if (paths.length > 0) {
+      // Mixed reset (keeps the working tree) so the index starts from HEAD, then stage
+      // exactly the selection — any other previously-staged path drops out of the index.
+      const reset = await run(['reset', '-q'], cwd)
+      if (reset.code !== 0) return fail(reset)
+      // `add -- <paths>` stages modifications, untracked adds, AND deletions of the
+      // selected tracked paths (git ≥2.0 default), so a deleted selected file commits too.
+      const add = await run(['add', '--', ...paths], cwd)
+      if (add.code !== 0) return fail(add)
+    } else {
+      // Commit-all: stage everything (incl. untracked + deletions).
+      const add = await run(['add', '-A'], cwd)
+      if (add.code !== 0) return fail(add)
+    }
+    const commit = await run(['-c', 'core.quotePath=false', 'commit', '-m', message], cwd)
+    if (commit.code !== 0) return fail(commit)
+    return { ok: true }
+  } catch (err) {
+    // A truly unexpected throw (a runner that rejects) still degrades to a result.
+    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+/**
+ * Map a non-zero git step to the failure result, surfacing the real reason. git writes
+ * hook / lock failures to STDERR and "nothing to commit" to STDOUT, so prefer stderr
+ * and fall back to stdout — never collapse to a generic message (#78 style).
+ */
+function fail(res: { stdout: string; stderr?: string; code: number }): GitCommitResult {
+  const reason = (res.stderr ?? '').trim() || res.stdout.trim() || 'git command failed'
+  return { ok: false, error: reason }
+}

--- a/src/main/git/commit.ts
+++ b/src/main/git/commit.ts
@@ -34,13 +34,21 @@ export async function gitCommit(
 ): Promise<GitCommitResult> {
   try {
     if (paths.length > 0) {
+      // A pre-staged RENAME shows in #84's status as ONE `R` row whose path is the NEW
+      // name only (the deleted source isn't a selectable row). `git reset -q` decomposes
+      // that staged rename into a `.D <orig>` + `? <new>`, so a plain `add -- <new>` would
+      // stage ONLY the add and DROP the deletion — committing both files. So FIRST collect
+      // the origins of any selected staged-renames (read before the reset destroys them)
+      // and stage BOTH halves below. (Best-effort: a failed status read yields no origins.)
+      const renameOrigins = await collectRenameOrigins(cwd, paths, run)
       // Mixed reset (keeps the working tree) so the index starts from HEAD, then stage
       // exactly the selection — any other previously-staged path drops out of the index.
       const reset = await run(['reset', '-q'], cwd)
       if (reset.code !== 0) return fail(reset)
-      // `add -- <paths>` stages modifications, untracked adds, AND deletions of the
-      // selected tracked paths (git ≥2.0 default), so a deleted selected file commits too.
-      const add = await run(['add', '--', ...paths], cwd)
+      // `add -- <paths + rename-origins>` stages modifications, untracked adds, deletions
+      // of the selected tracked paths (git ≥2.0 default), AND a selected rename's deleted
+      // source — so a deleted/renamed selected file commits whole.
+      const add = await run(['add', '--', ...paths, ...renameOrigins], cwd)
       if (add.code !== 0) return fail(add)
     } else {
       // Commit-all: stage everything (incl. untracked + deletions).
@@ -54,6 +62,43 @@ export async function gitCommit(
     // A truly unexpected throw (a runner that rejects) still degrades to a result.
     return { ok: false, error: err instanceof Error ? err.message : String(err) }
   }
+}
+
+/**
+ * The deleted-source paths of any SELECTED staged renames (#86 review fold). Reads
+ * `git status --porcelain=2` BEFORE the commit's reset (which would decompose the
+ * rename) and, for each `2`-entry (`<XY> <sub> <m…> <h…> <Xscore> <new>\t<orig>`)
+ * whose NEW path is in the selection, returns its `<orig>` so both halves get staged.
+ * Best-effort: a non-zero status read returns `[]` (the commit proceeds without it,
+ * degrading to the original add-the-new-only behaviour — never throws/blocks).
+ */
+async function collectRenameOrigins(cwd: string, paths: string[], run: GitRun): Promise<string[]> {
+  const selected = new Set(paths)
+  const res = await run(['-c', 'core.quotePath=false', 'status', '--porcelain=2'], cwd)
+  if (res.code !== 0) return []
+  const origins: string[] = []
+  for (const line of res.stdout.split('\n')) {
+    if (!line.startsWith('2 ')) continue // `2` = rename/copy entry
+    // The pathnames follow 9 space-delimited fields, as `<new>\t<orig>`.
+    const rest = afterFields(line, 9)
+    const tab = rest.indexOf('\t')
+    if (tab < 0) continue
+    const newPath = rest.slice(0, tab)
+    const orig = rest.slice(tab + 1)
+    if (orig && selected.has(newPath)) origins.push(orig)
+  }
+  return origins
+}
+
+/** Drop the first `n` space-delimited fields of a line, returning the remainder verbatim. */
+function afterFields(line: string, n: number): string {
+  let i = 0
+  for (let f = 0; f < n; f++) {
+    const sp = line.indexOf(' ', i)
+    if (sp < 0) return ''
+    i = sp + 1
+  }
+  return line.slice(i)
 }
 
 /**

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -15,12 +15,17 @@ import type { GitFile, GitStatus } from '../../shared/ipc'
  */
 
 /**
- * Run a git command and capture its stdout + exit code. Injectable for tests so they
- * never shell real git (Seam, mirroring `AcpClient.spawn`). The default resolves
- * `git` via the shell-env PATH (so a Finder/Dock launch still finds it, like the
- * agent spawn) and resolves — never rejects — with the exit code even on failure.
+ * Run a git command and capture its stdout + exit code (+ stderr). Injectable for
+ * tests so they never shell real git (Seam, mirroring `AcpClient.spawn`). The default
+ * resolves `git` via the shell-env PATH (so a Finder/Dock launch still finds it, like
+ * the agent spawn) and resolves — never rejects — with the exit code even on failure.
+ *
+ * `stderr` is OPTIONAL so #84/#85's read callers (and their fakes) need no change —
+ * they only read `stdout`/`code`. The WRITE path (#86 `gitCommit`) needs it: git puts
+ * a failed pre-commit hook / lock error on STDERR (and "nothing to commit" on stdout),
+ * so a commit failure must surface the actual reason from whichever stream carried it.
  */
-export type GitRun = (args: string[], cwd: string) => Promise<{ stdout: string; code: number }>
+export type GitRun = (args: string[], cwd: string) => Promise<{ stdout: string; stderr?: string; code: number }>
 
 export const defaultGitRun: GitRun = (args, cwd) =>
   new Promise((resolve) => {
@@ -28,12 +33,12 @@ export const defaultGitRun: GitRun = (args, cwd) =>
       'git',
       args,
       { cwd, env: getShellEnv(), encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 },
-      (err: ExecFileException | null, stdout: string) => {
+      (err: ExecFileException | null, stdout: string, stderr: string) => {
         // execFile's `err.code` is the numeric exit code on a non-zero exit, or a
         // string (e.g. 'ENOENT' when git is missing) on a spawn failure — map both
         // to a non-zero code so the caller degrades to `isRepo:false`.
         const code = err == null ? 0 : typeof err.code === 'number' ? err.code : 1
-        resolve({ stdout: stdout ?? '', code })
+        resolve({ stdout: stdout ?? '', stderr: stderr ?? '', code })
       },
     )
   })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,6 +5,8 @@ import { basename, join } from 'node:path'
 import {
   IPC,
   type DeleteThreadResult,
+  type GitCommitArgs,
+  type GitCommitResult,
   type GitDiffArgs,
   type GitDiffResult,
   type GitStatusEvent,
@@ -52,6 +54,7 @@ import { deleteThread } from './persistence/delete-thread'
 import { permissionRequestIdOf, ThreadStatusTracker, type ThreadStatusChange } from './thread-status'
 import { gitFetch, readGitStatus } from './git/status'
 import { readGitDiff } from './git/diff'
+import { gitCommit } from './git/commit'
 import { GitStatusManager } from './git/status-stream'
 import { chokidarWatchFactory, realClock } from './git/runtime'
 
@@ -901,6 +904,24 @@ function registerIpc(): void {
     // agent alive past its idle window (TB5 #50). Swallows git failure into the empty
     // result inside `readGitDiff` (never throws).
     return readGitDiff(args.workspaceDir, args.path, args.untracked, args.ignoreWhitespace ?? false)
+  })
+
+  ipcMain.handle(IPC.gitCommit, async (_event, args: GitCommitArgs): Promise<GitCommitResult> => {
+    // Commit working-tree changes from the Changes panel (#86, the first git WRITE).
+    // cwd is the Workspace dir (where #84's status ran, so `paths` key the same). NOT
+    // agent activity, so — like `git:diff` — it does NOT `pool.touch` (a commit must not
+    // keep a warm agent alive past its idle window, TB5 #50). `gitCommit` swallows every
+    // git failure into `{ok:false, error}` (never throws).
+    const result = await gitCommit(args.workspaceDir, args.message, args.paths)
+    if (result.ok) {
+      // Re-read status so the committed files drop off the panel: a commit touches only
+      // `.git/`, which the working-tree fs watcher ignores (exactly like #84's turn-end
+      // refresh for the agent's own commits). No-op unless the panel is subscribed.
+      gitStatus.refresh(args.workspaceDir)
+    } else {
+      console.error(`[vibe-mistro:git] commit failed (${args.workspaceDir}): ${result.error}`)
+    }
+    return result
   })
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4,6 +4,8 @@ import {
   type AcpEvent,
   type AgentEvictedEvent,
   type DeleteThreadResult,
+  type GitCommitArgs,
+  type GitCommitResult,
   type GitDiffArgs,
   type GitDiffResult,
   type GitStatusEvent,
@@ -60,6 +62,7 @@ const api = {
   gitUnsubscribeStatus: (args: GitStatusSubscriptionArgs): Promise<void> =>
     ipcRenderer.invoke(IPC.gitUnsubscribeStatus, args),
   gitDiff: (args: GitDiffArgs): Promise<GitDiffResult> => ipcRenderer.invoke(IPC.gitDiff, args),
+  gitCommit: (args: GitCommitArgs): Promise<GitCommitResult> => ipcRenderer.invoke(IPC.gitCommit, args),
   onAcpEvent: (listener: (event: AcpEvent) => void): (() => void) => {
     const handler = (_e: unknown, payload: AcpEvent): void => listener(payload)
     ipcRenderer.on(IPC.acpEvent, handler)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -524,8 +524,10 @@ export function App(): JSX.Element {
     }
   }
 
-  /** The connected view for a Workspace (SignedInBar + the controlled outlet). */
-  function renderConnected(conn: ThreadConnection, isActive: boolean): ReactNode {
+  /** The connected view for a Workspace (SignedInBar + the controlled outlet). `busy`
+   *  is the Workspace's rolled-up streaming flag (#86) — threaded to the Changes panel
+   *  so the commit affordance is disabled while a turn is in flight (the v1 guard). */
+  function renderConnected(conn: ThreadConnection, isActive: boolean, busy: boolean): ReactNode {
     const wts = workspaceThreadStateFor(workspaceThreads, conn.workspaceId)
     const cold = threadsForWorkspace(recents, conn.workspaceId)
     const activeId = wts?.active ?? conn.threadId
@@ -556,6 +558,7 @@ export function App(): JSX.Element {
           activeThread={activeThread}
           isLive={isLive}
           isActive={isActive}
+          busy={busy}
           seedSessionId={seed}
           controls={
             // A bound Thread sources its OWN live config (#70); a draft (no config
@@ -611,7 +614,7 @@ export function App(): JSX.Element {
         if (conn.status !== 'connected') return null
         return (
           <div key={wid} className="shell__connection" hidden={wid !== selectedWs}>
-            {renderConnected(conn.thread, wid === selectedWs)}
+            {renderConnected(conn.thread, wid === selectedWs, wsFlags[wid]?.streaming ?? false)}
           </div>
         )
       })}

--- a/src/renderer/src/connection/ConnectedWorkspace.tsx
+++ b/src/renderer/src/connection/ConnectedWorkspace.tsx
@@ -36,6 +36,7 @@ export function ConnectedWorkspace({
   activeThread,
   isLive,
   isActive,
+  busy,
   seedSessionId,
   controls,
   onSetConfig,
@@ -55,6 +56,13 @@ export function ConnectedWorkspace({
    * — not mere mount — to keep streaming active-Workspace-only (one watcher + fetch).
    */
   isActive: boolean
+  /**
+   * Whether this Workspace has a streaming turn (#86). Threaded to the Changes panel:
+   * the agent can `git commit` itself mid-turn, so the v1 concurrency guard disables the
+   * user's commit affordance while `busy` (no concurrent user+agent commit; status
+   * re-reads at turn end). No locks/queues — just a disabled button + a hint.
+   */
+  busy: boolean
   /** The session to seed a live view with (bound-this-session wins over the cursor). */
   seedSessionId: string | null
   /** The active Thread's OWN agent-controls (#70), or null when none are seeded yet. */
@@ -97,7 +105,7 @@ export function ConnectedWorkspace({
       </div>
       {/* Streamed git status (#84) — observational only; renders nothing for a non-repo
           Workspace and subscribes only while this is the active Workspace. */}
-      <ChangesPanel workspaceDir={connection.workspaceDir} isActive={isActive} />
+      <ChangesPanel workspaceDir={connection.workspaceDir} isActive={isActive} busy={busy} />
     </div>
   )
 }

--- a/src/renderer/src/git/ChangesPanel.tsx
+++ b/src/renderer/src/git/ChangesPanel.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, type JSX } from 'react'
 import { ChevronDown, ChevronRight, GitBranch, RefreshCw } from 'lucide-react'
 import type { GitStatus } from '../../../shared/ipc'
 import { cn } from '../lib/utils'
-import { buildChangesView, type GitFileView } from './status-view'
+import { buildChangesView, reconcileUnchecked, type GitFileView } from './status-view'
 import { DiffWorkerProvider } from './DiffWorkerProvider'
 import { DiffView } from './DiffView'
 
@@ -31,13 +31,29 @@ import { DiffView } from './DiffView'
 export function ChangesPanel({
   workspaceDir,
   isActive,
+  busy,
 }: {
   workspaceDir: string
   isActive: boolean
+  /**
+   * Whether this Workspace has a streaming turn (#86 concurrency guard). The agent can
+   * run `git commit` itself as a tool-call mid-turn, so the v1 guard simply DISABLES the
+   * commit affordance while a turn is in flight — there is no concurrent user+agent
+   * commit (no locks/queues). Status re-reads after the turn (#84 turn-end refresh), so
+   * the panel reflects whatever the agent committed before the user can commit again.
+   */
+  busy: boolean
 }): JSX.Element | null {
   const [status, setStatus] = useState<GitStatus | null>(null)
   const [collapsed, setCollapsed] = useState(false)
   const [selectedPath, setSelectedPath] = useState<string | null>(null)
+  // Commit-time file selection (#86), tracked as the paths the user DESELECTED — default
+  // empty = all selected, so a new file is selected by default. `message` is the commit
+  // message; `committing` blocks a double-submit; `commitError` surfaces git's reason.
+  const [unchecked, setUnchecked] = useState<Set<string>>(() => new Set())
+  const [message, setMessage] = useState('')
+  const [committing, setCommitting] = useState(false)
+  const [commitError, setCommitError] = useState<string | null>(null)
 
   useEffect(() => {
     if (!isActive) return
@@ -51,6 +67,14 @@ export function ChangesPanel({
     }
   }, [workspaceDir, isActive])
 
+  // Reconcile the deselection set on every status snapshot: drop a path that's vanished
+  // (committed / reverted), keep new files selected by default. `reconcileUnchecked`
+  // returns the same ref when nothing changed, so an unrelated tick is a no-op setState.
+  useEffect(() => {
+    const paths = status?.isRepo ? status.files.map((f) => f.path) : []
+    setUnchecked((prev) => reconcileUnchecked(prev, paths))
+  }, [status])
+
   // Manual refresh: a subscribe/unsubscribe pair re-emits a fresh snapshot without
   // changing the net ref-count (the panel keeps its own hold across this).
   function refresh(): void {
@@ -63,6 +87,28 @@ export function ChangesPanel({
   if (!status || !status.isRepo) return null
 
   const view = buildChangesView(status)
+
+  // The selected files = everything not explicitly deselected (#86). These are the exact
+  // paths handed to `gitCommit`; main stages precisely this selection then commits.
+  const selectedPaths = view.files.filter((f) => !unchecked.has(f.path)).map((f) => f.path)
+  const canCommit = message.trim().length > 0 && selectedPaths.length > 0 && !busy && !committing
+
+  async function commit(): Promise<void> {
+    if (!canCommit) return
+    setCommitting(true)
+    setCommitError(null)
+    const result = await window.api.gitCommit({ workspaceDir, message: message.trim(), paths: selectedPaths })
+    setCommitting(false)
+    if (result.ok) {
+      // The committed files drop off via the status refresh main triggers; clear the
+      // message so the next commit starts fresh. The deselection set reconciles itself
+      // as the now-committed paths vanish from the next snapshot.
+      setMessage('')
+    } else {
+      // Recoverable: surface git's actual reason inline; the user can edit + retry.
+      setCommitError(result.error)
+    }
+  }
 
   // DIFF mode, gated on `isActive` so a backgrounded (mounted-hidden) Workspace left
   // in DIFF doesn't keep the `@pierre/diffs` worker pool alive while off-screen — and
@@ -138,11 +184,60 @@ export function ChangesPanel({
           {view.files.length === 0 ? (
             <p className="px-3 py-3 text-xs text-muted">No changes — working tree clean.</p>
           ) : (
-            <ul className="flex flex-col py-1">
-              {view.files.map((file) => (
-                <FileRow key={file.path} file={file} onSelect={() => setSelectedPath(file.path)} />
-              ))}
-            </ul>
+            <>
+              <ul className="flex flex-col py-1">
+                {view.files.map((file) => (
+                  <FileRow
+                    key={file.path}
+                    file={file}
+                    checked={!unchecked.has(file.path)}
+                    onToggle={() =>
+                      setUnchecked((prev) => {
+                        const next = new Set(prev)
+                        if (next.has(file.path)) next.delete(file.path)
+                        else next.add(file.path)
+                        return next
+                      })
+                    }
+                    onSelect={() => setSelectedPath(file.path)}
+                  />
+                ))}
+              </ul>
+
+              {/* Commit area (#86): message + "Commit N". Disabled on an empty message,
+                  no selection, or `busy` (the v1 concurrency guard — no concurrent
+                  user+agent commit). git's reason surfaces inline + recoverable. */}
+              <div className="flex flex-col gap-2 border-t border-border px-3 py-2">
+                <textarea
+                  value={message}
+                  onChange={(e) => setMessage(e.target.value)}
+                  placeholder="Commit message"
+                  rows={2}
+                  className="w-full resize-y border border-border bg-panel px-2 py-1 text-xs text-text placeholder:text-muted focus:border-accent focus:outline-none"
+                  // Ctrl/Cmd+Enter commits, matching the prompt composer's submit chord.
+                  onKeyDown={(e) => {
+                    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+                      e.preventDefault()
+                      void commit()
+                    }
+                  }}
+                />
+                {commitError && (
+                  <p className="text-[11px] text-bad" role="alert">
+                    {commitError}
+                  </p>
+                )}
+                {busy && <p className="text-[11px] text-muted">Agent is working…</p>}
+                <button
+                  type="button"
+                  onClick={() => void commit()}
+                  disabled={!canCommit}
+                  className="bg-accent px-2 py-1 text-xs font-medium text-on-accent hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {committing ? 'Committing…' : `Commit ${selectedPaths.length}`}
+                </button>
+              </div>
+            </>
           )}
         </>
       )}
@@ -157,15 +252,37 @@ function glyphClass(glyph: string): string {
   return 'text-accent-text'
 }
 
-/** One changed-file row. Clicking opens the file's working-tree diff (#85, DIFF mode). */
-function FileRow({ file, onSelect }: { file: GitFileView; onSelect: () => void }): JSX.Element {
+/**
+ * One changed-file row. A leading checkbox toggles the file's commit selection (#86)
+ * WITHOUT opening the diff (it's a separate control, not nested in the row button);
+ * clicking the rest of the row opens the file's working-tree diff (#85, DIFF mode).
+ */
+function FileRow({
+  file,
+  checked,
+  onToggle,
+  onSelect,
+}: {
+  file: GitFileView
+  checked: boolean
+  onToggle: () => void
+  onSelect: () => void
+}): JSX.Element {
   return (
-    <li>
+    <li className="flex items-center hover:bg-accent/10">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={onToggle}
+        aria-label={`Include ${file.path} in commit`}
+        title="Include in commit"
+        className="ml-3 shrink-0 accent-accent"
+      />
       <button
         type="button"
         onClick={onSelect}
         title={file.path}
-        className="flex w-full items-center gap-2 px-3 py-1 text-left text-xs hover:bg-accent/10"
+        className="flex min-w-0 flex-1 items-center gap-2 px-2 py-1 text-left text-xs"
       >
         <span
           className={cn('w-3 shrink-0 text-center font-semibold tabular-nums', glyphClass(file.glyph))}

--- a/src/renderer/src/git/ChangesPanel.tsx
+++ b/src/renderer/src/git/ChangesPanel.tsx
@@ -97,16 +97,21 @@ export function ChangesPanel({
     if (!canCommit) return
     setCommitting(true)
     setCommitError(null)
-    const result = await window.api.gitCommit({ workspaceDir, message: message.trim(), paths: selectedPaths })
-    setCommitting(false)
-    if (result.ok) {
-      // The committed files drop off via the status refresh main triggers; clear the
-      // message so the next commit starts fresh. The deselection set reconciles itself
-      // as the now-committed paths vanish from the next snapshot.
-      setMessage('')
-    } else {
-      // Recoverable: surface git's actual reason inline; the user can edit + retry.
-      setCommitError(result.error)
+    try {
+      const result = await window.api.gitCommit({ workspaceDir, message: message.trim(), paths: selectedPaths })
+      if (result.ok) {
+        // The committed files drop off via the status refresh main triggers; clear the
+        // message so the next commit starts fresh. The deselection set reconciles itself
+        // as the now-committed paths vanish from the next snapshot.
+        setMessage('')
+      } else {
+        // Recoverable: surface git's actual reason inline; the user can edit + retry.
+        setCommitError(result.error)
+      }
+    } finally {
+      // Always re-enable the button — even if the IPC unexpectedly rejects, it can't
+      // stick on "Committing…".
+      setCommitting(false)
     }
   }
 

--- a/src/renderer/src/git/status-view.test.ts
+++ b/src/renderer/src/git/status-view.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { buildChangesView, fileGlyph } from './status-view'
+import { buildChangesView, fileGlyph, reconcileUnchecked } from './status-view'
 import type { GitFile, GitStatus } from '../../../shared/ipc'
 
 function file(partial: Partial<GitFile> & { path: string }): GitFile {
@@ -55,5 +55,30 @@ describe('buildChangesView', () => {
     const view = buildChangesView({ ...status, branch: null, files: [] })
     expect(view.branch).toBe('HEAD')
     expect(view.detached).toBe(true)
+  })
+})
+
+describe('reconcileUnchecked', () => {
+  it('drops a deselected path that has vanished from the changed set', () => {
+    const next = reconcileUnchecked(new Set(['a.txt', 'gone.txt']), ['a.txt', 'b.txt'])
+    expect([...next]).toEqual(['a.txt'])
+  })
+
+  it('keeps a NEW file selected by default (it is absent from the set)', () => {
+    // `new.txt` appears in the changed set but not in `unchecked` → stays selected.
+    const next = reconcileUnchecked(new Set(['a.txt']), ['a.txt', 'new.txt'])
+    expect([...next]).toEqual(['a.txt'])
+  })
+
+  it('returns the SAME set ref when nothing changed (no needless re-render)', () => {
+    const unchecked = new Set(['a.txt'])
+    expect(reconcileUnchecked(unchecked, ['a.txt', 'b.txt'])).toBe(unchecked)
+  })
+
+  it('returns a NEW set when an entry was dropped (ref changes)', () => {
+    const unchecked = new Set(['gone.txt'])
+    const next = reconcileUnchecked(unchecked, ['a.txt'])
+    expect(next).not.toBe(unchecked)
+    expect(next.size).toBe(0)
   })
 })

--- a/src/renderer/src/git/status-view.ts
+++ b/src/renderer/src/git/status-view.ts
@@ -45,6 +45,27 @@ export function fileGlyph(file: GitFile): { glyph: string; label: string } {
 /** Sort rank by glyph so like-changes group together; ties break on path. */
 const GLYPH_RANK: Record<string, number> = { M: 0, A: 1, D: 2, R: 3, C: 4, U: 5 }
 
+/**
+ * Reconcile the commit selection's `unchecked` set against the CURRENT changed paths
+ * (#86). Selection is tracked as the set of paths the user EXPLICITLY deselected
+ * (default empty = all selected), so a freshly-appearing file is selected by default
+ * (it's absent from the set) with no work here. The only reconcile needed is to DROP a
+ * path that has vanished from the changed set (reverted / committed / renamed away), so
+ * a stale entry can't suppress a later same-named file or skew the selected count.
+ * Returns the SAME set ref when nothing changed, so a status tick that doesn't touch
+ * the selection won't force a re-render (referential-stability for the caller's setState).
+ */
+export function reconcileUnchecked(unchecked: ReadonlySet<string>, paths: readonly string[]): Set<string> {
+  const present = new Set(paths)
+  let changed = false
+  const next = new Set<string>()
+  for (const path of unchecked) {
+    if (present.has(path)) next.add(path)
+    else changed = true
+  }
+  return changed ? next : (unchecked as Set<string>)
+}
+
 /** Build the render-ready view from a repo `GitStatus` (assumes `isRepo:true`). */
 export function buildChangesView(status: GitStatus): ChangesView {
   const files: GitFileView[] = status.files

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -113,6 +113,16 @@ export const IPC = {
    * touch the warm-agent pool. A git failure (or no diff) returns the empty result.
    */
   gitDiff: 'git:diff',
+  /**
+   * Renderer -> main: COMMIT working-tree changes from the Changes panel (#86,
+   * ADR-0008) — the first git WRITE. Invoke, `{ workspaceDir, message, paths }` ->
+   * `GitCommitResult`. `paths` is the commit-time file selection (empty = commit all);
+   * main stages exactly that selection then commits (no stage/unstage UI). On success
+   * main re-reads status (`gitStatus.refresh`) so the committed files drop off the
+   * panel — a `.git`-only change the fs watcher won't see, like #84's turn-end refresh.
+   * NOT agent activity, so it does NOT touch the warm-agent pool (like `git:diff`).
+   */
+  gitCommit: 'git:commit',
 } as const
 
 /**
@@ -605,3 +615,23 @@ export interface GitDiffResult {
   diffHash: string
   truncated: boolean
 }
+
+/**
+ * Args for `gitCommit` (#86): commit working-tree changes. `message` is the commit
+ * message (the panel disables Commit on an empty/whitespace one). `paths` is the
+ * commit-time selection of `GitFile.path`s — a NON-empty subset stages exactly those
+ * (a mixed `reset` + `add -- <paths>`), an EMPTY array commits ALL changes (`add -A`).
+ */
+export interface GitCommitArgs {
+  workspaceDir: string
+  message: string
+  paths: string[]
+}
+
+/**
+ * The `gitCommit` reply (#86). `{ok:true}` on a clean commit (main then refreshes the
+ * Changes panel so the committed files drop off). `{ok:false, error}` carries git's
+ * ACTUAL reason — "nothing to commit", a failed pre-commit hook, an index lock — not a
+ * collapsed "commit failed" (#78 style). The renderer shows `error` inline + recoverable.
+ */
+export type GitCommitResult = { ok: true } | { ok: false; error: string }


### PR DESCRIPTION
Closes #86. Git slice 2 (ADR-0008): the first git **write** — commit working-tree changes from the Changes panel.

## What

- **main `src/main/git/commit.ts`:** `gitCommit(cwd, message, paths)` → `{ok} | {ok:false, error}`. SUBSET = stage exactly the selection (`git reset -q` → `git add -- <paths>` → `commit`); commit-all = `git add -A` → commit. `core.quotePath=false`, spaces-safe argv, gates every step, surfaces git's **actual** reason (stderr||stdout), never throws. `GitRun` (status.ts) gained an optional `stderr` (read callers unchanged).
- **IPC `git:commit`** (no `pool.touch`); the handler calls `gitStatus.refresh` on success so committed files drop off the panel (a `.git`-only change the watcher misses).
- **renderer:** per-file checkboxes (default-all, reconciled on status updates), a message box + **"Commit N"** (⌘/Ctrl+Enter), inline error, recoverable. The checkbox is a sibling of the row's diff-open button (toggling it doesn't open the diff).
- **Concurrency guard (ADR-0008):** `busy = wsFlags.streaming` threaded `App → renderConnected → ConnectedWorkspace → ChangesPanel` disables Commit while a turn streams — so a user commit can't race the agent's own `git commit`; git's `index.lock` is the backstop.

## Review + verification

Implementer → my independent gate re-run + full diff read → adversarial reviewer (verified staging against **real git 2.45.0**; verdict **SHIP-WITH-FIXES**, no MUST-FIX; confirmed exact-selection staging incl. deletions, `reset -q` is mixed (no data loss), the concurrency guard, the checkbox/row separation, and `GitRun` backward-compat). Gates green: lint / typecheck / build / **402 tests**.

**Folded:** the one SHOULD-FIX (a pre-staged **rename** was half-committed — now stages both halves via a porcelain rename scan) + a NIT (`committing` try/finally). The zero-commit-repo concern was a non-issue (no-ref `reset -q` works on an unborn branch); the `add -A` branch is harmless defensive code.

## ⚠️ Residual: live commit NOT driven

Validated by code-trace + isolated real-git experiments + unit tests, but no end-to-end Electron commit. **Worth a manual smoke:** commit a subset, commit-all, a pre-commit-hook failure (error inline), and confirm committed rows drop off without a manual refresh + the Commit button disables during a streaming turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)