### PR TITLE
#88: surface the current branch's GitHub PR + create PR via gh (slice 4)

### DIFF
--- a/src/main/git/github.test.ts
+++ b/src/main/git/github.test.ts
@@ -73,6 +73,13 @@ describe('classifyGhError', () => {
     expect(classifyGhError('aborted: you must first push the current branch to a remote')).toBe('push')
   })
 
+  it('does NOT mislabel a permission/other error as push (narrowed match)', () => {
+    // A permission error mentions "push the branch" but isn't an unpushed-branch case —
+    // must surface verbatim, not the "push first" hint (review fold).
+    expect(classifyGhError('you do not have permission to push the branch to this repository')).toBe('other')
+    expect(classifyGhError('aborted: operation cancelled by hook')).toBe('other')
+  })
+
   it('falls back to other for an unrecognised reason', () => {
     expect(classifyGhError('GraphQL: Something exploded')).toBe('other')
   })

--- a/src/main/git/github.test.ts
+++ b/src/main/git/github.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest'
+import {
+  classifyGhError,
+  ghCreatePr,
+  ghCurrentPr,
+  GH_NOT_AUTHED_MESSAGE,
+  GH_NOT_FOUND,
+  GH_NOT_FOUND_MESSAGE,
+  GH_PUSH_FIRST_MESSAGE,
+  mapCreate,
+  mapPrView,
+  parsePrJson,
+  type GhRun,
+} from './github'
+
+/**
+ * #88 gh PR surfacing. The testable seams are the PURE pieces — `parsePrJson` (the real
+ * `gh pr view --json` shape), `classifyGhError` (the stderr -> category mapping verified
+ * against real gh 2.74 output), and `mapPrView` / `mapCreate` (the outcome mapping) — plus
+ * the `ghCurrentPr` / `ghCreatePr` COMMAND args + result over an injected `GhRun`. NO test
+ * shells real gh, and NO test creates a real PR (the whole point of the fake runner).
+ */
+
+/** A fake gh runner: records every `args` and returns a per-call canned `{stdout,stderr,code}`. */
+function fakeRun(seen: string[][], responses: { stdout?: string; stderr?: string; code: number }[] = []): GhRun {
+  let i = 0
+  return (args) => {
+    seen.push(args)
+    const r = responses[i++] ?? { code: 0 }
+    return Promise.resolve({ stdout: r.stdout ?? '', stderr: r.stderr ?? '', code: r.code })
+  }
+}
+
+describe('parsePrJson', () => {
+  it('parses a real gh pr view --json object', () => {
+    const json = JSON.stringify({ number: 42, state: 'OPEN', title: 'Add the thing', url: 'https://github.com/o/r/pull/42' })
+    expect(parsePrJson(json)).toEqual({
+      number: 42,
+      title: 'Add the thing',
+      url: 'https://github.com/o/r/pull/42',
+      state: 'OPEN',
+    })
+  })
+
+  it('returns null for empty / malformed / partial JSON (degrade, never throw)', () => {
+    expect(parsePrJson('')).toBeNull()
+    expect(parsePrJson('   ')).toBeNull()
+    expect(parsePrJson('not json')).toBeNull()
+    // Missing the required `url` field.
+    expect(parsePrJson(JSON.stringify({ number: 1, title: 't', state: 'OPEN' }))).toBeNull()
+  })
+})
+
+describe('classifyGhError', () => {
+  it('classifies the no-PR stderr (the common case)', () => {
+    expect(classifyGhError('no pull requests found for branch "feat/x"')).toBe('no-pr')
+    expect(classifyGhError('no open pull requests found')).toBe('no-pr')
+  })
+
+  it('classifies an auth failure', () => {
+    expect(classifyGhError('To get started with GitHub CLI, please run: gh auth login')).toBe('auth')
+    expect(classifyGhError('You are not logged in to any GitHub hosts')).toBe('auth')
+  })
+
+  it('classifies a no-remote / non-GitHub repo', () => {
+    expect(classifyGhError('no git remotes found')).toBe('no-remote')
+    expect(classifyGhError('none of the git remotes configured for this repository point to a known GitHub host')).toBe(
+      'no-remote',
+    )
+  })
+
+  it('classifies an unpushed-branch error', () => {
+    expect(classifyGhError('aborted: you must first push the current branch to a remote')).toBe('push')
+  })
+
+  it('falls back to other for an unrecognised reason', () => {
+    expect(classifyGhError('GraphQL: Something exploded')).toBe('other')
+  })
+})
+
+describe('mapPrView', () => {
+  it('exit 0 -> the parsed PR', () => {
+    const json = JSON.stringify({ number: 7, state: 'OPEN', title: 'T', url: 'https://github.com/o/r/pull/7' })
+    expect(mapPrView(json, '', 0)).toEqual({ ok: true, pr: { number: 7, title: 'T', url: 'https://github.com/o/r/pull/7', state: 'OPEN' } })
+  })
+
+  it('no-PR stderr -> {ok:true, pr:null} (NOT an error)', () => {
+    expect(mapPrView('', 'no pull requests found for branch "feat/x"', 1)).toEqual({ ok: true, pr: null })
+  })
+
+  it('no-remote / non-GitHub -> {ok:true, pr:null}', () => {
+    expect(mapPrView('', 'no git remotes found', 1)).toEqual({ ok: true, pr: null })
+  })
+
+  it('gh-not-found sentinel -> the install hint', () => {
+    expect(mapPrView('', '', GH_NOT_FOUND)).toEqual({ ok: false, error: GH_NOT_FOUND_MESSAGE })
+  })
+
+  it('auth stderr -> the login hint', () => {
+    expect(mapPrView('', 'gh auth login', 1)).toEqual({ ok: false, error: GH_NOT_AUTHED_MESSAGE })
+  })
+
+  it('any other failure -> gh stderr verbatim', () => {
+    expect(mapPrView('', 'GraphQL: rate limited', 1)).toEqual({ ok: false, error: 'GraphQL: rate limited' })
+  })
+})
+
+describe('mapCreate', () => {
+  it('exit 0 -> the new PR URL (last url line, trimmed)', () => {
+    const stdout = 'Creating pull request for feat/x into main\n\nhttps://github.com/o/r/pull/99\n'
+    expect(mapCreate(stdout, '', 0)).toEqual({ ok: true, url: 'https://github.com/o/r/pull/99' })
+  })
+
+  it('gh-not-found sentinel -> the install hint', () => {
+    expect(mapCreate('', '', GH_NOT_FOUND)).toEqual({ ok: false, error: GH_NOT_FOUND_MESSAGE })
+  })
+
+  it('auth failure -> the login hint', () => {
+    expect(mapCreate('', 'gh auth login', 1)).toEqual({ ok: false, error: GH_NOT_AUTHED_MESSAGE })
+  })
+
+  it('unpushed branch -> the push-first hint', () => {
+    expect(mapCreate('', 'aborted: you must first push the current branch', 1)).toEqual({
+      ok: false,
+      error: GH_PUSH_FIRST_MESSAGE,
+    })
+  })
+
+  it('any other failure -> gh stderr verbatim', () => {
+    expect(mapCreate('', 'pull request already exists', 1)).toEqual({ ok: false, error: 'pull request already exists' })
+  })
+})
+
+describe('ghCurrentPr', () => {
+  it('runs `pr view --json number,title,url,state` and maps the open PR', async () => {
+    const seen: string[][] = []
+    const json = JSON.stringify({ number: 5, state: 'OPEN', title: 'T', url: 'https://github.com/o/r/pull/5' })
+    const res = await ghCurrentPr('/repo', fakeRun(seen, [{ stdout: json, code: 0 }]))
+    expect(seen).toEqual([['pr', 'view', '--json', 'number,title,url,state']])
+    expect(res).toEqual({ ok: true, pr: { number: 5, title: 'T', url: 'https://github.com/o/r/pull/5', state: 'OPEN' } })
+  })
+
+  it('maps the no-PR exit to {ok:true, pr:null}', async () => {
+    const res = await ghCurrentPr('/repo', fakeRun([], [{ stderr: 'no pull requests found for branch "x"', code: 1 }]))
+    expect(res).toEqual({ ok: true, pr: null })
+  })
+
+  it('never throws when the runner rejects', async () => {
+    const rejecting: GhRun = () => Promise.reject(new Error('boom'))
+    const res = await ghCurrentPr('/repo', rejecting)
+    expect(res).toEqual({ ok: false, error: 'boom' })
+  })
+})
+
+describe('ghCreatePr', () => {
+  it('runs `pr create --title <t> --body <b>` (each value its own argv) and returns the URL', async () => {
+    const seen: string[][] = []
+    const res = await ghCreatePr(
+      '/repo',
+      { title: 'My title', body: 'My body' },
+      fakeRun(seen, [{ stdout: 'https://github.com/o/r/pull/12\n', code: 0 }]),
+    )
+    expect(seen).toEqual([['pr', 'create', '--title', 'My title', '--body', 'My body']])
+    expect(res).toEqual({ ok: true, url: 'https://github.com/o/r/pull/12' })
+  })
+
+  it('maps an unpushed-branch failure to the push-first hint', async () => {
+    const res = await ghCreatePr(
+      '/repo',
+      { title: 't', body: '' },
+      fakeRun([], [{ stderr: 'aborted: you must first push the current branch', code: 1 }]),
+    )
+    expect(res).toEqual({ ok: false, error: GH_PUSH_FIRST_MESSAGE })
+  })
+
+  it('never throws when the runner rejects', async () => {
+    const rejecting: GhRun = () => Promise.reject(new Error('spawn fail'))
+    const res = await ghCreatePr('/repo', { title: 't', body: 'b' }, rejecting)
+    expect(res).toEqual({ ok: false, error: 'spawn fail' })
+  })
+})

