### PR TITLE
Harden persistence seam + fix empty-Thread-on-Workspace-open (ADR-0011)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,7 +12,16 @@ _Avoid_: project, folder, repo (a workspace need not be a git repo).
 **Thread**:
 A user-facing conversation with the agent inside a Workspace. Maps one-to-one to an ACP session,
 but is our own domain concept (own id, name, persistence). A Workspace can have many Threads.
+A Thread starts as a Draft and becomes durable only on its first prompt (see **Draft Thread**).
 _Avoid_: chat, conversation, session (in the UI/app layer).
+
+**Draft Thread**:
+A newly created Thread that exists only in the renderer and is persisted nowhere. A Thread holds its
+minted id from creation, but is written to disk (metadata + transcript) only on its **first prompt** —
+the single event that makes a Thread durable. Abandoning a Draft leaves zero residue; the persisted
+Thread list contains only prompted Threads. Applies equally to both entry points — the New Thread
+button and opening a Workspace.
+_Avoid_: unsaved / temporary / phantom / ephemeral thread.
 
 **ACP session**:
 The protocol-level handle returned by `session/new` and addressed by `session/*` methods. Lives only

--- a/docs/adr/0011-draft-threads-persist-and-bind-on-first-prompt.md
+++ b/docs/adr/0011-draft-threads-persist-and-bind-on-first-prompt.md
@@ -1,0 +1,68 @@
+# Draft Threads: persist and bind an ACP session only on first prompt
+
+A Thread must leave **zero residue** until the user actually talks to the agent. Creating a Thread —
+whether via the New Thread (+) button or by opening a Workspace in the sidebar — produces a **Draft
+Thread**: a renderer-only object holding a minted id and nothing else. The Thread becomes durable, and
+an ACP session is opened for it, at exactly one moment: its **first prompt**. The persisted Thread list
+therefore contains only prompted Threads.
+
+This generalises the decision first made for the + button (commit `85e95ef`, "#58: make New-thread a
+renderer-only draft until first prompt") to **every** entry point, and pins down the ACP-session
+lifecycle that #58 left implicit.
+
+## Decision
+
+1. **First prompt is the single durability trigger.** No metadata record and no transcript file is
+   written for a Thread until its first prompt binds it (via the existing `mintAndBind` path). The
+   renderer mints the Thread id up front and preserves it across the bind, so the URL/selection is
+   stable while the Thread is still a Draft.
+2. **No eager `session/new`.** Opening a Workspace does **not** call `agent.openThread()`. The ACP
+   session is created together with the first-prompt persistence, not on select. Clicking around
+   Workspaces creates no sessions on `vibe-acp`.
+3. **Both entry points behave identically.** The Workspace-first-open path creates a renderer-only
+   Draft (same path as the + button) instead of the old eager `openThread()` + `recordThread()`.
+4. **Workspace metadata still persists on open.** Selecting a Workspace upserts the Workspace record
+   (dir, `lastOpenedAt`) and may warm its agent process (ADR-0006). Only the **Thread** write defers.
+   Workspace durability and Thread durability are separate rules.
+
+## Why
+
+The draft model already existed for one door but was violated at the other: opening a Workspace ran
+`agent.openThread()` + `recordThread()` and wrote an empty Thread to `metadata.json` with no user
+interaction — directly contradicting #58's stated goal that "the sidebar only ever lists prompted
+Threads." The principle lived only in a commit message, which was not enough to stop a second entry
+point from regressing it. Recording it as an ADR and as a glossary term (**Draft Thread**, CONTEXT.md)
+gives it a durable home and a name.
+
+## Considered options
+
+- **Eager `session/new` on Workspace-open, defer only the record** — rejected. First prompt is
+  marginally faster because the session already exists, but every Workspace click opens a real ACP
+  session on `vibe-acp` that is usually abandoned (session churn / orphans), and the two entry points
+  keep diverging at the protocol layer — so the store we intend to harden would still be fed by two
+  different session lifecycles.
+- **Draft everywhere; open session + persist on first prompt** (chosen) — one persistence rule and one
+  session rule through both doors. First prompt pays a `session/new` handshake, but on an already-warm
+  process (ADR-0006) that is a handshake, not a spawn.
+
+## Consequences
+
+- The `startThread` normal branch no longer opens-and-records a Thread; Workspace-open yields a
+  renderer-only Draft. `session/new` + persistence happen on first prompt through `mintAndBind`.
+- A Draft abandoned before its first prompt leaves nothing on disk and nothing on the agent.
+- First prompt carries the `session/new` round-trip. Acceptable: the process is warm; only the session
+  handshake is on the critical path.
+- **The first draft's agent-controls picker is empty until its first prompt.** vibe-acp advertises the
+  Mode/Model/Reasoning-effort option lists ONLY in the `session/new` / `session/load` response — never at
+  `initialize`/`agentCapabilities` (`docs/acp-capture.md:23-35`, `workspace-agent.ts:474-476`). With no
+  eager session there is nothing to populate the picker from until the first prompt binds one. This is
+  NOT a new regression: the Continue flow already behaves identically (`continueConnection` hard-codes
+  null controls until the lazy resume, `index.ts`). A future enhancement — an agent-level controls cache
+  seeded from the first `session/new` and reused for later drafts/continues — would populate the picker
+  after any Thread has run once in the Workspace; the very first Thread (no session yet) is unavoidable.
+  Deliberately deferred (not part of this change).
+- The persisted Thread list is guaranteed to contain only prompted Threads — the invariant a future
+  reader can rely on, and the reason not to "optimise" by re-introducing eager open (that is the
+  rejected option above).
+- Complements ADR-0005 (which owns the *storage engine* choice) and ADR-0006 (warm agent pool); it does
+  not supersede either.

--- a/docs/notes/threads-worktrees-persistence.md
+++ b/docs/notes/threads-worktrees-persistence.md
@@ -1,0 +1,199 @@
+# t3code: Threads, Worktrees & Local Persistence — Findings
+
+> Investigation notes. Line numbers reflect the repo state at time of writing (2026-07-01) and may drift.
+
+## Q1: Is each thread a git worktree?
+
+**No.** A thread is an orchestration/projection entity that belongs to a project
+(`projectId`) and carries an **optional, nullable `worktreePath`**. Thread → worktree is a
+*zero-or-one* reference (by filesystem path); worktree → threads is *one-to-many*.
+
+### Three possible states for a thread
+1. **Own worktree** — dedicated git worktree + temporary branch (`t3code/<hex>`).
+2. **Shared worktree** — multiple threads point at the same `worktreePath`.
+3. **Local mode** — no worktree; runs in the project root checkout (`workspaceRoot`).
+
+The env-mode toggle (`apps/web/src/components/BranchToolbarEnvModeSelector.tsx`) lets the
+user pick **"local"** vs **"worktree"** per thread.
+
+### Key locations
+- Thread shell shape (nullable `worktreePath`, `branch`): `packages/contracts/src/orchestration.ts:560`
+- Projection column `worktree_path AS "worktreePath"`: `apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts:127,331`
+- Worktree prepared only on first message + `sendEnvMode === "worktree"` + no existing path: `apps/web/src/components/ChatView.tsx:3969`
+- Server creates worktree then writes path/branch back to thread: `apps/server/src/ws.ts:836` (`gitWorkflow.createWorktree` + `thread.meta.update`)
+- Actual git call `git worktree add -b <branch> <path> <ref>`: `apps/server/src/vcs/GitVcsDriverCore.ts:2245`
+  - path: `worktreesDir/<repoName>/<sanitizedBranch>`; branch prefix `t3code/<hex>` (`packages/shared/src/git.ts`)
+- Fallback to project root when no worktree: `apps/server/src/ws.ts:1448`
+  - `workspaceRoot: thread.value.worktreePath ?? project.value.workspaceRoot`
+- Sharing evidence — orphan check skips worktrees still referenced by other threads:
+  `apps/web/src/worktreeCleanup.ts:11` (`getOrphanedWorktreePathForThread`)
+
+### Git isolation
+Opt-in per thread. "worktree" mode → dedicated worktree/branch (isolated cwd + branch).
+"local" / reused path → shares the checkout, no per-thread isolation. The same
+`worktreePath` flows into terminal sessions (`apps/server/src/terminal/Manager.ts`) and
+setup-script execution (`apps/server/src/project/ProjectSetupScriptRunner.ts:135`).
+
+---
+
+## Q2: How does t3code save threads & conversations locally?
+
+**One SQLite file, event-sourced (CQRS).** Default path: **`~/.t3/userdata/state.sqlite`**
+(+ `-wal` / `-shm` sidecars, WAL mode).
+
+### Storage engine
+SQLite via Effect's `unstable/sql`. Driver picked at runtime (`persistence/Layers/Sqlite.ts:19-31`):
+- Bun → `@effect/sql-sqlite-bun/SqliteClient`
+- Node → local `apps/server/src/persistence/NodeSqliteClient.ts` wrapping `node:sqlite`
+  (`DatabaseSync`; needs Node >=22.16/23.11/24)
+
+On connect: `PRAGMA journal_mode = WAL`, `PRAGMA foreign_keys = ON`, then run migrations
+(`Sqlite.ts:33-40`). No JSON/LevelDB store for chat data.
+
+### Architecture — event sourced, not a plain row store
+1. **Append-only event log** → `orchestration_events` (`Migrations/001_OrchestrationEvents.ts`).
+   Immutable rows; global `sequence AUTOINCREMENT` + per-stream `stream_version` with optimistic
+   concurrency (unique on `(aggregate_kind, stream_id, stream_version)`). Store only INSERTs /
+   reads forward (`persistence/Layers/OrchestrationEventStore.ts`).
+2. **Projector** folds events → read-model tables, tracking a per-projector cursor
+   `last_applied_sequence` in `projection_state` (`orchestration/Layers/ProjectionPipeline.ts`,
+   `persistence/Layers/ProjectionState.ts`).
+3. **Read side** queries the projection tables to build UI snapshots
+   (`orchestration/Layers/ProjectionSnapshotQuery.ts`).
+
+Flow: commands → append events → project into `projection_*` → snapshot queries read them.
+
+### Main read-model tables (`Migrations/005_Projections.ts`)
+- `projection_projects`
+- `projection_threads` — `thread_id PK`, `project_id`, `title`, `model`, `branch`,
+  `worktree_path`, `latest_turn_id`, timestamps, `deleted_at` (indexed by `project_id`)
+- `projection_thread_messages` — `message_id PK`, `thread_id`, `turn_id?`, `role`, `text`,
+  `is_streaming`, timestamps; `attachments_json` added in migration 007. Ordered history via
+  `idx_projection_thread_messages_thread_created (thread_id, created_at)`
+- `projection_turns` — one request/response cycle; `UNIQUE (thread_id, turn_id)`
+- `projection_thread_activities` (tool calls), `projection_thread_sessions` (live session state)
+
+Messages are written by idempotent upsert `INSERT ... ON CONFLICT(message_id) DO UPDATE`
+(`persistence/Layers/ProjectionThreadMessages.ts`), so streaming assistant text repeatedly
+upserts the same row. A message links to its conversation via `thread_id` and its cycle via `turn_id`.
+
+### On-disk path config (`ServerConfig`)
+- `apps/server/src/config.ts:91-121` (`deriveServerPaths`):
+  `stateDir = baseDir/{userdata|dev}`, `dbPath = stateDir/state.sqlite`
+- `apps/server/src/os-jank.ts:86-92` — default `baseDir = ~/.t3`; override via `--baseDir` /
+  `T3_HOME` (`apps/server/src/cli/config.ts:262-274`)
+- Wired in `persistence/Layers/Sqlite.ts:66-68` — `layerConfig` reads `dbPath` off `ServerConfig`;
+  `:memory:` variant for tests
+
+### Migrations
+`apps/server/src/persistence/Migrations/`, registered in `persistence/Migrations.ts` (32 migrations),
+run via Effect `Migrator` (tracking table `effect_sql_migrations`).
+
+---
+
+## Q3: vibe-mistro persistence vs t3code, and the adoption path
+
+### What vibe-mistro does today (`/Users/abdullahatrash/mistral/vibe-mistro`)
+Purely files, **no database** (design in `docs/adr/0005-persistence-json-metadata-vibe-owns-history.md`).
+Single-writer: only the Electron main process mutates; renderer is pure.
+
+- **`metadata.json`** — one flat index file: `{ workspaces[], threads[] }` (`src/main/persistence/metadata-store.ts`).
+  - `WorkspaceMeta` = `{ id, dir, displayName, lastOpenedAt }` (keyed by absolute `dir`)
+  - `ThreadMeta` = `{ id, workspaceId, sessionId, title, createdAt, lastActiveAt }` (`src/shared/ipc.ts:570`)
+  - **No messages here** — it's a light index. Atomic write via tmp + `fs.rename` (`metadata-store.ts:186`).
+- **`transcripts/<threadId>.jsonl`** — one append-only JSONL per thread (`src/main/persistence/transcript.ts`).
+  - Each line is a `TranscriptEntry` union: `user-prompt | acp-event | turn-complete | turn-error |
+    resolve-permission | agent-rebound` (`ipc.ts:598`)
+  - Replayed through the renderer's `conversationReducer` on reopen to rebuild the view.
+- Rooted at Electron `userData` (`app.getPath('userData')`, macOS `~/Library/Application Support/vibe-mistro/`),
+  derived in `src/main/index.ts:1004-1019`. Project dirs are referenced only by absolute path in metadata.
+- Store modules: `metadata-store.ts` (`load`/`persist`/`upsertWorkspace`/`upsertThread`/`deleteThread`),
+  `transcript.ts` (`append`/`read`/`delete`, per-thread promise-chained appends), `delete-thread.ts`.
+
+### Head-to-head
+
+| | vibe-mistro | t3code |
+|---|---|---|
+| Store | JSON index + per-thread JSONL | single SQLite `state.sqlite` (WAL) |
+| Model | metadata rows + append-only transcript | event log + projected read tables (CQRS) |
+| Source of truth | the JSONL transcript | `orchestration_events` (immutable) |
+| Read model | rebuilt in renderer reducer at open | `projection_*` tables, cursor-tracked |
+| Queries | load whole file, filter in JS | SQL (indexed by project/thread/turn) |
+| Schema evolution | ad-hoc shape-filtering on load | numbered migrations (`Migrator`) |
+
+**Key insight:** vibe-mistro already has the important half of t3code's design — an append-only event
+stream (its JSONL *is* the log; `TranscriptEntry` ≈ an event). What's missing is (1) a queryable
+projected read-model and (2) formal migrations. So this is less of a rewrite than it looks.
+
+### Adoption path (staged, each stage shippable)
+
+**Stage 0 — scope.** Likely don't need full CQRS. Real wins: SQL queryability, indexed lists,
+migrations. Target "SQLite + a projections layer," not "adopt the whole Effect orchestration engine."
+
+**Stage 1 — SQLite behind the existing store interface.**
+- Add `node:sqlite` (Node ≥22.16, like t3code's `NodeSqliteClient.ts`) or `better-sqlite3`.
+- Keep `MetadataStore`/`TranscriptStore` public methods identical; swap bodies for SQL. IPC/renderer unchanged.
+- On open: `journal_mode=WAL`, `foreign_keys=ON` (mirror `Sqlite.ts:33`).
+- _Captures ~80% of the durability benefit for ~10% of the effort._
+
+**Stage 2 — port the event log.**
+- Table `events(sequence INTEGER PK AUTOINCREMENT, thread_id, stream_version, type, payload_json, created_at)`
+  = the JSONL, one row per `TranscriptEntry`. `append()` → INSERT (mirror `OrchestrationEventStore.ts`).
+- Optional `UNIQUE(thread_id, stream_version)` for optimistic concurrency — probably skip initially
+  given single-writer.
+
+**Stage 3 — projection tables + projector.**
+- `projection_threads`, `projection_thread_messages`, `projection_turns` (crib from `Migrations/005_Projections.ts`),
+  plus `projection_state(name, last_applied_sequence)`.
+- Projector folds events → tables (mirror `ProjectionPipeline.ts`); messages via idempotent
+  `INSERT ... ON CONFLICT(message_id) DO UPDATE` for streaming (mirror `ProjectionThreadMessages.ts`).
+- `listMetadata` becomes an indexed SQL query instead of load-whole-JSON + filter.
+
+**Stage 4 — migrations + one-time importer.**
+- Adopt a numbered-migration runner (Effect `Migrator`, or a tiny `PRAGMA user_version` one).
+- Importer reads existing `metadata.json` + every `transcripts/*.jsonl`, replays into `events`,
+  rebuilds projections. Keep JSON files as backup for one release.
+
+**Pragmatic stopping points:** Stages 1–2 alone give atomic multi-thread writes, crash safety, and
+cross-thread queries without a projector. Stages 3–4 add the fast indexed read-model and safe schema
+evolution. Full Effect-style CQRS is optional — only worth it at t3code-like scale/concurrency.
+
+**Caveat:** vibe-mistro's current design is clean, documented, single-writer. Justify the migration by
+real pain: (a) large-JSON load/filter getting slow, (b) wanting relational cross-thread/turn queries,
+(c) schema-evolution churn. If none bite yet, do Stage 1 and stop.
+
+---
+
+## Decision log — grill session 2026-07-01 (branch `docs/persistence-adoption`)
+
+**Persistence migration: DEFERRED, per ADR-0005.** Re-evaluated adopting t3code's SQLite + event-
+sourcing. Verdict: no fired trigger.
+- Search (0005's stated trigger) is a *future* feature, not present → not yet.
+- The "slow cold-start" symptom was traced and is **NOT** a storage problem: launch reads only the small
+  `metadata.json`; zero JSONL is touched at startup; transcripts load lazily on thread-open. SQLite would
+  not fix it. Real suspects live outside persistence (`vibe-detect` `execFile`, bundle startup, lazy
+  agent spawn, per-open replay). *Separate investigation if cold-start is worth chasing.*
+
+**Instead: hardened the seam (done this session).**
+- **Seam audit: clean.** All `metadata.json` / `*.jsonl` access is funneled through `MetadataStore` /
+  `TranscriptStore`; path derivation single-sourced in `index.ts:1007/1013`; single-writer (main) holds;
+  renderer/preload go through IPC only. The SQLite swap is genuinely drop-in (reimplement the two classes
+  behind their injected `deps`). Added a SEAM CONTRACT comment atop each store to keep it that way.
+- **Metadata versioning + fail-closed.** `metadata.json` is now a `{ schemaVersion, workspaces, threads }`
+  envelope (`METADATA_SCHEMA_VERSION = 1`; legacy files read as v1). A file with a *newer* version
+  **locks** the store: `load()` refuses to load and `persist()` becomes a no-op, so an older build can
+  never atomically overwrite (wipe) newer data. `isLocked()` exposed for a future UI notice.
+- **Transcript versioning.** Each log's first line is a version header
+  (`TRANSCRIPT_SCHEMA_VERSION = 1`), written once, restart-safe (checks file contents), skipped on replay.
+  `transcriptVersionOf(raw)` for future migrators; legacy header-less logs read as v1.
+
+**Empty-thread bug: confirmed + specified fix (ADR-0011 written, code fix pending).**
+- Opening a Workspace persists an empty Thread (`startThread` → `openThread()` + `recordThread()`,
+  `index.ts:671`). The #58 draft fix (`85e95ef`) only ever covered the + button.
+- Decision: **Option 1** — Workspace-open creates a renderer-only Draft (like the + button); defer both
+  `session/new` and persistence to first prompt. Workspace metadata still persists on open; only the
+  Thread defers. Captured as the **Draft Thread** term (CONTEXT.md) + **ADR-0011**.
+- ⚠️ Code fix to `selectWorkspace`/`connectWorkspace`/`startThread` is NOT yet implemented — next task.
+
+**Docs touched:** `CONTEXT.md` (Thread + new Draft Thread terms), `docs/adr/0011-*.md` (new),
+`src/main/persistence/{metadata-store,transcript}.ts` (+ tests). All 501 tests green, typecheck clean.

--- a/docs/notes/threads-worktrees-persistence.md
+++ b/docs/notes/threads-worktrees-persistence.md
@@ -193,7 +193,14 @@ sourcing. Verdict: no fired trigger.
 - Decision: **Option 1** — Workspace-open creates a renderer-only Draft (like the + button); defer both
   `session/new` and persistence to first prompt. Workspace metadata still persists on open; only the
   Thread defers. Captured as the **Draft Thread** term (CONTEXT.md) + **ADR-0011**.
-- ⚠️ Code fix to `selectWorkspace`/`connectWorkspace`/`startThread` is NOT yet implemented — next task.
+- ✅ Code fix IMPLEMENTED. `startThread`'s normal branch (and the post-sign-in `openThread` handler) now
+  return a `draftConnection` — mint a Thread id, no `session/new`, no `recordThread` — mirroring the
+  proven `continueConnection` session-less shape. First prompt binds + persists via `mintAndBind`. Dead
+  `recordThread` / `connectionFor` / `ThreadIds` removed. Renderer unchanged (reducers already handle a
+  draft connection via the Continue flow). Typecheck clean, 501 tests green.
+- Controls note: vibe-acp only advertises Mode/Model/effort via `session/new`, so the first draft's
+  picker is empty until first prompt — same as the existing Continue flow, not a new regression. An
+  agent-level controls cache (deferred) would populate it after any Thread runs once. See ADR-0011.
 
 **Docs touched:** `CONTEXT.md` (Thread + new Draft Thread terms), `docs/adr/0011-*.md` (new),
 `src/main/persistence/{metadata-store,transcript}.ts` (+ tests). All 501 tests green, typecheck clean.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -38,7 +38,6 @@ import {
   type StartThreadResult,
   type ThreadAgentControls,
   type ThreadConnection,
-  type ThreadInfo,
   type ThreadStatusEvent,
 } from '../shared/ipc'
 import { detectVibe } from './vibe-detect'
@@ -264,8 +263,8 @@ let transcriptStore: TranscriptStore | null = null
  * for chokepoints with no sessionId in hand (e.g. `respondPermission`).
  *
  * Residual (documented): both routes miss during the brief window after
- * `session/new` returns but before `recordThread` persists the sessionId +
- * seeds the map — a `session/update` streamed THEN (notably the immediate
+ * `session/new` returns but before the first-prompt bind (`mintAndBind`) persists
+ * the sessionId + seeds the map — a `session/update` streamed THEN (notably the immediate
  * `available_commands_update`, not rendered this slice) is dropped from replay.
  * The Thread title is unaffected — it's also persisted in the metadata record.
  */
@@ -280,7 +279,7 @@ function threadIdForTee(agentId: string, sessionId?: string | null): string | nu
 
 /**
  * Tee one conversation INPUT to the active Thread's JSONL (ADR-0005). Best-effort
- * and fire-and-forget, guarded exactly like `recordThread`: an absent store or an
+ * and fire-and-forget, guarded exactly like `recordWorkspaceOpen`: an absent store or an
  * unresolved Thread id skips the write; the append itself swallows I/O errors.
  */
 function teeTranscript(threadId: string | null, entry: TranscriptEntry): void {
@@ -304,43 +303,42 @@ function bestEffortCloseFor(threadId: string): (() => Promise<void>) | undefined
   }
 }
 
-/** Our minted handles for a connected Thread (TB5) — carried to the renderer. */
-interface ThreadIds {
-  threadId: string
-  workspaceId: string
-}
-
 /**
- * Persist that this Workspace was opened and a Thread minted, and RETURN our
- * durable Thread + Workspace ids (TB5) so the renderer can later create drafts
- * and bind-on-first-prompt under them. The Thread id is distinct from its ACP
- * `sessionId` (the resume cursor for a reopen, TB3). Best-effort: a metadata
- * write must never break the live connect flow — on a store failure we synthesize
- * ids so the live conversation still works (the binding upsert simply retries).
- * Also seeds the `agentId -> threadId` transcript bridge so the agent's streamed
- * events tee to this Thread.
+ * Build a connection for a fresh DRAFT Thread (ADR-0011): mint our durable Thread
+ * id but open NO ACP session and persist NO record. The Thread stays a renderer-
+ * only draft until its FIRST prompt, which drives `session/new` + the persist via
+ * `ensureBoundSession`/`mintAndBind`. This is the fix for the empty-Thread bug —
+ * opening a Workspace no longer records a Thread nobody prompted.
+ *
+ * Mirrors `continueConnection`'s session-less shape (null session, null controls
+ * until the first prompt binds — consistent with the Continue flow); the only
+ * difference is a brand-new minted id rather than a resolved existing record. Also
+ * seeds the `agentId -> threadId` transcript bridge so a session-less lifecycle
+ * event tees to this Thread. `workspaceId` is the persisted Workspace id (from
+ * `recordWorkspaceOpen`) so the first-prompt `upsertThread` records under the real
+ * Workspace; a synthesized id is used only in degraded mode (no store), where the
+ * draft never persists anyway.
  */
-async function recordThread(agentId: string, workspaceDir: string, thread: ThreadInfo): Promise<ThreadIds> {
-  if (metadataStore) {
-    try {
-      const ws = await metadataStore.upsertWorkspace({
-        dir: workspaceDir,
-        displayName: basename(workspaceDir),
-      })
-      const record = await metadataStore.upsertThread({
-        workspaceId: ws.id,
-        sessionId: thread.sessionId,
-        title: thread.title,
-      })
-      transcriptThreads.set(agentId, record.id)
-      return { threadId: record.id, workspaceId: ws.id }
-    } catch {
-      // A persistence failure is non-fatal — fall through to synthesized ids.
-    }
+function draftConnection(
+  agentId: string,
+  agent: WorkspaceAgent,
+  workspaceId: string | null,
+): ThreadConnection {
+  const threadId = randomUUID()
+  transcriptThreads.set(agentId, threadId)
+  return {
+    agentId,
+    workspaceDir: agent.workspaceDir,
+    sessionId: null,
+    title: null,
+    modes: null,
+    models: null,
+    reasoningEffort: null,
+    threadId,
+    workspaceId: workspaceId ?? randomUUID(),
+    signOutAvailable: agent.signOutAvailable,
+    authMethods: agent.authMethods,
   }
-  const ids = { threadId: randomUUID(), workspaceId: randomUUID() }
-  transcriptThreads.set(agentId, ids.threadId)
-  return ids
 }
 
 /**
@@ -385,38 +383,24 @@ async function bindThreadSession(
 
 /**
  * Persist that a Workspace was opened, BEFORE the agent starts, so even a
- * not-signed-in Workspace lists. Best-effort exactly like `recordThread`: a
- * failing `persist()` (disk full / read-only userData) must NEVER reject the
- * connect flow — the renderer's onClick has no `.catch`, so a throw here would
- * wedge the UI on "Launching…".
+ * not-signed-in Workspace lists. Returns the persisted Workspace id (so a fresh
+ * draft's first-prompt `upsertThread` can record its Thread under the real
+ * Workspace), or `null` with no store / on failure. Best-effort: a failing
+ * `persist()` (disk full / read-only userData) must NEVER reject the connect
+ * flow — the renderer's onClick has no `.catch`, so a throw here would wedge the
+ * UI on "Launching…".
  */
-async function recordWorkspaceOpen(workspaceDir: string): Promise<void> {
-  if (!metadataStore) return
+async function recordWorkspaceOpen(workspaceDir: string): Promise<string | null> {
+  if (!metadataStore) return null
   try {
-    await metadataStore.upsertWorkspace({
+    const ws = await metadataStore.upsertWorkspace({
       dir: workspaceDir,
       displayName: basename(workspaceDir),
     })
+    return ws.id
   } catch {
-    // A persistence failure is non-fatal — the connect flow proceeds.
-  }
-}
-
-/** Build the renderer-facing connection (carries our minted ids + sign-out gate). */
-function connectionFor(
-  agentId: string,
-  agent: WorkspaceAgent,
-  thread: ThreadInfo,
-  ids: ThreadIds,
-): ThreadConnection {
-  return {
-    agentId,
-    workspaceDir: agent.workspaceDir,
-    ...thread,
-    threadId: ids.threadId,
-    workspaceId: ids.workspaceId,
-    signOutAvailable: agent.signOutAvailable,
-    authMethods: agent.authMethods,
+    // A persistence failure is non-fatal — the connect flow proceeds (degraded).
+    return null
   }
 }
 
@@ -645,7 +629,8 @@ function registerIpc(): void {
 
     // Persist the Workspace open up front (ADR-0005), so even a not-signed-in
     // Workspace shows in the cold list. Best-effort — must not reject connect.
-    await recordWorkspaceOpen(args.workspaceDir)
+    // Its id seeds a fresh draft's first-prompt upsert (below).
+    const workspaceId = await recordWorkspaceOpen(args.workspaceDir)
 
     try {
       // Idempotent: spawns + handshakes a fresh agent, no-ops a warm one (already
@@ -661,34 +646,33 @@ function registerIpc(): void {
 
       // Continue from the cold launch list (TB4 #33): connect to the EXISTING
       // Thread (its first prompt drives the lazy `session/load` resume) without
-      // opening — and persisting — a throwaway empty Thread. Falls through to the
-      // normal open when the record can't be resolved (degraded / no store).
+      // opening — and persisting — a throwaway empty Thread. Falls through to a
+      // fresh draft when the record can't be resolved (degraded / no store).
       if (args.continueThreadId) {
         const continued = continueConnection(agentId, agent, args.continueThreadId)
         if (continued) return { ok: true, thread: continued }
       }
 
-      const thread = await agent.openThread()
-      const ids = await recordThread(agentId, args.workspaceDir, thread)
-      return { ok: true, thread: connectionFor(agentId, agent, thread, ids) }
+      // Open a fresh DRAFT Thread (ADR-0011): NO `session/new`, NO empty record.
+      // The draft binds a session + persists only on its first prompt, so clicking
+      // a Workspace never leaves a Thread nobody prompted. The `agent.start()`
+      // above still surfaces a not-signed-in / handshake error via the catch.
+      return { ok: true, thread: draftConnection(agentId, agent, workspaceId) }
     } catch (err) {
       return threadFailureResult(agentId, agent, err)
     }
   })
 
   ipcMain.handle(IPC.openThread, async (_event, args: OpenThreadArgs): Promise<StartThreadResult> => {
-    // Open a Thread on an agent already started + signed in (after sign-in or an
-    // in-place re-auth). Reuses the retained agent — no re-spawn.
+    // Land in a fresh DRAFT Thread on an agent already started + signed in (after
+    // sign-in or an in-place re-auth). Reuses the retained agent — no re-spawn — and,
+    // like Workspace-open, opens NO session and persists NO record until the first
+    // prompt (ADR-0011). Records the Workspace open to learn its id for that upsert.
     const agent = pool.get(args.agentId)
     if (!agent) return { ok: false, kind: 'error', error: `No active agent for id ${args.agentId}.`, hint: null }
-    pool.touch(args.agentId) // opening a Thread is activity — outrank idle peers (TB5 #50)
-    try {
-      const thread = await agent.openThread()
-      const ids = await recordThread(args.agentId, agent.workspaceDir, thread)
-      return { ok: true, thread: connectionFor(args.agentId, agent, thread, ids) }
-    } catch (err) {
-      return threadFailureResult(args.agentId, agent, err)
-    }
+    pool.touch(args.agentId) // landing in a Thread is activity — outrank idle peers (TB5 #50)
+    const workspaceId = await recordWorkspaceOpen(agent.workspaceDir)
+    return { ok: true, thread: draftConnection(args.agentId, agent, workspaceId) }
   })
 
   ipcMain.handle(

--- a/src/main/persistence/metadata-store.test.ts
+++ b/src/main/persistence/metadata-store.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, afterAll } from 'vitest'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { groupThreadsByWorkspace, MetadataStore } from './metadata-store'
+import { groupThreadsByWorkspace, METADATA_SCHEMA_VERSION, MetadataStore } from './metadata-store'
 
 /**
  * The main-side Workspace/Thread metadata store (ADR-0005 metadata-first lazy
@@ -141,6 +141,62 @@ describe('MetadataStore round-trip', () => {
     // Listing the valid subset must not throw on the dropped malformed records.
     expect(() => groupThreadsByWorkspace(snap)).not.toThrow()
     expect(groupThreadsByWorkspace(snap)[0].threads.map((t) => t.id)).toEqual(['t1'])
+  })
+})
+
+describe('MetadataStore schema versioning (ADR-0005 hardening)', () => {
+  it('persists a versioned envelope: { schemaVersion, workspaces, threads }', async () => {
+    const file = join(dir, 'envelope.json')
+    const store = new MetadataStore({ filePath: file })
+    await store.load()
+    await store.upsertWorkspace({ dir: '/proj/env' })
+
+    const raw = JSON.parse(readFileSync(file, 'utf8'))
+    expect(raw.schemaVersion).toBe(METADATA_SCHEMA_VERSION)
+    expect(raw.workspaces).toHaveLength(1)
+    expect(Array.isArray(raw.threads)).toBe(true)
+  })
+
+  it('reads a legacy header-less file (no schemaVersion) as the current version', async () => {
+    // Files written before the envelope carry no schemaVersion — they ARE v1.
+    const file = join(dir, 'legacy.json')
+    writeFileSync(
+      file,
+      JSON.stringify({
+        workspaces: [{ id: 'w1', dir: '/legacy', displayName: 'L', lastOpenedAt: 5 }],
+        threads: [
+          { id: 't1', workspaceId: 'w1', sessionId: null, title: null, createdAt: 1, lastActiveAt: 2 },
+        ],
+      }),
+    )
+    const store = new MetadataStore({ filePath: file })
+    await store.load()
+
+    expect(store.isLocked()).toBe(false)
+    expect(store.snapshot().workspaces.map((w) => w.id)).toEqual(['w1'])
+    expect(store.snapshot().threads.map((t) => t.id)).toEqual(['t1'])
+  })
+
+  it('FAILS CLOSED on a newer schemaVersion: loads empty, locks, and never overwrites the file', async () => {
+    // The crux safety property: an older build must not atomically wipe history
+    // written by a newer one (which the pre-versioning degrade-to-empty would).
+    const file = join(dir, 'future.json')
+    const future = JSON.stringify({
+      schemaVersion: METADATA_SCHEMA_VERSION + 99,
+      workspaces: [{ id: 'wFuture', dir: '/future', displayName: 'F', lastOpenedAt: 9, brandNew: true }],
+      threads: [],
+    })
+    writeFileSync(file, future)
+    const store = new MetadataStore({ filePath: file })
+    await store.load()
+
+    // Refused to load the unknown-future shape — but LOCKED, not silently empty.
+    expect(store.isLocked()).toBe(true)
+    expect(store.snapshot()).toEqual({ workspaces: [], threads: [] })
+
+    // A subsequent write is a NO-OP: the newer on-disk file is preserved byte-for-byte.
+    await store.upsertWorkspace({ dir: '/proj/should-not-persist' })
+    expect(readFileSync(file, 'utf8')).toBe(future)
   })
 })
 

--- a/src/main/persistence/metadata-store.ts
+++ b/src/main/persistence/metadata-store.ts
@@ -11,6 +11,18 @@ import type { ThreadMeta, WorkspaceMeta, WorkspaceThreads } from '../../shared/i
  * seam (deps) so tests run over a temp-dir file without touching real `userData`,
  * mirroring the fs-read/fs-write handlers. A corrupt or missing file degrades to
  * empty state — never a throw — so a bad index can't wedge launch.
+ *
+ * SEAM CONTRACT (ADR-0005 hardening): this class is the ONLY reader/writer of the
+ * metadata file. No other module may derive its path or touch it directly — the
+ * `userData` path is single-sourced in `src/main/index.ts` and injected here. Keep
+ * it that way so the JSON→SQLite swap (ADR-0005 defers it) stays a drop-in: swap
+ * this class's body behind the same public methods + injected `deps`.
+ *
+ * SCHEMA VERSIONING: the file is a versioned envelope
+ * (`{ schemaVersion, workspaces, threads }`). Legacy files predate the envelope and
+ * are read as v1. A file whose version is NEWER than this build FAILS CLOSED: we
+ * refuse to load it AND refuse to overwrite it (see `load`/`persist`), so an older
+ * build can never atomically wipe history written by a newer one.
  */
 
 /**
@@ -25,6 +37,25 @@ export type ThreadRecord = ThreadMeta
 export interface MetadataSnapshot {
   workspaces: WorkspaceRecord[]
   threads: ThreadRecord[]
+}
+
+/**
+ * The on-disk schema version of the metadata envelope. Bump ONLY on a
+ * backward-incompatible layout change, and add a migration branch in `load()`
+ * for the older version(s). A file with a HIGHER version than this constant is
+ * refused (fail-closed) rather than migrated down.
+ */
+export const METADATA_SCHEMA_VERSION = 1
+
+/**
+ * The persisted envelope: the flat index wrapped with its `schemaVersion`.
+ * `workspaces`/`threads` are typed `unknown` because `load()` must tolerate an
+ * arbitrary/corrupt shape before its per-record guards run.
+ */
+interface PersistedIndex {
+  schemaVersion?: number
+  workspaces?: unknown
+  threads?: unknown
 }
 
 /** Upsert a Workspace by its `dir` (the natural key); mints `id` when new. */
@@ -69,6 +100,13 @@ export class MetadataStore {
   private readonly now: () => number
   private readonly mintId: () => string
   private state: MetadataSnapshot = { workspaces: [], threads: [] }
+  /**
+   * Set when `load()` saw a file written by a NEWER schema version. While locked,
+   * `persist()` is a no-op so we never overwrite (and thus destroy) data this
+   * build can't safely parse. Exposed via `isLocked()` so the caller can surface
+   * an honest "upgrade to open your data" notice instead of showing empty.
+   */
+  private locked = false
 
   constructor(deps: MetadataStoreDeps) {
     this.filePath = deps.filePath
@@ -84,20 +122,65 @@ export class MetadataStore {
    * a parseable-but-partially-malformed file degrades to its VALID subset —
    * each record is shape-checked so a single bad entry (e.g. a `null` thread)
    * can't later crash `snapshot()`/`groupThreadsByWorkspace`. Never throws.
+   *
+   * FAIL-CLOSED on a future version: if the file's `schemaVersion` is newer than
+   * this build understands, we DON'T degrade to empty (which would let the next
+   * `persist()` atomically overwrite real data) — we lock the store instead, so
+   * the newer file is preserved untouched until an upgraded build reads it.
    */
   async load(): Promise<void> {
+    let raw: string
     try {
-      const raw = await this.readFileFn(this.filePath)
-      const parsed = JSON.parse(raw) as Partial<MetadataSnapshot>
-      this.state = {
-        workspaces: (Array.isArray(parsed.workspaces) ? parsed.workspaces : []).filter(
-          isWorkspaceRecord,
-        ),
-        threads: (Array.isArray(parsed.threads) ? parsed.threads : []).filter(isThreadRecord),
-      }
+      raw = await this.readFileFn(this.filePath)
     } catch {
+      // Missing/unreadable file — the normal first-run case. Start empty; a file
+      // that never existed carries no version, so this is NOT a lock condition.
       this.state = { workspaces: [], threads: [] }
+      return
     }
+
+    let parsed: PersistedIndex
+    try {
+      parsed = JSON.parse(raw) as PersistedIndex
+    } catch {
+      // Unparseable JSON (a torn write or hand-edit) has no trustworthy version.
+      // Degrade to empty as before — locking here would wedge launch forever on
+      // genuine corruption. (Versioned fail-closed applies only to WELL-FORMED
+      // files that declare a newer version.)
+      this.state = { workspaces: [], threads: [] }
+      return
+    }
+
+    // Legacy files predate the envelope and carry no `schemaVersion` — they ARE
+    // v1 by definition, so a missing/non-numeric version reads as the current one.
+    const version =
+      typeof parsed.schemaVersion === 'number' ? parsed.schemaVersion : METADATA_SCHEMA_VERSION
+    if (version > METADATA_SCHEMA_VERSION) {
+      this.locked = true
+      this.state = { workspaces: [], threads: [] }
+      console.error(
+        `[MetadataStore] ${this.filePath} is schemaVersion ${version}; this build supports ` +
+          `${METADATA_SCHEMA_VERSION}. Refusing to load or overwrite it to avoid destroying ` +
+          `data written by a newer version of vibe-mistro. Upgrade to open these Workspaces/Threads.`,
+      )
+      return
+    }
+
+    this.state = {
+      workspaces: (Array.isArray(parsed.workspaces) ? parsed.workspaces : []).filter(
+        isWorkspaceRecord,
+      ),
+      threads: (Array.isArray(parsed.threads) ? parsed.threads : []).filter(isThreadRecord),
+    }
+  }
+
+  /**
+   * Whether the store is locked because the on-disk file was written by a newer
+   * schema version (see `load`). Callers should surface an honest "upgrade to
+   * open your data" notice rather than presenting the empty state as real.
+   */
+  isLocked(): boolean {
+    return this.locked
   }
 
   /**
@@ -182,10 +265,20 @@ export class MetadataStore {
    * index loads empty = silent total data loss). Residual: with a single writer
    * (main) this is safe; truly-concurrent writers would be last-rename-wins —
    * revisit if write frequency rises (TB2). No write queue/mutex for now.
+   *
+   * Wraps the state in the versioned envelope. NO-OP while locked: a store that
+   * loaded a newer-version file must never write, so the newer on-disk data is
+   * preserved (in-memory mutations are intentionally non-durable in that state).
    */
   private async persist(): Promise<void> {
+    if (this.locked) return
     const tmp = `${this.filePath}.tmp`
-    await this.writeFileFn(tmp, JSON.stringify(this.state, null, 2))
+    const envelope: PersistedIndex = {
+      schemaVersion: METADATA_SCHEMA_VERSION,
+      workspaces: this.state.workspaces,
+      threads: this.state.threads,
+    }
+    await this.writeFileFn(tmp, JSON.stringify(envelope, null, 2))
     await this.renameFn(tmp, this.filePath)
   }
 }

--- a/src/main/persistence/transcript.test.ts
+++ b/src/main/persistence/transcript.test.ts
@@ -8,12 +8,17 @@ import {
   parseTranscript,
   resolvePermissionEntry,
   sessionIdFromPayload,
+  TRANSCRIPT_SCHEMA_VERSION,
   TranscriptStore,
+  transcriptVersionOf,
   turnCompleteEntry,
   turnErrorEntry,
   userPromptEntry,
   type TranscriptEntry,
 } from './transcript'
+
+/** The version-header line every fresh log starts with (see TRANSCRIPT_SCHEMA_VERSION). */
+const HEADER_LINE = `{"t":"__transcript_header","v":${TRANSCRIPT_SCHEMA_VERSION}}`
 
 /**
  * The main-side per-Thread JSONL transcript (ADR-0005: vibe owns agent context,
@@ -31,12 +36,15 @@ function storeAt(): TranscriptStore {
 }
 
 describe('TranscriptStore append', () => {
-  it('appends a user-prompt entry to <threadId>.jsonl', async () => {
+  it('writes a version header then appends a user-prompt entry to <threadId>.jsonl', async () => {
     const store = storeAt()
     await store.append('thread-up', { t: 'user-prompt', id: 'u1', text: 'hello' })
 
     const raw = readFileSync(join(dir, 'thread-up.jsonl'), 'utf8')
-    expect(raw).toBe('{"t":"user-prompt","id":"u1","text":"hello"}\n')
+    // Line 1 is the schema-version header; the conversation entry follows it.
+    expect(raw).toBe(`${HEADER_LINE}\n{"t":"user-prompt","id":"u1","text":"hello"}\n`)
+    // read() skips the header and returns just the conversation entry.
+    expect(await store.read('thread-up')).toEqual([{ t: 'user-prompt', id: 'u1', text: 'hello' }])
   })
 
   it('appends acp-event then resolve-permission in order, append-only across turns', async () => {
@@ -55,6 +63,7 @@ describe('TranscriptStore append', () => {
 
     const lines = readFileSync(join(dir, `${id}.jsonl`), 'utf8').trimEnd().split('\n')
     expect(lines).toEqual([
+      HEADER_LINE, // written once, as line 1, before the first entry
       '{"t":"user-prompt","id":"u1","text":"go"}',
       '{"t":"acp-event","payload":{"method":"session/update"}}',
       '{"t":"resolve-permission","requestId":7,"optionId":"allow","name":"Allow"}',
@@ -112,6 +121,46 @@ describe('TranscriptStore read / parseTranscript', () => {
 
     const read = await store.read(id)
     expect(read).toEqual([{ t: 'user-prompt', id: 'u1', text: 'hi' }])
+  })
+})
+
+describe('TranscriptStore schema versioning (ADR-0005 hardening)', () => {
+  it('writes the header exactly once, not before every append', async () => {
+    const store = storeAt()
+    const id = 'thread-header-once'
+    await store.append(id, { t: 'user-prompt', id: 'u1', text: 'a' })
+    await store.append(id, { t: 'user-prompt', id: 'u2', text: 'b' })
+
+    const lines = readFileSync(join(dir, `${id}.jsonl`), 'utf8').trimEnd().split('\n')
+    expect(lines.filter((l) => l === HEADER_LINE)).toHaveLength(1)
+    expect(lines[0]).toBe(HEADER_LINE) // and it's line 1
+  })
+
+  it('does NOT prepend a header to a legacy header-less log (restart-safe)', async () => {
+    // A log written before versioning starts with a real entry, not a header.
+    // Re-opening and appending must leave it header-less (it reads back as v1),
+    // never inject a header into the MIDDLE of the file.
+    const id = 'thread-legacy'
+    const path = join(dir, `${id}.jsonl`)
+    appendFileSync(path, '{"t":"user-prompt","id":"old","text":"pre-versioning"}\n')
+
+    const store = storeAt() // fresh instance: header fast-path set is empty
+    await store.append(id, { t: 'user-prompt', id: 'new', text: 'after upgrade' })
+
+    const lines = readFileSync(path, 'utf8').trimEnd().split('\n')
+    expect(lines).toEqual([
+      '{"t":"user-prompt","id":"old","text":"pre-versioning"}',
+      '{"t":"user-prompt","id":"new","text":"after upgrade"}',
+    ])
+    expect(transcriptVersionOf(readFileSync(path, 'utf8'))).toBe(1)
+  })
+
+  it('transcriptVersionOf reads the header version, or 1 for a legacy log', () => {
+    expect(transcriptVersionOf(`${HEADER_LINE}\n{"t":"turn-complete"}\n`)).toBe(
+      TRANSCRIPT_SCHEMA_VERSION,
+    )
+    expect(transcriptVersionOf('{"t":"user-prompt","id":"u1","text":"hi"}\n')).toBe(1)
+    expect(transcriptVersionOf('')).toBe(1)
   })
 })
 
@@ -212,9 +261,14 @@ describe('TranscriptStore serializes concurrent appends (M1)', () => {
     }
     await tail
 
-    expect(written.map((l) => (JSON.parse(l) as { text: string }).text)).toEqual(
-      Array.from({ length: 10 }, (_, i) => String(i)),
-    )
+    // Ignore the one-time version header (not a conversation entry); the
+    // user-prompt entries must land in strict call order.
+    expect(
+      written
+        .map((l) => JSON.parse(l) as { t: string; text?: string })
+        .filter((e) => e.t === 'user-prompt')
+        .map((e) => e.text),
+    ).toEqual(Array.from({ length: 10 }, (_, i) => String(i)))
   })
 
   it('preserves order with the real fs writer over a temp dir (mirrors production concurrency)', async () => {

--- a/src/main/persistence/transcript.ts
+++ b/src/main/persistence/transcript.ts
@@ -14,8 +14,51 @@ import type { TranscriptEntry } from '../../shared/ipc'
  * `TranscriptEntry` (the entry union, mirroring the reducer's `ConversationAction`
  * inputs) lives in `src/shared/ipc.ts` so the renderer replay can name it across
  * the composite project boundary; re-exported here for the main-side writers.
+ *
+ * SEAM CONTRACT (ADR-0005 hardening): this class is the ONLY reader/writer of the
+ * transcript files. No other module may build a `<threadId>.jsonl` path or touch
+ * that dir — the `userData` transcripts dir is single-sourced in `src/main/index.ts`
+ * and injected here. Keep it that way so the JSONL→SQLite swap stays a drop-in.
+ *
+ * SCHEMA VERSIONING: each log's FIRST line is a version header (see
+ * `TRANSCRIPT_SCHEMA_VERSION`), so a future reader/migrator can tell which format
+ * a file is in. Legacy logs predate the header and are read as v1. The header is
+ * NOT a conversation entry — replay skips it (`isTranscriptEntry` rejects it).
  */
 export type { TranscriptEntry }
+
+/**
+ * The on-disk format version, written as the first line of every new transcript.
+ * Bump ONLY on a backward-incompatible change to the entry format, and teach the
+ * reader/migrator to branch on the header version. A log with no header is v1.
+ */
+export const TRANSCRIPT_SCHEMA_VERSION = 1
+
+/** The header line's discriminator tag. Deliberately outside the entry union so
+ * `isTranscriptEntry` drops it and replay never sees it as a conversation event. */
+const TRANSCRIPT_HEADER_TAG = '__transcript_header'
+
+/** The version-header record written as line 1 of a fresh log. */
+function transcriptHeader(): { t: typeof TRANSCRIPT_HEADER_TAG; v: number } {
+  return { t: TRANSCRIPT_HEADER_TAG, v: TRANSCRIPT_SCHEMA_VERSION }
+}
+
+/**
+ * The format version of a raw transcript: the `v` from its header line, or `1`
+ * for a legacy header-less log. For future migrators (JSONL→SQLite) to branch on;
+ * `parseTranscript` itself is version-agnostic today (only v1 exists).
+ */
+export function transcriptVersionOf(raw: string): number {
+  const first = raw.split('\n', 1)[0]
+  if (!first) return TRANSCRIPT_SCHEMA_VERSION
+  try {
+    const parsed = JSON.parse(first) as { t?: unknown; v?: unknown }
+    if (parsed.t === TRANSCRIPT_HEADER_TAG && typeof parsed.v === 'number') return parsed.v
+  } catch {
+    // First line isn't a header (legacy log starts with a real entry) — v1.
+  }
+  return TRANSCRIPT_SCHEMA_VERSION
+}
 
 /** The user's prompt, teed at `sendPrompt` — mirrors the `send-prompt` action. */
 export function userPromptEntry(id: string, text: string): TranscriptEntry {
@@ -112,6 +155,13 @@ export class TranscriptStore {
    * scrambles, or a `tool_call_update` folds before its `tool_call`).
    */
   private readonly tails = new Map<string, Promise<void>>()
+  /**
+   * Threads whose header we've already ensured this session (so we don't re-check
+   * on every append). Cleared on `delete` so a re-created log gets a fresh header.
+   * Restart-safe because `ensureHeader` checks the file's CONTENTS, not this set,
+   * to decide whether to write — the set is only a per-session fast-path.
+   */
+  private readonly headerEnsured = new Set<string>()
 
   constructor(deps: TranscriptDeps) {
     this.dir = deps.dir
@@ -136,12 +186,45 @@ export class TranscriptStore {
     const path = this.pathFor(threadId)
     const line = `${JSON.stringify(entry)}\n`
     const prev = this.tails.get(threadId) ?? Promise.resolve()
-    const next = prev.then(() => this.appendFn(path, line)).catch(() => {
-      // A transcript write failure is non-fatal — the conversation proceeds, and
-      // the chain stays alive (resolved) so later appends still run in order.
-    })
+    const next = prev
+      // Ensure the version header is line 1 BEFORE this entry, inside the same
+      // serialized chain so it can't race a concurrent append.
+      .then(() => this.ensureHeader(threadId, path))
+      .then(() => this.appendFn(path, line))
+      .catch(() => {
+        // A transcript write failure is non-fatal — the conversation proceeds, and
+        // the chain stays alive (resolved) so later appends still run in order.
+      })
     this.tails.set(threadId, next)
     return next
+  }
+
+  /**
+   * Guarantee a fresh log's FIRST line is the version header, exactly once per
+   * file. Restart-safe: it checks the file's CURRENT contents rather than an
+   * in-memory "first append" flag, so after a restart an existing non-empty log
+   * (header, or a legacy header-less v1 log) is left intact and only a brand-new
+   * or empty file gets the header. Self-guarded: a header read/write failure is
+   * swallowed so it can never cost the entry that follows it — a missing header
+   * simply reads back as v1.
+   */
+  private async ensureHeader(threadId: string, path: string): Promise<void> {
+    if (this.headerEnsured.has(threadId)) return
+    this.headerEnsured.add(threadId)
+    try {
+      let existing = ''
+      try {
+        existing = await this.readFileFn(path)
+      } catch {
+        existing = '' // ENOENT — a brand-new log
+      }
+      if (existing.length === 0) {
+        await this.appendFn(path, `${JSON.stringify(transcriptHeader())}\n`)
+      }
+    } catch {
+      // Header write failed — proceed to append the entry regardless. Losing the
+      // header (reads back as v1) must never lose the conversation line.
+    }
   }
 
   /**
@@ -175,6 +258,8 @@ export class TranscriptStore {
    */
   async delete(threadId: string): Promise<void> {
     this.tails.delete(threadId)
+    // Forget the header fast-path so a re-created log for this id re-writes it.
+    this.headerEnsured.delete(threadId)
     try {
       await this.unlinkFn(this.pathFor(threadId))
     } catch {
@@ -188,6 +273,10 @@ export class TranscriptStore {
  * trailing line. A crash mid-append (or a torn write) can leave the final line
  * truncated; we parse each line independently and SKIP any that don't yield a
  * well-formed entry rather than throwing — so the valid prefix always replays.
+ *
+ * The version-header line (present on logs written since the versioning change)
+ * is not a conversation entry, so `isTranscriptEntry` drops it here — replay is
+ * unaffected. Read the version separately via `transcriptVersionOf` if needed.
  */
 export function parseTranscript(raw: string): TranscriptEntry[] {
   const entries: TranscriptEntry[] = []


### PR DESCRIPTION
## Summary

Two related changes to the Workspace/Thread persistence layer, plus the docs behind them. Grew out of a review of whether to adopt t3code's SQLite/event-sourcing model — verdict: **defer per ADR-0005, harden the current design instead.**

### 1. Harden the persistence seam (`a841ac7`)
The seam audit found all `metadata.json` / `*.jsonl` access already funneled through `MetadataStore` / `TranscriptStore` with single-sourced paths and a single (main) writer — so a future JSONL→SQLite swap is drop-in. This locks that in and closes two schema-evolution gaps **before data exists in the wild**:
- **Metadata** is now a versioned envelope `{ schemaVersion, workspaces, threads }` (legacy files read as v1). A file with a **newer** version **fails closed**: `load()` refuses to load and `persist()` no-ops, so an older build can never atomically overwrite (wipe) newer data. `isLocked()` exposed for a future upgrade notice.
- **Transcript** logs now start with a version header (written once, restart-safe, skipped on replay). `transcriptVersionOf()` added for future migrators.
- SEAM CONTRACT comments on both stores.

### 2. Fix: opening a Workspace no longer persists an empty Thread (`2a4acec`, ADR-0011)
Clicking a Workspace ran `openThread()` + `recordThread()`, writing a Thread record with **zero user interaction** — contradicting the #58 draft model, which only ever covered the **+ New Thread** button. `startThread`'s normal branch (and the post-sign-in `openThread` handler) now return a **draft connection**: mint the Thread id, but open **no** `session/new` and write **no** record. The Thread stays a renderer-only draft until its first prompt binds a session + persists via the existing `mintAndBind`. Workspace metadata still persists on open. Mirrors the proven `continueConnection` shape, so **the renderer is unchanged**; removed dead `recordThread` / `connectionFor` / `ThreadIds`.

**Known consequence (documented in ADR-0011):** vibe-acp advertises Mode/Model/effort only via `session/new`, so the first draft's picker is empty until first prompt — **same as the existing Continue flow, not a new regression.** An agent-level controls cache (deferred) would populate it after any Thread runs once.

## Docs
- `CONTEXT.md` — new **Draft Thread** term + first-prompt durability rule on **Thread**
- `docs/adr/0011-draft-threads-persist-and-bind-on-first-prompt.md`
- `docs/notes/threads-worktrees-persistence.md` — findings + decision log

## Tests
Typecheck clean; full suite **501 passing** (+6 new for versioning / fail-closed). No renderer changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)