### PR TITLE
#105: follow-up queue — compose-while-streaming + auto-flush (queue-vs-steer slice 2)

### DIFF
--- a/src/renderer/src/conversation/Conversation.tsx
+++ b/src/renderer/src/conversation/Conversation.tsx
@@ -43,6 +43,7 @@ import {
   moveSelection,
 } from './command-autocomplete'
 import { ACCEPTED_IMAGE_TYPES, isAcceptedImageType, parseDataUrl } from './image-attach'
+import { isSending, nextQueueId, useFollowUpQueue } from './follow-up-queue'
 
 /** Process-local counter for unique echoed-prompt ids. */
 let promptSeq = 0
@@ -170,6 +171,11 @@ export function Conversation({
   // clobbering events that streamed in before the JSONL read resolved.
   const liveSeen = useRef(false)
 
+  // The follow-up queue for THIS Thread (#105, ADR-0009): submitting while a turn
+  // streams enqueues here (the queue lives in a module store ABOVE this remount, so
+  // it survives a Thread switch), and every turn-end auto-flushes one message.
+  const followUps = useFollowUpQueue(thread.threadId)
+
   // Hydrate this Thread's saved history from JSONL once (TB5): switching INTO a
   // previously-used Thread shows its conversation before live events resume. A
   // draft (or a fresh Thread) has none, so this is a no-op there.
@@ -272,32 +278,37 @@ export function Conversation({
     setPendingImages((prev) => prev.filter((img) => img.id !== id))
   }
 
-  async function send(): Promise<void> {
-    const text = draft.trim()
-    // Allow a send with images and no text; still block while a turn is streaming.
-    if ((!text && pendingImages.length === 0) || state.isProcessing) return
+  // The actual send of ONE message as a fresh `session/prompt` (#105). Owns the
+  // whole turn lifecycle — echo dispatch, IPC, result handling, and (in `finally`)
+  // `turn-complete` THEN a drain of the next queued message. It NEVER touches
+  // composer state (draft/pendingImages) — clearing is the caller's job — so it can
+  // send a queued message that has no relation to the current composer contents.
+  // The module-level `sending` latch (via `followUps.beginSend`/`endSend`) is held for
+  // the whole call so NO second turn can start for this Thread — across component
+  // instances — while this one is open (a concurrent `session/prompt` would -32602).
+  async function submitPrompt(
+    text: string,
+    images: Array<{ data: string; mimeType: string; previewUrl: string }>,
+  ): Promise<boolean> {
+    followUps.beginSend()
     dispatch({
       type: 'send-prompt',
       id: `user:${promptSeq++}`,
       text,
-      images: pendingImages.map(({ previewUrl }) => ({ previewUrl })),
+      images: images.map(({ previewUrl }) => ({ previewUrl })),
     })
+    let ok = false
     try {
       const result = await window.api.sendPrompt({
         agentId: thread.agentId,
         threadId: thread.threadId,
         workspaceId: thread.workspaceId,
-        sessionId: boundSessionId,
+        sessionId: boundRef.current,
         text,
-        images: pendingImages.map(({ data, mimeType }) => ({ data, mimeType })),
+        images: images.map(({ data, mimeType }) => ({ data, mimeType })),
       })
       if (result.ok) {
-        // The turn was accepted: drop the staged images AND clear the text/draft.
-        // On ANY failure below we KEEP both so the user can retry (e.g. switch to a
-        // vision model) without re-typing or re-attaching (#100).
-        setPendingImages([])
-        setDraft('')
-        clearDraft(window.localStorage, thread.threadId)
+        ok = true
         // Reuse the now-bound session on the next prompt (no second session/new),
         // and lift it so a switch-away-and-back doesn't re-mint. `thread:bound`
         // already set this for a fresh draft; this also covers the no-store path.
@@ -320,10 +331,78 @@ export function Conversation({
         dispatch({ type: 'turn-error', message })
       }
     } finally {
-      // The turn's stopReason resolves sendPrompt; flip back to the user's turn.
+      // The turn's stopReason resolves sendPrompt; flip back to the user's turn and
+      // release the module `sending` latch. Releasing it NOTIFIES, which re-fires the
+      // flush effect below on the CURRENTLY-mounted instance — so it drains the next
+      // queued follow-up (even if THIS instance has since unmounted). We do NOT drain
+      // here directly: a dead instance must not send (its echo would go to a dead
+      // reducer). Flush happens on EVERY turn end — natural OR cancelled (ADR-0009).
       dispatch({ type: 'turn-complete' })
+      followUps.endSend()
+    }
+    return ok
+  }
+
+  // Drain exactly ONE queued follow-up as a fresh turn. Gated on the LIVE module latch
+  // `isSending(threadId)` (not a per-instance ref / the lagging reducer snapshot), so it
+  // NEVER starts a turn while one is already open for this Thread — the strict-
+  // serialization guarantee (vibe-acp -32602) that holds ACROSS the remount, and the
+  // strict-mode double-invoke guard (`beginSend` sets the latch synchronously, so a
+  // second call bails).
+  function flushNext(): void {
+    if (isSending(thread.threadId)) return
+    const head = followUps.dequeueHead()
+    if (head) void submitPrompt(head.text, head.images)
+  }
+
+  // Composer submit (Enter or the Send/Queue button). When a turn is streaming we
+  // ENQUEUE the composer payload and clear the composer (it flushes on the next turn
+  // end); when idle we send immediately, preserving #100's clear-on-success /
+  // keep-on-failure UX (a failed send keeps the text + staged images for retry).
+  async function send(): Promise<void> {
+    const text = draft.trim()
+    const hasContent = text.length > 0 || pendingImages.length > 0
+    if (!hasContent) return
+    const images = pendingImages.map(({ data, mimeType, previewUrl }) => ({
+      data,
+      mimeType,
+      previewUrl,
+    }))
+    if (followUps.sending) {
+      // A turn is live for this Thread (authoritative module latch, not the per-
+      // instance reducer snapshot which lags on a remount) — queue it (protocol forbids
+      // a concurrent prompt) and clear the composer so the user can compose the next
+      // follow-up. It auto-flushes on the next turn end.
+      followUps.enqueue({ id: nextQueueId(), text, images })
+      setDraft('')
+      clearDraft(window.localStorage, thread.threadId)
+      setPendingImages([])
+      return
+    }
+    // Idle: send now. `submitPrompt` echoes text/images by value up front, so we can
+    // clear the composer AFTER, but only on a successful outcome — preserving #100's
+    // clear-on-success / keep-on-failure (a failed send keeps text + staged images
+    // for retry, e.g. switching to a vision model).
+    const ok = await submitPrompt(text, images)
+    if (ok) {
+      setPendingImages([])
+      setDraft('')
+      clearDraft(window.localStorage, thread.threadId)
     }
   }
+
+  // The SOLE auto-flush trigger (#105): re-run whenever this Thread's `sending` latch
+  // or queue changes. `flushNext` self-gates on the live `isSending` latch, so it fires
+  // exactly when a turn ends (latch clears) or the queue gains its first item while idle,
+  // and bails while a turn is open. Because effects run ONLY on the mounted instance, a
+  // turn started by a since-unmounted instance is drained here by the currently-mounted
+  // one (correct reducer/echo) — and a remount with a pre-existing queue flushes on its
+  // first run. This replaces the per-instance ref + one-shot mount effect that couldn't
+  // serialize across the remount (the -32602 hazard).
+  useEffect(() => {
+    flushNext()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [followUps.sending, followUps.queued])
 
   // Answer a pending permission request: relay the choice to the agent and mark
   // the prompt resolved so it stops asking (state stays renderer-owned).
@@ -505,6 +584,32 @@ export function Conversation({
           onSetConfig={(axis, value) => onSetConfig?.(axis, value, boundSessionId)}
         />
 
+        {followUps.queued.length > 0 && (
+          // Queued follow-ups (#105, ADR-0009): messages submitted while a turn
+          // streams, auto-flushed one per turn end. Each row shows its text (or a
+          // `📎 N image(s)` label when text-empty; a `📎 N` marker when it has both)
+          // and a ✕ to drop it. Edit-in-place is deferred.
+          <div className="composer-queue">
+            {followUps.queued.map((m) => (
+              <div key={m.id} className="queued">
+                <span className="queued__text">
+                  {m.text ? m.text : `📎 ${m.images.length} image${m.images.length === 1 ? '' : 's'}`}
+                  {m.text && m.images.length > 0 && (
+                    <span className="queued__marker"> 📎 {m.images.length}</span>
+                  )}
+                </span>
+                <button
+                  className="queued__remove"
+                  aria-label="Remove queued message"
+                  onClick={() => followUps.remove(m.id)}
+                >
+                  ✕
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+
         {pendingImages.length > 0 && (
           // Staged-image strip (#100): thumbnails with a ✕ remove, above the composer.
           <div className="composer-attachments">
@@ -585,7 +690,6 @@ export function Conversation({
             aria-label="Attach images"
             title="Attach images"
             onClick={() => fileInputRef.current?.click()}
-            disabled={state.isProcessing}
           >
             📎
           </button>
@@ -607,9 +711,9 @@ export function Conversation({
           <button
             className="btn"
             onClick={() => void send()}
-            disabled={state.isProcessing || (draft.trim().length === 0 && pendingImages.length === 0)}
+            disabled={draft.trim().length === 0 && pendingImages.length === 0}
           >
-            {state.isProcessing ? 'Sending…' : 'Send'}
+            {followUps.sending ? 'Queue' : 'Send'}
           </button>
         </div>
       </div>

--- a/src/renderer/src/conversation/follow-up-queue.test.ts
+++ b/src/renderer/src/conversation/follow-up-queue.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  _resetQueueStore,
+  beginSend,
+  dequeueHead,
+  dequeueThreadHead,
+  endSend,
+  enqueue,
+  enqueueMessage,
+  getThreadQueue,
+  isSending,
+  nextQueueId,
+  peekHead,
+  removeById,
+  removeQueued,
+  subscribe,
+  type QueueMap,
+  type QueuedMessage,
+} from './follow-up-queue'
+
+/**
+ * Follow-up queue (#105): the load-bearing core is the PURE immutable ops over a
+ * `Record<threadId, QueuedMessage[]>` — append, dequeue-head-with-prune, remove,
+ * peek, multi-thread isolation, no input mutation — plus the module store's
+ * stable-reference snapshot contract that keeps `useSyncExternalStore` from looping.
+ */
+
+function msg(id: string, text = id): QueuedMessage {
+  return { id, text, images: [] }
+}
+
+describe('pure ops', () => {
+  it('enqueue appends without mutating the input map or array', () => {
+    const a = msg('a')
+    const b = msg('b')
+    const m0: QueueMap = {}
+    const m1 = enqueue(m0, 't1', a)
+    const m2 = enqueue(m1, 't1', b)
+    expect(m0).toEqual({})
+    expect(m1['t1']).toEqual([a])
+    expect(m1['t1']).not.toBe(m2['t1'])
+    expect(m2['t1']).toEqual([a, b])
+  })
+
+  it('dequeueHead returns + removes the head, keeping the tail', () => {
+    const m = enqueue(enqueue({}, 't1', msg('a')), 't1', msg('b'))
+    const { map, head } = dequeueHead(m, 't1')
+    expect(head).toEqual(msg('a'))
+    expect(map['t1']).toEqual([msg('b')])
+    // input untouched
+    expect(m['t1']).toHaveLength(2)
+  })
+
+  it('dequeueHead prunes the per-thread key when the queue empties', () => {
+    const m = enqueue({}, 't1', msg('only'))
+    const { map, head } = dequeueHead(m, 't1')
+    expect(head).toEqual(msg('only'))
+    expect('t1' in map).toBe(false)
+  })
+
+  it('dequeueHead on an empty thread returns the same map + null head', () => {
+    const m: QueueMap = {}
+    const { map, head } = dequeueHead(m, 'missing')
+    expect(head).toBeNull()
+    expect(map).toBe(m)
+  })
+
+  it('removeById drops the matching message and prunes when emptied', () => {
+    const m = enqueue(enqueue({}, 't1', msg('a')), 't1', msg('b'))
+    const afterB = removeById(m, 't1', 'b')
+    expect(afterB['t1']).toEqual([msg('a')])
+    const afterA = removeById(afterB, 't1', 'a')
+    expect('t1' in afterA).toBe(false)
+  })
+
+  it('removeById is a no-op (same reference) when the id is absent', () => {
+    const m = enqueue({}, 't1', msg('a'))
+    expect(removeById(m, 't1', 'nope')).toBe(m)
+    expect(removeById(m, 'other', 'a')).toBe(m)
+  })
+
+  it('peekHead returns the head or null without removing it', () => {
+    expect(peekHead({}, 't1')).toBeNull()
+    const m = enqueue(enqueue({}, 't1', msg('a')), 't1', msg('b'))
+    expect(peekHead(m, 't1')).toEqual(msg('a'))
+    expect(m['t1']).toHaveLength(2)
+  })
+
+  it('keeps threads isolated', () => {
+    const m = enqueue(enqueue({}, 't1', msg('a')), 't2', msg('x'))
+    const { map } = dequeueHead(m, 't1')
+    expect('t1' in map).toBe(false)
+    expect(map['t2']).toEqual([msg('x')])
+  })
+})
+
+describe('store', () => {
+  afterEach(() => _resetQueueStore())
+
+  it('nextQueueId mints unique incrementing ids', () => {
+    expect(nextQueueId()).not.toBe(nextQueueId())
+  })
+
+  it('enqueueMessage makes getThreadQueue reflect the append + notifies', () => {
+    let notified = 0
+    const unsub = subscribe(() => notified++)
+    enqueueMessage('t1', msg('a'))
+    expect(getThreadQueue('t1')).toEqual([msg('a')])
+    expect(notified).toBe(1)
+    unsub()
+  })
+
+  it('getThreadQueue keeps a STABLE reference until that thread changes', () => {
+    const empty1 = getThreadQueue('t1')
+    // Same shared empty across calls and across an UNRELATED thread's change.
+    expect(getThreadQueue('t1')).toBe(empty1)
+    enqueueMessage('t2', msg('x'))
+    expect(getThreadQueue('t1')).toBe(empty1)
+    const snap = getThreadQueue('t2')
+    expect(getThreadQueue('t2')).toBe(snap)
+    // A change to t2 mints a new reference for t2 only.
+    enqueueMessage('t2', msg('y'))
+    expect(getThreadQueue('t2')).not.toBe(snap)
+  })
+
+  it('dequeueThreadHead removes the head and notifies; empty is a silent null', () => {
+    let notified = 0
+    const unsub = subscribe(() => notified++)
+    enqueueMessage('t1', msg('a'))
+    enqueueMessage('t1', msg('b'))
+    notified = 0
+    expect(dequeueThreadHead('t1')).toEqual(msg('a'))
+    expect(getThreadQueue('t1')).toEqual([msg('b')])
+    expect(notified).toBe(1)
+    // Drain the rest, then an empty dequeue must NOT notify.
+    dequeueThreadHead('t1')
+    notified = 0
+    expect(dequeueThreadHead('t1')).toBeNull()
+    expect(notified).toBe(0)
+    unsub()
+  })
+
+  it('removeQueued drops a message + notifies; absent is silent', () => {
+    let notified = 0
+    const unsub = subscribe(() => notified++)
+    enqueueMessage('t1', msg('a'))
+    notified = 0
+    removeQueued('t1', 'a')
+    expect(getThreadQueue('t1')).toEqual([])
+    expect(notified).toBe(1)
+    removeQueued('t1', 'gone')
+    expect(notified).toBe(1)
+    unsub()
+  })
+
+  it('sending latch is per-Thread, idempotent, and notifies on real transitions', () => {
+    let notified = 0
+    const unsub = subscribe(() => notified++)
+    expect(isSending('t1')).toBe(false)
+    beginSend('t1')
+    expect(isSending('t1')).toBe(true)
+    expect(isSending('t2')).toBe(false) // isolated per Thread
+    expect(notified).toBe(1)
+    beginSend('t1') // already set — no-op, no notify
+    expect(notified).toBe(1)
+    endSend('t1')
+    expect(isSending('t1')).toBe(false)
+    expect(notified).toBe(2)
+    endSend('t1') // already clear — no-op, no notify
+    expect(notified).toBe(2)
+    unsub()
+  })
+
+  it('_resetQueueStore clears the sending latch too', () => {
+    beginSend('t1')
+    expect(isSending('t1')).toBe(true)
+    _resetQueueStore()
+    expect(isSending('t1')).toBe(false)
+  })
+})

--- a/src/renderer/src/conversation/follow-up-queue.ts
+++ b/src/renderer/src/conversation/follow-up-queue.ts
@@ -1,0 +1,223 @@
+/**
+ * Follow-up queue (#105, ADR-0009): when the user submits a message WHILE a
+ * Thread's turn is streaming, we can't send it (vibe-acp rejects a concurrent
+ * `session/prompt` with -32602, acp-capture §12), so we QUEUE it renderer-side and
+ * auto-flush one message per turn-end. The queue is per-Thread, multi-message, and
+ * EPHEMERAL — renderer-only, never persisted (ADR-0009 keeps follow-ups transient
+ * intent, unlike the durable transcript). It must SURVIVE the `Conversation`
+ * remount (that view is keyed by `threadId`), so it lives in a MODULE-LEVEL store
+ * above the component, addressed by `threadId`.
+ *
+ * Split like the app's other load-bearing renderer logic: PURE immutable ops over
+ * a `Record<threadId, QueuedMessage[]>` (unit-tested here), plus a thin module
+ * singleton wiring them to a `useSyncExternalStore` subscription. The subscription
+ * demands a STABLE snapshot reference — `getThreadQueue` returns the same array
+ * identity until THAT thread's queue changes (and a shared frozen empty otherwise),
+ * so React never loops.
+ */
+import { useCallback, useSyncExternalStore } from 'react'
+
+/** A staged image carried on a queued message (mirrors the composer's PendingImage,
+ *  minus the `name`/`id` the composer strip needs). `data` is bare base64 for send;
+ *  `previewUrl` is the full data URL for the echoed user turn / any row thumbnail. */
+export interface QueuedImage {
+  data: string
+  mimeType: string
+  previewUrl: string
+}
+
+/** One queued follow-up: the composer's text + any staged images, plus a stable id
+ *  so a row can be removed by identity (not index). */
+export interface QueuedMessage {
+  id: string
+  text: string
+  images: QueuedImage[]
+}
+
+/** The per-Thread queue map: threadId -> ordered pending messages (head = next). */
+export type QueueMap = Record<string, QueuedMessage[]>
+
+/** Shared frozen empty array so an absent thread's snapshot has a STABLE identity
+ *  (a fresh `[]` per call would loop `useSyncExternalStore`). */
+const EMPTY: readonly QueuedMessage[] = Object.freeze([])
+
+// --- Pure immutable ops (never mutate inputs; prune empty per-thread arrays) ---
+
+/** Append `msg` to a Thread's queue, returning a NEW map (inputs untouched). */
+export function enqueue(map: QueueMap, threadId: string, msg: QueuedMessage): QueueMap {
+  const current = map[threadId] ?? []
+  return { ...map, [threadId]: [...current, msg] }
+}
+
+/**
+ * Remove + return a Thread's HEAD. When the queue empties, the per-thread key is
+ * PRUNED (no `[]` litter left behind for a switched-away Thread). Returns the same
+ * map + `head: null` when the Thread has nothing queued.
+ */
+export function dequeueHead(
+  map: QueueMap,
+  threadId: string,
+): { map: QueueMap; head: QueuedMessage | null } {
+  const current = map[threadId]
+  if (!current || current.length === 0) return { map, head: null }
+  const [head, ...rest] = current
+  const next: QueueMap = { ...map }
+  if (rest.length === 0) delete next[threadId]
+  else next[threadId] = rest
+  return { map: next, head }
+}
+
+/** Drop the message with `id` from a Thread's queue, pruning the key if emptied. */
+export function removeById(map: QueueMap, threadId: string, id: string): QueueMap {
+  const current = map[threadId]
+  if (!current) return map
+  const rest = current.filter((m) => m.id !== id)
+  if (rest.length === current.length) return map
+  const next: QueueMap = { ...map }
+  if (rest.length === 0) delete next[threadId]
+  else next[threadId] = rest
+  return next
+}
+
+/** The Thread's next message without removing it, or null when empty. */
+export function peekHead(map: QueueMap, threadId: string): QueuedMessage | null {
+  const current = map[threadId]
+  return current && current.length > 0 ? current[0] : null
+}
+
+// --- The module singleton store (state + listeners) ---
+
+let queues: QueueMap = {}
+const listeners = new Set<() => void>()
+
+function notify(): void {
+  for (const listener of listeners) listener()
+}
+
+/** Module-local incrementing id source (NOT Math.random/Date) — unique per queued
+ *  message so a row's ✕ removes exactly it. */
+let queueSeq = 0
+
+/** Mint the next stable queue-message id. */
+export function nextQueueId(): string {
+  return `queued:${queueSeq++}`
+}
+
+/** Subscribe to any queue change; returns an unsubscribe. */
+export function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+/**
+ * A Thread's queue as a STABLE reference: the SAME array identity until that
+ * thread's queue changes (the pure ops only replace the mutated thread's array),
+ * and a shared frozen empty otherwise. Safe as a `useSyncExternalStore` snapshot.
+ */
+export function getThreadQueue(threadId: string): QueuedMessage[] {
+  return queues[threadId] ?? (EMPTY as QueuedMessage[])
+}
+
+/** Append a message to a Thread's queue and notify. */
+export function enqueueMessage(threadId: string, msg: QueuedMessage): void {
+  queues = enqueue(queues, threadId, msg)
+  notify()
+}
+
+/** Remove + return a Thread's head, notifying when something was dequeued. */
+export function dequeueThreadHead(threadId: string): QueuedMessage | null {
+  const { map, head } = dequeueHead(queues, threadId)
+  if (head) {
+    queues = map
+    notify()
+  }
+  return head
+}
+
+/** Remove a queued message by id and notify (no-op + no notify when absent). */
+export function removeQueued(threadId: string, id: string): void {
+  const next = removeById(queues, threadId, id)
+  if (next !== queues) {
+    queues = next
+    notify()
+  }
+}
+
+// --- per-Thread in-flight latch (serialization ACROSS component instances) ---
+//
+// The queue + a Thread's turn lifecycle both outlive the `Conversation` remount, but
+// a `useRef` latch is per-instance — so a remounted instance (or a dead instance's
+// `finally`) could start a second `session/prompt` while the first is still open on the
+// agent (→ -32602, and a lost follow-up). This module-level set is the SINGLE authority
+// for "Thread X has a prompt in flight": set synchronously by whoever starts a turn,
+// checked by every flush. It notifies so the mounted composer re-renders (button label)
+// and its flush effect re-fires when a turn ends — including one driven by a now-unmounted
+// instance, so the CURRENTLY-mounted instance drains the next message (correct echo).
+const sending = new Set<string>()
+
+/** Whether a `session/prompt` is currently in flight for `threadId` (live, synchronous). */
+export function isSending(threadId: string): boolean {
+  return sending.has(threadId)
+}
+
+/** Mark a Thread's turn as started (before the IPC) — notifies subscribers. */
+export function beginSend(threadId: string): void {
+  if (!sending.has(threadId)) {
+    sending.add(threadId)
+    notify()
+  }
+}
+
+/** Mark a Thread's turn as ended (in the send's `finally`) — notifies subscribers. */
+export function endSend(threadId: string): void {
+  if (sending.delete(threadId)) notify()
+}
+
+/** Test-only reset so the module singleton doesn't leak state across tests. */
+export function _resetQueueStore(): void {
+  queues = {}
+  listeners.clear()
+  sending.clear()
+  queueSeq = 0
+}
+
+/** The handle a Thread's composer holds. */
+export interface FollowUpQueue {
+  queued: QueuedMessage[]
+  /** Reactive: a `session/prompt` is in flight for this Thread (across instances). */
+  sending: boolean
+  enqueue: (msg: QueuedMessage) => void
+  dequeueHead: () => QueuedMessage | null
+  remove: (id: string) => void
+  beginSend: () => void
+  endSend: () => void
+}
+
+/**
+ * Bind the module store to one Thread for the composer: a live, stable-reference
+ * `queued` snapshot via `useSyncExternalStore`, plus mutators pre-bound to
+ * `threadId`. The snapshot's identity is stable across unrelated notifications
+ * (getThreadQueue returns the same array until THIS thread changes), so the
+ * subscription doesn't loop.
+ */
+export function useFollowUpQueue(threadId: string): FollowUpQueue {
+  const queued = useSyncExternalStore(subscribe, () => getThreadQueue(threadId))
+  // A separate primitive snapshot — booleans are inherently stable, so no loop.
+  const sendingNow = useSyncExternalStore(subscribe, () => isSending(threadId))
+  const enqueue = useCallback((msg: QueuedMessage) => enqueueMessage(threadId, msg), [threadId])
+  const dequeueHeadBound = useCallback(() => dequeueThreadHead(threadId), [threadId])
+  const remove = useCallback((id: string) => removeQueued(threadId, id), [threadId])
+  const beginSendBound = useCallback(() => beginSend(threadId), [threadId])
+  const endSendBound = useCallback(() => endSend(threadId), [threadId])
+  return {
+    queued,
+    sending: sendingNow,
+    enqueue,
+    dequeueHead: dequeueHeadBound,
+    remove,
+    beginSend: beginSendBound,
+    endSend: endSendBound,
+  }
+}

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -988,6 +988,52 @@ body {
   cursor: pointer;
 }
 
+/* --- Follow-up queue rows (#105) --- */
+
+.composer-queue {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.queued {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--panel);
+}
+
+.queued__text {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  color: var(--text);
+}
+
+.queued__marker {
+  color: var(--muted);
+}
+
+.queued__remove {
+  flex: none;
+  padding: 0;
+  width: 18px;
+  height: 18px;
+  line-height: 1;
+  font-size: 11px;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: var(--panel);
+  color: var(--text);
+  cursor: pointer;
+}
+
 .composer__attach {
   align-self: flex-end;
 }


### PR DESCRIPTION
Closes #105. Second and final slice of **queue-vs-steer follow-ups** (ADR-0009) — completes the queue+interrupt epic. Steer stays dropped (protocol-blocked, #102/§12).

## What it does
Submitting a message while a Thread's turn streams **queues** it (text + staged images) instead of hitting the concurrent-prompt error; each turn end **auto-flushes** one as a fresh `session/prompt`. Compose stays enabled while streaming; the Send button becomes **Queue**; queued rows appear above the composer with ✕ remove.

## The load-bearing correctness concern: strict serialization
vibe-acp rejects a concurrent `session/prompt` with `-32602` (§12) — the queue exists to serialize. `Conversation` is `key={threadId}` so it **remounts on Thread switch**, and the queue + turn lifecycle span that remount. 

**An initial per-instance `useRef` latch was NOT enough** — adversarial review found it let a remounted instance flush into a still-running background turn → `-32602` + a lost follow-up (the exact invariant this slice protects). **Fixed**: serialization is lifted to a **module-level per-Thread `sending` latch** (reactive, synchronous), and the sole flush is an effect gated on the **live** latch. A follow-up verification pass confirmed (all CONFIRMED): no concurrent prompt across a remount, no dead-instance send, no infinite loop, strict-mode-safe, no stall.

## Layers
- Pure `follow-up-queue.ts` (+ 15 tests): immutable per-Thread queue ops + a `useSyncExternalStore` module store (survives remount; stable snapshots) + the `sending` latch.
- `Conversation.tsx`: `submitPrompt`/`send`/`flushNext` + the flush effect; enqueue-vs-send on the authoritative latch; queued-row UI; Send→Queue label; 📎 enabled mid-turn.

## Verification
- Independent re-run of all four gates: lint/typecheck/build clean, **495 tests** (480 + 15 new).
- Read the full diff; adversarial review + a dedicated fix-verification pass (the serialization was reworked after review). #100 (clear-on-success/keep-on-failure), #103 (Stop; a cancelled turn still flushes next), #95 (`/`-autocomplete Enter) all confirmed intact.

## Deferred
Edit-in-place, restart persistence, re-queue-on-flush-failure, per-message steer override (no steer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)