### PR TITLE
#87: branch list / checkout / create (slice 3)

### DIFF
--- a/src/main/git/branches.test.ts
+++ b/src/main/git/branches.test.ts
@@ -125,18 +125,20 @@ describe('gitBranches', () => {
 })
 
 describe('gitCheckout', () => {
-  it('runs git switch <name> and returns {ok:true}', async () => {
+  it('runs git switch <name> for a LOCAL branch (track:false), returns {ok:true}', async () => {
     const seen: string[][] = []
-    const result = await gitCheckout('/repo', 'feature', fakeRun(seen))
+    const result = await gitCheckout('/repo', 'feat/87-x', false, fakeRun(seen))
     expect(result).toEqual({ ok: true })
-    expect(seen[0]).toEqual(['-c', 'core.quotePath=false', 'switch', 'feature'])
+    // A local name with a `/` switches verbatim (never stripped).
+    expect(seen[0]).toEqual(['-c', 'core.quotePath=false', 'switch', 'feat/87-x'])
   })
 
-  it('passes the caller’s switch target verbatim (renderer pre-strips a remote prefix)', async () => {
+  it('runs git switch --track <remote>/<branch> for a remote-only branch (track:true)', async () => {
     const seen: string[][] = []
-    // The renderer hands the bare trailing name for a remote-only `origin/foo` -> DWIM.
-    await gitCheckout('/repo', 'foo', fakeRun(seen))
-    expect(seen[0]).toEqual(['-c', 'core.quotePath=false', 'switch', 'foo'])
+    // `--track origin/foo` creates a tracking local UNAMBIGUOUSLY (vs a bare DWIM that
+    // errors when two remotes share the trailing name).
+    await gitCheckout('/repo', 'origin/foo', true, fakeRun(seen))
+    expect(seen[0]).toEqual(['-c', 'core.quotePath=false', 'switch', '--track', 'origin/foo'])
   })
 
   it('a dirty-tree refusal → {ok:false} with git’s reason (NO data loss — git protects)', async () => {
@@ -144,7 +146,7 @@ describe('gitCheckout', () => {
       [],
       [{ stderr: 'error: Your local changes to the following files would be overwritten by checkout:', code: 1 }],
     )
-    expect(await gitCheckout('/repo', 'other', run)).toEqual({
+    expect(await gitCheckout('/repo', 'other', false, run)).toEqual({
       ok: false,
       error: 'error: Your local changes to the following files would be overwritten by checkout:',
     })

--- a/src/main/git/branches.test.ts
+++ b/src/main/git/branches.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest'
+import { defaultBranchName, gitBranches, gitCheckout, gitCreateBranch, parseBranches } from './branches'
+import type { GitRun } from './status'
+
+/**
+ * #87 branch ops. The testable seams are (1) the PURE `parseBranches` over real
+ * `for-each-ref` text + a default name (parse, exclude origin/HEAD, dedupe, flags) and
+ * (2) the checkout/create COMMAND args + failure mapping over an injected `GitRun` — no
+ * test shells real git.
+ */
+
+/** A fake runner: records every `args` and returns a per-call canned `{stdout,stderr,code}`. */
+function fakeRun(
+  seen: string[][],
+  responses: { stdout?: string; stderr?: string; code: number }[] = [],
+): GitRun {
+  let i = 0
+  return (args) => {
+    seen.push(args)
+    const r = responses[i++] ?? { code: 0 }
+    return Promise.resolve({ stdout: r.stdout ?? '', stderr: r.stderr ?? '', code: r.code })
+  }
+}
+
+describe('parseBranches', () => {
+  it('parses local + remote refs, marks the current branch, strips the ref prefixes', () => {
+    const text = ['* refs/heads/main', '  refs/heads/feat/x', '  refs/remotes/origin/only-remote'].join('\n')
+    expect(parseBranches(text, null)).toEqual([
+      { name: 'main', isRemote: false, current: true, isDefault: false },
+      { name: 'feat/x', isRemote: false, current: false, isDefault: false },
+      { name: 'origin/only-remote', isRemote: true, current: false, isDefault: false },
+    ])
+  })
+
+  it('drops a remote branch whose trailing name matches a LOCAL head (dedupe)', () => {
+    const text = ['* refs/heads/main', '  refs/remotes/origin/main', '  refs/remotes/origin/feature'].join('\n')
+    const branches = parseBranches(text, null)
+    // origin/main is deduped (local main exists); origin/feature is remote-only -> kept.
+    expect(branches.map((b) => b.name)).toEqual(['main', 'origin/feature'])
+  })
+
+  it('dedupes a multi-segment branch name too (origin/docs/x vs local docs/x)', () => {
+    const text = ['  refs/heads/docs/x', '  refs/remotes/origin/docs/x', '  refs/remotes/origin/docs/y'].join('\n')
+    const branches = parseBranches(text, null)
+    expect(branches.map((b) => b.name)).toEqual(['docs/x', 'origin/docs/y'])
+  })
+
+  it('EXCLUDES the refs/remotes/*/HEAD symbolic pointer (not a branch)', () => {
+    const text = ['  refs/remotes/origin/HEAD', '  refs/remotes/origin/foo'].join('\n')
+    expect(parseBranches(text, null).map((b) => b.name)).toEqual(['origin/foo'])
+  })
+
+  it('marks isDefault for the local branch the default name points at', () => {
+    const text = ['* refs/heads/main', '  refs/heads/dev'].join('\n')
+    const branches = parseBranches(text, 'main')
+    expect(branches.find((b) => b.name === 'main')?.isDefault).toBe(true)
+    expect(branches.find((b) => b.name === 'dev')?.isDefault).toBe(false)
+  })
+
+  it('marks isDefault for a remote-only default (no local match)', () => {
+    const text = ['* refs/heads/dev', '  refs/remotes/origin/main'].join('\n')
+    const branches = parseBranches(text, 'main')
+    // No local main, so origin/main stays AND is the default (trailing name matches).
+    expect(branches.find((b) => b.name === 'origin/main')?.isDefault).toBe(true)
+  })
+
+  it('returns [] for empty / blank input', () => {
+    expect(parseBranches('', null)).toEqual([])
+    expect(parseBranches('\n\n', null)).toEqual([])
+  })
+})
+
+describe('defaultBranchName', () => {
+  it('extracts the trailing name from a symbolic-ref', () => {
+    expect(defaultBranchName('refs/remotes/origin/main\n')).toBe('main')
+    expect(defaultBranchName('refs/remotes/origin/feat/x\n')).toBe('feat/x')
+  })
+
+  it('returns null when unresolved / not a remote ref', () => {
+    expect(defaultBranchName('')).toBeNull()
+    expect(defaultBranchName('refs/heads/main')).toBeNull()
+  })
+})
+
+describe('gitBranches', () => {
+  it('runs for-each-ref (+ best-effort symbolic-ref) and returns the parsed branches', async () => {
+    const seen: string[][] = []
+    const run = fakeRun(seen, [
+      { stdout: '* refs/heads/main\n  refs/remotes/origin/main\n  refs/remotes/origin/feature\n', code: 0 },
+      { stdout: 'refs/remotes/origin/main\n', code: 0 },
+    ])
+    const result = await gitBranches('/repo', run)
+    expect(seen[0]).toEqual([
+      '-c',
+      'core.quotePath=false',
+      'for-each-ref',
+      '--format=%(HEAD) %(refname)',
+      'refs/heads',
+      'refs/remotes',
+    ])
+    expect(seen[1]).toEqual(['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'])
+    expect(result).toEqual({
+      ok: true,
+      branches: [
+        { name: 'main', isRemote: false, current: true, isDefault: true },
+        { name: 'origin/feature', isRemote: true, current: false, isDefault: false },
+      ],
+    })
+  })
+
+  it('still lists branches when the default-branch probe fails (no origin/HEAD)', async () => {
+    const seen: string[][] = []
+    const run = fakeRun(seen, [
+      { stdout: '* refs/heads/main\n', code: 0 },
+      { stderr: 'fatal: ref refs/remotes/origin/HEAD is not a symbolic ref', code: 1 },
+    ])
+    const result = await gitBranches('/repo', run)
+    expect(result).toEqual({ ok: true, branches: [{ name: 'main', isRemote: false, current: true, isDefault: false }] })
+  })
+
+  it('a failing for-each-ref → {ok:false} carrying git’s reason', async () => {
+    const run = fakeRun([], [{ stderr: 'fatal: not a git repository', code: 128 }])
+    expect(await gitBranches('/repo', run)).toEqual({ ok: false, error: 'fatal: not a git repository' })
+  })
+})
+
+describe('gitCheckout', () => {
+  it('runs git switch <name> and returns {ok:true}', async () => {
+    const seen: string[][] = []
+    const result = await gitCheckout('/repo', 'feature', fakeRun(seen))
+    expect(result).toEqual({ ok: true })
+    expect(seen[0]).toEqual(['-c', 'core.quotePath=false', 'switch', 'feature'])
+  })
+
+  it('passes the caller’s switch target verbatim (renderer pre-strips a remote prefix)', async () => {
+    const seen: string[][] = []
+    // The renderer hands the bare trailing name for a remote-only `origin/foo` -> DWIM.
+    await gitCheckout('/repo', 'foo', fakeRun(seen))
+    expect(seen[0]).toEqual(['-c', 'core.quotePath=false', 'switch', 'foo'])
+  })
+
+  it('a dirty-tree refusal → {ok:false} with git’s reason (NO data loss — git protects)', async () => {
+    const run = fakeRun(
+      [],
+      [{ stderr: 'error: Your local changes to the following files would be overwritten by checkout:', code: 1 }],
+    )
+    expect(await gitCheckout('/repo', 'other', run)).toEqual({
+      ok: false,
+      error: 'error: Your local changes to the following files would be overwritten by checkout:',
+    })
+  })
+})
+
+describe('gitCreateBranch', () => {
+  it('runs git switch -c <name> and returns {ok:true}', async () => {
+    const seen: string[][] = []
+    const result = await gitCreateBranch('/repo', 'feat/new', fakeRun(seen))
+    expect(result).toEqual({ ok: true })
+    expect(seen[0]).toEqual(['-c', 'core.quotePath=false', 'switch', '-c', 'feat/new'])
+  })
+
+  it('a name collision → {ok:false} with git’s reason', async () => {
+    const run = fakeRun([], [{ stderr: "fatal: a branch named 'dev' already exists", code: 128 }])
+    expect(await gitCreateBranch('/repo', 'dev', run)).toEqual({
+      ok: false,
+      error: "fatal: a branch named 'dev' already exists",
+    })
+  })
+})

--- a/src/main/git/branches.ts
+++ b/src/main/git/branches.ts
@@ -108,20 +108,32 @@ export async function gitBranches(cwd: string, run: GitRun = defaultGitRun): Pro
 }
 
 /**
- * Impure checkout (#87): `git switch <name>`. The caller passes the SWITCH TARGET — for a
- * local branch that's its name; for a remote-only `origin/foo` the renderer strips the
- * remote prefix and passes the bare `foo`, so git's DWIM creates a tracking local
- * (`git switch foo` <=> `git switch -c foo --track origin/foo`). Main can't strip safely
- * itself — a LOCAL branch name can also contain `/` (e.g. `feat/87-…`) — so the renderer,
- * which knows `isRemote`, decides the target.
+ * Impure checkout (#87): switch to a branch. The renderer (which knows `isRemote`) passes
+ * the branch's full `name` plus `track`: a LOCAL branch (`track:false`) → `git switch
+ * <name>` (the name may contain `/`, e.g. `feat/87-…`, so it's never stripped); a
+ * remote-only branch (`track:true`) → `git switch --track <remote>/<branch>`, which
+ * creates a tracking local UNAMBIGUOUSLY (a bare DWIM `git switch <branch>` would error
+ * when two remotes share the trailing name).
  *
  * A dirty-tree switch git refuses ("Your local changes … would be overwritten") exits
  * non-zero -> `{ok:false, error: <git reason>}`. NO data loss: git protects the tree; we
  * surface the reason and the user resolves it (commit/stash). Never throws.
  */
-export async function gitCheckout(cwd: string, name: string, run: GitRun = defaultGitRun): Promise<GitOpResult> {
+export async function gitCheckout(
+  cwd: string,
+  name: string,
+  track = false,
+  run: GitRun = defaultGitRun,
+): Promise<GitOpResult> {
   try {
-    const res = await run(['-c', 'core.quotePath=false', 'switch', name], cwd)
+    // `track` (a remote-only branch): `git switch --track <remote>/<branch>` creates a
+    // local branch (named after the trailing segment) tracking that EXACT remote ref —
+    // unambiguous even when two remotes share a trailing name, where a bare DWIM
+    // `git switch <branch>` would error. A LOCAL branch (`track:false`) switches by name.
+    const args = track
+      ? ['-c', 'core.quotePath=false', 'switch', '--track', name]
+      : ['-c', 'core.quotePath=false', 'switch', name]
+    const res = await run(args, cwd)
     if (res.code !== 0) return { ok: false, error: failReason(res) }
     return { ok: true }
   } catch (err) {

--- a/src/main/git/branches.ts
+++ b/src/main/git/branches.ts
@@ -1,0 +1,154 @@
+import { defaultGitRun, type GitRun } from './status'
+import type { GitBranch, GitBranchesResult, GitOpResult } from '../../shared/ipc'
+
+/**
+ * Branch list / checkout / create on a Workspace's working tree (#87, slice 3 of the
+ * Changes panel, ADR-0008). Like #84's status read, #85's diff read, and #86's commit
+ * write, git runs in MAIN via `child_process` through the injectable `GitRun` seam
+ * (reused from `status.ts`) — no git2 / isomorphic-git. The PURE `parseBranches` is the
+ * testable seam (it never shells out); `gitBranches` is the thin impure shell that runs
+ * the commands and feeds the parser.
+ *
+ * Every failure is SWALLOWED into a result — these NEVER throw (mirroring #84/#85/#86):
+ * a list failure returns `{ok:false, error}`, a checkout/create failure returns
+ * `{ok:false, error}` carrying git's ACTUAL reason. A dirty-tree checkout git refuses
+ * ("Your local changes would be overwritten…") is a NON-zero exit we just surface — git
+ * protects the tree, there is NO data loss; we never `--force`/`--discard`.
+ */
+
+/**
+ * PURE parser (#87): turn `git for-each-ref --format='%(HEAD) %(refname)'` text +
+ * the resolved default-branch name into the `GitBranch[]` the panel renders.
+ *
+ * The `for-each-ref` grammar (verified against real git, see branches.test.ts):
+ *  - `%(HEAD)` is `*` for the CURRENT branch, else a single space — so each line is
+ *    `<*| > <refname>`, i.e. the marker is `line[0]` and the refname is `line.slice(2)`.
+ *  - `refs/heads/<name>`        -> a LOCAL branch  `{name, isRemote:false, current}`.
+ *  - `refs/remotes/<remote>/<name>` -> a REMOTE branch `{name:'<remote>/<name>', isRemote:true}`.
+ *  - a `refs/remotes/<remote>/HEAD` ref is the symbolic origin/HEAD POINTER, not a
+ *    branch — EXCLUDED.
+ *
+ * Then DEDUPE (pure, mirroring t3code's `dedupeRemoteBranchesWithLocalMatches`): drop a
+ * remote branch whose trailing name has a matching LOCAL head (e.g. drop `origin/main`
+ * when local `main` exists) so the list shows the local + only the remote-ONLY branches.
+ *
+ * `isDefault` marks the branch the default-ref points at (best-effort; all false when
+ * unresolved): a local whose name matches, or a remote-only whose trailing name matches.
+ */
+export function parseBranches(forEachRef: string, defaultName: string | null): GitBranch[] {
+  const locals: GitBranch[] = []
+  const remotes: GitBranch[] = []
+  const localNames = new Set<string>()
+
+  for (const line of forEachRef.split('\n')) {
+    if (!line) continue
+    // `%(HEAD)` is one char (`*`/space) then a literal space, so the refname starts at 2.
+    const current = line[0] === '*'
+    const refname = line.slice(2)
+    if (refname.startsWith('refs/heads/')) {
+      const name = refname.slice('refs/heads/'.length)
+      if (!name) continue
+      localNames.add(name)
+      locals.push({ name, isRemote: false, current, isDefault: name === defaultName })
+    } else if (refname.startsWith('refs/remotes/')) {
+      const name = refname.slice('refs/remotes/'.length)
+      // `<remote>/<branch>` — exclude the `<remote>/HEAD` symbolic pointer (not a branch).
+      if (!name || name.endsWith('/HEAD')) continue
+      const trailing = remoteTrailingName(name)
+      remotes.push({ name, isRemote: true, current: false, isDefault: trailing === defaultName })
+    }
+    // Any other ref namespace is ignored.
+  }
+
+  // Dedupe: keep a remote ONLY when no local head shares its trailing branch name.
+  const remoteOnly = remotes.filter((r) => !localNames.has(remoteTrailingName(r.name)))
+  return [...locals, ...remoteOnly]
+}
+
+/** The branch portion of a `<remote>/<branch>` name (drop the leading remote segment). */
+function remoteTrailingName(name: string): string {
+  const slash = name.indexOf('/')
+  return slash >= 0 ? name.slice(slash + 1) : name
+}
+
+/**
+ * PURE: resolve the default branch name from `git symbolic-ref refs/remotes/origin/HEAD`
+ * stdout (e.g. `refs/remotes/origin/main` -> `main`). Returns null when unresolved, so a
+ * missing origin/HEAD just leaves every branch `isDefault:false` (best-effort).
+ */
+export function defaultBranchName(symbolicRef: string): string | null {
+  const ref = symbolicRef.trim()
+  if (!ref.startsWith('refs/remotes/')) return null
+  const name = remoteTrailingName(ref.slice('refs/remotes/'.length))
+  return name || null
+}
+
+/**
+ * Impure list (#87): run `for-each-ref` for `cwd` and parse it, with a best-effort
+ * default-branch lookup. The default lookup NEVER fails the whole call — a missing
+ * origin/HEAD (a clone with no remote, a fresh repo) just yields no default. A failed
+ * `for-each-ref` is swallowed into `{ok:false, error}` (its git reason). Never throws.
+ */
+export async function gitBranches(cwd: string, run: GitRun = defaultGitRun): Promise<GitBranchesResult> {
+  try {
+    // `-c core.quotePath=false` keeps unicode branch names plain UTF-8 (consistent with
+    // #84-#86). `--format` is ONE argv element (no shell, so no surrounding quotes).
+    const refs = await run(
+      ['-c', 'core.quotePath=false', 'for-each-ref', '--format=%(HEAD) %(refname)', 'refs/heads', 'refs/remotes'],
+      cwd,
+    )
+    if (refs.code !== 0) return { ok: false, error: failReason(refs) }
+    // Best-effort default-branch probe — a non-zero exit (no origin/HEAD) leaves it null.
+    const sym = await run(['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'], cwd)
+    const defaultName = sym.code === 0 ? defaultBranchName(sym.stdout) : null
+    return { ok: true, branches: parseBranches(refs.stdout, defaultName) }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+/**
+ * Impure checkout (#87): `git switch <name>`. The caller passes the SWITCH TARGET — for a
+ * local branch that's its name; for a remote-only `origin/foo` the renderer strips the
+ * remote prefix and passes the bare `foo`, so git's DWIM creates a tracking local
+ * (`git switch foo` <=> `git switch -c foo --track origin/foo`). Main can't strip safely
+ * itself — a LOCAL branch name can also contain `/` (e.g. `feat/87-…`) — so the renderer,
+ * which knows `isRemote`, decides the target.
+ *
+ * A dirty-tree switch git refuses ("Your local changes … would be overwritten") exits
+ * non-zero -> `{ok:false, error: <git reason>}`. NO data loss: git protects the tree; we
+ * surface the reason and the user resolves it (commit/stash). Never throws.
+ */
+export async function gitCheckout(cwd: string, name: string, run: GitRun = defaultGitRun): Promise<GitOpResult> {
+  try {
+    const res = await run(['-c', 'core.quotePath=false', 'switch', name], cwd)
+    if (res.code !== 0) return { ok: false, error: failReason(res) }
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+/**
+ * Impure create (#87): `git switch -c <name>` from the current HEAD (no base ref in v1).
+ * A name collision (`fatal: a branch named '<name>' already exists`) exits non-zero ->
+ * `{ok:false, error}` carrying git's reason. Never throws.
+ */
+export async function gitCreateBranch(cwd: string, name: string, run: GitRun = defaultGitRun): Promise<GitOpResult> {
+  try {
+    const res = await run(['-c', 'core.quotePath=false', 'switch', '-c', name], cwd)
+    if (res.code !== 0) return { ok: false, error: failReason(res) }
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+/**
+ * Map a non-zero git step to its failure reason. git puts switch refusals / collisions on
+ * STDERR, so prefer stderr and fall back to stdout — never collapse to a generic message
+ * (#78 / #86 style).
+ */
+function failReason(res: { stdout: string; stderr?: string; code: number }): string {
+  return (res.stderr ?? '').trim() || res.stdout.trim() || 'git command failed'
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -941,7 +941,7 @@ function registerIpc(): void {
     // the working tree, so on success re-read status (`gitStatus.refresh`) to update the
     // panel header (branch / ahead-behind) and file list. NOT agent activity, so no
     // `pool.touch` (consistent with git:diff/commit). Never throws.
-    const result = await gitCheckout(args.workspaceDir, args.name)
+    const result = await gitCheckout(args.workspaceDir, args.name, args.track ?? false)
     if (result.ok) gitStatus.refresh(args.workspaceDir)
     else console.error(`[vibe-mistro:git] checkout failed (${args.workspaceDir} -> ${args.name}): ${result.error}`)
     return result

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,10 +5,14 @@ import { basename, join } from 'node:path'
 import {
   IPC,
   type DeleteThreadResult,
+  type GitBranchesArgs,
+  type GitBranchesResult,
+  type GitBranchOpArgs,
   type GitCommitArgs,
   type GitCommitResult,
   type GitDiffArgs,
   type GitDiffResult,
+  type GitOpResult,
   type GitStatusEvent,
   type GitStatusSubscriptionArgs,
   type ListMetadataResult,
@@ -55,6 +59,7 @@ import { permissionRequestIdOf, ThreadStatusTracker, type ThreadStatusChange } f
 import { gitFetch, readGitStatus } from './git/status'
 import { readGitDiff } from './git/diff'
 import { gitCommit } from './git/commit'
+import { gitBranches, gitCheckout, gitCreateBranch } from './git/branches'
 import { GitStatusManager } from './git/status-stream'
 import { chokidarWatchFactory, realClock } from './git/runtime'
 
@@ -921,6 +926,34 @@ function registerIpc(): void {
     } else {
       console.error(`[vibe-mistro:git] commit failed (${args.workspaceDir}): ${result.error}`)
     }
+    return result
+  })
+
+  ipcMain.handle(IPC.gitBranches, (_event, args: GitBranchesArgs): Promise<GitBranchesResult> => {
+    // List the active Workspace's branches for the header dropdown (#87). cwd is the
+    // Workspace dir (where #84's status ran). Read-only, so — like `git:diff` — it does
+    // NOT `pool.touch`. `gitBranches` swallows git failure into `{ok:false, error}`.
+    return gitBranches(args.workspaceDir)
+  })
+
+  ipcMain.handle(IPC.gitCheckout, async (_event, args: GitBranchOpArgs): Promise<GitOpResult> => {
+    // Check out a branch on the active Workspace (#87). A switch changes `.git/HEAD` +
+    // the working tree, so on success re-read status (`gitStatus.refresh`) to update the
+    // panel header (branch / ahead-behind) and file list. NOT agent activity, so no
+    // `pool.touch` (consistent with git:diff/commit). Never throws.
+    const result = await gitCheckout(args.workspaceDir, args.name)
+    if (result.ok) gitStatus.refresh(args.workspaceDir)
+    else console.error(`[vibe-mistro:git] checkout failed (${args.workspaceDir} -> ${args.name}): ${result.error}`)
+    return result
+  })
+
+  ipcMain.handle(IPC.gitCreateBranch, async (_event, args: GitBranchOpArgs): Promise<GitOpResult> => {
+    // Create + switch to a new branch on the active Workspace (#87). Like checkout, a
+    // successful create moves HEAD, so re-read status to update the header. No
+    // `pool.touch`. Never throws.
+    const result = await gitCreateBranch(args.workspaceDir, args.name)
+    if (result.ok) gitStatus.refresh(args.workspaceDir)
+    else console.error(`[vibe-mistro:git] create-branch failed (${args.workspaceDir} -> ${args.name}): ${result.error}`)
     return result
   })
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4,10 +4,14 @@ import {
   type AcpEvent,
   type AgentEvictedEvent,
   type DeleteThreadResult,
+  type GitBranchesArgs,
+  type GitBranchesResult,
+  type GitBranchOpArgs,
   type GitCommitArgs,
   type GitCommitResult,
   type GitDiffArgs,
   type GitDiffResult,
+  type GitOpResult,
   type GitStatusEvent,
   type GitStatusSubscriptionArgs,
   type ListMetadataResult,
@@ -63,6 +67,12 @@ const api = {
     ipcRenderer.invoke(IPC.gitUnsubscribeStatus, args),
   gitDiff: (args: GitDiffArgs): Promise<GitDiffResult> => ipcRenderer.invoke(IPC.gitDiff, args),
   gitCommit: (args: GitCommitArgs): Promise<GitCommitResult> => ipcRenderer.invoke(IPC.gitCommit, args),
+  gitBranches: (args: GitBranchesArgs): Promise<GitBranchesResult> =>
+    ipcRenderer.invoke(IPC.gitBranches, args),
+  gitCheckout: (args: GitBranchOpArgs): Promise<GitOpResult> =>
+    ipcRenderer.invoke(IPC.gitCheckout, args),
+  gitCreateBranch: (args: GitBranchOpArgs): Promise<GitOpResult> =>
+    ipcRenderer.invoke(IPC.gitCreateBranch, args),
   onAcpEvent: (listener: (event: AcpEvent) => void): (() => void) => {
     const handler = (_e: unknown, payload: AcpEvent): void => listener(payload)
     ipcRenderer.on(IPC.acpEvent, handler)

--- a/src/renderer/src/git/ChangesPanel.tsx
+++ b/src/renderer/src/git/ChangesPanel.tsx
@@ -302,12 +302,12 @@ function BranchMenu({
     setBusyOp(true)
     setOpError(null)
     try {
-      // A remote-only branch's `name` is `<remote>/<branch>`; pass the bare trailing name
-      // so git's DWIM creates a tracking local. A local name (which may itself contain
-      // `/`, e.g. `feat/x`) is passed verbatim — `info.isRemote` decides which.
+      // Pass the branch's FULL name + `track`: a remote-only `<remote>/<branch>` goes
+      // through `git switch --track` (an unambiguous tracking-local create — robust even
+      // with two remotes sharing a trailing name); a local name (which may contain `/`,
+      // e.g. `feat/x`) switches verbatim. `info.isRemote` decides.
       const info = branches?.find((b) => b.name === name)
-      const target = info?.isRemote ? trailingBranchName(name) : name
-      const result = await window.api.gitCheckout({ workspaceDir, name: target })
+      const result = await window.api.gitCheckout({ workspaceDir, name, track: info?.isRemote ?? false })
       // On success the streamed status refresh updates the header to the new branch.
       if (!result.ok) setOpError(result.error)
     } finally {
@@ -390,6 +390,7 @@ function BranchMenu({
         <div className="flex items-center gap-1.5 border-b border-border px-3 py-2">
           <input
             autoFocus
+            aria-label="New branch name"
             value={newName}
             onChange={(e) => setNewName(e.target.value)}
             placeholder="New branch name"
@@ -425,12 +426,6 @@ function BranchMenu({
       )}
     </>
   )
-}
-
-/** The branch portion of a `<remote>/<branch>` name (drop the leading remote segment). */
-function trailingBranchName(name: string): string {
-  const slash = name.indexOf('/')
-  return slash >= 0 ? name.slice(slash + 1) : name
 }
 
 /** A glyph's accent: added/untracked read positive, deleted negative, else neutral. */

--- a/src/renderer/src/git/ChangesPanel.tsx
+++ b/src/renderer/src/git/ChangesPanel.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState, type JSX } from 'react'
-import { ChevronDown, ChevronRight, GitBranch, RefreshCw } from 'lucide-react'
-import type { GitStatus } from '../../../shared/ipc'
+import { Check, ChevronDown, ChevronRight, GitBranch, RefreshCw } from 'lucide-react'
+import type { GitBranch as GitBranchInfo, GitStatus } from '../../../shared/ipc'
 import { cn } from '../lib/utils'
+import { Menu, MenuContent, MenuItem, MenuSeparator, MenuTrigger } from '../ui/menu'
 import { buildChangesView, reconcileUnchecked, type GitFileView } from './status-view'
 import { DiffWorkerProvider } from './DiffWorkerProvider'
 import { DiffView } from './DiffView'
@@ -172,19 +173,13 @@ export function ChangesPanel({
 
       {!collapsed && (
         <>
-          <div className="flex items-center gap-1.5 border-b border-border px-3 py-2 text-xs text-muted">
-            <GitBranch size={13} aria-hidden className="shrink-0" />
-            <span className="min-w-0 flex-1 truncate font-medium text-text" title={view.branch}>
-              {view.branch}
-            </span>
-            {(view.ahead > 0 || view.behind > 0) && (
-              <span className="shrink-0 tabular-nums" title={`${view.ahead} ahead, ${view.behind} behind`}>
-                {view.ahead > 0 && <>↑{view.ahead}</>}
-                {view.ahead > 0 && view.behind > 0 && ' '}
-                {view.behind > 0 && <>↓{view.behind}</>}
-              </span>
-            )}
-          </div>
+          <BranchMenu
+            workspaceDir={workspaceDir}
+            branch={view.branch}
+            ahead={view.ahead}
+            behind={view.behind}
+            busy={busy}
+          />
 
           {view.files.length === 0 ? (
             <p className="px-3 py-3 text-xs text-muted">No changes — working tree clean.</p>
@@ -248,6 +243,194 @@ export function ChangesPanel({
       )}
     </aside>
   )
+}
+
+/**
+ * The branch header dropdown (#87): the current branch name as a base-ui Menu trigger
+ * that, ON OPEN, fetches the Workspace's branches (`gitBranches`) and lists them for a
+ * one-click checkout (`gitCheckout`); a "Create branch…" item reveals an inline input
+ * (`gitCreateBranch`). The ahead/behind indicator stays beside the trigger (unchanged).
+ *
+ * Disabled while `busy` (a turn streams) — the same guard as commit: we don't switch
+ * branches under the agent mid-turn (a switch rewrites the working tree). A checkout /
+ * create error surfaces inline + recoverable (the common one is git's dirty-tree
+ * refusal — NO data loss, git protects). The status STREAM updates the header on a
+ * successful switch (main re-reads after the op), so this holds no branch-name state.
+ */
+function BranchMenu({
+  workspaceDir,
+  branch,
+  ahead,
+  behind,
+  busy,
+}: {
+  workspaceDir: string
+  branch: string
+  ahead: number
+  behind: number
+  busy: boolean
+}): JSX.Element {
+  const [branches, setBranches] = useState<GitBranchInfo[] | null>(null)
+  const [listError, setListError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  // The recoverable error from a checkout / create (dirty-tree refusal, name collision).
+  const [opError, setOpError] = useState<string | null>(null)
+  // The inline "Create branch…" affordance: revealed by the menu item, below the header.
+  const [creating, setCreating] = useState(false)
+  const [newName, setNewName] = useState('')
+  const [busyOp, setBusyOp] = useState(false)
+
+  // Fetch the branch list each time the menu opens, so it reflects branches created out
+  // of band (a terminal `git branch`, the agent) without a panel-wide subscription.
+  async function loadBranches(): Promise<void> {
+    setLoading(true)
+    setListError(null)
+    try {
+      const result = await window.api.gitBranches({ workspaceDir })
+      if (result.ok) setBranches(result.branches)
+      else {
+        setBranches([])
+        setListError(result.error)
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function checkout(name: string): Promise<void> {
+    if (busy || busyOp) return
+    setBusyOp(true)
+    setOpError(null)
+    try {
+      // A remote-only branch's `name` is `<remote>/<branch>`; pass the bare trailing name
+      // so git's DWIM creates a tracking local. A local name (which may itself contain
+      // `/`, e.g. `feat/x`) is passed verbatim — `info.isRemote` decides which.
+      const info = branches?.find((b) => b.name === name)
+      const target = info?.isRemote ? trailingBranchName(name) : name
+      const result = await window.api.gitCheckout({ workspaceDir, name: target })
+      // On success the streamed status refresh updates the header to the new branch.
+      if (!result.ok) setOpError(result.error)
+    } finally {
+      setBusyOp(false)
+    }
+  }
+
+  async function createBranch(): Promise<void> {
+    const name = newName.trim()
+    if (!name || busy || busyOp) return
+    setBusyOp(true)
+    setOpError(null)
+    try {
+      const result = await window.api.gitCreateBranch({ workspaceDir, name })
+      if (result.ok) {
+        // The header updates via the streamed status refresh; clear + close the input.
+        setNewName('')
+        setCreating(false)
+      } else {
+        setOpError(result.error)
+      }
+    } finally {
+      setBusyOp(false)
+    }
+  }
+
+  return (
+    <>
+      <div className="flex items-center gap-1.5 border-b border-border px-3 py-2 text-xs text-muted">
+        <Menu
+          onOpenChange={(open) => {
+            if (open) void loadBranches()
+          }}
+        >
+          <MenuTrigger
+            disabled={busy}
+            title={busy ? 'Agent is working…' : branch}
+            className={cn(
+              'flex min-w-0 flex-1 items-center gap-1.5 text-left',
+              'hover:text-accent-text disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:text-muted',
+            )}
+          >
+            <GitBranch size={13} aria-hidden className="shrink-0" />
+            <span className="min-w-0 flex-1 truncate font-medium text-text">{branch}</span>
+            <ChevronDown size={12} aria-hidden className="shrink-0" />
+          </MenuTrigger>
+          <MenuContent align="start" className="max-h-80 min-w-48 overflow-y-auto">
+            {loading ? (
+              <div className="px-3 py-1.5 text-xs text-muted">Loading…</div>
+            ) : listError ? (
+              <div className="px-3 py-1.5 text-xs text-bad">{listError}</div>
+            ) : branches && branches.length > 0 ? (
+              branches.map((b) => (
+                <MenuItem key={b.name} onClick={() => void checkout(b.name)} disabled={b.current}>
+                  <Check size={12} aria-hidden className={cn('shrink-0', b.current ? 'opacity-100' : 'opacity-0')} />
+                  <span className="min-w-0 flex-1 truncate">{b.name}</span>
+                  {b.isRemote && <span className="shrink-0 text-[10px] uppercase text-muted">remote</span>}
+                </MenuItem>
+              ))
+            ) : (
+              <div className="px-3 py-1.5 text-xs text-muted">No branches.</div>
+            )}
+            <MenuSeparator className="my-1 h-px bg-border" />
+            <MenuItem onClick={() => setCreating(true)}>
+              <span className="w-3 shrink-0" aria-hidden />
+              Create branch…
+            </MenuItem>
+          </MenuContent>
+        </Menu>
+        {(ahead > 0 || behind > 0) && (
+          <span className="shrink-0 tabular-nums" title={`${ahead} ahead, ${behind} behind`}>
+            {ahead > 0 && <>↑{ahead}</>}
+            {ahead > 0 && behind > 0 && ' '}
+            {behind > 0 && <>↓{behind}</>}
+          </span>
+        )}
+      </div>
+
+      {creating && (
+        <div className="flex items-center gap-1.5 border-b border-border px-3 py-2">
+          <input
+            autoFocus
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            placeholder="New branch name"
+            disabled={busy || busyOp}
+            className="min-w-0 flex-1 border border-border bg-panel px-2 py-1 text-xs text-text placeholder:text-muted focus:border-accent focus:outline-none disabled:opacity-50"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                void createBranch()
+              } else if (e.key === 'Escape') {
+                e.preventDefault()
+                setCreating(false)
+                setNewName('')
+                setOpError(null)
+              }
+            }}
+          />
+          <button
+            type="button"
+            onClick={() => void createBranch()}
+            disabled={busy || busyOp || newName.trim().length === 0}
+            className="shrink-0 bg-accent px-2 py-1 text-xs font-medium text-on-accent hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Create
+          </button>
+        </div>
+      )}
+
+      {opError && (
+        <p className="border-b border-border px-3 py-2 text-[11px] text-bad" role="alert">
+          {opError}
+        </p>
+      )}
+    </>
+  )
+}
+
+/** The branch portion of a `<remote>/<branch>` name (drop the leading remote segment). */
+function trailingBranchName(name: string): string {
+  const slash = name.indexOf('/')
+  return slash >= 0 ? name.slice(slash + 1) : name
 }
 
 /** A glyph's accent: added/untracked read positive, deleted negative, else neutral. */

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -123,6 +123,29 @@ export const IPC = {
    * NOT agent activity, so it does NOT touch the warm-agent pool (like `git:diff`).
    */
   gitCommit: 'git:commit',
+  /**
+   * Renderer -> main: list the active Workspace's branches (#87, ADR-0008). Invoke,
+   * `{ workspaceDir }` -> `GitBranchesResult` (local + remote-only branches, deduped).
+   * Read-only, so — like `git:diff` — it does NOT touch the warm-agent pool. A git
+   * failure returns `{ok:false, error}` (never throws). The dropdown fetches on open.
+   */
+  gitBranches: 'git:branches',
+  /**
+   * Renderer -> main: CHECK OUT a branch on the active Workspace (#87). Invoke,
+   * `{ workspaceDir, name }` -> `GitOpResult`. `name` is the SWITCH TARGET — a local
+   * branch name, or the bare trailing name for a remote-only branch (the renderer
+   * strips the remote prefix so git's DWIM creates a tracking local). On success main
+   * re-reads status (`gitStatus.refresh`) so the panel header shows the new branch. A
+   * dirty-tree refusal returns `{ok:false, error}` (NO data loss — git protects).
+   */
+  gitCheckout: 'git:checkout',
+  /**
+   * Renderer -> main: CREATE + switch to a new branch on the active Workspace (#87).
+   * Invoke, `{ workspaceDir, name }` -> `GitOpResult` (`git switch -c <name>` from the
+   * current HEAD; no base ref in v1). On success main re-reads status so the header
+   * shows the new branch. A name collision returns `{ok:false, error}` (never throws).
+   */
+  gitCreateBranch: 'git:create-branch',
 } as const
 
 /**
@@ -635,3 +658,50 @@ export interface GitCommitArgs {
  * collapsed "commit failed" (#78 style). The renderer shows `error` inline + recoverable.
  */
 export type GitCommitResult = { ok: true } | { ok: false; error: string }
+
+/**
+ * One branch in a Workspace's repo (#87). `name` is the local branch name (e.g. `main`,
+ * `feat/x`) or, for a remote-only branch, the `<remote>/<branch>` name (e.g.
+ * `origin/feature`). `isRemote` distinguishes the two; `current` marks the checked-out
+ * branch; `isDefault` marks the repo's default branch (best-effort from origin/HEAD,
+ * false everywhere when unresolved). The list shows local branches + only the remotes
+ * with NO matching local (deduped), so a tracked branch appears once.
+ */
+export interface GitBranch {
+  name: string
+  isRemote: boolean
+  current: boolean
+  isDefault: boolean
+}
+
+/**
+ * The `gitBranches` reply (#87). `{ok:true, branches}` on a successful list (local +
+ * remote-only, deduped). `{ok:false, error}` carries git's actual reason (e.g. not a
+ * git repository) — never a collapsed message. The dropdown surfaces the error inline.
+ */
+export type GitBranchesResult = { ok: true; branches: GitBranch[] } | { ok: false; error: string }
+
+/**
+ * The reply shape for a branch WRITE — `gitCheckout` / `gitCreateBranch` (#87).
+ * `{ok:true}` on a clean switch/create (main then refreshes status so the panel header
+ * shows the new branch). `{ok:false, error}` carries git's ACTUAL reason — a dirty-tree
+ * checkout refusal (NO data loss; git protects), a name collision — surfaced inline +
+ * recoverable.
+ */
+export type GitOpResult = { ok: true } | { ok: false; error: string }
+
+/** Args for `gitBranches` (#87): list one Workspace's branches. */
+export interface GitBranchesArgs {
+  workspaceDir: string
+}
+
+/**
+ * Args for `gitCheckout` / `gitCreateBranch` (#87). `name` is the SWITCH TARGET for a
+ * checkout (a local name, or the bare trailing name of a remote-only branch — the
+ * renderer strips the remote prefix so git's DWIM creates a tracking local) or the NEW
+ * branch name for a create.
+ */
+export interface GitBranchOpArgs {
+  workspaceDir: string
+  name: string
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -696,12 +696,13 @@ export interface GitBranchesArgs {
 }
 
 /**
- * Args for `gitCheckout` / `gitCreateBranch` (#87). `name` is the SWITCH TARGET for a
- * checkout (a local name, or the bare trailing name of a remote-only branch — the
- * renderer strips the remote prefix so git's DWIM creates a tracking local) or the NEW
- * branch name for a create.
+ * Args for `gitCheckout` / `gitCreateBranch` (#87). For a checkout `name` is the branch's
+ * full name and `track` says whether it's a remote-only branch: `track:true` →
+ * `git switch --track <remote>/<branch>` (an unambiguous tracking-local create), else
+ * `git switch <name>`. For a create, `name` is the NEW branch name (`track` unused).
  */
 export interface GitBranchOpArgs {
   workspaceDir: string
   name: string
+  track?: boolean
 }


### PR DESCRIPTION
Closes #87. Git slice 3 (ADR-0008): branch list / checkout / create from the Changes panel header.

## What

- **main `src/main/git/branches.ts`:** pure `parseBranches` (over `git for-each-ref --format='%(HEAD) %(refname)'`) → `GitBranch[]` with current/default flags, **dedupes** a remote whose trailing name has a local head, excludes `<remote>/HEAD`; best-effort default-branch detection (`symbolic-ref origin/HEAD`). `gitCheckout` = `git switch <name>` (local) / `git switch --track <remote>/<branch>` (remote-only — unambiguous tracking-local create); `gitCreateBranch` = `git switch -c <name>`. All swallow to `{ok:false, error}` (git's real reason), **never throw, no `--force`** (git protects the tree → no data loss).
- **IPC** `git:branches` / `git:checkout` / `git:create-branch`; handlers `gitStatus.refresh` after a successful switch/create (the stream updates the header), no `pool.touch`.
- **renderer:** the branch name in the panel header becomes a base-ui Menu dropdown — re-fetches branches on open, one-click checkout, an inline "Create branch…" input. **Disabled while a turn streams** (the `busy` guard — don't switch under the agent); checkout/create errors (the common one is git's dirty-tree refusal) surface inline + recoverable.

## Review + verification

Implementer → my independent gate re-run + full diff read → adversarial reviewer (verified the `for-each-ref` format + grepped for destructive flags against **real git**; verdict **SHIP**, no MUST/SHOULD-FIX — every edge fails safe). Gates green: lint / typecheck / build / **419 tests**.

**Folded two NITs:** robust remote checkout via `--track` (fixes the multi-remote trailing-name ambiguity *and* simplifies the renderer), and an input aria-label. Remaining NITs are cosmetic (no in-flight spinner, no `--` end-of-options guard).

## Notes / residual

- `git switch` requires git ≥ 2.23 (2019); an older git surfaces the error, no data loss.
- Live checkout/create NOT driven (static + unit only). **Worth a manual smoke:** switch a branch, create one, and a dirty-tree refusal (edit a file, try to switch → git's reason inline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)