### PR TITLE
#103: interrupt the active turn — Stop button (queue-vs-steer slice 1) + ADR-0009

### DIFF
--- a/docs/adr/0009-follow-ups-queue-plus-interrupt-steer-protocol-blocked.md
+++ b/docs/adr/0009-follow-ups-queue-plus-interrupt-steer-protocol-blocked.md
@@ -1,0 +1,60 @@
+# Follow-ups are handled by client-side QUEUE + INTERRUPT; steer is protocol-blocked and deferred
+
+When the user submits a message while a Thread's turn is still streaming, vibe-mistro **queues** it
+(client-side) and auto-sends it as a fresh `session/prompt` once the turn ends, and offers a **Stop**
+button that **interrupts** the active turn via `session/cancel`. It does **not** "steer" (inject into the
+live turn): the #102 spike proved vibe-acp rejects a concurrent `session/prompt` and exposes no steer
+method. This mirrors CodexMonitor's Queue + Interrupt (`turn/start` + `turn/interrupt`) but drops its
+third verb (`turn/steer`) until vibe-acp gains one.
+
+## Verified protocol (acp-capture §12, spike #102, vibe-acp 2.18.3)
+
+- **`session/cancel` is a NOTIFICATION** (no id, no response), params `{sessionId}`. Sent mid-turn, the
+  in-flight `session/prompt` **resolves** (not rejects) with `stopReason:"cancelled"` (zero usage) and
+  streaming stops immediately. So `stopReason ∈ {end_turn, cancelled}`.
+- **Concurrent prompts are REJECTED**: a second `session/prompt` while the first streams fails with
+  `-32602 "Concurrent prompts are not supported yet, wait for agent loop to finish"`. There is **no
+  steer / mid-turn injection** — not a method, and a concurrent call hard-errors.
+
+## Decisions
+
+- **Queue + Interrupt, NOT steer.** A follow-up submitted during a turn is held in a client-side queue and
+  sent as a normal `session/prompt` after the turn's `stopReason` resolves; a Stop control interrupts the
+  turn via the `session/cancel` notification. Steer (inject-without-stopping) is **out** — protocol-blocked.
+  The error wording ("not supported *yet*") suggests vibe may add it; we leave the composer's send path a
+  natural seam to add a `steer` intent later, but ship nothing speculative.
+- **Interrupt first, then Queue** (build order). Slice 1 = the Stop button (`session/cancel`), atomic and
+  independently useful for runaway turns. Slice 2 = the follow-up queue on top. Steer, if ever, is a later
+  slice gated on a new protocol capability.
+- **Interrupt needs no new turn-resolution path.** Because the cancelled `session/prompt` *resolves*
+  (`stopReason:"cancelled"`), main's existing `runPromptTurn` returns `{ok:true, result}` and the renderer's
+  `turn-complete` already flips `isProcessing` off and tees a clean turn end. A cancel is therefore a thin
+  new *input* (an IPC that fires the notification), not a new *output* shape — no ErrorItem, no "cancelled"
+  notice for v1 (the turn simply ends where it stopped).
+- **The Stop notification is a new fire-and-forget IPC** (`cancelTurn {agentId, sessionId}`) → main resolves
+  the pool agent and calls `WorkspaceAgent.cancel(sessionId)` → `client.notify('session/cancel', {sessionId})`.
+  No-op when the sessionId is null (an unbound draft has no turn) or the agent isn't initialized. This keeps
+  the single-`acp:event`-channel discipline (ADR-0001) — cancel is an outbound control, not an event.
+- **The follow-up queue is renderer-only, per-Thread, ephemeral (slice 2).** It holds MULTIPLE pending
+  messages keyed by `threadId`, lives ABOVE the conversation view's per-Thread remount (so it survives a
+  Thread switch), and is NOT persisted across app restart (like CodexMonitor; drafts/composer state are
+  renderer-only, ADR-0006). It auto-flushes one message at a time as a fresh `session/prompt` when the
+  Thread's turn ends. Queued messages render as removable rows above the composer; edit-in-place is deferred.
+- **Compose stays enabled while streaming (slice 2).** Enter during a turn ENQUEUES (composer no longer
+  hard-disables mid-turn); the Stop button interrupts. This is the CodexMonitor posture minus steer. The
+  per-message override key (queue-vs-steer flip) is moot without steer, so it is not built.
+
+## Considered alternatives
+
+- **Steer (mid-turn injection), à la CodexMonitor `turn/steer`.** Rejected as impossible today: vibe-acp has
+  no steer method and rejects concurrent prompts (`-32602`, spike #102). Revisit if vibe adds a steer/inject
+  capability; the queue's flush seam is where it would attach.
+- **Interrupt-only, no queue (t3code posture: block the composer while running + a Stop button).** Rejected
+  as the end state — it's strictly less than what vibe supports (a client can safely serialize follow-ups).
+  But it IS effectively slice 1 in isolation, so we ship it first and add the queue second.
+- **Persist the queue across restart / in the metadata store.** Rejected for v1: follow-ups are transient
+  intent, not durable Thread state (ADR-0005 owns only durable Thread id/title/transcript); a queued message
+  that outlives a restart would surprise the user. Renderer-only ephemeral state matches drafts (#60).
+- **A "cancelled" notice/ErrorItem in the transcript.** Rejected for v1: the turn resolving `cancelled` is a
+  normal, user-initiated end; surfacing it as an error would be noise. The partial output already streamed
+  stays; the turn just stops. Revisit if users want an explicit "stopped here" marker.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'node:crypto'
 import { basename, join } from 'node:path'
 import {
   IPC,
+  type CancelTurnArgs,
   type DeleteThreadResult,
   type GitBranchesArgs,
   type GitBranchesResult,
@@ -742,6 +743,15 @@ function registerIpc(): void {
     // Clear the Thread's `needsAttention` (#53): the blocking permission is answered.
     emitThreadStatus(threadStatus.resolvePermission(args.agentId, args.requestId))
     agent?.respondPermission(args.requestId, args.optionId)
+  })
+
+  ipcMain.handle(IPC.cancelTurn, (_event, args: CancelTurnArgs) => {
+    // Interrupt the active turn (#103, ADR-0009): resolve the pool agent and fire
+    // the `session/cancel` notification. The cancelled `session/prompt` resolves
+    // via the normal turn-complete path — no new output shape here.
+    if (!args.sessionId) return // an unbound draft has no active turn to cancel
+    const agent = pool.get(args.agentId)
+    agent?.cancel(args.sessionId)
   })
 
   ipcMain.handle(IPC.setActiveAgent, (_event, agentId: string | null) => {

--- a/src/main/workspace-agent.test.ts
+++ b/src/main/workspace-agent.test.ts
@@ -848,6 +848,19 @@ describe('WorkspaceAgent.prompt()', () => {
     const reply = sent(fake).find((m) => m.id === 0 && m.result !== undefined)
     expect(reply?.result).toEqual({ content: 'file body' })
   })
+
+  it('cancel() writes a `session/cancel` NOTIFICATION (no id) with {sessionId} (#103)', async () => {
+    const fake = makeCapturingFake()
+    const agent = await connect(fake)
+
+    agent.cancel(SESSION_ID)
+
+    const cancel = sent(fake).find((m) => m.method === 'session/cancel')
+    expect(cancel).toBeDefined()
+    expect(cancel?.params?.sessionId).toBe(SESSION_ID)
+    // It's a NOTIFICATION (acp-capture §12) — no JSON-RPC id, no response expected.
+    expect(cancel?.id).toBeUndefined()
+  })
 })
 
 // --- TB6: best-effort session close (#35) -----------------------------------

--- a/src/main/workspace-agent.ts
+++ b/src/main/workspace-agent.ts
@@ -645,6 +645,17 @@ export class WorkspaceAgent extends EventEmitter {
   }
 
   /**
+   * Cancel the active turn on a Thread (#103, acp-capture §12). `session/cancel`
+   * is a NOTIFICATION — the in-flight `session/prompt` then resolves with
+   * `stopReason:"cancelled"` (handled by the normal turn-complete path). Fire-and-
+   * forget: no-op if the agent isn't initialized (nothing is streaming).
+   */
+  cancel(sessionId: string): void {
+    if (!this.initialized) return
+    this.client.notify('session/cancel', { sessionId })
+  }
+
+  /**
    * Forward every server-initiated request for transparency, and serve the
    * file-I/O requests Vibe delegates to us so turns don't stall: `fs/read` for
    * reads and `fs/write` for approved writes (docs/acp-capture.md §5, §7).

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3,6 +3,7 @@ import {
   IPC,
   type AcpEvent,
   type AgentEvictedEvent,
+  type CancelTurnArgs,
   type DeleteThreadResult,
   type GitBranchesArgs,
   type GitBranchesResult,
@@ -50,6 +51,7 @@ const api = {
     ipcRenderer.invoke(IPC.sendPrompt, args),
   respondPermission: (args: RespondPermissionArgs): Promise<void> =>
     ipcRenderer.invoke(IPC.respondPermission, args),
+  cancelTurn: (args: CancelTurnArgs): Promise<void> => ipcRenderer.invoke(IPC.cancelTurn, args),
   signIn: (args: SignInArgs): Promise<SignInResult> => ipcRenderer.invoke(IPC.signIn, args),
   signOut: (args: SignOutArgs): Promise<SignOutResult> => ipcRenderer.invoke(IPC.signOut, args),
   checkAuthStatus: (args: CheckAuthStatusArgs): Promise<CheckAuthStatusResult> =>

--- a/src/renderer/src/conversation/Conversation.tsx
+++ b/src/renderer/src/conversation/Conversation.tsx
@@ -589,6 +589,21 @@ export function Conversation({
           >
             📎
           </button>
+          {state.isProcessing && boundSessionId && (
+            // Interrupt the active turn (#103, ADR-0009): fire `session/cancel`. The
+            // turn then resolves `cancelled`, which the existing turn-complete path
+            // flips `isProcessing` off on — no new local state needed here. Gated on
+            // `boundSessionId` so it only shows once there's a turn it can cancel (a
+            // draft's first prompt is pre-bind for its session/new round-trip).
+            <button
+              className="btn btn--stop"
+              onClick={() =>
+                void window.api.cancelTurn({ agentId: thread.agentId, sessionId: boundSessionId })
+              }
+            >
+              ⏹ Stop
+            </button>
+          )}
           <button
             className="btn"
             onClick={() => void send()}

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -867,6 +867,13 @@ body {
   border: 1px solid var(--border);
 }
 
+/* Interrupt (#103): an outline action distinct from the primary Send. */
+.btn--stop {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+
 .recover {
   align-self: flex-start;
   background: transparent;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -18,6 +18,13 @@ export const IPC = {
   sendPrompt: 'thread:prompt',
   /** Answer a `session/request_permission` by its JSON-RPC request id. */
   respondPermission: 'permission:respond',
+  /**
+   * Interrupt a Thread's active turn (#103, ADR-0009) — fire the `session/cancel`
+   * NOTIFICATION (acp-capture §12). The in-flight `session/prompt` then RESOLVES
+   * with `stopReason:"cancelled"`, so the existing turn-complete path flips
+   * `isProcessing` off; cancel is a thin outbound control, NOT a new event/output.
+   */
+  cancelTurn: 'thread:cancel',
   /** Drive Vibe's browser sign-in on a not-signed-in agent (`authenticate`). */
   signIn: 'auth:sign-in',
   /** Sign out the agent's session (`_auth/signOut`). */
@@ -435,6 +442,18 @@ export type SendPromptResult =
  * through just as a turn began; the renderer leaves the row in place.
  */
 export type DeleteThreadResult = { ok: true } | { ok: false; reason: 'streaming' }
+
+/**
+ * Interrupt a Thread's active turn (#103, ADR-0009). Fired by the Stop button,
+ * routed to `WorkspaceAgent.cancel` -> `session/cancel` notification. A no-op when
+ * `sessionId` is null (an unbound draft has no active turn to cancel).
+ */
+export interface CancelTurnArgs {
+  /** agent hosting the Thread. */
+  agentId: string
+  /** the Thread's bound ACP session, or null if not yet bound. */
+  sessionId: string | null
+}
 
 /** Reply to an agent `session/request_permission` with the user's choice. */
 export interface RespondPermissionArgs {


### PR DESCRIPTION
Closes #103. First slice of **queue-vs-steer follow-ups**, reshaped to **queue + interrupt** by the #102 spike (steer is protocol-blocked). Includes **ADR-0009**. **Depends on #102** (cites `acp-capture.md` §12 — merge #102 first).

## What it does
A **⏹ Stop** button, shown while a Thread's turn streams, that interrupts it.

## Why it's small (the spike paid off)
`session/cancel` is a **notification** `{sessionId}`; the in-flight `session/prompt` then **resolves** `stopReason:"cancelled"`. So a cancel is a thin new *input* — it rides main's existing `{ok:true}` + renderer `turn-complete` path (which already flips `isProcessing` off and tees a clean turn end). No new output shape, no ErrorItem, no `stopReason` branching anywhere.

## Layers
- ipc: `cancelTurn` channel + `CancelTurnArgs {agentId, sessionId}`.
- main: `WorkspaceAgent.cancel(sessionId)` → `client.notify('session/cancel', …)` (no-op pre-init); thin handler mirrors `respondPermission`, resolves the pool agent, no-ops on null sessionId.
- renderer: `⏹ Stop` while `isProcessing && boundSessionId` (gated so it never shows inert during a draft's pre-bind first prompt — review finding folded); distinct `.btn--stop` outline style. Existing "recover" hatch untouched.

## Verification
- Independent re-run of all four gates: lint/typecheck/build clean, **480 tests** (479 + 1 new). New test asserts `cancel` writes a `session/cancel` **notification** (`id` undefined), params `{sessionId}`.
- Read the full diff; adversarial review found **no correctness bugs**. Folded its one actionable finding (Stop inert pre-bind → gated on `boundSessionId`). Documented follow-ups (not blocking): reconcile the overlapping "recover" vs Stop affordances; verify cancel-while-blocked-on-permission (has a working `recover` fallback); optional disable-after-click.

## Design (ADR-0009)
Queue + Interrupt; **steer dropped** (vibe rejects concurrent prompts, `-32602`; no steer method — revisit if vibe adds one). Slice 2 = the follow-up queue (compose-while-streaming, queued rows, auto-flush).

🤖 Generated with [Claude Code](https://claude.com/claude-code)