### PR TITLE
#111: core primitive library — base-ui + Tailwind + CVA

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@pierre/diffs": "^1.2.12",
     "@tailwindcss/vite": "^4",
     "chokidar": "^5.0.0",
+    "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.564",
     "react": "^19.1.0",

--- a/src/renderer/src/ui/avatar.tsx
+++ b/src/renderer/src/ui/avatar.tsx
@@ -1,0 +1,50 @@
+import type { ComponentProps, JSX } from 'react'
+import { Avatar as BaseAvatar } from '@base-ui/react/avatar'
+import { cn } from '../lib/utils'
+
+/**
+ * A user/account avatar over base-ui's Avatar (Root/Image/Fallback). The Root
+ * clips to `rounded-md` (~the tokens doc's avatar radius); the account gradient
+ * (`--accent-grad-avatar`) is applied by the caller as a fallback background.
+ */
+export function Avatar({
+  className,
+  ...props
+}: ComponentProps<typeof BaseAvatar.Root>): JSX.Element {
+  return (
+    <BaseAvatar.Root
+      data-slot="avatar"
+      className={cn('relative flex size-8 shrink-0 overflow-hidden rounded-md select-none', className)}
+      {...props}
+    />
+  )
+}
+
+export function AvatarImage({
+  className,
+  ...props
+}: ComponentProps<typeof BaseAvatar.Image>): JSX.Element {
+  return (
+    <BaseAvatar.Image
+      data-slot="avatar-image"
+      className={cn('aspect-square size-full object-cover', className)}
+      {...props}
+    />
+  )
+}
+
+export function AvatarFallback({
+  className,
+  ...props
+}: ComponentProps<typeof BaseAvatar.Fallback>): JSX.Element {
+  return (
+    <BaseAvatar.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        'flex size-full items-center justify-center text-sm text-on-accent',
+        className,
+      )}
+      {...props}
+    />
+  )
+}

