### PR TITLE
docs: design-system epic handoff — component-adaptation guide + HANDOFF pointers

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -3,9 +3,9 @@
 > You are picking up an in-flight project. Read this top to bottom once, then keep it open.
 > It tells you **what this is**, **how we work**, **what exists**, **what's next**, and **where the
 > authoritative information lives** (in-repo docs + three local reference repos). Last updated
-> 2026-07-01, `main` @ `6fa1321`, **495 tests**, **0 open issues** (backlog empty). Composer-extras epic
-> is largely shipped (`/` autocomplete, image attachments, queue+interrupt); next up: a **design-system
-> pass** (layouts + components) before complexity grows — see §6. `$`/`@` autocomplete stays paused.
+> 2026-07-01, `main` @ `65c23a5`, **495 tests**. The **design-system epic is SCOPED AND FILED**: grilled →
+> **ADR-0010** + `docs/design-tokens.md` + `docs/design-system-components.md` → **PRD #109** → tracer-bullet
+> issues **#110–#119**. **Start with #110 (token layer)** — see §6/§8. `$`/`@` autocomplete stays paused.
 
 ---
 
@@ -303,9 +303,22 @@ review round):** the in-flight latch MUST be module-level per-Thread (`sending` 
 
 ## 6. What's next
 
-**Backlog is empty (no open issues).** The Agent-controls, sign-in, git/GitHub, and most of the
-composer-extras epic are shipped. **The chosen next intermediate epic is a DESIGN-SYSTEM pass** —
-establish layouts + a component library NOW, before the app grows and refactors get expensive.
+**The DESIGN-SYSTEM epic is scoped, ADR'd, and filed as issues #110–#119** (parent PRD #109, all
+`ready-for-agent`). Pipeline done: `/grill-with-docs` → **ADR-0010** + `docs/design-tokens.md` (exact token
+values) + `docs/design-system-components.md` (what to lift from shadcn/t3code + how to adapt) → PRD #109 →
+`/to-issues`. **START HERE: issue #110 (token layer)** — no blockers, highest-impact/lowest-risk (the whole
+app repaints toward the design with zero structural change). Slice order + deps:
+- **#110** token layer (—) → **#111** primitives (base-ui+CVA, #110) → **#113** shell (#110,#111)
+- **#112** streamdown spike (#110) → **#114** conversation A / Response+Message+Bubble+scroll **[HITL]**
+  (#111,#112) → **#115** conversation B / tool+reasoning+working (#114) → **#116** conversation C /
+  approval-inline+actions+file-links (#114)
+- **#117** composer (#111,#113) · **#118** auth (#111) · **#119** git panel (#111) — parallel after #110/#111
+Each issue carries `/tdd` build instructions; each is a **behavior-identical restyle** (existing ~495 tests
+MUST stay green) that retires its area's BEM from `styles.css`. Reference `docs/design-system-components.md`
+for the shadcn (`/Users/abdullahatrash/mistral/ui` `bases/base`) + t3code component-adaptation details.
+
+**The chosen next intermediate epic (context):** a DESIGN-SYSTEM pass — establish layouts + a component
+library NOW, before the app grows and refactors get expensive.
 
 **► NEXT: Design-system pass (layouts + components).** Goal: lock in a coherent design system (tokens,
 primitives, layout shells) and migrate the per-area UI onto it, on the #61 foundation (Tailwind v4 +
@@ -375,6 +388,12 @@ Parity target: `docs/codexmonitor-reference.md`.
   `stopReason:"cancelled"`). Interrupt = Stop button (#104); queue = compose-while-streaming + auto-flush
   (#106), serialized via a MODULE-level per-Thread latch (a per-instance ref can't serialize across the
   `Conversation` remount). Steer deferred pending a vibe steer method.
+- **0010** — design-system epic: keep the CSS-vars→`@theme` token hybrid, adopt the prototype values (warm
+  neutrals, rounded radius scale reversing `--radius:0`, softer gradient-orange `#cf6a3a`/`#e07a3e`); a
+  base-ui+Tailwind+**CVA** primitive library under `ui/` copy-adapted from shadcn `bases/base` + t3code,
+  retiring BEM area-by-area; conversation keeps the discriminated-union item+switch (ADR-0001) with reusable
+  inner primitives (Response=streamdown, gated); migrate area-by-area behavior-identical. Values →
+  `docs/design-tokens.md`; adaptation notes → `docs/design-system-components.md`; PRD #109; issues #110–#119.
 
 If a new slice needs to revisit one of these, that's an **HITL** decision — write a new ADR and get the
 user's call; don't just diverge.
@@ -383,14 +402,17 @@ user's call; don't just diverge.
 
 ## 8. First moves for the new agent
 
-1. Read this file, then skim `docs/acp-capture.md` and the `composer-extras-epic` memory (the in-flight
-   epic's decomposition + per-sub-feature protocol readiness).
+1. Read this file, then **ADR-0010** + `docs/design-tokens.md` + `docs/design-system-components.md` (the
+   filed design-system epic), and skim the `composer-extras-epic` memory.
 2. Confirm the baseline: `cd /Users/abdullahatrash/mistral/vibe-mistro` (on `main`), run the gates
    (`export PATH=...nvm...; bun run lint && bun run typecheck && bun run build && bun run test`) →
    expect **495 tests green**.
-3. Check the backlog: `GH_HOST=github.com gh issue list --state open` → expect **empty**. The next move
-   is the **design-system pass** (the chosen next epic, §6) — START by grilling its scope with the user
-   (grill-with-docs → ADR → tracer-bullet slices). Verification debt remains: the #80 sign-in re-check
+3. The next move is the **design-system epic** — it's already filed: `GH_HOST=github.com gh issue list
+   --state open --label ready-for-agent` shows PRD #109 + slices #110–#119 (§6). **Start with #110 (token
+   layer)** — no blockers. Run the **team loop (§3)** per slice: manual worktree (real `bun install`),
+   implementer agent (the issue carries `/tdd`), your independent verify + diff read, adversarial review,
+   fold, push, **user merges**, cleanup, re-run gates on `main`, update memory. Verification debt remains:
+   the #80 sign-in re-check
    and the #87/#88 git slices haven't been smoked live (§6).
 4. When the user picks a roadmap item (or says "start <N>"), run the **team loop in §3** — manual
    worktree (real `bun install`, NOT a node_modules symlink — §2), implementer agent, your independent

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -2,7 +2,7 @@
 
 > You are picking up an in-flight project. Read this top to bottom once, then keep it open.
 > It tells you **what this is**, **how we work**, **what exists**, **what's next**, and **where the
-> authoritative information lives** (in-repo docs + three local reference repos). Last updated
+> authoritative information lives** (in-repo docs + the local reference repos in §4). Last updated
 > 2026-07-01, `main` @ `65c23a5`, **495 tests**. The **design-system epic is SCOPED AND FILED**: grilled →
 > **ADR-0010** + `docs/design-tokens.md` + `docs/design-system-components.md` → **PRD #109** → tracer-bullet
 > issues **#110–#119**. **Start with #110 (token layer)** — see §6/§8. `$`/`@` autocomplete stays paused.
@@ -138,13 +138,17 @@ repeat — never horizontal "all tests then all code").
 - `docs/opencode-electron-patterns.md` — Electron mechanics (PATH resolution, electron-store, etc.).
 - `docs/t3code-reference.md` — patterns adopted from t3code.
 - `docs/conventions.md` — code conventions.
-- `docs/design/brand.md` — Mistral branding tokens (light mode, orange `--accent #fa500f` for
-  fills/borders only; `--accent-text #c2410c` for orange TEXT (AA-safe); zero border-radius / sharp edges).
-- `docs/adr/0001..0006` — **the load-bearing decisions. Respect them; don't silently contradict.** See §7.
+- **Design system (the active epic — ADR-0010):** `docs/adr/0010-…` (decisions) + `docs/design-tokens.md`
+  (exact token values) + `docs/design-system-components.md` (what to lift from shadcn/t3code + how). ⚠️
+  These **supersede `docs/design/brand.md`** — the design epic REVERSES the old brand (bright `--accent
+  #fa500f` → softer gradient-orange `#cf6a3a`/`#e07a3e`; **zero radius → a rounded scale**). Use
+  `design-tokens.md`, not `brand.md`, for anything visual from now on.
+- `docs/adr/0001..0010` — **the load-bearing decisions. Respect them; don't silently contradict.** See §7.
 
-### The three local reference repos (in `/Users/abdullahatrash/mistral/`)
+### The local reference repos (in `/Users/abdullahatrash/mistral/`)
 These are **cloned, real codebases** — grep them for concrete implementations. They are inspiration,
-not dependencies; right-size their ideas to our thin-orchestrator scope.
+not dependencies; right-size their ideas to our thin-orchestrator scope. Copy-adapt + own in-repo — never
+add them as npm deps.
 
 1. **`CodexMonitor/`** — *the concept we're cloning.* Tauri/**Rust** GUI orchestrator for **Codex**.
    ⚠️ This is also the **session's cwd**, so shell commands reset here. Use it for **what features to
@@ -153,12 +157,20 @@ not dependencies; right-size their ideas to our thin-orchestrator scope.
 2. **`opencode/packages/desktop/`** — *same stack as us* (electron-vite + Bun, but SolidJS). Use it for
    **Electron mechanics**: shell-env PATH resolution, electron-store persistence, window-state,
    electron-updater, electron-log, node-pty terminal, electron-builder packaging.
-3. **`t3code/`** — *a mature multi-agent Effect-TS GUI* (cloned at `/Users/abdullahatrash/mistral/t3code`;
-   ignore its `.repos/` vendored deps and `node_modules`). Our **north star for Thread/Session modeling
-   and UI shell**. Use it for: Thread-vs-Session + resume-cursor, snapshot-then-stream, draft handling
-   (we mirrored its client-only thread-draft model in #58, and #60 mirrors its composer-draft store —
-   `apps/web/src/composerDraftStore.ts`, key `t3code:composer-drafts:v1`, `shouldRemoveDraft` pruning).
-   Most of its multi-provider/CQRS/Effect machinery is **overkill for us** — take patterns, not the stack.
+3. **`t3code/`** — *a mature multi-agent Effect-TS GUI* (`/Users/abdullahatrash/mistral/t3code`; ignore its
+   `.repos/` + `node_modules`). Our **north star for Thread/Session modeling, the UI shell, AND the rich
+   conversation aesthetic** (design-system epic mines its chat: `apps/web/src/components/chat/*` +
+   `ChatMarkdown.tsx` — message/bubble, file-path links, `SimpleWorkEntryRow` tool rows, reasoning, working
+   indicator; see `docs/design-system-components.md`). Its stack matches ours (Tailwind v4 + base-ui + CVA +
+   lucide). Take patterns, not the Effect/CQRS machinery.
+4. **`ui/`** — the **shadcn/ui monorepo** (`/Users/abdullahatrash/mistral/ui`). The **primitive-library
+   source for the design-system epic**: base-ui components under `apps/v4/registry/bases/base/ui/` (the
+   `base` base, NOT `radix`) — Button CVA exemplar + Message/Bubble/MessageScroller. Copy-adapt to our
+   tokens (swap their `cn-*` theme tokens for inline Tailwind). Details in `docs/design-system-components.md`.
+5. **`mistral-vibe/`** — the **cloned Vibe CLI / ACP backend source** (`/Users/abdullahatrash/mistral/mistral-vibe`,
+   package under `vibe/`). Ground truth for **how the agent behaves over ACP** — e.g. `vibe/acp/acp_agent_loop.py`
+   resolved that skills fold into the `available_commands_update` list (`$`≡`/`) and `@path` is expanded
+   server-side via `render_path_prompt`. Read it to verify protocol behavior instead of guessing.
 
 ### Persistent memory (across sessions)
 There is a file-based memory at

--- a/docs/design-system-components.md
+++ b/docs/design-system-components.md
@@ -1,0 +1,120 @@
+# Design-system build reference — what to lift, from where, and how to adapt
+
+Companion to **ADR-0010** (decisions), **`docs/design-tokens.md`** (exact token values), **PRD #109**, and
+build issues **#110–#119**. This captures the reusable findings from the t3code + shadcn/ui explorations so
+the build session doesn't re-derive them. **Copy-adapt and own in-repo; never add shadcn/t3code as deps.**
+
+Local sources:
+- **shadcn/ui** — `/Users/abdullahatrash/mistral/ui`, components under `apps/v4/registry/bases/base/ui/`
+  (the **base-ui** variant — imports `@base-ui/react`). Ignore the `radix` base.
+- **t3code** — `/Users/abdullahatrash/mistral/t3code`, chat under `apps/web/src/components/chat/*` +
+  `components/ChatMarkdown.tsx`; `ui/` primitives under `apps/web/src/components/ui/*`.
+- **prototype** — `/Users/abdullahatrash/mistral/Vibe Mistro.html` (exact tokens/layout).
+
+Both t3code and shadcn use **our stack** (Tailwind v4 + `@base-ui/react` + CVA + `cn()` + lucide), so the
+primitives are near-liftable. Deps to add: **CVA** (`class-variance-authority`); **streamdown** +
+**`@streamdown/code`** if the #112 spike passes; optionally **`use-stick-to-bottom`** (or vendor shadcn's
+message-scroller engine).
+
+---
+
+## 1. Primitive library (issue #111) — lift from shadcn `bases/base/ui/`
+
+**Pattern (every primitive):** import headless part from `@base-ui/react/<name>`; wrap each part in a thin
+component that adds `data-slot="…"`, merges classes with `cn()`, spreads `...props`, types via
+`React.ComponentProps<typeof Primitive.Part>`. Base-ui's composition prop is **`render`** (not Radix
+`asChild`); polymorphism via `useRender` + `mergeProps`. Variants via `cva()` only where needed.
+
+**The one gotcha:** shadcn's `bases/base` uses a two-layer model — structural Tailwind inline **+** semantic
+`cn-*` theme tokens (e.g. `cn-button-variant-default`) defined in swappable `style-*.css` files. **When
+adapting, replace each `cn-*` token with the actual Tailwind utility string** (resolved through OUR tokens).
+The CVA *structure* and compound APIs transfer 1:1; only the variant *values* need substituting.
+
+**Button — the CVA exemplar** (`ui/button.tsx`): base `inline-flex shrink-0 items-center justify-center …
+outline-none disabled:opacity-50`; **6 variants** (default/outline/secondary/ghost/destructive/link) — add
+our **`stop`** (outline, from #103); **8 sizes** (default/xs/sm/lg/icon/icon-xs/icon-sm/icon-lg). Same shape
+for Badge/Tabs/Attachment.
+
+**Primitives + their base-ui import:** Button (`/button`, CVA), Input (`/input`), Textarea (native),
+DropdownMenu (`/menu` — extend our existing `ui/menu.tsx`), Dialog (`/dialog`), Popover (`/popover`),
+Tooltip (`/tooltip`), Tabs (`/tabs`, CVA), ScrollArea (`/scroll-area`), Separator (`/separator`), Avatar
+(`/avatar`), Badge (`use-render`, CVA), Collapsible (`/collapsible`), Select (`/select`). App-specific
+(hand-build to tokens): **NavItem**, **Panel** (side-panel container), **Card**, **Chip** (borderless
+icon+label+chevron — see tokens doc), **IconButton** (Button `size=icon`), **Spinner**. Compound exports
+follow the standard shape (Dialog/DialogTrigger/DialogContent…, Menu parts, Select parts).
+
+---
+
+## 2. Conversation (issues #114–#116) — mine t3code, structure from shadcn
+
+**Architecture (keep ours):** both refs use a discriminated-union + switch, NOT deep compound components —
+t3code = row `kind` union + one `TimelineRowContent` dispatcher (+ React Context for shared state);
+shadcn = `message.parts.map()` switching on `part.type`. This is our `ConversationState.items` (`kind`) +
+`Item` switch (ADR-0001). **Keep it**; build the inner pieces as reusable primitives fed by our reducer.
+
+**Message / Bubble** (#114): user = **right-aligned rounded bubble** (`rounded-2xl border bg-secondary p-3`,
+`max-w-[80%]`, `items-end`); assistant = **no bubble**, full-width flowing markdown (`px-1 py-0.5`). shadcn's
+`Message` takes an `align` prop (`start`/`end`) with `data-align` for descendant styling — role→layout lives
+in the caller. This asymmetry matches our mockup.
+
+**Response / markdown** (#114, gated by #112): prefer **streamdown + @streamdown/code** (streaming-native —
+renders incomplete markdown safely; shiki highlighting + copy built in; shadcn's Response uses it). Fallback:
+`react-markdown` + `remark-gfm`/`remark-breaks` + shiki (t3code's `ChatMarkdown.tsx` is the blueprint — but
+they called their shiki+LRU-cache layer their "most over-engineered piece", which streamdown packages).
+- **File-path links** (the standout — t3code `MarkdownFileLink` in `ChatMarkdown.tsx`): resolve `href`/path →
+  a clickable **chip** (file icon + name + `L12:C3` line ref), orange, with disambiguated labels when
+  basenames collide. This is genuinely new **pure logic → TDD it** (href/path → {label, line, col}).
+- **Inline code** = subtle grey chip (CSS: 1px border, small radius, `bg var(--muted)`). **Code blocks** =
+  header toolbar (file-type icon + title/lang + wrap-toggle + copy) over the highlighted body.
+- t3code's markdown styling is a **self-contained global CSS block** (`.chat-markdown-*`, theme-var driven,
+  `index.css` ~417–720) — copyable if not using streamdown's styling.
+
+**MessageScroller / autoscroll** (#114): vendor shadcn's engine (`packages/react/src/message-scroller/`) or
+use `use-stick-to-bottom`. Provides viewport/content/item + a floating scroll-to-bottom pill; pin newest via
+`scrollAnchor` on the latest user turn. Replaces our naive `scrollTop = scrollHeight` effect.
+
+**ToolRow** (#115 — t3code `SimpleWorkEntryRow`, `MessagesTimeline.tsx`): compact `flex items-center gap-1.5
+rounded-md px-0.5 py-0.5`, `hover:bg-accent/20` when expandable. **Leading tone-icon** via a name→lucide map
+(terminal=command, eye=read, square-pen=edit, globe=web, wrench=mcp, hammer=tool, message-circle=user-input,
+bot/zap/check/circle-alert fallbacks) — use an explicit name→component switch (no dynamic import). **Heading**
+(`font-medium truncate`) + **dimmed preview** (`text-muted-foreground/55`, suppressed if it dups the heading).
+**Right status glyph** (`size-4`): pending→running→done via a turn-in-progress flag → `Check`; failure →
+destructive `X`; running = absence of a terminal check while the turn is live. **Map to OUR ACP status**
+`pending/in_progress/completed/failed` — this mapping is new pure logic → TDD it. **Expand:** rotating
+`ChevronDown` → indented `<pre>` body (`mt-1 ms-7 border-s ps-3 max-h-64 overflow-auto whitespace-pre-wrap
+font-mono text-[11px]`); clicks inside `stopPropagation`.
+
+**Reasoning** (#115): a **Collapsible** "thinking" block, **auto-open while streaming**. (t3code renders
+reasoning as a dimmed tool-like row; shadcn renders a flat shimmer — we do the collapsible auto-open per
+ADR-0010.)
+
+**Working indicator** (#115): t3code `WorkingTimelineRow` — three pulsing dots (`h-1 w-1 rounded-full
+bg-muted-foreground/30 animate-pulse` staggered `[animation-delay:200ms/400ms]`) + a **self-ticking**
+"Working for 12s" label (`WorkingTimer` updates `textContent` via `setInterval`, no React re-render). Copy
+this pattern.
+
+**Approval** (#116 — kept **INLINE**, unlike t3code which puts it in the composer footer): restyle our
+existing `PermissionRow`. Map buttons to OUR ACP permission options (allow-once / reject-once / etc.).
+t3code's **numbered-option keyboard panel** (`ComposerPendingUserInputPanel` — 1–9 kbd chips, auto-advance,
+selected `border-primary/30 bg-primary/8`) is a nice reference if we later render option prompts.
+
+**Actions bar** (#116): hover-reveal (`opacity-0 group-hover:opacity-100 transition-opacity`) — **copy**
+(icon→check + **anchored toast** on the button, not inline; t3code `MessageCopyButton`) + **thumbs up/down** +
+**retry** (we add thumbs/retry per the mockup; t3code only had copy+revert). Assistant copy hidden while
+streaming.
+
+**Strip from t3code** (their coupling — do NOT port): worktree/checkpoint diff summaries, revert/"revert to
+message", proposed-plan cards, terminal/element/preview-annotation contexts, skills inline, **Pierre file
+icons** (`PierreEntryIcon` → use lucide), `localApi`/editor-open plumbing in file links, the
+`session-logic.ts`/`MessagesTimeline.logic.ts` derivation layer (replace with our ACP reducer output), and
+the `@legendapp/list` virtualization (optional — our conversations are short; a `.map()` is fine).
+
+---
+
+## 3. Composer / Auth / Git (issues #117–#119)
+Straightforward restyles onto §1 primitives; re-home existing behavior (attachments #100 / stop #103 / queue
+#106 in the composer). See the issues + tokens doc; no new external component to mine.
+
+## 4. Icons
+lucide throughout — the name map is in `docs/design-tokens.md` §Icons. For tool-kind icons, see the ToolRow
+name→lucide map above.


### PR DESCRIPTION
Turnkey handoff for the design-system epic so a **fresh session** can build issues #110–#119 without re-deriving the t3code/shadcn explorations.

- **`docs/design-system-components.md`** (new) — the build reference: what to lift from shadcn `bases/base` (base-ui + CVA primitives; the Button CVA exemplar; the `cn-*` → inline-Tailwind swap) and t3code (user-bubble/assistant-flowing asymmetry, file-path chip links, the `SimpleWorkEntryRow` tool-row pattern, reasoning, working indicator, inline approval, actions bar), what to **strip** from t3code, the streamdown decision, and the deps to add (CVA; streamdown if #112 passes).
- **`HANDOFF.md`** — header/§6/§7/§8 now point at the filed epic (ADR-0010, PRD #109, slices #110–#119), the **start-with-#110** entry, and the per-slice team-loop; `main` @ `65c23a5`, 495 tests; ADR-0010 added to the list.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)