### PR TITLE
#100: image attachments in the composer — paste + file picker (composer extras slice 2)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -549,13 +549,16 @@ async function runPromptTurn(
   // sending it, so it precedes the streamed events it triggers. We hold the
   // Thread id, so no bridge lookup — a draft's first prompt can't misroute to
   // another Thread. Main has no renderer item id, so mint an opaque replay key.
+  // v1 does NOT persist image base64 — the transcript tees text only (#100). Image
+  // attachments live only in the in-memory echo for this session's live view; a
+  // reopen replays the text-only prompt. Intentional for this slice.
   teeTranscript(args.threadId, userPromptEntry(randomUUID(), args.text))
   // On a re-bind (TB4 #33), persist the "context reset" notice right AFTER the
   // user's prompt and BEFORE the turn's events — so a later reopen replays it
   // in the same position the live view rendered it (`thread:bound` -> notice).
   if (rebound) teeTranscript(args.threadId, agentReboundEntry())
   try {
-    const result = await agent.prompt(sessionId, args.text)
+    const result = await agent.prompt(sessionId, args.text, args.images)
     // Tee the clean turn end: this signal lives ONLY in this IPC response
     // (never an `acp:event`), so without it a replay leaves `isProcessing`
     // stuck true. Serialized after the turn's events (TranscriptStore chain).
@@ -572,7 +575,14 @@ async function runPromptTurn(
     }
     const message = err instanceof Error ? err.message : String(err)
     teeTranscript(args.threadId, turnErrorEntry(message))
-    return { ok: false, kind: 'error', error: message }
+    // Carry the JSON-RPC/app code (e.g. -31008 for an unsupported/oversized image,
+    // #100) so the renderer can special-case it rather than show a generic error.
+    return {
+      ok: false,
+      kind: 'error',
+      error: message,
+      code: err instanceof WorkspaceAgentError ? err.code ?? undefined : undefined,
+    }
   }
 }
 

--- a/src/main/workspace-agent.test.ts
+++ b/src/main/workspace-agent.test.ts
@@ -785,10 +785,49 @@ describe('WorkspaceAgent.prompt()', () => {
     await expect(turn).resolves.toMatchObject({ stopReason: 'end_turn' })
   })
 