--- a/src/renderer/src/ui/badge.tsx
+++ b/src/renderer/src/ui/badge.tsx
@@ -1,0 +1,46 @@
+import type { JSX } from 'react'
+import { mergeProps } from '@base-ui/react/merge-props'
+import { useRender } from '@base-ui/react/use-render'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '../lib/utils'
+
+/**
+ * A small pill label (history / needs-attention counters, status tags). Uses
+ * base-ui's `useRender` so it can render as a `<span>` by default or compose onto
+ * a custom element via the `render` prop — the shadcn `badge.tsx` idiom, with its
+ * `cn-badge-variant-*` tokens swapped for our real utilities. Rounded to
+ * `rounded-lg` (pill) per the tokens doc.
+ */
+export const badgeVariants = cva(
+  'inline-flex w-fit shrink-0 items-center justify-center gap-1 whitespace-nowrap rounded-lg px-2 py-0.5 text-xs font-medium [&>svg]:pointer-events-none [&>svg]:size-3',
+  {
+    variants: {
+      variant: {
+        default: 'bg-accent text-on-accent',
+        accent: 'bg-accent/10 text-accent-text',
+        destructive: 'bg-bad/10 text-bad',
+        ok: 'bg-ok/10 text-ok',
+        outline: 'border border-border text-text',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+)
+
+export function Badge({
+  className,
+  variant,
+  render,
+  ...props
+}: useRender.ComponentProps<'span'> & VariantProps<typeof badgeVariants>): JSX.Element {
+  return useRender({
+    defaultTagName: 'span',
+    render,
+    props: mergeProps<'span'>(
+      { className: cn(badgeVariants({ variant }), className) },
+      props,
+    ),
+  })
+}

--- a/src/renderer/src/ui/button.tsx
+++ b/src/renderer/src/ui/button.tsx
@@ -1,0 +1,60 @@
+import type { ComponentProps, JSX } from 'react'
+import { Button as BaseButton } from '@base-ui/react/button'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '../lib/utils'
+
+/**
+ * The CVA exemplar for the kit. Structure lifted from shadcn's base-ui `button.tsx`;
+ * the semantic `cn-button-variant-*` theme tokens it ships are swapped for real
+ * Tailwind utility strings resolved through OUR tokens (`bg-accent`, `text-on-accent`,
+ * `border-border`, …). Radii come from the new rounded scale (#110): text buttons
+ * `rounded-md` (10px), icon buttons `rounded-sm` (7px). `text-on-accent` is the warm
+ * dark ink (AA-safe on the softer orange), NOT white.
+ */
+export const buttonVariants = cva(
+  'inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors outline-none select-none disabled:pointer-events-none disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-accent/40 [&_svg]:pointer-events-none [&_svg]:shrink-0',
+  {
+    variants: {
+      variant: {
+        default: 'bg-accent text-on-accent hover:bg-accent/90',
+        outline: 'border border-border bg-transparent text-text hover:bg-accent/10',
+        secondary: 'border border-border bg-surface text-text hover:bg-accent/10',
+        ghost: 'text-text hover:bg-accent/10',
+        destructive: 'bg-bad text-white hover:bg-bad/90',
+        link: 'text-accent-text underline-offset-4 hover:underline',
+        // Interrupt action (#103) — an outline distinct from the primary Send;
+        // mirrors the existing `.btn--stop` (transparent bg, muted border).
+        stop: 'border border-border bg-transparent text-text hover:bg-accent/10',
+      },
+      size: {
+        default: 'h-9 px-4 py-2',
+        xs: 'h-7 px-2 text-xs',
+        sm: 'h-8 px-3',
+        lg: 'h-10 px-6',
+        icon: 'size-9 rounded-sm',
+        'icon-xs': 'size-6 rounded-sm',
+        'icon-sm': 'size-8 rounded-sm',
+        'icon-lg': 'size-10 rounded-sm',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+)
+
+export function Button({
+  className,
+  variant,
+  size,
+  ...props
+}: ComponentProps<typeof BaseButton> & VariantProps<typeof buttonVariants>): JSX.Element {
+  return (
+    <BaseButton
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size }), className)}
+      {...props}
+    />
+  )
+}

--- a/src/renderer/src/ui/card.tsx
+++ b/src/renderer/src/ui/card.tsx
@@ -1,0 +1,50 @@
+import type { ComponentProps, JSX } from 'react'
+import { cn } from '../lib/utils'
+
+/**
+ * A surface container (composer card, panels' inner blocks). `--surface` bg, a warm
+ * `--border`, `rounded-2xl` (20px per the tokens doc), soft shadow. The Header/Title/
+ * Description/Content/Footer parts mirror shadcn's card triad, restyled to our tokens.
+ */
+export function Card({ className, ...props }: ComponentProps<'div'>): JSX.Element {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        'flex flex-col gap-4 rounded-2xl border border-border bg-surface p-6 text-text shadow-sm',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export function CardHeader({ className, ...props }: ComponentProps<'div'>): JSX.Element {
+  return <div data-slot="card-header" className={cn('flex flex-col gap-1.5', className)} {...props} />
+}
+
+export function CardTitle({ className, ...props }: ComponentProps<'div'>): JSX.Element {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn('font-semibold text-text-strong', className)}
+      {...props}
+    />
+  )
+}
+
+export function CardDescription({ className, ...props }: ComponentProps<'div'>): JSX.Element {
+  return (
+    <div data-slot="card-description" className={cn('text-sm text-muted', className)} {...props} />
+  )
+}
+
+export function CardContent({ className, ...props }: ComponentProps<'div'>): JSX.Element {
+  return <div data-slot="card-content" className={cn(className)} {...props} />
+}
+
+export function CardFooter({ className, ...props }: ComponentProps<'div'>): JSX.Element {
+  return (
+    <div data-slot="card-footer" className={cn('flex items-center gap-2', className)} {...props} />
+  )
+}

--- a/src/renderer/src/ui/chip.tsx
+++ b/src/renderer/src/ui/chip.tsx
@@ -1,0 +1,31 @@
+import type { ComponentProps, JSX } from 'react'
+import { cn } from '../lib/utils'
+
+/**
+ * A **borderless** inline `icon + label + chevron` group (context chips: local /
+ * git-branch / model). Per the tokens doc these are NOT bordered pills — just a
+ * muted, gap-6/8 cluster that tints on hover. Compose freely:
+ *
+ *   <Chip><Monitor className="size-4" /> local <ChevronDown className="size-3.5" /></Chip>
+ *
+ * `active` lifts it to the accent text colour.
+ */
+export function Chip({
+  className,
+  active = false,
+  ...props
+}: ComponentProps<'div'> & { active?: boolean }): JSX.Element {
+  return (
+    <div
+      data-slot="chip"
+      data-active={active || undefined}
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-lg px-1.5 py-0.5 text-sm text-muted transition-colors',
+        '[&_svg]:pointer-events-none [&_svg]:shrink-0',
+        active && 'text-accent-text',
+        className,
+      )}
+      {...props}
+    />
+  )
+}