--- a/src/main/git/github.ts
+++ b/src/main/git/github.ts
@@ -1,0 +1,216 @@
+import { execFile, type ExecFileException } from 'node:child_process'
+import { getShellEnv } from '../shell-env'
+import type { GhCreateResult, GhPr, GhPrResult } from '../../shared/ipc'
+
+/**
+ * Surface the current branch's GitHub PR + a create-PR action (#88, slice 4 of the
+ * Changes panel, ADR-0008) — the LAST git slice. Unlike #84-#87's git operations, this
+ * shells the **`gh` CLI** (the GitHub CLI), inheriting the user's own `gh auth` session —
+ * NO Octokit, no token handling here (ADR-0008: GitHub-only, GitLab parity out of scope).
+ * `gh` runs in MAIN via `child_process` through an injectable `GhRun` seam (mirroring
+ * #84's `GitRun`), resolved on the shell-env PATH so a Finder/Dock launch still finds it.
+ *
+ * The PURE pieces are the testable seams: `parsePrJson` (the `gh pr view --json` shape)
+ * and `mapPrView` / `mapCreate` (the stderr -> category outcome mapping). These NEVER
+ * shell out and NEVER throw — every failure is folded into a result, exactly like the
+ * git slices. The two impure shells (`ghCurrentPr`, `ghCreatePr`) just run `gh` and feed
+ * the pure mappers, so a missing / unauthenticated / non-GitHub `gh` degrades to a typed
+ * result rather than a crash.
+ */
+
+/**
+ * Run a `gh` command and capture its stdout + exit code (+ stderr). Injectable for tests
+ * (Seam, mirroring `GitRun`) so they never shell real `gh` — and so they NEVER open a
+ * real PR. The default resolves `gh` via the shell-env PATH (like the git/agent spawns)
+ * and resolves — never rejects — with the exit code even on failure.
+ *
+ * On a SPAWN failure (`gh` not installed — `err.code` is a string like `ENOENT`, not a
+ * numeric exit), it resolves with the `GH_NOT_FOUND` sentinel code so the pure mapper can
+ * distinguish "gh missing" from a normal non-zero `gh` exit and surface the install hint.
+ */
+export type GhRun = (args: string[], cwd: string) => Promise<{ stdout: string; stderr: string; code: number }>
+
+/**
+ * Sentinel exit code the default runner resolves with when `gh` could not be SPAWNED
+ * (not installed). A real `gh` process never exits with a negative code, so this can't
+ * collide with a genuine non-zero exit — `mapPrView`/`mapCreate` test it first.
+ */
+export const GH_NOT_FOUND = -1
+
+export const defaultGhRun: GhRun = (args, cwd) =>
+  new Promise((resolve) => {
+    execFile(
+      'gh',
+      args,
+      { cwd, env: getShellEnv(), encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 },
+      (err: ExecFileException | null, stdout: string, stderr: string) => {
+        // A numeric `err.code` is gh's exit code; a STRING code (e.g. 'ENOENT') is a spawn
+        // failure (gh not installed) -> the `GH_NOT_FOUND` sentinel so the caller maps it
+        // to the install hint rather than a generic non-zero.
+        const code = err == null ? 0 : typeof err.code === 'number' ? err.code : GH_NOT_FOUND
+        resolve({ stdout: stdout ?? '', stderr: stderr ?? '', code })
+      },
+    )
+  })
+
+/** The error messages, kept as named constants so the tests assert the exact copy. */
+export const GH_NOT_FOUND_MESSAGE = 'GitHub CLI (gh) not found — install it to use PR features.'
+export const GH_NOT_AUTHED_MESSAGE = 'Not logged in to GitHub — run `gh auth login`.'
+export const GH_PUSH_FIRST_MESSAGE = 'Push your branch to GitHub first, then create the PR.'
+
+/**
+ * PURE: parse a `gh pr view --json number,title,url,state` stdout into a `GhPr`. The JSON
+ * is a single object, e.g. `{"number":42,"state":"OPEN","title":"…","url":"https://…/42"}`
+ * (state is uppercase OPEN/CLOSED/MERGED — kept verbatim; the renderer tints on it).
+ * Returns null when the JSON is absent/malformed or missing the required fields, so a
+ * surprising gh payload degrades to "no PR" rather than throwing.
+ */
+export function parsePrJson(stdout: string): GhPr | null {
+  const text = stdout.trim()
+  if (!text) return null
+  try {
+    const raw = JSON.parse(text) as Partial<GhPr>
+    if (
+      typeof raw.number !== 'number' ||
+      typeof raw.title !== 'string' ||
+      typeof raw.url !== 'string' ||
+      typeof raw.state !== 'string'
+    ) {
+      return null
+    }
+    return { number: raw.number, title: raw.title, url: raw.url, state: raw.state }
+  } catch {
+    return null
+  }
+}
+
+/** The categories a non-zero `gh` exit's stderr maps to. */
+type GhErrorCategory = 'no-pr' | 'auth' | 'no-remote' | 'push' | 'other'
+
+/**
+ * PURE: classify a non-zero `gh` exit's stderr into a category (verified against real gh
+ * 2.74 output, see github.test.ts). Lowercased substring matches, ordered most- to
+ * least-specific:
+ *  - `no-pr`: "no pull requests found" / "no open pull requests" — the COMMON case for a
+ *    branch without a PR (gh exits non-zero on it), NOT an error.
+ *  - `auth`: an authentication failure ("gh auth login" / "not logged in" / "authentication").
+ *  - `no-remote`: no GitHub remote ("no git remotes found" / "not a git repository" /
+ *    "none of the git remotes … point to a known github host") — no PR surface.
+ *  - `push`: the branch isn't pushed (`gh pr create` non-interactively can't prompt to push).
+ *  - `other`: anything else — surfaced verbatim.
+ */
+export function classifyGhError(stderr: string): GhErrorCategory {
+  const s = stderr.toLowerCase()
+  if (s.includes('no pull requests found') || s.includes('no open pull requests')) return 'no-pr'
+  if (
+    s.includes('gh auth login') ||
+    s.includes('not logged in') ||
+    s.includes('to get started with github cli') ||
+    s.includes('authentication required') ||
+    s.includes('requires authentication')
+  ) {
+    return 'auth'
+  }
+  if (
+    s.includes('no git remotes found') ||
+    s.includes('not a git repository') ||
+    s.includes('none of the git remotes') ||
+    s.includes('to a known github host')
+  ) {
+    return 'no-remote'
+  }
+  if (s.includes('must first push') || s.includes('push the') || s.includes('aborted')) return 'push'
+  return 'other'
+}
+
+/**
+ * PURE: map a `gh pr view` outcome (stdout/stderr/code) to a `GhPrResult`.
+ *  - `GH_NOT_FOUND` sentinel → the install-gh hint.
+ *  - exit 0 → parse the JSON → `{ok:true, pr}` (pr null only if the payload is unparseable).
+ *  - non-zero: `no-pr` / `no-remote` → `{ok:true, pr:null}` (no PR surface, the common case,
+ *    NOT an error); `auth` → the login hint; anything else → gh's stderr reason.
+ */
+export function mapPrView(stdout: string, stderr: string, code: number): GhPrResult {
+  if (code === GH_NOT_FOUND) return { ok: false, error: GH_NOT_FOUND_MESSAGE }
+  if (code === 0) return { ok: true, pr: parsePrJson(stdout) }
+  const category = classifyGhError(stderr)
+  if (category === 'no-pr' || category === 'no-remote') return { ok: true, pr: null }
+  if (category === 'auth') return { ok: false, error: GH_NOT_AUTHED_MESSAGE }
+  return { ok: false, error: stderr.trim() || 'gh pr view failed' }
+}
+
+/**
+ * PURE: map a `gh pr create` outcome to a `GhCreateResult`. On exit 0, gh prints the new
+ * PR's URL on stdout — captured + trimmed. On failure, map gh-missing / not-authed / push
+ * the same friendly way as `mapPrView`; surface any other reason verbatim.
+ */
+export function mapCreate(stdout: string, stderr: string, code: number): GhCreateResult {
+  if (code === GH_NOT_FOUND) return { ok: false, error: GH_NOT_FOUND_MESSAGE }
+  if (code === 0) {
+    const url = lastUrl(stdout)
+    if (url) return { ok: true, url }
+    return { ok: false, error: 'gh pr create succeeded but returned no URL.' }
+  }
+  const category = classifyGhError(stderr)
+  if (category === 'auth') return { ok: false, error: GH_NOT_AUTHED_MESSAGE }
+  if (category === 'push') return { ok: false, error: GH_PUSH_FIRST_MESSAGE }
+  return { ok: false, error: stderr.trim() || 'gh pr create failed' }
+}
+
+/**
+ * The PR URL from `gh pr create` stdout. gh prints the URL as the LAST line on success
+ * (it may emit a "Creating pull request…" preamble first), so take the last non-empty
+ * line that looks like an http(s) URL.
+ */
+function lastUrl(stdout: string): string | null {
+  const lines = stdout
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean)
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (/^https?:\/\//.test(lines[i])) return lines[i]
+  }
+  return null
+}
+
+/**
+ * Impure read (#88): the current branch's GitHub PR (or null). Runs
+ * `gh pr view --json number,title,url,state` in `cwd` and feeds the pure `mapPrView`.
+ * This is a NETWORK call (gh hits the GitHub API), fine on demand (the renderer fetches
+ * on branch-change, not on every status tick). NEVER throws — a runner that rejects still
+ * degrades to a result.
+ */
+export async function ghCurrentPr(cwd: string, run: GhRun = defaultGhRun): Promise<GhPrResult> {
+  try {
+    const res = await run(['pr', 'view', '--json', 'number,title,url,state'], cwd)
+    return mapPrView(res.stdout, res.stderr, res.code)
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+/**
+ * Impure write (#88): create a PR for the current branch. Runs
+ * `gh pr create --title <t> --body <b>` in `cwd` and feeds the pure `mapCreate`. We do NOT
+ * pass `--base` — gh defaults to the repo's default branch (acp-capture / `gh pr create
+ * --help`), and guessing it wrong would target the wrong base; letting gh resolve it is
+ * safer. We also do NOT push: `gh pr create` non-interactively (no TTY) CANNOT prompt to
+ * push, so an unpushed branch errors (`push` category -> the "push first" hint). The
+ * renderer GATES the affordance on the branch having an upstream (#84's status), so this
+ * push error is a backstop, not the primary path — we never `git push` on the user's
+ * behalf here (no surprise writes to their remote). NEVER throws.
+ */
+export async function ghCreatePr(
+  cwd: string,
+  fields: { title: string; body: string },
+  run: GhRun = defaultGhRun,
+): Promise<GhCreateResult> {
+  try {
+    // Each value is its own argv element (no shell), so a title/body with spaces or shell
+    // metacharacters is safe. An empty body is passed as `--body ''` (gh accepts it).
+    const res = await run(['pr', 'create', '--title', fields.title, '--body', fields.body], cwd)
+    return mapCreate(res.stdout, res.stderr, res.code)
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}

--- a/src/main/git/github.ts
+++ b/src/main/git/github.ts
@@ -119,7 +119,11 @@ export function classifyGhError(stderr: string): GhErrorCategory {
   ) {
     return 'no-remote'
   }
-  if (s.includes('must first push') || s.includes('push the') || s.includes('aborted')) return 'push'
+  // Narrow: ONLY the explicit unpushed-branch message. Bare `'aborted'` / `'push the'`
+  // were too broad — a permission error ("you do not have permission to push the branch…")
+  // or any "aborted" failure would be mislabeled "push first", HIDING the real reason.
+  // Everything else falls to `other` and is surfaced verbatim.
+  if (s.includes('must first push') || s.includes('push the current branch')) return 'push'
   return 'other'
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -13,6 +13,10 @@ import {
   type GitDiffArgs,
   type GitDiffResult,
   type GitOpResult,
+  type GhCreatePrArgs,
+  type GhCreateResult,
+  type GhCurrentPrArgs,
+  type GhPrResult,
   type GitStatusEvent,
   type GitStatusSubscriptionArgs,
   type ListMetadataResult,
@@ -60,6 +64,7 @@ import { gitFetch, readGitStatus } from './git/status'
 import { readGitDiff } from './git/diff'
 import { gitCommit } from './git/commit'
 import { gitBranches, gitCheckout, gitCreateBranch } from './git/branches'
+import { ghCreatePr, ghCurrentPr } from './git/github'
 import { GitStatusManager } from './git/status-stream'
 import { chokidarWatchFactory, realClock } from './git/runtime'
 
@@ -954,6 +959,24 @@ function registerIpc(): void {
     const result = await gitCreateBranch(args.workspaceDir, args.name)
     if (result.ok) gitStatus.refresh(args.workspaceDir)
     else console.error(`[vibe-mistro:git] create-branch failed (${args.workspaceDir} -> ${args.name}): ${result.error}`)
+    return result
+  })
+
+  ipcMain.handle(IPC.ghCurrentPr, (_event, args: GhCurrentPrArgs): Promise<GhPrResult> => {
+    // Read the current branch's GitHub PR via `gh` (#88, slice 4). cwd is the Workspace
+    // dir (where #84's status ran). A NETWORK call, but read-only, so — like git:diff — it
+    // does NOT `pool.touch` (surfacing a PR must not keep a warm agent alive past its idle
+    // window, TB5 #50). `ghCurrentPr` swallows every gh failure into a result (never throws).
+    return ghCurrentPr(args.workspaceDir)
+  })
+
+  ipcMain.handle(IPC.ghCreatePr, async (_event, args: GhCreatePrArgs): Promise<GhCreateResult> => {
+    // Create a PR for the current branch via `gh pr create` (#88). cwd is the Workspace
+    // dir. NOT agent activity, so no `pool.touch`. `ghCreatePr` swallows every gh failure
+    // into `{ok:false, error}` (never throws); no status refresh needed (a PR creation
+    // doesn't change the working tree — the renderer swaps in the new chip from the URL).
+    const result = await ghCreatePr(args.workspaceDir, { title: args.title, body: args.body })
+    if (!result.ok) console.error(`[vibe-mistro:gh] create-pr failed (${args.workspaceDir}): ${result.error}`)
     return result
   })
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -12,6 +12,10 @@ import {
   type GitDiffArgs,
   type GitDiffResult,
   type GitOpResult,
+  type GhCreatePrArgs,
+  type GhCreateResult,
+  type GhCurrentPrArgs,
+  type GhPrResult,
   type GitStatusEvent,
   type GitStatusSubscriptionArgs,
   type ListMetadataResult,
@@ -73,6 +77,10 @@ const api = {
     ipcRenderer.invoke(IPC.gitCheckout, args),
   gitCreateBranch: (args: GitBranchOpArgs): Promise<GitOpResult> =>
     ipcRenderer.invoke(IPC.gitCreateBranch, args),
+  ghCurrentPr: (args: GhCurrentPrArgs): Promise<GhPrResult> =>
+    ipcRenderer.invoke(IPC.ghCurrentPr, args),
+  ghCreatePr: (args: GhCreatePrArgs): Promise<GhCreateResult> =>
+    ipcRenderer.invoke(IPC.ghCreatePr, args),
   onAcpEvent: (listener: (event: AcpEvent) => void): (() => void) => {
     const handler = (_e: unknown, payload: AcpEvent): void => listener(payload)
     ipcRenderer.on(IPC.acpEvent, handler)

--- a/src/renderer/src/git/ChangesPanel.tsx
+++ b/src/renderer/src/git/ChangesPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type JSX } from 'react'
-import { Check, ChevronDown, ChevronRight, GitBranch, RefreshCw } from 'lucide-react'
-import type { GitBranch as GitBranchInfo, GitStatus } from '../../../shared/ipc'
+import { Check, ChevronDown, ChevronRight, GitBranch, GitPullRequest, RefreshCw } from 'lucide-react'
+import type { GhPr, GhPrResult, GitBranch as GitBranchInfo, GitStatus } from '../../../shared/ipc'
 import { cn } from '../lib/utils'
 import { Menu, MenuContent, MenuItem, MenuSeparator, MenuTrigger } from '../ui/menu'
 import { buildChangesView, reconcileUnchecked, type GitFileView } from './status-view'
@@ -55,6 +55,10 @@ export function ChangesPanel({
   const [message, setMessage] = useState('')
   const [committing, setCommitting] = useState(false)
   const [commitError, setCommitError] = useState<string | null>(null)
+  // Bumped by the header refresh button so the PR section re-fetches `ghCurrentPr` on a
+  // manual refresh too (its own effect otherwise only fires on a branch change — a PR is a
+  // network call we don't tie to every status tick).
+  const [prRefreshKey, setPrRefreshKey] = useState(0)
 
   useEffect(() => {
     if (!isActive) return
@@ -82,6 +86,8 @@ export function ChangesPanel({
     void window.api
       .gitSubscribeStatus({ workspaceDir })
       .then(() => window.api.gitUnsubscribeStatus({ workspaceDir }))
+    // Also re-check the current branch's PR (a network call the PR section keys on this).
+    setPrRefreshKey((k) => k + 1)
   }
 
   // No panel before the first snapshot, or for a non-repo Workspace (degrade quietly).
@@ -179,6 +185,15 @@ export function ChangesPanel({
             ahead={view.ahead}
             behind={view.behind}
             busy={busy}
+          />
+
+          <PrSection
+            workspaceDir={workspaceDir}
+            branch={view.branch}
+            detached={view.detached}
+            hasUpstream={status.upstream !== null}
+            busy={busy}
+            refreshKey={prRefreshKey}
           />
 
           {view.files.length === 0 ? (
@@ -425,6 +440,217 @@ function BranchMenu({
         </p>
       )}
     </>
+  )
+}
+
+/**
+ * The PR chip / Create-PR affordance (#88, slice 4) below the branch header. On a branch
+ * change (and a manual refresh, via `refreshKey`) it fetches the current branch's GitHub
+ * PR through `gh` (`ghCurrentPr` — a NETWORK call, so NOT tied to every status tick):
+ *  - a PR exists → a compact, state-tinted chip rendered as an EXTERNAL anchor
+ *    (`target="_blank"`): clicking it routes through main's `setWindowOpenHandler` ->
+ *    `shell.openExternal`, opening the PR in the system browser (no new IPC).
+ *  - no PR (and the branch is sensible — not detached, not the repo's default) → a
+ *    "Create PR" affordance: a small title+body form -> `ghCreatePr`. GATED on the branch
+ *    having an upstream (`hasUpstream`): `gh pr create` non-interactively can't prompt to
+ *    push, so without an upstream we show "Push your branch first" instead of failing. The
+ *    form is DISABLED while `busy` (a turn streams) — the same guard as commit/branch ops.
+ *  - gh missing / not authed (`{ok:false}`) → a subtle muted hint, never a crash.
+ * The default-branch check is a best-effort `gitBranches` probe (local, no network); when
+ * it can't resolve a default, we simply allow Create-PR (gh would surface any real error).
+ */
+function PrSection({
+  workspaceDir,
+  branch,
+  detached,
+  hasUpstream,
+  busy,
+  refreshKey,
+}: {
+  workspaceDir: string
+  branch: string
+  detached: boolean
+  hasUpstream: boolean
+  busy: boolean
+  refreshKey: number
+}): JSX.Element | null {
+  // `'loading'` before the first fetch resolves; then the `GhPrResult`. Null only while
+  // detached (no PR surface). The created-PR chip lands via a re-fetch after a create.
+  const [result, setResult] = useState<GhPrResult | 'loading' | null>('loading')
+  const [isDefault, setIsDefault] = useState(false)
+  const [creating, setCreating] = useState(false)
+  const [title, setTitle] = useState('')
+  const [body, setBody] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [createError, setCreateError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (detached) {
+      setResult(null)
+      return
+    }
+    let cancelled = false
+    setResult('loading')
+    setCreating(false)
+    setCreateError(null)
+    void window.api.ghCurrentPr({ workspaceDir }).then((res) => {
+      if (!cancelled) setResult(res)
+    })
+    // Best-effort default-branch probe (local git, no network): suppress Create-PR on the
+    // repo's default branch. A failed/unresolved probe leaves `isDefault:false` (allow).
+    void window.api.gitBranches({ workspaceDir }).then((res) => {
+      if (cancelled) return
+      setIsDefault(res.ok ? (res.branches.find((b) => b.current)?.isDefault ?? false) : false)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [workspaceDir, branch, detached, refreshKey])
+
+  async function createPr(): Promise<void> {
+    const t = title.trim()
+    if (!t || busy || submitting) return
+    setSubmitting(true)
+    setCreateError(null)
+    try {
+      const res = await window.api.ghCreatePr({ workspaceDir, title: t, body: body.trim() })
+      if (res.ok) {
+        // Re-fetch so the freshly-created PR renders as the real chip (number/title/state);
+        // the form closes. gh already printed the URL — the chip's anchor opens it.
+        setCreating(false)
+        setResult('loading')
+        void window.api.ghCurrentPr({ workspaceDir }).then(setResult)
+      } else {
+        setCreateError(res.error)
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  // Detached HEAD / before the first fetch: render nothing (no PR surface).
+  if (detached || result === null) return null
+  if (result === 'loading') {
+    return <p className="border-b border-border px-3 py-1.5 text-[11px] text-muted">Checking pull request…</p>
+  }
+  // gh missing / not authed / an unexpected gh failure: a subtle hint, not a crash.
+  if (!result.ok) {
+    return (
+      <p className="border-b border-border px-3 py-1.5 text-[11px] text-muted" title={result.error}>
+        {result.error}
+      </p>
+    )
+  }
+  // A PR exists → the state-tinted chip, opened externally via target="_blank".
+  if (result.pr) return <PrChip pr={result.pr} />
+
+  // No PR: offer Create-PR only on a sensible branch (not the default). On the default
+  // branch there's nothing to render.
+  if (isDefault) return null
+
+  return (
+    <div className="border-b border-border px-3 py-2">
+      {!hasUpstream ? (
+        // The push gate: `gh pr create` non-interactively can't prompt to push an
+        // unpushed branch, and we never push on the user's behalf — so guide them first.
+        <p className="text-[11px] text-muted">Push your branch to GitHub to open a pull request.</p>
+      ) : !creating ? (
+        <button
+          type="button"
+          onClick={() => {
+            // Prefill the title from the branch name — the common, editable starting point.
+            setTitle(branch)
+            setBody('')
+            setCreateError(null)
+            setCreating(true)
+          }}
+          disabled={busy}
+          title={busy ? 'Agent is working…' : 'Create a pull request for this branch'}
+          className="flex items-center gap-1.5 text-xs text-muted hover:text-accent-text disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <GitPullRequest size={13} aria-hidden className="shrink-0" />
+          Create PR
+        </button>
+      ) : (
+        <div className="flex flex-col gap-2">
+          <input
+            autoFocus
+            aria-label="Pull request title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="PR title"
+            disabled={busy || submitting}
+            className="w-full border border-border bg-panel px-2 py-1 text-xs text-text placeholder:text-muted focus:border-accent focus:outline-none disabled:opacity-50"
+          />
+          <textarea
+            aria-label="Pull request body"
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            placeholder="Description (optional)"
+            rows={2}
+            disabled={busy || submitting}
+            className="w-full resize-y border border-border bg-panel px-2 py-1 text-xs text-text placeholder:text-muted focus:border-accent focus:outline-none disabled:opacity-50"
+          />
+          {createError && (
+            <p className="text-[11px] text-bad" role="alert">
+              {createError}
+            </p>
+          )}
+          {busy && <p className="text-[11px] text-muted">Agent is working…</p>}
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => void createPr()}
+              disabled={busy || submitting || title.trim().length === 0}
+              className="bg-accent px-2 py-1 text-xs font-medium text-on-accent hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {submitting ? 'Creating…' : 'Create PR'}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setCreating(false)
+                setCreateError(null)
+              }}
+              disabled={submitting}
+              className="text-xs text-muted hover:text-accent-text disabled:opacity-50"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** A PR's chip accent by gh state — open reads positive, merged accent, closed negative. */
+function prStateClass(state: string): string {
+  const s = state.toUpperCase()
+  if (s === 'MERGED') return 'text-accent-text'
+  if (s === 'CLOSED') return 'text-bad'
+  return 'text-ok' // OPEN (and any unknown) reads as live.
+}
+
+/**
+ * The compact PR chip: `#<number> · <title>`, state-tinted, as an EXTERNAL anchor. The
+ * `target="_blank"` + `rel="noreferrer"` makes Electron route the click through main's
+ * `setWindowOpenHandler` -> `shell.openExternal`, opening the PR in the system browser
+ * (no new IPC). `href` is the gh-provided PR URL.
+ */
+function PrChip({ pr }: { pr: GhPr }): JSX.Element {
+  return (
+    <a
+      href={pr.url}
+      target="_blank"
+      rel="noreferrer"
+      title={`#${pr.number} · ${pr.title} (${pr.state})`}
+      className="flex items-center gap-1.5 border-b border-border px-3 py-2 text-xs hover:bg-accent/10"
+    >
+      <GitPullRequest size={13} aria-hidden className={cn('shrink-0', prStateClass(pr.state))} />
+      <span className={cn('shrink-0 font-medium tabular-nums', prStateClass(pr.state))}>#{pr.number}</span>
+      <span className="min-w-0 flex-1 truncate text-text">{pr.title}</span>
+    </a>
   )
 }
 

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -146,6 +146,23 @@ export const IPC = {
    * shows the new branch. A name collision returns `{ok:false, error}` (never throws).
    */
   gitCreateBranch: 'git:create-branch',
+  /**
+   * Renderer -> main: read the CURRENT branch's GitHub PR via the `gh` CLI (#88, slice 4,
+   * ADR-0008). Invoke, `{ workspaceDir }` -> `GhPrResult` — `{ok:true, pr}` (the PR or
+   * null when the branch has none / the repo isn't on GitHub), or `{ok:false, error}` for
+   * gh-missing / not-authed / an unexpected gh failure. A NETWORK call (gh hits the GitHub
+   * API), so the renderer fetches on branch-change + manual refresh, NOT on every status
+   * tick. Read-only, so — like the other git ops — it does NOT touch the warm-agent pool.
+   */
+  ghCurrentPr: 'gh:current-pr',
+  /**
+   * Renderer -> main: CREATE a PR for the current branch via `gh pr create` (#88). Invoke,
+   * `{ workspaceDir, title, body }` -> `GhCreateResult` (`{ok:true, url}` — the new PR's
+   * URL — or `{ok:false, error}`). gh inherits the user's `gh auth`; we pass no `--base`
+   * (gh defaults to the repo's default branch) and do NOT push (the renderer gates the
+   * affordance on the branch having an upstream). NOT agent activity, so no `pool.touch`.
+   */
+  ghCreatePr: 'gh:create-pr',
 } as const
 
 /**
@@ -705,4 +722,45 @@ export interface GitBranchOpArgs {
   workspaceDir: string
   name: string
   track?: boolean
+}
+
+/**
+ * A GitHub pull request, as `gh pr view --json number,title,url,state` reports it (#88).
+ * `state` is gh's uppercase status — `OPEN` / `CLOSED` / `MERGED` (kept verbatim; the
+ * renderer tints the chip on it). `url` is the PR's web URL (opened externally via the
+ * renderer's `target="_blank"` anchor -> main's `setWindowOpenHandler` -> `shell.openExternal`).
+ */
+export interface GhPr {
+  number: number
+  title: string
+  url: string
+  state: string
+}
+
+/**
+ * The `ghCurrentPr` reply (#88). `{ok:true, pr}` where `pr` is the current branch's PR or
+ * `null` (no PR for the branch, or the repo isn't on GitHub — both a normal "no PR
+ * surface", NOT an error). `{ok:false, error}` is reserved for gh-missing / not-authed /
+ * an unexpected gh failure — surfaced as a subtle hint in the panel, never a crash.
+ */
+export type GhPrResult = { ok: true; pr: GhPr | null } | { ok: false; error: string }
+
+/**
+ * The `ghCreatePr` reply (#88). `{ok:true, url}` carries the new PR's URL (gh prints it on
+ * success — the renderer shows the chip + opens it externally). `{ok:false, error}` carries
+ * a friendly reason: gh-missing, the `gh auth login` hint, "push your branch first", or
+ * gh's verbatim stderr — surfaced inline + recoverable.
+ */
+export type GhCreateResult = { ok: true; url: string } | { ok: false; error: string }
+
+/** Args for `ghCurrentPr` (#88): read one Workspace's current-branch PR. */
+export interface GhCurrentPrArgs {
+  workspaceDir: string
+}
+
+/** Args for `ghCreatePr` (#88): create a PR for one Workspace's current branch. */
+export interface GhCreatePrArgs {
+  workspaceDir: string
+  title: string
+  body: string
 }


### PR DESCRIPTION
Closes #88. The **final** git slice (ADR-0008): surface the current branch's GitHub PR + a create-PR action via the `gh` CLI. Completes the git/GitHub epic.

## What

- **main `src/main/git/github.ts`:** shells `gh` (inherits the user's `gh auth`, no Octokit). `ghCurrentPr` = `gh pr view --json …` → pure `parsePrJson`/`classifyGhError`/`mapPrView` → `{ok:true, pr|null} | {ok:false, error}`; `ghCreatePr` = `gh pr create --title --body` (NO `--base`, NO push). Friendly errors: gh-missing (`GH_NOT_FOUND` sentinel) / not-authed (`gh auth login`) / no-PR & no-remote → `pr:null` / push-needed → "push first"; else verbatim. Argv (no shell), never throws.
- **IPC** `gh:current-pr` / `gh:create-pr` (no `pool.touch`). The PR URL opens in the system browser via a plain `<a target="_blank">` (the existing `setWindowOpenHandler` → `shell.openExternal`; no new IPC).
- **renderer `PrSection`:** fetches on branch-change + manual refresh (a network call, not per status tick). A PR → a state-tinted chip; no PR → a Create-PR form **gated on the branch having an upstream** (we never push for you), not-default, not-detached, disabled while a turn streams; gh-missing/not-authed → a muted hint.

## Safety

- **No surprise writes:** `ghCreatePr` doesn't `git push` and passes no `--base`; Create-PR is gated on an existing upstream (non-interactive `gh pr create` can't prompt to push), so we never push to the user's remote on their behalf.
- **No real PR created during development** — all `gh` integration is unit-tested over a fake runner + read-only `gh` inspection.

## Review + verification

Implementer → my independent gate re-run + full diff read → adversarial reviewer (verified no push/injection, the chip opens externally, no #84-87 regression; verdict **SHIP-WITH-FIXES**, no MUST-FIX). Gates green: lint / typecheck / build / **444 tests**.

**Folded the one SHOULD-FIX:** narrowed `classifyGhError`'s push match so a permission/other create error isn't mislabeled "push first" (was matching bare `'aborted'`/`'push the'`) + a regression test. NITs left: no gh-spawn timeout (a `--json` hang is unlikely; a naive timeout would mis-message as gh-not-found), "PR already exists" shows the URL inline rather than auto-swapping the chip.

## ⚠️ Residual: live gh NOT driven

No real `gh pr create`/surface in-app (no real PR created). **Worth one manual smoke before relying on it:** on a pushed branch with an open PR, confirm the chip appears + opens in the browser; on a pushed branch with no PR, create one; confirm the not-authed / no-upstream messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)