### PR TITLE
docs: ADR-0010 — design-system epic (tokens, primitives, conversation, migration)

### DIFF
--- a/docs/adr/0010-design-system-tokens-primitives-migration.md
+++ b/docs/adr/0010-design-system-tokens-primitives-migration.md
@@ -1,0 +1,94 @@
+# The design-system epic: adopt the final-design tokens on our CSS-vars→`@theme` hybrid, build base-ui + CVA primitives, keep the conversation's discriminated-union model, and migrate the UI area-by-area (behavior-identical)
+
+vibe-mistro grew its UI slice-by-slice on the #61 stack (Tailwind v4 + `@base-ui/react` + lucide),
+accumulating ~1230 lines of BEM-ish classes in `styles.css` and a deliberately sharp (`--radius: 0`)
+look. Before the app grows further, we run a **design-system epic**: lock a token layer + a shared
+primitive library, and migrate the existing UI onto them to match the user's **final-design prototype**
+(`Vibe Mistro.html`) and mockups — pixel-perfect, area by area. This ADR records the load-bearing calls;
+`docs/design-tokens.md` holds the exact token values.
+
+References mined (all local): the design **prototype** `/Users/abdullahatrash/mistral/Vibe Mistro.html`
+(exact tokens) + the PNG mockups; **t3code** `/Users/abdullahatrash/mistral/t3code` (rich chat aesthetic,
+near-identical stack); **shadcn/ui** `/Users/abdullahatrash/mistral/ui` (`apps/v4/registry/bases/base/` —
+base-ui primitives + the message/scroller/bubble/marker primitives).
+
+## Decisions
+
+- **Scope boundary: design system + restyle-what-exists; net-new features are static placeholders.** This
+  epic ships the token/theme layer, the primitive library, the layout shells, and a pixel-perfect
+  restyle/rebuild of the areas we ALREADY have (shell/sidebar, conversation+composer, auth, git panel).
+  The mockups' net-new features — Search / Scheduled / Plugins, account+tier, the **terminal**, the
+  side-panel **view modes**, the multi-tool dock (Review / Terminal / Browser / Files), the git
+  "Environment / Sources" concepts — render as **static/placeholder chrome** so the look is complete, but
+  their functionality is deferred to their own later feature epics. This keeps every area a
+  behavior-identical migration.
+
+- **Token strategy: keep the CSS-vars → `@theme inline` hybrid; re-populate it with the prototype's exact
+  values.** The plumbing (CSS custom properties in `:root` as the single source of truth, bridged into
+  Tailwind v4 so both hand-written CSS and `bg-accent`/`text-muted` utilities resolve to the same vars) is
+  already correct — we change VALUES, not architecture. Adopt the prototype wholesale: the **warm neutral
+  ramp** (bg `#fbfaf8` · sidebar `#f5f3ef` · card `#fdfcfb` · white panel · warm borders), a **rounded
+  radius scale** (7 buttons · 9 rows · 10 nav · 12 pill · 20 card · full circle — reversing today's
+  `--radius: 0`), the **softer, gradient-forward orange** (`#cf6a3a` interactive text, `#e07a3e` heading
+  emphasis, + the logo/send/avatar gradients — NOT the old bright `#fa500f`), a **type scale**, and a
+  **spacing scale**. Exact values: `docs/design-tokens.md`. Rejected: pure-Tailwind-`@theme` (loses the
+  var indirection our hand-written CSS needs) and pure-CSS-vars (throws away utilities already in use).
+
+- **Styling convention: a primitive component library on base-ui + Tailwind + CVA; retire BEM
+  area-by-area.** Grow `src/renderer/src/ui/` (today just `menu.tsx`) into the library: headless behavior
+  from `@base-ui/react` (the `render`-prop / `useRender`+`mergeProps` slot pattern), styled with Tailwind
+  utilities resolved through our token vars, composed via `cn()` (clsx + tailwind-merge, already deps),
+  with variants declared in **CVA** (new dep). Consumers write `<Button variant="ghost">` / `<Chip>` /
+  `<Panel>` — never hand-rolled class strings. `styles.css` shrinks to tokens (`:root` + `@theme`), global
+  resets, the custom scrollbar, and the `vmCursorBlink` keyframe. **Copy-adapt, own it:** lift component
+  source from shadcn `bases/base/ui/` (swapping their `cn-*` theme-token indirection for our inline
+  Tailwind utility strings) and t3code's `ui/` — we vendor + restyle, never add shadcn as a dependency.
+  Rejected: keeping BEM-first (the growing-`styles.css` maintainability problem this epic exists to fix);
+  pure inline utilities with no primitives (class soup, no canonical component look, pixel drift).
+
+- **Conversation: keep the discriminated-union item model + switch dispatcher; build the inner pieces as
+  reusable primitives.** Both references converge on this — t3code uses a row-`kind` union + one
+  dispatcher; shadcn maps `message.parts` switching on `part.type` — and it matches our existing
+  `ConversationState.items` (`kind`) + `Item` switch (ADR-0001, renderer owns conversation state). So we do
+  NOT adopt a deep compound-component API; composability comes from the **primitive layer + the part
+  switch**. Build/restyle: **MessageScroller** (autoscroll — vendor shadcn's engine or `use-stick-to-bottom`,
+  replacing the naive `scrollTop=scrollHeight`), **Message/Bubble** (user = right bubble, assistant =
+  full-width flowing markdown — both refs + the mockup agree), **Response** (markdown — see next), **ToolRow**
+  (t3code's compact tone-icon + heading + dimmed preview + right status glyph + chevron→indented `<pre>`;
+  map its status to our ACP `pending/in_progress/completed/failed`), **Reasoning** (a `Collapsible`
+  "thinking" block, auto-open while streaming), **Approval** (our `PermissionRow` restyled — kept **inline**
+  in the conversation, NOT in the composer footer like t3code, matching our app + mockup), an **Actions**
+  bar (hover-reveal copy/👍/👎/retry with an anchored toast), **file-path chip links** (t3code's pattern:
+  path → icon chip + `L12:C3`, orange, clickable), and a **Working** indicator (pulsing dots + self-ticking
+  timer). We feed all of these OUR ACP reducer data, not any AI-SDK message shape.
+
+- **Markdown/Response layer: adopt `streamdown` + `@streamdown/code`, contingent on a compat spike.**
+  Replace the current `react-markdown` `ChatMarkdown` with streamdown — it is *streaming-native* (renders
+  incomplete markdown safely mid-stream) with shiki code highlighting + copy built in, purpose-built for a
+  streaming agent, and is what shadcn's Response uses (t3code hand-rolled the same thing and called it their
+  "most over-engineered piece"). **Gate:** a quick spike at the start of the conversation slice must confirm
+  streamdown themes to our tokens and works under Electron/Vite before we commit; the fallback is keeping
+  `react-markdown` and adding shiki ourselves. This is the only decision here with an open verification.
+
+- **Migration strategy: area-by-area, behavior-identical, in dependency order.** Not big-bang. Order:
+  (1) **Foundation** — tokens repopulated + scales, `cn()` (have it) + CVA, the base primitives;
+  (2) **Shell** — sidebar (nav / projects+threads / account chip), main layout, window chrome (new nav +
+  account as placeholders); (3) **Conversation** — the hard core, sub-sliced (Response/markdown →
+  tool/reasoning → approval/actions/file-links); (4) **Composer** — card (empty+active), mode/model/effort
+  controls, context chips, re-homing the existing attachments (#100), stop (#103), queue (#106) onto
+  primitives; (5) **Auth**; (6) **Git/"Review" panel**. Each area restyles AND retires its BEM classes, and
+  keeps its tests green (behavior unchanged — this is a restyle, not a rewrite of logic).
+
+## Considered alternatives
+
+- **Treat this as pure design-system consolidation (tokens + primitives) without restyling to the new
+  mockups.** Rejected: the user has final designs and wants the UI to match them now; consolidating without
+  moving the look would force re-migration later.
+- **Pure Tailwind `@theme` tokens / pure CSS-vars (drop the hybrid).** Rejected — see token decision.
+- **Deep compound components for the conversation (`<Message><Message.Content/>`, à la the classic AI
+  Elements).** Rejected: neither best-in-class reference does it, and it fights our reducer-item model
+  (ADR-0001). Reusable primitives + a part switch give the composability without the ceremony.
+- **Keep `react-markdown`/`ChatMarkdown`, add shiki ourselves.** Held as the streamdown fallback; rejected
+  as the default because it re-implements what streamdown packages for streaming.
+- **Build the deferred features (terminal, view modes, Search/Plugins) inside this epic.** Rejected: scope
+  explosion; they are their own feature epics. This epic only makes their chrome look right.

--- a/docs/design-tokens.md
+++ b/docs/design-tokens.md
@@ -1,0 +1,117 @@
+# Design tokens (from the final-design prototype)
+
+The exact token values the design-system epic (ADR-0010) builds the foundation slice from, extracted from
+`/Users/abdullahatrash/mistral/Vibe Mistro.html`. These populate `:root` (single source of truth) and are
+bridged into Tailwind v4 via `@theme inline`. **Warm neutrals · softer gradient-forward orange · rounded.**
+
+## Colors
+
+### Neutrals (warm off-white ramp)
+| Token | Value | Use |
+|---|---|---|
+| `--bg` | `#fbfaf8` | page background |
+| `--sidebar` | `#f5f3ef` | sidebar surface |
+| `--surface` | `#fdfcfb` | cards (composer) |
+| `--panel` | `#ffffff` | side panel / expanded view |
+| `--border` | `#ecdfd3` | warm card/composer border |
+| `--border-muted` | `#eae3da` / `#efe8e0` / `#eae5de` | panel/header/footer dividers |
+
+### Text
+| Token | Value | Use |
+|---|---|---|
+| `--text` | `#1c1c1c` | primary |
+| `--text-strong` | `#20201e` / `#26231f` | headings, account name |
+| `--text-body` | `#33302c` | nav labels, project names |
+| `--text-secondary` | `#524d47` | thread rows |
+| `--muted` | `#6b645d` / `#7a736b` | icon strokes, chip labels |
+| `--placeholder` | `#a89f95` | input placeholder |
+| `--faint` | `#a79f96` / `#b3aaa0` | section headers, timestamps |
+| `--on-accent` | `#ffffff` | text/icon on orange |
+
+### Accent (softer, gradient-forward — NOT the old `#fa500f`)
+| Token | Value | Use |
+|---|---|---|
+| `--accent-text` | `#cf6a3a` | interactive text/icons (e.g. "New chat") |
+| `--accent-emphasis` | `#e07a3e` | heading emphasis ("in chatjs?") |
+| `--accent-grad-logo` | `linear-gradient(#f6c445 0%, #ef8a3c 50%, #e2452a 100%)` | the "M" mark (vertical) |
+| `--accent-grad-action` | `linear-gradient(160deg, #ee9b5b, #df6f38)` | circular send button |
+| `--accent-grad-avatar` | `linear-gradient(160deg, #ef9f5f, #e07640)` | account avatar |
+| `--accent-tint` | `#f8e0cf` | the one filled tint (New-chat pill) |
+| `--active-bg` | `#ece4da` | active window-control / nav bg |
+| `--accent-shadow` | `rgba(200,90,30,0.3)` | send-button glow |
+
+### Status / misc
+| Token | Value | Use |
+|---|---|---|
+| `--tl-red` / `--tl-yellow` / `--tl-green` | `#ec6a5e` / `#f4bf4f` / `#61c554` | window traffic lights |
+| `--card-shadow` | `0 1px 2px rgba(0,0,0,0.02)` | composer card |
+| `--scrollbar-thumb` | `rgba(0,0,0,0.08)` | 8px webkit scrollbar |
+| Terminal (deferred, for later) | bg `#1c1b1a`, fg `#d8d2ca`, green `#7fb56b`, blue `#6ba0d6`, gray `#a49c93` | powerline prompt |
+
+> No dedicated success/danger UI tokens in the prototype beyond traffic lights + terminal green. Keep the
+> existing `--ok`/`--bad` (+ tints) for functional states (errors, diff counts) — reconcile per-area.
+
+## Radius (reverses today's `--radius: 0`)
+| Token | px | Use |
+|---|---|---|
+| `--radius-sm` | 7 | icon buttons / window controls |
+| `--radius` | 9 | list rows (project/thread), avatar |
+| `--radius-md` | 10 | nav items |
+| `--radius-pill` | 12 | New-chat pill |
+| `--radius-card` | 20 | composer card, side panels |
+| `--radius-full` | 9999 | circular send button, dots |
+
+Bridge into `@theme` so `rounded-md`/`rounded-2xl` map to these (undo the current all-zero override).
+
+## Typography
+- **UI stack:** `-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', system-ui, sans-serif`
+- **Mono stack:** `'SF Mono', ui-monospace, 'Menlo', monospace` (code, terminal)
+- No webfont loaded — system fonts.
+
+| Role | size | weight | line-height | tracking |
+|---|---|---|---|---|
+| Hero H1 | 37px | 600 | — | -0.6px |
+| Workspace title | 20px | 600 | — | -0.2px |
+| Composer placeholder | 17px | 400 | — | — |
+| Nav label / New chat | 15.5px | 400 / 600 | — | — |
+| Body / project row / chip | 15px | 400 | 1.25 | — |
+| Thread row / context chip | 14.5px | 400 | — | — |
+| Section header ("Projects") | 13px | 500 | — | — |
+| Timestamp / plan / small | 13px | 400 | — | — |
+| Code / terminal body | 13px | 400 | 1.7 | — |
+
+## Spacing scale
+`2 · 4 · 6 · 8 · 10 · 12 · 14 · 16 · 18 · 20 · 22 · 24 · 40 · 42 · 44` (micro 2–12; macro 14–24; hero 40–44).
+
+## Fixed dimensions
+| Element | Size |
+|---|---|
+| Sidebar | **338px** (flex-shrink:0) |
+| Side panel (collapsed) | **460px** (`border-left`) |
+| Side panel (expanded) | `flex:1` (chat hidden) |
+| Composer / hero content max-width | **830px** |
+| Terminal dock height | **230px** |
+| Circular send button | 36×36 |
+| Account avatar | 32×32 |
+| Window-control buttons | 30×30 |
+| Logo mark | 30 (header) · 52 (hero) · 38 (panel) |
+| Root min-height | 660px |
+
+## Component notes (for the primitive library)
+- **Chips are borderless** inline `icon + label + chevron` groups (gap 6–8) — NOT bordered pills. The
+  only filled pill is the peach New-chat (`--accent-tint`); the only active-bg is `--active-bg`.
+- **Composer card:** `--surface` bg, `1px --border`, `--radius-card` (20), `--card-shadow`, padding
+  `22px 24px 14px`, a 44px gap between the placeholder and the control row.
+- **Send button:** 36px circle, `--accent-grad-action`, white arrow-up, `--accent-shadow` glow, no border.
+- **Sidebar rows:** nav `padding:9px 12px` `--radius-md`; project `7px 12px` `--radius`; thread indented
+  `7px 12px 7px 42px`, title truncates, right timestamp `--faint`.
+- **Animation:** one keyframe — `@keyframes vmCursorBlink { 0%,49%{opacity:1} 50%,100%{opacity:0} }`
+  (terminal cursor, `1.1s step-end infinite`).
+
+## Icons (lucide)
+Nav: `square-pen` (new chat) · `search` · `clock` (scheduled) · `atom` (plugins). Sidebar: `panel-left`,
+`arrow-left`/`arrow-right`, `folder`, `chevron-down`. Composer: `plus`, `shield` (approval),
+`maximize-2` (expand), `arrow-up` (send), `mic`, `sliders`/`shuffle` (reasoning). Context: `monitor`
+(local), `git-branch` (branch). Top-right modes: `panel-right`, `terminal`, `maximize-2`. Panel/git:
+`git-branch`, `git-commit-horizontal`, `file`, `x`. Message actions: `copy`, `thumbs-up`, `thumbs-down`,
+`git-branch`/`repeat` (retry). Account: gradient avatar + `chevron-down`.


### PR DESCRIPTION
Outcome of the grill on the **design-system pass**. Records the load-bearing decisions (ADR-0010) + the exact token values from the final-design prototype (`docs/design-tokens.md`).

## Decisions locked
1. **Scope** — design system + restyle-what-exists; net-new features (Search/Scheduled/Plugins, terminal, side-panel view modes, the Review/Terminal/Browser/Files dock, git Environment/Sources) render as **static placeholders**, built later.
2. **Tokens** — keep the CSS-vars → `@theme inline` hybrid; adopt the prototype wholesale: warm neutral ramp, **rounded** radius scale (reversing `--radius:0`), **softer gradient-forward orange** (`#cf6a3a`/`#e07a3e`, not `#fa500f`), type + spacing scales.
3. **Styling** — a base-ui + Tailwind + **CVA** primitive library under `src/renderer/src/ui/`; copy-adapt from shadcn `bases/base/ui/` + t3code (own it, restyle to our tokens); retire the ~1230 lines of BEM area-by-area.
4. **Conversation** — keep the discriminated-union item + `Item` switch (both t3code and shadcn converge on it; matches ADR-0001); build reusable inner primitives (MessageScroller / Message / Bubble / Response / ToolRow / Reasoning / Approval / Actions / file-path links); approval kept **inline**. Response/markdown = **streamdown + @streamdown/code**, gated on an Electron/Vite + theming compat spike.
5. **Migration** — area-by-area, behavior-identical: foundation → shell → conversation → composer → auth → git.

References mined (local): the prototype `Vibe Mistro.html`, **t3code** (rich chat aesthetic; near-identical stack), **shadcn/ui** (`/Users/abdullahatrash/mistral/ui` — base-ui primitives + message/scroller/bubble primitives).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)