--- a/src/renderer/src/ui/collapsible.tsx
+++ b/src/renderer/src/ui/collapsible.tsx
@@ -1,0 +1,12 @@
+import { Collapsible as BaseCollapsible } from '@base-ui/react/collapsible'
+
+/**
+ * A thin re-export of base-ui's Collapsible (Root/Trigger/Panel). Behaviour is
+ * headless — the "thinking"/reasoning block (#115, auto-open while streaming) and
+ * any disclosure section style the trigger + panel at the call site. base-ui's
+ * panel part is `Panel` (exported here as `CollapsibleContent` for the familiar
+ * shadcn triad).
+ */
+export const Collapsible = BaseCollapsible.Root
+export const CollapsibleTrigger = BaseCollapsible.Trigger
+export const CollapsibleContent = BaseCollapsible.Panel

--- a/src/renderer/src/ui/dialog.tsx
+++ b/src/renderer/src/ui/dialog.tsx
@@ -1,0 +1,110 @@
+import type { ComponentProps, JSX } from 'react'
+import { Dialog as BaseDialog } from '@base-ui/react/dialog'
+import { X } from 'lucide-react'
+import { cn } from '../lib/utils'
+import { IconButton } from './icon-button'
+
+/**
+ * A modal dialog over base-ui's Dialog (Root/Trigger/Portal/Backdrop/Popup/Title/…).
+ * shadcn's `cn-dialog-*` structural tokens are replaced with real utilities on our
+ * tokens: a dimming backdrop, a centred `--panel` card at `rounded-2xl` (20px), and
+ * a ghost close button in the corner.
+ */
+export const Dialog = BaseDialog.Root
+export const DialogTrigger = BaseDialog.Trigger
+export const DialogPortal = BaseDialog.Portal
+export const DialogClose = BaseDialog.Close
+
+export function DialogBackdrop({
+  className,
+  ...props
+}: ComponentProps<typeof BaseDialog.Backdrop>): JSX.Element {
+  return (
+    <BaseDialog.Backdrop
+      data-slot="dialog-backdrop"
+      className={cn('fixed inset-0 z-50 bg-black/30', className)}
+      {...props}
+    />
+  )
+}
+
+export function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: ComponentProps<typeof BaseDialog.Popup> & {
+  showCloseButton?: boolean
+}): JSX.Element {
+  return (
+    <DialogPortal>
+      <DialogBackdrop />
+      <BaseDialog.Popup
+        data-slot="dialog-content"
+        className={cn(
+          'fixed top-1/2 left-1/2 z-50 w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-border bg-panel p-6 text-text shadow-lg outline-none',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <BaseDialog.Close
+            render={<IconButton size="icon-sm" className="absolute top-3 right-3" />}
+            aria-label="Close"
+          >
+            <X className="size-4" />
+          </BaseDialog.Close>
+        )}
+      </BaseDialog.Popup>
+    </DialogPortal>
+  )
+}
+
+export function DialogHeader({
+  className,
+  ...props
+}: ComponentProps<'div'>): JSX.Element {
+  return (
+    <div data-slot="dialog-header" className={cn('flex flex-col gap-1.5', className)} {...props} />
+  )
+}
+
+export function DialogFooter({
+  className,
+  ...props
+}: ComponentProps<'div'>): JSX.Element {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn('mt-4 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+      {...props}
+    />
+  )
+}
+
+export function DialogTitle({
+  className,
+  ...props
+}: ComponentProps<typeof BaseDialog.Title>): JSX.Element {
+  return (
+    <BaseDialog.Title
+      data-slot="dialog-title"
+      className={cn('text-base font-semibold text-text-strong', className)}
+      {...props}
+    />
+  )
+}
+
+export function DialogDescription({
+  className,
+  ...props
+}: ComponentProps<typeof BaseDialog.Description>): JSX.Element {
+  return (
+    <BaseDialog.Description
+      data-slot="dialog-description"
+      className={cn('text-sm text-muted', className)}
+      {...props}
+    />
+  )
+}

--- a/src/renderer/src/ui/icon-button.tsx
+++ b/src/renderer/src/ui/icon-button.tsx
@@ -1,0 +1,15 @@
+import type { ComponentProps, JSX } from 'react'
+import { Button } from './button'
+
+/**
+ * A {@link Button} pre-set to a square icon size — the app has many icon-only
+ * affordances (kebab, close, expand, send). Defaults to `variant="ghost"` +
+ * `size="icon"`; both are still overridable. Wrap the lucide glyph as the child.
+ */
+export function IconButton({
+  variant = 'ghost',
+  size = 'icon',
+  ...props
+}: ComponentProps<typeof Button>): JSX.Element {
+  return <Button data-slot="icon-button" variant={variant} size={size} {...props} />
+}