+  it('prepends image blocks with snake_case mime_type + bare base64 before the text block (#100)', () => {
+    const fake = makeCapturingFake()
+    return connect(fake).then((agent) => {
+      void agent.prompt(SESSION_ID, 'what is this?', [
+        { data: 'aGVsbG8=', mimeType: 'image/png' },
+        { data: '/9j/4AAQ', mimeType: 'image/jpeg' },
+      ])
+      const promptReq = sent(fake).find((m) => m.method === 'session/prompt')
+      // acp-capture §11: field is snake_case `mime_type` with BARE base64 in `data`
+      // (the ACP-conventional camelCase `mimeType` is silently accepted but leaves
+      // the model blind). Image blocks come BEFORE the text block.
+      expect(promptReq?.params?.prompt).toEqual([
+        { type: 'image', data: 'aGVsbG8=', mime_type: 'image/png' },
+        { type: 'image', data: '/9j/4AAQ', mime_type: 'image/jpeg' },
+        { type: 'text', text: 'what is this?' },
+      ])
+    })
+  })
+
   it('rejects when prompting an unknown sessionId', async () => {
     const fake = makeCapturingFake()
     const agent = await connect(fake)
     await expect(agent.prompt('nope', 'hi')).rejects.toBeInstanceOf(WorkspaceAgentError)
+  })
+
+  it('preserves a non-auth app code (e.g. -31008 images-unsupported) on the error (#100)', async () => {
+    const fake = makeCapturingFake()
+    const agent = await connect(fake)
+
+    const turn = agent.prompt(SESSION_ID, 'what is this?', [{ data: 'aGk=', mimeType: 'image/png' }])
+    const promptReq = sent(fake).find((m) => m.method === 'session/prompt')
+    fake.feed(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: promptReq?.id,
+        error: { code: -31008, message: 'Model `devstral-small` does not support images. Switch model…' },
+      }) + '\n',
+    )
+    const err = await turn.catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(WorkspaceAgentError)
+    // The renderer special-cases this code into a "switch to a vision model" hint.
+    expect((err as WorkspaceAgentError).code).toBe(-31008)
+    expect((err as WorkspaceAgentError).authState).toBeNull()
   })
 
   it('serves an fs/read_text_file server request by replying {content}', async () => {

--- a/src/main/workspace-agent.ts
+++ b/src/main/workspace-agent.ts
@@ -7,6 +7,7 @@ import { BLOCKING_AUTH_METHOD_ID, DELEGATED_AUTH_METHOD_ID } from '../shared/ipc
 import type {
   AuthMethod,
   AuthState,
+  PromptImage,
   PromptResult,
   ThreadInfo,
   ThreadModes,
@@ -533,7 +534,7 @@ export class WorkspaceAgent extends EventEmitter {
    * channel; per ADR-0001 the renderer reduces them — we only own the turn's
    * lifecycle here. Resolves with `{stopReason, usage, userMessageId}`.
    */
-  async prompt(sessionId: string, text: string): Promise<PromptResult> {
+  async prompt(sessionId: string, text: string, images?: PromptImage[]): Promise<PromptResult> {
     if (!this.initialized) {
       throw new WorkspaceAgentError('Agent is not initialized; call start() first.')
     }
@@ -541,10 +542,19 @@ export class WorkspaceAgent extends EventEmitter {
       throw new WorkspaceAgentError(`No open Thread for sessionId ${sessionId}.`)
     }
 
+    // Image content blocks (#100, acp-capture §11): the field is snake_case
+    // `mime_type` with BARE base64 in `data` (no `data:` URI prefix). The
+    // ACP-conventional camelCase `mimeType` is silently accepted but leaves the
+    // model BLIND to the image, so we MUST emit `mime_type` here. Image blocks go
+    // BEFORE the text block in the `prompt[]` array.
+    const blocks = [
+      ...(images ?? []).map((img) => ({ type: 'image', data: img.data, mime_type: img.mimeType })),
+      { type: 'text', text },
+    ]
     try {
       return await this.client.request<PromptResult>('session/prompt', {
         sessionId,
-        prompt: [{ type: 'text', text }],
+        prompt: blocks,
       })
     } catch (err) {
       throw this.mapErrorAndCacheAuth(err)
@@ -770,7 +780,10 @@ export class WorkspaceAgent extends EventEmitter {
         'not-signed-in',
       )
     }
-    return new WorkspaceAgentError(message)
+    // Preserve the JSON-RPC/app code (the ctor's docstring promises it) so callers
+    // can special-case app errors — e.g. -31008 images-unsupported (#100), which
+    // the renderer turns into a "switch to a vision model" hint.
+    return new WorkspaceAgentError(message, null, null, rpcErrorParts(err).code)
   }
 }
 

--- a/src/renderer/src/conversation/Conversation.tsx
+++ b/src/renderer/src/conversation/Conversation.tsx
@@ -1,4 +1,13 @@
-import { useEffect, useReducer, useRef, useState, type JSX, type KeyboardEvent } from 'react'
+import {
+  useEffect,
+  useReducer,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type ClipboardEvent,
+  type JSX,
+  type KeyboardEvent,
+} from 'react'
 import type {
   AuthMethod,
   ThreadAgentControls,
@@ -33,9 +42,31 @@ import {
   getCommandQuery,
   moveSelection,
 } from './command-autocomplete'
+import { ACCEPTED_IMAGE_TYPES, isAcceptedImageType, parseDataUrl } from './image-attach'
 
 /** Process-local counter for unique echoed-prompt ids. */
 let promptSeq = 0
+
+/** Process-local counter for unique pending-image ids (not Math.random/Date). */
+let imageSeq = 0
+
+/** The picker's `accept` list — the accepted image mime types, comma-joined. */
+const IMAGE_ACCEPT = ACCEPTED_IMAGE_TYPES.join(',')
+
+/** Vibe's app code for "this model can't ingest images" (acp-capture §11, #100). */
+const IMAGES_UNSUPPORTED_CODE = -31008
+
+/**
+ * An image staged in the composer before send (#100). `data` is BARE base64 (sent
+ * to the agent); `previewUrl` is the full data URL (thumbnail + echoed user turn).
+ */
+interface PendingImage {
+  id: string
+  data: string
+  mimeType: string
+  name: string
+  previewUrl: string
+}
 
 /**
  * The live handle for one Thread hosted on a Workspace agent (TB5). `sessionId`
@@ -102,6 +133,10 @@ export function Conversation({
   // draft fresh, with no stale carry-over (no re-seed effect needed). Reading here
   // must not write, so we only persist on change/send below.
   const [draft, setDraft] = useState(() => getDraft(window.localStorage, thread.threadId))
+  // Images staged in the composer, awaiting send (#100). Renderer-only, ephemeral:
+  // this view remounts on a Thread switch (keyed by threadId), so the strip starts
+  // empty per Thread. Kept on a failed send so the user can retry / switch model.
+  const [pendingImages, setPendingImages] = useState<PendingImage[]>([])
   // The session this Thread is bound to — null until a draft's first prompt binds
   // it (via main's `thread:bound`). Seeded from the record; mirrored into a ref so
   // the event subscription reads the LATEST value without re-subscribing (a stale
@@ -113,6 +148,8 @@ export function Conversation({
   onBoundRef.current = onBound
   const listRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
+  // The hidden file picker behind the 📎 button (#100).
+  const fileInputRef = useRef<HTMLInputElement>(null)
   // Ephemeral `/` slash-command autocomplete state (#95): the open trigger (the
   // `/`'s index + the query after it) and the highlighted row. Purely renderer-local
   // — no IPC, no persistence — so a Thread switch (which remounts this view, keyed by
@@ -191,13 +228,60 @@ export function Conversation({
     if (list) list.scrollTop = list.scrollHeight
   }, [state.items])
 
+  // Read a pasted/picked image blob to a data URL (DOM: FileReader lives here, not
+  // in the pure module), split it into bare base64 + mime via `parseDataUrl`, and
+  // stage it. Non-accepted types are skipped up front so we don't read junk.
+  function addFile(file: File | Blob, name: string): void {
+    if (!isAcceptedImageType(file.type)) return
+    const reader = new FileReader()
+    reader.onload = () => {
+      const dataUrl = typeof reader.result === 'string' ? reader.result : ''
+      const parsed = parseDataUrl(dataUrl)
+      if (!parsed) return
+      setPendingImages((prev) => [
+        ...prev,
+        { id: `img:${imageSeq++}`, data: parsed.data, mimeType: parsed.mimeType, name, previewUrl: dataUrl },
+      ])
+    }
+    reader.readAsDataURL(file)
+  }
+
+  // Clipboard paste (#100): stage any pasted image files. `preventDefault` fires
+  // ONLY when at least one image was handled, so a normal text paste is untouched.
+  function onPaste(e: ClipboardEvent<HTMLTextAreaElement>): void {
+    let handled = false
+    for (const item of e.clipboardData.items) {
+      if (item.kind !== 'file' || !isAcceptedImageType(item.type)) continue
+      const file = item.getAsFile()
+      if (!file) continue
+      addFile(file, file.name || 'pasted-image')
+      handled = true
+    }
+    if (handled) e.preventDefault()
+  }
+
+  // File picker (#100): stage each selected image, then reset the input value so
+  // re-picking the SAME file fires `change` again.
+  function onPickFiles(e: ChangeEvent<HTMLInputElement>): void {
+    const files = e.target.files
+    if (files) for (const file of files) addFile(file, file.name)
+    e.target.value = ''
+  }
+
+  function removeImage(id: string): void {
+    setPendingImages((prev) => prev.filter((img) => img.id !== id))
+  }
+
   async function send(): Promise<void> {
     const text = draft.trim()
-    if (!text || state.isProcessing) return
-    setDraft('')
-    // The text is now in the transcript — drop the persisted draft (#60).
-    clearDraft(window.localStorage, thread.threadId)
-    dispatch({ type: 'send-prompt', id: `user:${promptSeq++}`, text })
+    // Allow a send with images and no text; still block while a turn is streaming.
+    if ((!text && pendingImages.length === 0) || state.isProcessing) return
+    dispatch({
+      type: 'send-prompt',
+      id: `user:${promptSeq++}`,
+      text,
+      images: pendingImages.map(({ previewUrl }) => ({ previewUrl })),
+    })
     try {
       const result = await window.api.sendPrompt({
         agentId: thread.agentId,
@@ -205,8 +289,15 @@ export function Conversation({
         workspaceId: thread.workspaceId,
         sessionId: boundSessionId,
         text,
+        images: pendingImages.map(({ data, mimeType }) => ({ data, mimeType })),
       })
       if (result.ok) {
+        // The turn was accepted: drop the staged images AND clear the text/draft.
+        // On ANY failure below we KEEP both so the user can retry (e.g. switch to a
+        // vision model) without re-typing or re-attaching (#100).
+        setPendingImages([])
+        setDraft('')
+        clearDraft(window.localStorage, thread.threadId)
         // Reuse the now-bound session on the next prompt (no second session/new),
         // and lift it so a switch-away-and-back doesn't re-mint. `thread:bound`
         // already set this for a fresh draft; this also covers the no-store path.
@@ -220,7 +311,13 @@ export function Conversation({
         onAuthExpired(result.authMethods)
       } else {
         // Surface a failed turn as a conversation item rather than dropping it.
-        dispatch({ type: 'turn-error', message: result.error })
+        // -31008 (images-unsupported, acp-capture §11) gets an actionable hint —
+        // the staged images are kept above, so switching model + resend just works.
+        const message =
+          result.code === IMAGES_UNSUPPORTED_CODE
+            ? "This model can't see images. Switch to a vision-capable model (e.g. mistral-medium-3.5) and resend."
+            : result.error
+        dispatch({ type: 'turn-error', message })
       }
     } finally {
       // The turn's stopReason resolves sendPrompt; flip back to the user's turn.
@@ -408,6 +505,24 @@ export function Conversation({
           onSetConfig={(axis, value) => onSetConfig?.(axis, value, boundSessionId)}
         />
 
+        {pendingImages.length > 0 && (
+          // Staged-image strip (#100): thumbnails with a ✕ remove, above the composer.
+          <div className="composer-attachments">
+            {pendingImages.map((img) => (
+              <div key={img.id} className="attachment">
+                <img className="attachment__thumb" src={img.previewUrl} alt={img.name} />
+                <button
+                  className="attachment__remove"
+                  aria-label={`Remove ${img.name}`}
+                  onClick={() => removeImage(img.id)}
+                >
+                  ✕
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+
         <div className="composer">
           {showCommands && (
             <ul className="command-autocomplete" role="listbox" aria-label="Slash commands">
@@ -453,12 +568,31 @@ export function Conversation({
               refreshCommandTrigger(e.currentTarget.value, e.currentTarget.selectionStart)
             }
             onKeyDown={onKeyDown}
+            onPaste={onPaste}
             rows={2}
           />
+          <input
+            ref={fileInputRef}
+            type="file"
+            className="composer__file-input"
+            accept={IMAGE_ACCEPT}
+            multiple
+            hidden
+            onChange={onPickFiles}
+          />
+          <button
+            className="btn btn--ghost composer__attach"
+            aria-label="Attach images"
+            title="Attach images"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={state.isProcessing}
+          >
+            📎
+          </button>
           <button
             className="btn"
             onClick={() => void send()}
-            disabled={state.isProcessing || draft.trim().length === 0}
+            disabled={state.isProcessing || (draft.trim().length === 0 && pendingImages.length === 0)}
           >
             {state.isProcessing ? 'Sending…' : 'Send'}
           </button>
@@ -518,7 +652,15 @@ function UserRow({ item }: { item: UserItem }): JSX.Element {
   return (
     <div className="msg msg--user">
       <div className="msg__role">You</div>
-      <div className="msg__body">{item.text}</div>
+      {item.images && item.images.length > 0 && (
+        // Echo the sent attachments in the user bubble (#100).
+        <div className="msg__images">
+          {item.images.map((img, i) => (
+            <img key={i} className="msg__image" src={img.previewUrl} alt="attachment" />
+          ))}
+        </div>
+      )}
+      {item.text && <div className="msg__body">{item.text}</div>}
     </div>
   )
 }

--- a/src/renderer/src/conversation/image-attach.test.ts
+++ b/src/renderer/src/conversation/image-attach.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { ACCEPTED_IMAGE_TYPES, isAcceptedImageType, parseDataUrl } from './image-attach'
+
+describe('isAcceptedImageType', () => {
+  it('accepts the four supported image mime types', () => {
+    for (const type of ACCEPTED_IMAGE_TYPES) {
+      expect(isAcceptedImageType(type)).toBe(true)
+    }
+  })
+
+  it('rejects non-image and unsupported image mime types', () => {
+    expect(isAcceptedImageType('text/plain')).toBe(false)
+    expect(isAcceptedImageType('image/svg+xml')).toBe(false)
+    expect(isAcceptedImageType('image/tiff')).toBe(false)
+    expect(isAcceptedImageType('')).toBe(false)
+  })
+})
+
+describe('parseDataUrl', () => {
+  it('parses a valid png data URL into bare base64 + mime type', () => {
+    expect(parseDataUrl('data:image/png;base64,aGVsbG8=')).toEqual({
+      data: 'aGVsbG8=',
+      mimeType: 'image/png',
+    })
+  })
+
+  it('parses a valid jpeg data URL', () => {
+    expect(parseDataUrl('data:image/jpeg;base64,/9j/4AAQ')).toEqual({
+      data: '/9j/4AAQ',
+      mimeType: 'image/jpeg',
+    })
+  })
+
+  it('returns null for non-data-url input', () => {
+    expect(parseDataUrl('https://example.com/a.png')).toBeNull()
+    expect(parseDataUrl('aGVsbG8=')).toBeNull()
+    expect(parseDataUrl('')).toBeNull()
+  })
+
+  it('returns null for a non-base64 data url', () => {
+    expect(parseDataUrl('data:image/png,rawtext')).toBeNull()
+    expect(parseDataUrl('data:image/png;charset=utf-8,hello')).toBeNull()
+  })
+
+  it('returns null for an unknown / unsupported mime type', () => {
+    expect(parseDataUrl('data:image/svg+xml;base64,PHN2Zz4=')).toBeNull()
+    expect(parseDataUrl('data:text/plain;base64,aGVsbG8=')).toBeNull()
+  })
+
+  it('returns null for an empty base64 payload', () => {
+    expect(parseDataUrl('data:image/png;base64,')).toBeNull()
+  })
+})

--- a/src/renderer/src/conversation/image-attach.ts
+++ b/src/renderer/src/conversation/image-attach.ts
@@ -1,0 +1,37 @@
+/**
+ * Image-attachment helpers (#100) — the PURE, unit-tested core of composer image
+ * support. No DOM, no IPC: this module only does string parsing + type checks.
+ * `FileReader` (DOM) stays in the component; it hands us the resulting data URL.
+ *
+ * The wire contract (acp-capture §11) wants BARE base64 (no `data:` prefix) plus
+ * the mime type; `parseDataUrl` splits a browser-produced `data:` URL into exactly
+ * that shape.
+ */
+
+/** The image mime types the composer accepts (paste + picker). */
+export const ACCEPTED_IMAGE_TYPES = [
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/gif',
+] as const
+
+/** True when `type` is one of the accepted image mime types. */
+export function isAcceptedImageType(type: string): boolean {
+  return (ACCEPTED_IMAGE_TYPES as readonly string[]).includes(type)
+}
+
+/**
+ * Parse a `data:<mime>;base64,<payload>` URL into `{ mimeType, data }`, where
+ * `data` is the BARE base64 (the `data:…;base64,` prefix stripped). Returns null
+ * unless it's a base64 image data URL whose mime is one we accept.
+ */
+export function parseDataUrl(dataUrl: string): { data: string; mimeType: string } | null {
+  const match = /^data:([^;,]+);base64,(.*)$/s.exec(dataUrl)
+  if (!match) return null
+  const mimeType = match[1]
+  const data = match[2]
+  if (!isAcceptedImageType(mimeType)) return null
+  if (data.length === 0) return null
+  return { data, mimeType }
+}

--- a/src/renderer/src/conversation/reducer.test.ts
+++ b/src/renderer/src/conversation/reducer.test.ts
@@ -149,6 +149,20 @@ describe('conversationReducer (Seam A)', () => {
     expect(state.isProcessing).toBe(false)
   })
 
+  it('echoes image attachments on the sent user item (#100)', () => {
+    const state = conversationReducer(initialConversationState, {
+      type: 'send-prompt',
+      id: 'user:0',
+      text: 'what is in this image?',
+      images: [{ previewUrl: 'data:image/png;base64,aGVsbG8=' }],
+    })
+    expect(state.items[0]).toMatchObject({
+      kind: 'user',
+      text: 'what is in this image?',
+      images: [{ previewUrl: 'data:image/png;base64,aGVsbG8=' }],
+    })
+  })
+
   it('ignores non-session/update payloads (lifecycle, server requests)', () => {
     const before = initialConversationState
     const after = [

--- a/src/renderer/src/conversation/reducer.ts
+++ b/src/renderer/src/conversation/reducer.ts
@@ -25,10 +25,17 @@
  * optimistic processing flag (driven by the `session/prompt` response).
  */
 
+/** An image echoed in a sent user turn (#100). `previewUrl` is the full data URL. */
+export interface UserImage {
+  previewUrl: string
+}
+
 export interface UserItem {
   kind: 'user'
   id: string
   text: string
+  /** Image attachments echoed with this turn (#100); absent on replay from JSONL. */
+  images?: UserImage[]
 }
 
 export interface ReasoningItem {
@@ -185,7 +192,7 @@ export const initialConversationState: ConversationState = {
 }
 
 export type ConversationAction =
-  | { type: 'send-prompt'; id: string; text: string }
+  | { type: 'send-prompt'; id: string; text: string; images?: UserImage[] }
   | { type: 'acp-event'; payload: unknown }
   | { type: 'turn-complete' }
   | { type: 'turn-error'; message: string }
@@ -210,7 +217,10 @@ export function conversationReducer(
       return {
         ...state,
         isProcessing: true,
-        items: [...state.items, { kind: 'user', id: action.id, text: action.text }],
+        items: [
+          ...state.items,
+          { kind: 'user', id: action.id, text: action.text, images: action.images },
+        ],
       }
     case 'turn-complete':
       return { ...state, isProcessing: false }

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -943,6 +943,61 @@ body {
   white-space: nowrap;
 }
 
+/* --- Image attachments (#100) --- */
+
+.composer-attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.attachment {
+  position: relative;
+  width: 56px;
+  height: 56px;
+}
+
+.attachment__thumb {
+  width: 56px;
+  height: 56px;
+  object-fit: cover;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.attachment__remove {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  line-height: 1;
+  font-size: 11px;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: var(--panel);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.composer__attach {
+  align-self: flex-end;
+}
+
+.msg__images {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.msg__image {
+  max-width: 200px;
+  max-height: 200px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
 .composer__input {
   flex: 1;
   resize: vertical;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -385,6 +385,18 @@ export interface PromptResult {
   userMessageId?: string
 }
 
+/**
+ * An image attachment on a prompt (#100). Our IPC type uses camelCase `mimeType`;
+ * the ACP snake_case `mime_type` conversion happens ONLY at the ACP boundary in
+ * `workspace-agent.ts` (see acp-capture §11 — the model is blind to camelCase).
+ */
+export interface PromptImage {
+  /** BARE base64 (no data: prefix). */
+  data: string
+  /** e.g. 'image/png'. */
+  mimeType: string
+}
+
 export interface SendPromptArgs {
   /** Id of the Workspace agent (one `vibe-acp` process) hosting the Thread. */
   agentId: string
@@ -400,6 +412,8 @@ export interface SendPromptArgs {
   sessionId: string | null
   /** The user's prompt text. */
   text: string
+  /** Optional image attachments (#100). */
+  images?: PromptImage[]
 }
 
 export type SendPromptResult =
@@ -409,7 +423,9 @@ export type SendPromptResult =
   // Mid-session expiry (-32000): the agent stays alive so the renderer can route
   // to the sign-in panel in place and re-auth on the same agent (no restart).
   | { ok: false; kind: 'not-signed-in'; agentId: string; authMethods: AuthMethod[] }
-  | { ok: false; kind: 'error'; error: string }
+  // `code` carries the JSON-RPC/app error code when known (#100) — e.g. -31008 —
+  // so the renderer can special-case it (an image-too-large / unsupported reason).
+  | { ok: false; kind: 'error'; error: string; code?: number }
 
 /**
  * The `deleteThread` reply (#53). `ok` when the records came down (or there was


### PR DESCRIPTION
Closes #100. Composer-extras slice 2. **Depends on #99** (the spike + `acp-capture.md` §11 the code cites — merge #99 first).

## What it does
Attach images to a prompt via **clipboard paste** and a **file picker** (📎), send them to the agent, and echo them in the sent user turn. Cross-layer: ipc → main/ACP → renderer.

## The wire contract (spike-verified in #99)
Image blocks go in `session/prompt` `prompt[]` as **`{type:"image", data:<bare base64>, `mime_type`}`** (snake_case), **before** the text block. The ACP-conventional camelCase `mimeType` is silently accepted but the model goes **blind** — so the ACP boundary emits `mime_type`. Our IPC/domain type stays camelCase `mimeType`, converted only there. (Also verified live during review: an image + empty-text block returns `end_turn`, so image-only sends are fine.)

## Your two scoping decisions, delivered
- **Ingest = paste + picker** (drag-drop / HEIC deferred); accepts png/jpeg/webp/gif.
- **Model gating = allow + recoverable `-31008`.** Support is per-model, gated before the call (only `mistral-medium-3.5` has vision here). We thread the app code and the renderer turns `-31008` into an actionable *"switch to a vision-capable model (e.g. mistral-medium-3.5) and resend"* hint. Staged images **and text** are kept on any failure (cleared only on success) — retry needs no re-typing/re-attaching.

## Layers
- `ipc.ts`: `PromptImage {data; mimeType}`; `SendPromptArgs.images?`; error result `code?`.
- `workspace-agent.ts`: `prompt()` builds the `mime_type` blocks; `mapErrorAndCacheAuth` now **preserves the JSON-RPC/app code** (fixes a latent gap — auth errors kept it, generic ones dropped it).
- `index.ts`: `runPromptTurn` passes `images`, returns `code`.
- renderer: pure `image-attach.ts` (`parseDataUrl` + type guard, tested); composer paste/picker/thumbnail strip; `UserItem.images` echoed in the bubble. v1 does not persist image base64 to the JSONL transcript (text only — documented).

## Verification
- Independent re-run of all four gates on the branch: lint/typecheck/build clean, **479 tests** (468 baseline + 11 new).
- Read the full diff (the `mime_type` boundary especially). Adversarial review found no `mime_type` regression; its two Medium findings are **folded** here — the inert `-31008` code path is now live end-to-end (matching the chosen UX), and text is kept on failure (was: images kept but text dropped). Its Low "empty text block" concern was **verified accepted** by the live binary (no change needed). The "paste drops co-pasted text" nicety is deferred.
- Fixed a merge hazard: the implementer duplicated §11 into the capture doc (owned by #99); reverted so this PR is code-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)