### PR TITLE
#134: adopt the official vibe-mistro SVG logo

### DIFF
--- a/src/renderer/src/shell/logo.tsx
+++ b/src/renderer/src/shell/logo.tsx
@@ -1,25 +1,34 @@
 import type { JSX } from 'react'
 
+/** The official mark's intrinsic aspect ratio (viewBox 191×135). */
+const LOGO_RATIO = 191 / 135
+
 /**
- * The Vibe Mistro "M" mark — a rounded square filled with the vertical brand
- * gradient (`--accent-grad-logo`) and a white "M". Sized by `size` (px): 30 in the
- * sidebar header, 52 on the empty-state hero (per the tokens doc). The gradient is
- * applied as an inline style so it resolves the CSS var directly (robust under the
- * Vite/Electron build); everything else is token-driven.
+ * The official Vibe Mistro "M" mark — an inline SVG of the stepped brand palette
+ * (yellow → orange). Inline (not a raster asset) so it scales crisply and adds no
+ * bundle image. `size` is the HEIGHT in px (30 in the sidebar header, 52 on the
+ * empty-state hero, per the tokens doc); width scales to the mark's 191:135 ratio.
+ * The logo keeps its own brand fills — independent of the softer UI accent tokens.
  */
 export function Logo({ size = 30 }: { size?: number }): JSX.Element {
   return (
-    <span
+    <svg
       aria-hidden
-      className="inline-flex shrink-0 items-center justify-center rounded-md font-bold leading-none text-white"
-      style={{
-        width: size,
-        height: size,
-        fontSize: Math.round(size * 0.58),
-        backgroundImage: 'var(--accent-grad-logo)',
-      }}
+      className="shrink-0"
+      width={Math.round(size * LOGO_RATIO)}
+      height={size}
+      viewBox="0 0 191 135"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
     >
-      M
-    </span>
+      <path d="M54.3221 0H27.1531V27.0892H54.3221V0Z" fill="#FFD800" />
+      <path d="M162.984 0H135.815V27.0892H162.984V0Z" fill="#FFD800" />
+      <path d="M81.4823 27.0918H27.1531V54.181H81.4823V27.0918Z" fill="#FFAF00" />
+      <path d="M162.99 27.0918H108.661V54.181H162.99V27.0918Z" fill="#FFAF00" />
+      <path d="M162.972 54.168H27.1531V81.2572H162.972V54.168Z" fill="#FF8205" />
+      <path d="M54 81H27V135H54V81Z" fill="#FA500F" />
+      <path d="M108.661 81.2598H81.4917V108.349H108.661V81.2598Z" fill="#FA500F" />
+      <path d="M163 81H136V135H163V81Z" fill="#FA500F" />
+    </svg>
   )
 }


### PR DESCRIPTION
Closes #134. Follow-up to #113 (design-system shell).

## What
Replaces the placeholder gradient-"M" badge (`shell/logo.tsx`) with the **official vibe-mistro SVG** — the stepped brand palette (yellow → orange) pixel-"M" — inlined as an SVG component (no raster asset). `size` is the height in px; width auto-scales to the mark's 191:135 ratio. The `Logo({ size })` interface is unchanged, so the sidebar header (30px) and empty-state hero (52px) call sites are untouched. The logo keeps its own brand fills, independent of the softer UI accent tokens.

## Gates
`bun run lint && bun run typecheck && bun run build && bun run test` — all green, **511 tests** (single-file change, no logic).

## Needs a live smoke
The mark is wider than the old square badge (191:135), so eyeball the header alignment next to the "vibe mistro" wordmark and the hero size — a quick `bun run dev` look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)