--- a/src/renderer/src/ui/index.ts
+++ b/src/renderer/src/ui/index.ts
@@ -1,0 +1,63 @@
+/**
+ * The shared primitive library (#111). Headless behaviour from `@base-ui/react`,
+ * styled with Tailwind utilities resolved through OUR tokens (styles.css `@theme
+ * inline`), composed via `cn()`, variants via CVA. This barrel enumerates every
+ * primitive so feature areas know what exists — and gives tsc a consumer so the
+ * whole kit is type-checked even before the areas migrate onto it (#113/#117–119).
+ *
+ * Consumers write `<Button variant="ghost">` / `<Chip>` / `<Panel>` — never
+ * hand-rolled class strings. Add BEM nowhere; retire it area-by-area in later slices.
+ */
+
+export { Button, buttonVariants } from './button'
+export { IconButton } from './icon-button'
+export { Input } from './input'
+export { Textarea } from './textarea'
+export { Badge, badgeVariants } from './badge'
+export { Chip } from './chip'
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogPortal,
+  DialogClose,
+  DialogBackdrop,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+} from './dialog'
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverTitle, PopoverDescription } from './popover'
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from './tooltip'
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent } from './collapsible'
+
+export { ScrollArea, ScrollBar } from './scroll-area'
+
+export {
+  Select,
+  SelectValue,
+  SelectGroup,
+  SelectTrigger,
+  SelectContent,
+  SelectItem,
+  SelectGroupLabel,
+  SelectSeparator,
+} from './select'
+
+export { Separator } from './separator'
+
+export { Avatar, AvatarImage, AvatarFallback } from './avatar'
+
+export { Spinner } from './spinner'
+
+export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from './card'
+
+export { NavItem } from './nav-item'
+
+export { Panel, PanelHeader, PanelTitle, PanelContent } from './panel'
+
+export { Menu, MenuTrigger, MenuContent, MenuItem, MenuSeparator } from './menu'

