### PR TITLE
#95: `/` slash-command autocomplete in the composer (composer extras slice 1)

### DIFF
--- a/src/renderer/src/conversation/Conversation.tsx
+++ b/src/renderer/src/conversation/Conversation.tsx
@@ -11,6 +11,7 @@ import { AgentControls } from './AgentControls'
 import {
   conversationReducer,
   initialConversationState,
+  type AcpCommand,
   type AssistantItem,
   type ConversationItem,
   type ErrorItem,
@@ -26,6 +27,12 @@ import { eventBelongsToThread } from './event-routing'
 import { replayTranscript } from './replay'
 import { ChatMarkdown } from './ChatMarkdown'
 import { getDraft, setDraft as persistDraft, clearDraft } from './composer-draft-store'
+import {
+  applyCommand,
+  filterCommands,
+  getCommandQuery,
+  moveSelection,
+} from './command-autocomplete'
 
 /** Process-local counter for unique echoed-prompt ids. */
 let promptSeq = 0
@@ -105,6 +112,20 @@ export function Conversation({
   const onBoundRef = useRef(onBound)
   onBoundRef.current = onBound
   const listRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLTextAreaElement>(null)
+  // Ephemeral `/` slash-command autocomplete state (#95): the open trigger (the
+  // `/`'s index + the query after it) and the highlighted row. Purely renderer-local
+  // — no IPC, no persistence — so a Thread switch (which remounts this view, keyed by
+  // threadId) always starts with the popover closed. `null` = closed.
+  const [commandTrigger, setCommandTrigger] = useState<{ start: number; query: string } | null>(
+    null,
+  )
+  const [commandIndex, setCommandIndex] = useState(0)
+  // Esc-dismiss latch (#95): the `/`-token start the user dismissed. While it holds,
+  // re-deriving the SAME token keeps the popover closed — so Esc stays dismissed as
+  // you keep typing (the escape hatch for sending literal `/text`). Cleared once the
+  // token closes/deletes or a different `/` opens, so a fresh trigger reopens.
+  const dismissedStartRef = useRef<number | null>(null)
   // True once any live event has been folded in: guards the async hydrate from
   // clobbering events that streamed in before the JSONL read resolved.
   const liveSeen = useRef(false)
@@ -246,7 +267,88 @@ export function Conversation({
     dispatch({ type: 'recover' })
   }
 
+  // The `/` autocomplete's live matches (#95): folded from the Vibe-streamed
+  // `availableCommands`, filtered prefix-then-substring by the open query. The
+  // popover shows only with an active trigger AND at least one match; `commandRows`
+  // is empty otherwise so the keyboard handlers are inert. `activeIndex` clamps the
+  // stored highlight in case the match count shrank as the query grew.
+  const commandRows: AcpCommand[] = commandTrigger
+    ? filterCommands(state.availableCommands, commandTrigger.query)
+    : []
+  const showCommands = commandTrigger !== null && commandRows.length > 0
+  const activeIndex = Math.min(commandIndex, commandRows.length - 1)
+
+  // Re-derive the trigger from the composer's value + caret after any edit or caret
+  // move. Reads the live caret so `hello /re` (mid-line) never triggers while `/re`
+  // (line start) does. Resetting the highlight to the top on every re-derive is safe:
+  // list navigation preventDefaults the caret move, so it never re-runs this.
+  function refreshCommandTrigger(value: string, caret: number | null): void {
+    const trigger = caret === null ? null : getCommandQuery(value, caret)
+    if (!trigger || !trigger.active) {
+      // Token gone — drop any dismissal so a later `/` reopens fresh.
+      dismissedStartRef.current = null
+      setCommandTrigger(null)
+      setCommandIndex(0)
+      return
+    }
+    if (dismissedStartRef.current === trigger.start) {
+      // Still the Esc-dismissed token — stay closed as the query grows.
+      setCommandTrigger(null)
+      return
+    }
+    dismissedStartRef.current = null
+    setCommandTrigger({ start: trigger.start, query: trigger.query })
+    setCommandIndex(0)
+  }
+
+  // Accept a completion: splice `/<name> ` in over the `/query` token, keep the
+  // draft + persisted draft (#60) in lockstep, then restore focus and drop the caret
+  // just past the inserted space. The DOM caret is set after commit (rAF) so React's
+  // controlled value doesn't stomp it; the resulting `onSelect` closes the popover.
+  function acceptCommand(command: AcpCommand): void {
+    if (!commandTrigger) return
+    const node = inputRef.current
+    const caret = node ? node.selectionStart : draft.length
+    const next = applyCommand(draft, commandTrigger.start, caret, command.name)
+    setDraft(next.value)
+    persistDraft(window.localStorage, thread.threadId, next.value)
+    setCommandTrigger(null)
+    setCommandIndex(0)
+    requestAnimationFrame(() => {
+      const el = inputRef.current
+      if (!el) return
+      el.focus()
+      el.setSelectionRange(next.caret, next.caret)
+    })
+  }
+
   function onKeyDown(e: KeyboardEvent<HTMLTextAreaElement>): void {
+    // Popover-open key interception (#95): navigation + accept must win over Enter's
+    // send and Tab's focus move. When closed, every key falls through unchanged.
+    if (showCommands) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setCommandIndex(moveSelection(activeIndex, commandRows.length, 1))
+        return
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setCommandIndex(moveSelection(activeIndex, commandRows.length, -1))
+        return
+      }
+      if (e.key === 'Enter' || e.key === 'Tab') {
+        e.preventDefault()
+        acceptCommand(commandRows[activeIndex])
+        return
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        // Latch this token as dismissed so typing more doesn't reopen it (#95).
+        dismissedStartRef.current = commandTrigger?.start ?? null
+        setCommandTrigger(null)
+        return
+      }
+    }
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
       void send()
@@ -298,7 +400,34 @@ export function Conversation({
         />
 
         <div className="composer">
+          {showCommands && (
+            <ul className="command-autocomplete" role="listbox" aria-label="Slash commands">
+              {commandRows.map((command, i) => (
+                <li
+                  key={command.name}
+                  role="option"
+                  aria-selected={i === activeIndex}
+                  className={
+                    i === activeIndex
+                      ? 'command-autocomplete__row command-autocomplete__row--active'
+                      : 'command-autocomplete__row'
+                  }
+                  // mousedown (not click) so we accept BEFORE the textarea blurs.
+                  onMouseDown={(e) => {
+                    e.preventDefault()
+                    acceptCommand(command)
+                  }}
+                >
+                  <span className="command-autocomplete__name">/{command.name}</span>
+                  {command.description && (
+                    <span className="command-autocomplete__desc">{command.description}</span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
           <textarea
+            ref={inputRef}
             className="composer__input"
             placeholder="Ask Vibe… (Enter to send, Shift+Enter for a newline)"
             value={draft}
@@ -306,7 +435,13 @@ export function Conversation({
               // Write-through: keep React state and the persisted draft (#60) in lockstep.
               setDraft(e.target.value)
               persistDraft(window.localStorage, thread.threadId, e.target.value)
+              // Re-derive the `/` autocomplete trigger from the new value + caret (#95).
+              refreshCommandTrigger(e.target.value, e.target.selectionStart)
             }}
+            // Caret moves (arrows/click) with no edit also open/close the trigger (#95).
+            onSelect={(e) =>
+              refreshCommandTrigger(e.currentTarget.value, e.currentTarget.selectionStart)
+            }
             onKeyDown={onKeyDown}
             rows={2}
           />

--- a/src/renderer/src/conversation/command-autocomplete.test.ts
+++ b/src/renderer/src/conversation/command-autocomplete.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest'
+import {
+  applyCommand,
+  filterCommands,
+  getCommandQuery,
+  moveSelection,
+} from './command-autocomplete'
+import type { AcpCommand } from './reducer'
+
+/**
+ * `/` slash-command autocomplete (#95): the pure derivation behind the composer
+ * popover — trigger detection, prefix-then-substring filtering, the insertion
+ * transform, and wrapping selection. All DOM-free, so these exercise the logic as
+ * plain data with no renderer.
+ */
+
+const COMMANDS: AcpCommand[] = [
+  { name: 'init', description: 'Initialise' },
+  { name: 'review', description: 'Review the diff' },
+  { name: 'rewind' },
+  { name: 'clear' },
+]
+
+describe('getCommandQuery — trigger detection', () => {
+  it('activates on a `/`-token at input start with the caret after the slash', () => {
+    expect(getCommandQuery('/re', 3)).toEqual({ active: true, query: 're', start: 0 })
+  })
+
+  it('reports an empty query right after a bare slash', () => {
+    expect(getCommandQuery('/', 1)).toEqual({ active: true, query: '', start: 0 })
+  })
+
+  it('does NOT activate when the token is not at the start of the input', () => {
+    expect(getCommandQuery('hello /re', 9).active).toBe(false)
+  })
+
+  it('does NOT activate once the token is closed by a trailing space', () => {
+    expect(getCommandQuery('/init ', 6).active).toBe(false)
+  })
+
+  it('does NOT activate when the caret sits before the word after a closed token', () => {
+    // `/init arg` with the caret inside `arg` — the token closed at the space.
+    expect(getCommandQuery('/init arg', 9).active).toBe(false)
+  })
+
+  it('does NOT activate when the caret rests on the slash itself', () => {
+    expect(getCommandQuery('/re', 0).active).toBe(false)
+  })
+
+  it('activates for a `/`-token at the start of a later line', () => {
+    // "hello\n/re" — the slash opens the second line (index 6), caret at end.
+    expect(getCommandQuery('hello\n/re', 9)).toEqual({ active: true, query: 're', start: 6 })
+  })
+
+  it('does NOT activate for a non-slash line', () => {
+    expect(getCommandQuery('hello world', 5).active).toBe(false)
+  })
+
+  it('uses the caret, not the end of value, for the query', () => {
+    // Caret sits after `rev`, before the trailing `iew`.
+    expect(getCommandQuery('/review', 4)).toEqual({ active: true, query: 'rev', start: 0 })
+  })
+
+  it('clamps an out-of-range caret rather than throwing', () => {
+    expect(getCommandQuery('/re', 99)).toEqual({ active: true, query: 're', start: 0 })
+    expect(getCommandQuery('/re', -5).active).toBe(false)
+  })
+})
+
+describe('filterCommands — prefix then substring, case-insensitive', () => {
+  it('keeps every command for an empty query', () => {
+    expect(filterCommands(COMMANDS, '')).toEqual(COMMANDS)
+  })
+
+  it('orders prefix matches before substring matches', () => {
+    // `re` prefixes `review`/`rewind`; it is a substring of nothing else here.
+    expect(filterCommands(COMMANDS, 're').map((c) => c.name)).toEqual(['review', 'rewind'])
+  })
+
+  it('includes substring matches after prefix matches', () => {
+    // `i` prefixes `init`; it is a substring of `review` and `rewind`.
+    expect(filterCommands(COMMANDS, 'i').map((c) => c.name)).toEqual([
+      'init',
+      'review',
+      'rewind',
+    ])
+  })
+
+  it('is case-insensitive on both sides', () => {
+    expect(filterCommands([{ name: 'Init' }], 'IN').map((c) => c.name)).toEqual(['Init'])
+  })
+
+  it('drops non-matches', () => {
+    expect(filterCommands(COMMANDS, 'zzz')).toEqual([])
+  })
+
+  it('preserves original order within each group', () => {
+    const cmds: AcpCommand[] = [{ name: 'ab' }, { name: 'ba' }, { name: 'aa' }]
+    // Query `a`: prefix group is ab, aa (original order); substring group is ba.
+    expect(filterCommands(cmds, 'a').map((c) => c.name)).toEqual(['ab', 'aa', 'ba'])
+  })
+})
+
+describe('applyCommand — insertion transform', () => {
+  it('replaces the `/query` token with `/<name> ` and places the caret after', () => {
+    expect(applyCommand('/re', 0, 3, 'rewind')).toEqual({ value: '/rewind ', caret: 8 })
+  })
+
+  it('expands a bare slash', () => {
+    expect(applyCommand('/', 0, 1, 'init')).toEqual({ value: '/init ', caret: 6 })
+  })
+
+  it('keeps text after the caret intact', () => {
+    // Accepting at the start line of a two-line draft keeps the second line.
+    const out = applyCommand('/re\nkeep', 0, 3, 'review')
+    expect(out.value).toBe('/review \nkeep')
+    expect(out.caret).toBe(8)
+  })
+
+  it('applies to a token that starts mid-value (a later line)', () => {
+    const out = applyCommand('hi\n/re', 3, 6, 'rewind')
+    expect(out.value).toBe('hi\n/rewind ')
+    expect(out.caret).toBe(11)
+  })
+})
+
+describe('moveSelection — wrapping', () => {
+  it('advances within range', () => {
+    expect(moveSelection(0, 3, 1)).toBe(1)
+  })
+
+  it('wraps past the end', () => {
+    expect(moveSelection(2, 3, 1)).toBe(0)
+  })
+
+  it('wraps past the start', () => {
+    expect(moveSelection(0, 3, -1)).toBe(2)
+  })
+
+  it('clamps to 0 for an empty list', () => {
+    expect(moveSelection(0, 0, 1)).toBe(0)
+  })
+})

--- a/src/renderer/src/conversation/command-autocomplete.ts
+++ b/src/renderer/src/conversation/command-autocomplete.ts
@@ -1,0 +1,109 @@
+/**
+ * `/` slash-command autocomplete logic (#95): the pure core of the composer's
+ * command popover. The commands themselves are Vibe-owned — they arrive on the
+ * `available_commands_update` stream and are already folded into the reducer's
+ * `state.availableCommands` (reducer.ts). This module owns ONLY the derivation:
+ * trigger detection, filtering, the insertion transform, and selection wrapping.
+ * It is deliberately DOM-free and side-effect-free so it unit-tests as plain data
+ * (command-autocomplete.test.ts) while `Conversation.tsx` keeps the thin JSX +
+ * keyboard wiring.
+ *
+ * Trigger rule: the popover is active only for a `/`-prefixed token at the START
+ * of the input (input start, or the start of a line after a newline), with the
+ * caret inside or after that token. A closed token — one the caret has moved past
+ * a whitespace of — does not qualify, matching a shell's "first word" feel.
+ */
+
+import type { AcpCommand } from './reducer'
+
+/**
+ * The result of probing the composer value + caret for an active `/` trigger.
+ * `active` gates the popover; `query` is the text after the `/` up to the caret
+ * (lower-cased matching happens in `filterCommands`); `start` is the index of the
+ * `/` so `applyCommand` knows where the token begins.
+ */
+export interface CommandTrigger {
+  active: boolean
+  query: string
+  start: number
+}
+
+/** An inactive probe result — the single shape returned when no trigger qualifies. */
+const NO_TRIGGER: CommandTrigger = { active: false, query: '', start: -1 }
+
+/** Whitespace closes a `/`-token: a caret past one of these is no longer inside it. */
+const TOKEN_WHITESPACE = /\s/
+
+/**
+ * Detect a `/`-command trigger at the caret. Active only when the `/` sits at the
+ * start of the caret's line (input start or just after a `\n`) and the text from
+ * the `/` up to the caret contains no whitespace (the token is still open). Returns
+ * the query (text after `/`, up to the caret) and the `/`'s index on a hit.
+ *
+ * `caret` is clamped defensively — a caller may hand us a DOM `selectionStart` that
+ * a controlled re-render has momentarily desynced from `value`.
+ */
+export function getCommandQuery(value: string, caret: number): CommandTrigger {
+  const pos = Math.max(0, Math.min(caret, value.length))
+  // Start of the caret's line: one past the last newline at/before the caret, or 0.
+  const lineStart = value.lastIndexOf('\n', pos - 1) + 1
+  // The token must open with a `/` at the line start, and the caret must sit AFTER
+  // that `/` (a caret resting on the `/` itself isn't inside the token yet).
+  if (value[lineStart] !== '/' || pos <= lineStart) return NO_TRIGGER
+  const query = value.slice(lineStart + 1, pos)
+  // A whitespace before the caret means the token closed — the caret is on a later
+  // word (e.g. `/init ` with the caret past the space), so the popover must not show.
+  if (TOKEN_WHITESPACE.test(query)) return NO_TRIGGER
+  return { active: true, query, start: lineStart }
+}
+
+/**
+ * Filter commands by name against a query, case-insensitively: prefix matches first
+ * (in their original order), then the remaining substring matches (also in order),
+ * with non-matches dropped. An empty query keeps every command (all are prefixed by
+ * ''), so the popover opens showing the full list right after a bare `/`.
+ */
+export function filterCommands(commands: AcpCommand[], query: string): AcpCommand[] {
+  const needle = query.toLowerCase()
+  const prefix: AcpCommand[] = []
+  const substring: AcpCommand[] = []
+  for (const command of commands) {
+    const name = command.name.toLowerCase()
+    if (name.startsWith(needle)) prefix.push(command)
+    else if (name.includes(needle)) substring.push(command)
+  }
+  return [...prefix, ...substring]
+}
+
+/** The value + caret produced by accepting a completion, applied to the composer. */
+export interface CommandInsertion {
+  value: string
+  caret: number
+}
+
+/**
+ * Replace the `/query` token (from `start` up to `caret`) with `/<name> ` — a
+ * trailing space so the user types the command's argument straight after — and
+ * report the caret position just past that space. Text after the caret is kept, so
+ * accepting mid-line splices the command in without eating what follows.
+ */
+export function applyCommand(
+  value: string,
+  start: number,
+  caret: number,
+  name: string,
+): CommandInsertion {
+  const insert = `/${name} `
+  const nextValue = value.slice(0, start) + insert + value.slice(caret)
+  return { value: nextValue, caret: start + insert.length }
+}
+
+/**
+ * Move a wrapping selection index by `delta` (typically ±1 for ↑/↓) over a list of
+ * `length` rows, wrapping past either end. An empty list clamps to 0 so callers can
+ * pass the result back without a special case.
+ */
+export function moveSelection(current: number, length: number, delta: number): number {
+  if (length <= 0) return 0
+  return (((current + delta) % length) + length) % length
+}

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -890,9 +890,57 @@ body {
 }
 
 .composer {
+  position: relative;
   display: flex;
   gap: 8px;
   align-items: flex-end;
+}
+
+/* --- `/` slash-command autocomplete popover (#95) --- */
+
+.command-autocomplete {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  right: 0;
+  margin: 0 0 4px;
+  padding: 4px;
+  list-style: none;
+  max-height: 220px;
+  overflow-y: auto;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.08);
+  z-index: 10;
+}
+
+.command-autocomplete__row {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 6px 8px;
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+
+.command-autocomplete__row--active {
+  background: var(--accent-tint);
+}
+
+.command-autocomplete__name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--accent-text);
+  white-space: nowrap;
+}
+
+.command-autocomplete__desc {
+  font-size: 12px;
+  color: var(--muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .composer__input {


### PR DESCRIPTION
Closes #95. First slice of the **composer extras** epic (CodexMonitor build order #5). **Renderer-only** — no main/preload/IPC/protocol change.

## What it does
Renders the agent's slash commands as a `/` autocomplete popover in the composer. The commands are already Vibe-streamed via `available_commands_update` and folded into the reducer's `state.availableCommands` (pre-existing, "stored, not rendered") — this slice renders them.

- Trigger: a `/`-token at the **start of the input or a line**, caret after the `/`, token still open (no whitespace). `hello /re` (mid-line) does not trigger; `/re` does.
- Popover: filter by name (prefix-first, then substring, case-insensitive) showing `/name` + description; ↑/↓ wrap, Enter/Tab accept, Esc dismiss, click accept.
- Accept: splices `/<name> ` over the token, keeps text after the caret, syncs the React draft **and** the localStorage draft (#60), restores focus + caret (rAF).
- Enter interception: only while the popover is open — Enter/Tab accept; when closed, Enter sends as before (no double-action).
- Esc has a **per-token dismiss latch** so typing more doesn't reopen it (the escape hatch for sending literal `/text`).

## Design
- All load-bearing logic in a pure, DOM-free module `conversation/command-autocomplete.ts` (`getCommandQuery` / `filterCommands` / `applyCommand` / `moveSelection`) with **24 colocated unit tests**; `Conversation.tsx` keeps only thin JSX + keyboard/caret wiring. styles.css adds the overlay popover.

## Verification
- Independent re-run of all four gates on the branch: `lint` / `typecheck` / `build` clean, **468 tests** (444 baseline + 24 new).
- Adversarial review: no severe bugs across trigger/caret math, insertion, Enter double-action, focus/caret race, index bounds, cross-thread leak, conventions. The one actionable UX finding (Esc reopened on next keystroke) is **folded** here (the dismiss latch). Deferred/out-of-scope: partial-in-token-selection tail (matches the documented keep-text-after-caret contract) and IME-guard on Enter (pre-existing on `send()`, not worsened).

## Not in this slice (own future slices)
Image attachments (needs a wire-shape spike), queue-vs-steer (needs an ADR + cancel/steer spike), `$` skills / `@` file-path autocomplete (`$` mechanism unverified in vibe-acp; `@` blocked on the unbuilt file tree). Command **execution** wiring is also deferred — this slice only inserts the `/name ` text; the user sends it as a normal prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)