--- a/src/renderer/src/ui/input.tsx
+++ b/src/renderer/src/ui/input.tsx
@@ -1,0 +1,26 @@
+import type { ComponentProps, JSX } from 'react'
+import { Input as BaseInput } from '@base-ui/react/input'
+import { cn } from '../lib/utils'
+
+/**
+ * A single-line text field over base-ui's Input. shadcn's `cn-input` structural
+ * token is expanded to real utilities on our tokens: `--bg` field, `--border`
+ * (accent on focus), `--placeholder` text, `--radius-md`.
+ */
+export function Input({
+  className,
+  ...props
+}: ComponentProps<typeof BaseInput>): JSX.Element {
+  return (
+    <BaseInput
+      data-slot="input"
+      className={cn(
+        'flex h-9 w-full min-w-0 rounded-md border border-border bg-bg px-3 py-1 text-sm text-text outline-none transition-colors',
+        'placeholder:text-placeholder focus-visible:border-accent',
+        'disabled:pointer-events-none disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  )
+}

--- a/src/renderer/src/ui/menu.tsx
+++ b/src/renderer/src/ui/menu.tsx
@@ -6,7 +6,7 @@ import { cn } from '../lib/utils'
  * A small brand-styled wrapper over base-ui's Menu primitive. base-ui owns the
  * hard parts — focus management, roving keyboard nav, type-ahead, portalling,
  * outside-click/ESC dismissal — so these components only layer on the Mistral look
- * (square corners via the zero radius scale, `--panel` surface, `--border`, an
+ * (rounded corners from the new radius scale, `--panel` surface, `--border`, an
  * accent hover tint). Compose them like the base parts:
  *
  *   <Menu>
@@ -37,7 +37,7 @@ export function MenuContent({
       <BaseMenu.Positioner sideOffset={sideOffset} align={align}>
         <BaseMenu.Popup
           className={cn(
-            'min-w-32 rounded-none border border-border bg-panel py-1 text-sm text-text shadow-md outline-none',
+            'min-w-32 rounded-md border border-border bg-panel py-1 text-sm text-text shadow-md outline-none',
             className,
           )}
           {...props}

--- a/src/renderer/src/ui/nav-item.tsx
+++ b/src/renderer/src/ui/nav-item.tsx
@@ -1,0 +1,32 @@
+import type { ComponentProps, JSX } from 'react'
+import { cn } from '../lib/utils'
+
+/**
+ * A sidebar navigation row (New chat / Search / Scheduled / Plugins, project + thread
+ * rows). App-specific — hand-built to the tokens doc: `padding 9px 12px`, `--radius-md`
+ * (10px), a muted resting label that tints on hover and lifts to a stronger accent
+ * wash when `active` (the `--active-bg` token isn't bridged into `@theme`, so we use
+ * the bridged `accent` at a higher alpha). Renders a `<button>` by default; pass
+ * children (icon + label) as content.
+ */
+export function NavItem({
+  className,
+  active = false,
+  ...props
+}: ComponentProps<'button'> & { active?: boolean }): JSX.Element {
+  return (
+    <button
+      type="button"
+      data-slot="nav-item"
+      data-active={active || undefined}
+      className={cn(
+        'flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-left text-[15.5px] text-text-body outline-none transition-colors',
+        '[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:text-muted',
+        'hover:bg-accent/10 focus-visible:bg-accent/10',
+        active && 'bg-accent/15 font-semibold text-text-strong [&_svg]:text-text-strong',
+        className,
+      )}
+      {...props}
+    />
+  )
+}

--- a/src/renderer/src/ui/panel.tsx
+++ b/src/renderer/src/ui/panel.tsx
@@ -1,0 +1,53 @@
+import type { ComponentProps, JSX } from 'react'
+import { cn } from '../lib/utils'
+
+/**
+ * The side-panel container (git "Review" panel, expanded views). App-specific — a
+ * `--panel` (white) surface with a leading `--border` divider, filling its column.
+ * The Header/Title/Content parts give a consistent panel chrome; Content scrolls.
+ */
+export function Panel({ className, ...props }: ComponentProps<'div'>): JSX.Element {
+  return (
+    <div
+      data-slot="panel"
+      className={cn(
+        'flex h-full min-h-0 flex-col border-l border-border bg-panel text-text',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export function PanelHeader({ className, ...props }: ComponentProps<'div'>): JSX.Element {
+  return (
+    <div
+      data-slot="panel-header"
+      className={cn(
+        'flex flex-none items-center gap-2 border-b border-border-muted px-4 py-3',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export function PanelTitle({ className, ...props }: ComponentProps<'div'>): JSX.Element {
+  return (
+    <div
+      data-slot="panel-title"
+      className={cn('flex-1 text-sm font-semibold text-text-strong', className)}
+      {...props}
+    />
+  )
+}
+
+export function PanelContent({ className, ...props }: ComponentProps<'div'>): JSX.Element {
+  return (
+    <div
+      data-slot="panel-content"
+      className={cn('min-h-0 flex-1 overflow-y-auto p-4', className)}
+      {...props}
+    />
+  )
+}

--- a/src/renderer/src/ui/popover.tsx
+++ b/src/renderer/src/ui/popover.tsx
@@ -1,0 +1,72 @@
+import type { ComponentProps, JSX } from 'react'
+import { Popover as BasePopover } from '@base-ui/react/popover'
+import { cn } from '../lib/utils'
+
+/**
+ * A floating popover over base-ui's Popover, wrapped Portal→Positioner→Popup like
+ * our Menu. shadcn's `cn-popover-content` token becomes real utilities: a `--panel`
+ * surface, `--border`, `rounded-md`, shadow. Positioner props (`side`/`align`/
+ * offsets) are surfaced on the content for callers.
+ */
+export const Popover = BasePopover.Root
+export const PopoverTrigger = BasePopover.Trigger
+
+export function PopoverContent({
+  className,
+  align = 'center',
+  alignOffset = 0,
+  side = 'bottom',
+  sideOffset = 4,
+  ...props
+}: ComponentProps<typeof BasePopover.Popup> &
+  Pick<
+    ComponentProps<typeof BasePopover.Positioner>,
+    'align' | 'alignOffset' | 'side' | 'sideOffset'
+  >): JSX.Element {
+  return (
+    <BasePopover.Portal>
+      <BasePopover.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="z-50"
+      >
+        <BasePopover.Popup
+          data-slot="popover-content"
+          className={cn(
+            'z-50 w-72 rounded-md border border-border bg-panel p-4 text-sm text-text shadow-md outline-none',
+            className,
+          )}
+          {...props}
+        />
+      </BasePopover.Positioner>
+    </BasePopover.Portal>
+  )
+}
+
+export function PopoverTitle({
+  className,
+  ...props
+}: ComponentProps<typeof BasePopover.Title>): JSX.Element {
+  return (
+    <BasePopover.Title
+      data-slot="popover-title"
+      className={cn('text-sm font-semibold text-text-strong', className)}
+      {...props}
+    />
+  )
+}
+
+export function PopoverDescription({
+  className,
+  ...props
+}: ComponentProps<typeof BasePopover.Description>): JSX.Element {
+  return (
+    <BasePopover.Description
+      data-slot="popover-description"
+      className={cn('text-sm text-muted', className)}
+      {...props}
+    />
+  )
+}

--- a/src/renderer/src/ui/scroll-area.tsx
+++ b/src/renderer/src/ui/scroll-area.tsx
@@ -1,0 +1,52 @@
+import type { ComponentProps, JSX } from 'react'
+import { ScrollArea as BaseScrollArea } from '@base-ui/react/scroll-area'
+import { cn } from '../lib/utils'
+
+/**
+ * A custom-scrollbar viewport over base-ui's ScrollArea (Root→Viewport + a thin
+ * Scrollbar/Thumb). shadcn's `cn-scroll-area-*` tokens become plain utilities on
+ * our `--border` thumb. The children scroll inside the Viewport.
+ */
+export function ScrollArea({
+  className,
+  children,
+  ...props
+}: ComponentProps<typeof BaseScrollArea.Root>): JSX.Element {
+  return (
+    <BaseScrollArea.Root data-slot="scroll-area" className={cn('relative', className)} {...props}>
+      <BaseScrollArea.Viewport
+        data-slot="scroll-area-viewport"
+        className="size-full rounded-[inherit] outline-none"
+      >
+        {children}
+      </BaseScrollArea.Viewport>
+      <ScrollBar />
+      <BaseScrollArea.Corner />
+    </BaseScrollArea.Root>
+  )
+}
+
+export function ScrollBar({
+  className,
+  orientation = 'vertical',
+  ...props
+}: ComponentProps<typeof BaseScrollArea.Scrollbar>): JSX.Element {
+  return (
+    <BaseScrollArea.Scrollbar
+      data-slot="scroll-area-scrollbar"
+      orientation={orientation}
+      className={cn(
+        'flex touch-none p-px transition-colors select-none',
+        orientation === 'vertical' && 'h-full w-2',
+        orientation === 'horizontal' && 'h-2 w-full flex-col',
+        className,
+      )}
+      {...props}
+    >
+      <BaseScrollArea.Thumb
+        data-slot="scroll-area-thumb"
+        className="relative flex-1 rounded-full bg-border"
+      />
+    </BaseScrollArea.Scrollbar>
+  )
+}

--- a/src/renderer/src/ui/select.tsx
+++ b/src/renderer/src/ui/select.tsx
@@ -1,0 +1,126 @@
+import type { ComponentProps, JSX } from 'react'
+import { Select as BaseSelect } from '@base-ui/react/select'
+import { Check, ChevronDown } from 'lucide-react'
+import { cn } from '../lib/utils'
+
+/**
+ * A listbox select over base-ui's Select (Root/Trigger/Value/Positioner/Popup/
+ * Item/…). shadcn's base-ui `select.tsx`, with its `cn-select-*` tokens swapped for
+ * real utilities on our tokens and its icon-registry placeholders swapped for lucide
+ * (ChevronDown trigger icon, Check item indicator). Used for the model/effort pickers.
+ */
+export const Select = BaseSelect.Root
+export const SelectValue = BaseSelect.Value
+export const SelectGroup = BaseSelect.Group
+
+export function SelectTrigger({
+  className,
+  children,
+  ...props
+}: ComponentProps<typeof BaseSelect.Trigger>): JSX.Element {
+  return (
+    <BaseSelect.Trigger
+      data-slot="select-trigger"
+      className={cn(
+        'flex h-9 w-fit items-center justify-between gap-2 rounded-md border border-border bg-surface px-3 text-sm text-text outline-none transition-colors',
+        'hover:bg-accent/10 focus-visible:border-accent disabled:pointer-events-none disabled:opacity-50',
+        '[&_svg]:pointer-events-none [&_svg]:shrink-0',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <BaseSelect.Icon render={<ChevronDown className="size-4 text-muted" />} />
+    </BaseSelect.Trigger>
+  )
+}
+
+export function SelectContent({
+  className,
+  children,
+  side = 'bottom',
+  sideOffset = 4,
+  align = 'center',
+  alignOffset = 0,
+  ...props
+}: ComponentProps<typeof BaseSelect.Popup> &
+  Pick<
+    ComponentProps<typeof BaseSelect.Positioner>,
+    'align' | 'alignOffset' | 'side' | 'sideOffset'
+  >): JSX.Element {
+  return (
+    <BaseSelect.Portal>
+      <BaseSelect.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        className="z-50"
+      >
+        <BaseSelect.Popup
+          data-slot="select-content"
+          className={cn(
+            'z-50 max-h-(--available-height) min-w-32 overflow-y-auto rounded-md border border-border bg-panel py-1 text-sm text-text shadow-md outline-none',
+            className,
+          )}
+          {...props}
+        >
+          {/* `List` is the element that carries `role="listbox"` + registers the
+             scroll/positioning container in base-ui — keep children inside it. */}
+          <BaseSelect.List>{children}</BaseSelect.List>
+        </BaseSelect.Popup>
+      </BaseSelect.Positioner>
+    </BaseSelect.Portal>
+  )
+}
+
+export function SelectItem({
+  className,
+  children,
+  ...props
+}: ComponentProps<typeof BaseSelect.Item>): JSX.Element {
+  return (
+    <BaseSelect.Item
+      data-slot="select-item"
+      className={cn(
+        'relative flex cursor-default items-center gap-2 py-1.5 pr-8 pl-3 outline-none select-none',
+        'data-[highlighted]:bg-accent data-[highlighted]:text-on-accent',
+        'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        '[&_svg]:pointer-events-none [&_svg]:shrink-0',
+        className,
+      )}
+      {...props}
+    >
+      <BaseSelect.ItemText>{children}</BaseSelect.ItemText>
+      <BaseSelect.ItemIndicator className="absolute right-3 flex items-center">
+        <Check className="size-4" />
+      </BaseSelect.ItemIndicator>
+    </BaseSelect.Item>
+  )
+}
+
+export function SelectGroupLabel({
+  className,
+  ...props
+}: ComponentProps<typeof BaseSelect.GroupLabel>): JSX.Element {
+  return (
+    <BaseSelect.GroupLabel
+      data-slot="select-label"
+      className={cn('px-3 py-1.5 text-xs text-muted', className)}
+      {...props}
+    />
+  )
+}
+
+export function SelectSeparator({
+  className,
+  ...props
+}: ComponentProps<typeof BaseSelect.Separator>): JSX.Element {
+  return (
+    <BaseSelect.Separator
+      data-slot="select-separator"
+      className={cn('my-1 h-px bg-border', className)}
+      {...props}
+    />
+  )
+}

--- a/src/renderer/src/ui/separator.tsx
+++ b/src/renderer/src/ui/separator.tsx
@@ -1,0 +1,27 @@
+import type { ComponentProps, JSX } from 'react'
+import { Separator as BaseSeparator } from '@base-ui/react/separator'
+import { cn } from '../lib/utils'
+
+/**
+ * A hairline divider over base-ui's Separator — a `--border`-coloured 1px rule,
+ * horizontal or vertical. Lifted straight from shadcn (its classes already use
+ * `bg-border`, which maps to our token).
+ */
+export function Separator({
+  className,
+  orientation = 'horizontal',
+  ...props
+}: ComponentProps<typeof BaseSeparator>): JSX.Element {
+  return (
+    <BaseSeparator
+      data-slot="separator"
+      orientation={orientation}
+      className={cn(
+        'shrink-0 bg-border',
+        orientation === 'horizontal' ? 'h-px w-full' : 'w-px self-stretch',
+        className,
+      )}
+      {...props}
+    />
+  )
+}

--- a/src/renderer/src/ui/spinner.tsx
+++ b/src/renderer/src/ui/spinner.tsx
@@ -1,0 +1,20 @@
+import type { ComponentProps, JSX } from 'react'
+import { Loader2 } from 'lucide-react'
+import { cn } from '../lib/utils'
+
+/**
+ * A spinning loading glyph — lucide `loader-2` with `animate-spin`. `size-4` by
+ * default; override via `className` (e.g. `size-3` for inline). Carries a `status`
+ * role for a11y.
+ */
+export function Spinner({ className, ...props }: ComponentProps<typeof Loader2>): JSX.Element {
+  return (
+    <Loader2
+      data-slot="spinner"
+      role="status"
+      aria-label="Loading"
+      className={cn('size-4 animate-spin', className)}
+      {...props}
+    />
+  )
+}

--- a/src/renderer/src/ui/textarea.tsx
+++ b/src/renderer/src/ui/textarea.tsx
@@ -1,0 +1,25 @@
+import type { ComponentProps, JSX } from 'react'
+import { cn } from '../lib/utils'
+
+/**
+ * A native multi-line text field (base-ui has no textarea primitive) styled to
+ * match {@link Input}. `field-sizing-content` lets it grow with its content;
+ * consumers can still override to a fixed `resize`.
+ */
+export function Textarea({
+  className,
+  ...props
+}: ComponentProps<'textarea'>): JSX.Element {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        'flex field-sizing-content min-h-16 w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-text outline-none transition-colors',
+        'placeholder:text-placeholder focus-visible:border-accent',
+        'disabled:pointer-events-none disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  )
+}

--- a/src/renderer/src/ui/tooltip.tsx
+++ b/src/renderer/src/ui/tooltip.tsx
@@ -1,0 +1,56 @@
+import type { ComponentProps, JSX } from 'react'
+import { Tooltip as BaseTooltip } from '@base-ui/react/tooltip'
+import { cn } from '../lib/utils'
+
+/**
+ * A hover/focus tooltip over base-ui's Tooltip. `TooltipProvider` shares delay
+ * across a subtree (mount once near the app root). The content is a dark inverted
+ * chip (`--text` bg / `--bg` fg) — shadcn's `bg-foreground text-background`,
+ * re-expressed on our tokens.
+ */
+export function TooltipProvider({
+  delay = 300,
+  ...props
+}: ComponentProps<typeof BaseTooltip.Provider>): JSX.Element {
+  return <BaseTooltip.Provider data-slot="tooltip-provider" delay={delay} {...props} />
+}
+
+export const Tooltip = BaseTooltip.Root
+export const TooltipTrigger = BaseTooltip.Trigger
+
+export function TooltipContent({
+  className,
+  side = 'top',
+  sideOffset = 4,
+  align = 'center',
+  alignOffset = 0,
+  children,
+  ...props
+}: ComponentProps<typeof BaseTooltip.Popup> &
+  Pick<
+    ComponentProps<typeof BaseTooltip.Positioner>,
+    'align' | 'alignOffset' | 'side' | 'sideOffset'
+  >): JSX.Element {
+  return (
+    <BaseTooltip.Portal>
+      <BaseTooltip.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        className="z-50"
+      >
+        <BaseTooltip.Popup
+          data-slot="tooltip-content"
+          className={cn(
+            'z-50 w-fit max-w-xs rounded-sm bg-text px-2 py-1 text-xs text-bg shadow-md',
+            className,
+          )}
+          {...props}
+        >
+          {children}
+        </BaseTooltip.Popup>
+      </BaseTooltip.Positioner>
+    </BaseTooltip.Portal>
+  )
+}


### PR DESCRIPTION
Closes #111. Slice 2 of the design-system epic (PRD #109, ADR-0010).

## What
Grows `src/renderer/src/ui/` (previously just `menu.tsx`) into the shared primitive library the later area slices (#113/#117–#119) consume. Headless behavior from `@base-ui/react@1.6.0`, styled with Tailwind utilities resolved through our #110 tokens, composed via `cn()`, variants via **CVA** (new dep `class-variance-authority`).

**Primitives** (18 files + a `ui/index.ts` barrel):
- **Button** (CVA exemplar) — variants `default/outline/secondary/ghost/destructive/link/stop`, sizes `default/xs/sm/lg/icon/icon-xs/icon-sm/icon-lg`; exports `buttonVariants`. **IconButton**, **Input**, **Textarea**, **Badge** (CVA + `useRender`), **Chip** (borderless per tokens doc).
- Compound base-ui: **Dialog**, **Popover**, **Tooltip**, **Collapsible**, **ScrollArea**, **Select**, **Separator**, **Avatar**. **Spinner** (lucide). App-specific: **NavItem**, **Panel**, **Card**.
- **Menu** lightly refreshed (`rounded-none`→`rounded-md`); API/behavior byte-identical, its three consumers (Shell / ChangesPanel / AgentControls) unaffected.

## Key adaptations
- Swapped shadcn `bases/base`'s `cn-*` semantic theme tokens for **real Tailwind utilities on our bridged tokens** (`bg-accent text-on-accent`, `border-border`, etc.). Every token utility used is verified against the `@theme inline` bridge — **no silent no-ops** (`--active-bg`/`--accent-tint` are unbridged, so NavItem uses `bg-accent/15` instead).
- `text-on-accent` is the AA-safe warm dark ink from #110 (not white) on `bg-accent`.
- Reconciled base-ui 1.6.0 part names (e.g. `Collapsible.Panel`, orientation-driven `Separator`/`ScrollBar`).
- **Not wired into any feature area** — this is the kit only; areas migrate in their slices. The `ui/index.ts` barrel gives tsc full coverage of the otherwise-unimported kit.

## Review fold
Adversarial review caught that `SelectContent` omitted base-ui's `Select.List` wrapper (loses `role="listbox"` + the scroll/positioning container). Wrapped children in `<BaseSelect.List>` to match the reference and fix the a11y semantics before the pickers wire onto it (#117). Also corrected an Avatar doc-comment radius nit.

## Gates (independently re-run)
`bun run lint && bun run typecheck && bun run build && bun run test` — all green, **495 tests unchanged**. Typecheck is the real gate here: via the barrel it type-checks every primitive against base-ui 1.6.0. No `styles.css`/feature-area edits; no BEM added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)