### PR TITLE
#129: Projects header — drop sidebar Open-project button, add +new-project + sort options

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -45,15 +45,7 @@ import {
   type ThreadStatusMap,
 } from './conversation/thread-status'
 import { clearDraft } from './conversation/composer-draft-store'
-import {
-  ArrowLeft,
-  ArrowRight,
-  FolderOpen,
-  Maximize2,
-  PanelRight,
-  Settings,
-  Terminal,
-} from 'lucide-react'
+import { ArrowLeft, ArrowRight, Maximize2, PanelRight, Settings, Terminal } from 'lucide-react'
 import { Button } from './ui/button'
 import { IconButton } from './ui/icon-button'
 import { Shell, type WorkspaceFlags } from './shell/Shell'
@@ -466,22 +458,14 @@ export function App(): JSX.Element {
     connDispatch({ type: 'set', workspaceId, state: { status: 'not-signed-in', agentId, workspaceDir, authMethods } })
   }
 
-  // The sidebar's pinned top: the Open-project control + a settings affordance that
-  // reveals the environment status on demand (#49). The env card is no longer pinned
-  // permanently — it lives behind this gear once everything's installed, and is
-  // surfaced prominently in the outlet's first-run state when something's missing.
+  // The sidebar's pinned top: a settings affordance that reveals the environment
+  // status on demand (#49). The Open-project control now lives in the Projects
+  // header's new-project + (#129); the env card is no longer pinned permanently — it
+  // lives behind this gear once everything's installed, and is surfaced prominently in
+  // the outlet's first-run state when something's missing.
   const sidebarTop = (
     <div className="flex flex-col gap-2">
-      <div className="flex items-center gap-2">
-        <Button
-          variant="secondary"
-          className="flex-1 justify-start gap-2"
-          onClick={() => void openProject()}
-          disabled={opening}
-        >
-          <FolderOpen className="size-4" aria-hidden />
-          {opening ? 'Connecting…' : 'Open project'}
-        </Button>
+      <div className="flex items-center justify-end gap-2">
         <IconButton
           aria-label="Environment & settings"
           title="Environment & settings"
@@ -711,6 +695,8 @@ export function App(): JSX.Element {
         protectedThreadId={protectedThreadId}
         canCreateThread={canCreateThread}
         outlet={outlet}
+        opening={opening}
+        onOpenProject={() => void openProject()}
         onSelectWorkspace={selectWorkspace}
         onSelectThread={selectThreadInWorkspace}
         onNewThread={() => selectedWs && newThread(selectedWs)}

--- a/src/renderer/src/shell/Shell.tsx
+++ b/src/renderer/src/shell/Shell.tsx
@@ -1,11 +1,25 @@
 import { useState, type JSX, type ReactNode } from 'react'
-import { Atom, Check, ChevronDown, Clock, Folder, MoreVertical, Search, SquarePen, Trash2 } from 'lucide-react'
+import {
+  Atom,
+  Check,
+  ChevronDown,
+  Clock,
+  Ellipsis,
+  Folder,
+  MoreVertical,
+  Plus,
+  Search,
+  SquarePen,
+  Trash2,
+} from 'lucide-react'
 import type { ListMetadataResult, ThreadMeta } from '../../../shared/ipc'
 import type { NavState } from './nav-reducer'
 import { backgroundAttention } from './background-attention'
 import { isThreadDeletable, type UnifiedThreadRow } from './unified-threads'
+import { getSortOrder, setSortOrder, sortWorkspaces, type WorkspaceSortOrder } from './workspace-sort'
 import { Badge } from '../ui/badge'
-import { Menu, MenuContent, MenuItem, MenuTrigger } from '../ui/menu'
+import { IconButton } from '../ui/icon-button'
+import { Menu, MenuContent, MenuItem, MenuRadioGroup, MenuRadioItem, MenuTrigger } from '../ui/menu'
 import { NavItem } from '../ui/nav-item'
 import { Spinner } from '../ui/spinner'
 import { Logo } from './logo'
@@ -47,6 +61,8 @@ export function Shell({
   protectedThreadId,
   canCreateThread,
   outlet,
+  opening,
+  onOpenProject,
   onSelectWorkspace,
   onSelectThread,
   onNewThread,
@@ -54,7 +70,7 @@ export function Shell({
 }: {
   /** Persisted Workspaces (cold metadata) for the switcher rows + display names. */
   workspaces: ListMetadataResult
-  /** App-owned controls pinned above the list (Open project + environment status). */
+  /** App-owned controls pinned above the list (environment status; the gear). */
   sidebarTop: ReactNode
   /** The current navigation selection (controlled by App). */
   nav: NavState
@@ -68,6 +84,10 @@ export function Shell({
   canCreateThread: boolean
   /** The fully-computed conversation outlet (connection views / cold replay). */
   outlet: ReactNode
+  /** Whether an Open-project connect is in flight — busies the header's new-project +. */
+  opening: boolean
+  /** Open a project via the OS dialog (the existing `openProject`), from the Projects header +. */
+  onOpenProject: () => void
   /** Select a Workspace — App pins it in nav and connect-or-reuses its warm agent. */
   onSelectWorkspace: (workspaceId: string) => void
   /** Select a Thread — App pins it in nav and (if live) remembers it as active. */
@@ -89,6 +109,8 @@ export function Shell({
           workspaceFlags={workspaceFlags}
           rows={rows}
           protectedThreadId={protectedThreadId}
+          opening={opening}
+          onOpenProject={onOpenProject}
           onSelectWorkspace={onSelectWorkspace}
           onSelectThread={onSelectThread}
           onDeleteThread={onDeleteThread}
@@ -211,6 +233,8 @@ function WorkspaceNav({
   workspaceFlags,
   rows,
   protectedThreadId,
+  opening,
+  onOpenProject,
   onSelectWorkspace,
   onSelectThread,
   onDeleteThread,
@@ -220,16 +244,31 @@ function WorkspaceNav({
   workspaceFlags: Readonly<Record<string, WorkspaceFlags>>
   rows: UnifiedThreadRow[]
   protectedThreadId: string | null
+  opening: boolean
+  onOpenProject: () => void
   onSelectWorkspace: (workspaceId: string) => void
   onSelectThread: (workspaceId: string, threadId: string) => void
   onDeleteThread: (thread: ThreadMeta) => Promise<void>
 }): JSX.Element {
   const [expandedThreads, setExpandedThreads] = useState(false)
+  // The switcher's DISPLAY-ONLY sort order (#129): renderer-only UI state seeded
+  // from localStorage (default 'recent'), persisted on change. It reorders the
+  // switcher dropdown ONLY — never selection, nav, or the Thread list below.
+  const [sortOrder, setSortOrderState] = useState<WorkspaceSortOrder>(() =>
+    getSortOrder(window.localStorage),
+  )
+  function changeSortOrder(order: WorkspaceSortOrder): void {
+    setSortOrderState(order)
+    setSortOrder(window.localStorage, order)
+  }
   // ONE Date.now() per render, injected into the pure formatter at each call site.
   const nowMs = Date.now()
 
   const activeId = nav.selectedWorkspaceId
   const activeWorkspace = workspaces.find((w) => w.id === activeId) ?? null
+  // A sorted COPY for the switcher dropdown — the `workspaces` prop is never mutated
+  // and the active/selection logic still keys off ids, so ordering is presentation-only.
+  const sortedWorkspaces = sortWorkspaces(workspaces, sortOrder)
   // The roll-up of every NON-active Workspace's status, for the collapsed trigger —
   // so a background Workspace blocked on a permission is visible without opening.
   const background = backgroundAttention(workspaceFlags, activeId)
@@ -251,7 +290,46 @@ function WorkspaceNav({
 
   return (
     <nav className="flex flex-col gap-0.5">
-      <div className="px-3 py-1.5 text-[13px] font-medium text-faint">Projects</div>
+      {/* Projects header row (#129): the label on the left, and on the right a
+          new-project + (→ the existing openProject) plus an options "…" menu holding
+          the switcher's display-only sort order. The + stays available even with zero
+          Workspaces, so the first project can still be opened from here. */}
+      <div className="flex items-center justify-between px-3 py-1.5">
+        <span className="text-[13px] font-medium text-faint">Projects</span>
+        <div className="flex items-center gap-0.5">
+          <IconButton
+            size="icon-xs"
+            aria-label="Open project"
+            title="Open project"
+            disabled={opening}
+            onClick={onOpenProject}
+          >
+            {opening ? (
+              <Spinner className="size-3.5" aria-label="Opening project" />
+            ) : (
+              <Plus className="size-4" aria-hidden />
+            )}
+          </IconButton>
+          <Menu>
+            <MenuTrigger
+              aria-label="Project list options"
+              title="Project list options"
+              className="inline-flex size-6 items-center justify-center rounded-sm text-muted outline-none transition-colors hover:bg-accent/10 hover:text-text focus-visible:bg-accent/10 data-[popup-open]:bg-accent/10"
+            >
+              <Ellipsis className="size-4" aria-hidden />
+            </MenuTrigger>
+            <MenuContent align="end" className="min-w-[180px]">
+              <MenuRadioGroup
+                value={sortOrder}
+                onValueChange={(value) => changeSortOrder(value as WorkspaceSortOrder)}
+              >
+                <MenuRadioItem value="recent">Recent</MenuRadioItem>
+                <MenuRadioItem value="name">Name (A–Z)</MenuRadioItem>
+              </MenuRadioGroup>
+            </MenuContent>
+          </Menu>
+        </div>
+      </div>
 
       {workspaces.length === 0 ? (
         <p className="px-3 py-1 text-[13px] leading-relaxed text-muted">
@@ -279,7 +357,7 @@ function WorkspaceNav({
             <ChevronDown className="size-4 shrink-0 text-muted" aria-hidden />
           </MenuTrigger>
           <MenuContent align="start" className="min-w-[290px]">
-            {workspaces.map((w) => {
+            {sortedWorkspaces.map((w) => {
               const flags = workspaceFlags[w.id]
               const isActive = w.id === activeId
               return (

--- a/src/renderer/src/shell/workspace-sort.test.ts
+++ b/src/renderer/src/shell/workspace-sort.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_SORT_ORDER,
+  WORKSPACE_SORT_STORAGE_KEY,
+  getSortOrder,
+  setSortOrder,
+  sortWorkspaces,
+  type SortOrderStorage,
+} from './workspace-sort'
+
+/** A minimal Workspace-shaped row for the sort. */
+function ws(displayName: string): { id: string; displayName: string } {
+  return { id: displayName, displayName }
+}
+
+describe('sortWorkspaces', () => {
+  it("'recent' preserves the incoming (App-provided recency) order", () => {
+    const list = [ws('Zed'), ws('alpha'), ws('Beta')]
+    expect(sortWorkspaces(list, 'recent').map((w) => w.displayName)).toEqual(['Zed', 'alpha', 'Beta'])
+  })
+
+  it("'name' sorts by displayName case-insensitively", () => {
+    const list = [ws('Zed'), ws('alpha'), ws('Beta')]
+    expect(sortWorkspaces(list, 'name').map((w) => w.displayName)).toEqual(['alpha', 'Beta', 'Zed'])
+  })
+
+  it("'name' is stable for case-folded-equal names (keeps incoming order)", () => {
+    const list = [
+      { id: '1', displayName: 'repo' },
+      { id: '2', displayName: 'Repo' },
+      { id: '3', displayName: 'REPO' },
+    ]
+    expect(sortWorkspaces(list, 'name').map((w) => w.id)).toEqual(['1', '2', '3'])
+  })
+
+  it('returns a new array and never mutates the input', () => {
+    const list = [ws('b'), ws('a')]
+    const out = sortWorkspaces(list, 'name')
+    expect(out).not.toBe(list)
+    expect(list.map((w) => w.displayName)).toEqual(['b', 'a']) // input untouched
+  })
+
+  it('handles the empty and single-element cases', () => {
+    expect(sortWorkspaces([], 'name')).toEqual([])
+    expect(sortWorkspaces([ws('only')], 'name').map((w) => w.displayName)).toEqual(['only'])
+  })
+})
+
+/** An in-memory storage double implementing the injected seam. */
+function fakeStorage(initial?: Record<string, string>): SortOrderStorage & { map: Record<string, string> } {
+  const map: Record<string, string> = { ...initial }
+  return {
+    map,
+    getItem: (k) => (k in map ? map[k] : null),
+    setItem: (k, v) => {
+      map[k] = v
+    },
+  }
+}
+
+describe('getSortOrder', () => {
+  it('defaults when absent, missing storage, or unknown value', () => {
+    expect(getSortOrder(fakeStorage())).toBe(DEFAULT_SORT_ORDER)
+    expect(getSortOrder(null)).toBe(DEFAULT_SORT_ORDER)
+    expect(getSortOrder(fakeStorage({ [WORKSPACE_SORT_STORAGE_KEY]: 'bogus' }))).toBe(DEFAULT_SORT_ORDER)
+  })
+
+  it('reads a stored known order', () => {
+    expect(getSortOrder(fakeStorage({ [WORKSPACE_SORT_STORAGE_KEY]: 'name' }))).toBe('name')
+    expect(getSortOrder(fakeStorage({ [WORKSPACE_SORT_STORAGE_KEY]: 'recent' }))).toBe('recent')
+  })
+
+  it('never throws when the store throws', () => {
+    const throwing: SortOrderStorage = {
+      getItem: () => {
+        throw new Error('blocked')
+      },
+      setItem: () => {},
+    }
+    expect(getSortOrder(throwing)).toBe(DEFAULT_SORT_ORDER)
+  })
+})
+
+describe('setSortOrder', () => {
+  it('persists the chosen order under the versioned key', () => {
+    const storage = fakeStorage()
+    setSortOrder(storage, 'name')
+    expect(storage.map[WORKSPACE_SORT_STORAGE_KEY]).toBe('name')
+  })
+
+  it('never throws on a missing or blocked store', () => {
+    expect(() => setSortOrder(null, 'name')).not.toThrow()
+    const throwing: SortOrderStorage = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error('quota')
+      },
+    }
+    expect(() => setSortOrder(throwing, 'name')).not.toThrow()
+  })
+})

--- a/src/renderer/src/shell/workspace-sort.ts
+++ b/src/renderer/src/shell/workspace-sort.ts
@@ -1,0 +1,88 @@
+/**
+ * The Projects switcher's sort order (#129): a renderer-only, display-only choice
+ * for how the project-switcher dropdown lists Workspaces. It NEVER changes which
+ * Workspace is active or the Thread list — it only reorders the switcher rows.
+ *
+ * `'recent'` (the default) preserves the incoming order — App already hands the
+ * list most-recent-first (`lastOpenedAt`), so recency is the identity ordering.
+ * `'name'` sorts by `displayName`, case-insensitively and STABLY (equal names keep
+ * their incoming relative order). The sort is PURE and returns a NEW array; the
+ * caller's `workspaces` prop is never mutated.
+ *
+ * The chosen order is EPHEMERAL UI state, so — like composer drafts (#60) — it
+ * lives in localStorage only (no IPC, no main). The storage seam is INJECTED so
+ * tests pass a fake and render code passes `window.localStorage`; every path
+ * tolerates an unavailable/throwing/corrupt store and falls back to the default.
+ */
+
+/** How the project-switcher dropdown orders its Workspace rows. */
+export type WorkspaceSortOrder = 'recent' | 'name'
+
+/** The order applied when nothing is stored (or the store is unreadable). */
+export const DEFAULT_SORT_ORDER: WorkspaceSortOrder = 'recent'
+
+/** The single localStorage key holding the chosen sort order. */
+export const WORKSPACE_SORT_STORAGE_KEY = 'vibe-mistro:workspace-sort:v1'
+
+/** The slice of the Web Storage API we depend on — `window.localStorage` satisfies it. */
+export interface SortOrderStorage {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+}
+
+/** A Workspace as far as sorting cares — just its display label. */
+interface Sortable {
+  displayName: string
+}
+
+/**
+ * Return a NEW array of Workspaces in the chosen order — the input is never
+ * mutated. `'recent'` is the identity ordering (App already provides recency);
+ * `'name'` sorts by `displayName` case-insensitively and stably (`Array.sort` is
+ * stable, and equal case-folded names compare 0, so their incoming order holds).
+ */
+export function sortWorkspaces<T extends Sortable>(
+  workspaces: readonly T[],
+  order: WorkspaceSortOrder,
+): T[] {
+  const copy = workspaces.slice()
+  if (order !== 'name') return copy
+  return copy.sort((a, b) => {
+    const an = a.displayName.toLowerCase()
+    const bn = b.displayName.toLowerCase()
+    if (an < bn) return -1
+    if (an > bn) return 1
+    return 0
+  })
+}
+
+/** Narrow an arbitrary stored value to a known order (else the default). */
+function coerce(value: string | null): WorkspaceSortOrder {
+  return value === 'name' || value === 'recent' ? value : DEFAULT_SORT_ORDER
+}
+
+/**
+ * The stored sort order, or the default when absent/unknown/unavailable. Never
+ * throws — a blocked/throwing store must not break the sidebar's render.
+ */
+export function getSortOrder(storage: SortOrderStorage | null | undefined): WorkspaceSortOrder {
+  if (!storage) return DEFAULT_SORT_ORDER
+  try {
+    return coerce(storage.getItem(WORKSPACE_SORT_STORAGE_KEY))
+  } catch {
+    return DEFAULT_SORT_ORDER
+  }
+}
+
+/** Persist the chosen order best-effort; a quota/security exception is swallowed. */
+export function setSortOrder(
+  storage: SortOrderStorage | null | undefined,
+  order: WorkspaceSortOrder,
+): void {
+  if (!storage) return
+  try {
+    storage.setItem(WORKSPACE_SORT_STORAGE_KEY, order)
+  } catch {
+    // Best-effort: a full/blocked storage must never throw from a click.
+  }
+}

--- a/src/renderer/src/ui/index.ts
+++ b/src/renderer/src/ui/index.ts
@@ -60,4 +60,12 @@ export { NavItem } from './nav-item'
 
 export { Panel, PanelHeader, PanelTitle, PanelContent } from './panel'
 
-export { Menu, MenuTrigger, MenuContent, MenuItem, MenuSeparator } from './menu'
+export {
+  Menu,
+  MenuTrigger,
+  MenuContent,
+  MenuItem,
+  MenuSeparator,
+  MenuRadioGroup,
+  MenuRadioItem,
+} from './menu'

--- a/src/renderer/src/ui/menu.tsx
+++ b/src/renderer/src/ui/menu.tsx
@@ -1,5 +1,6 @@
 import type { ComponentProps, JSX } from 'react'
 import { Menu as BaseMenu } from '@base-ui/react/menu'
+import { Check } from 'lucide-react'
 import { cn } from '../lib/utils'
 
 /**
@@ -65,3 +66,41 @@ export function MenuItem({
 }
 
 export const MenuSeparator = BaseMenu.Separator
+
+/**
+ * A single-choice group inside a menu (e.g. a sort-order picker). base-ui owns the
+ * `role="menuitemradio"` + `aria-checked` semantics and the `value`/`onValueChange`
+ * state, so a screen reader announces which option is selected. Wrap {@link
+ * MenuRadioItem}s and drive it with `value` + `onValueChange`.
+ */
+export const MenuRadioGroup = BaseMenu.RadioGroup
+
+/**
+ * One option in a {@link MenuRadioGroup}, styled like {@link MenuItem} with a leading
+ * check that renders only for the active `value` (base-ui shows the indicator when
+ * checked; the fixed slot keeps rows aligned). Accessible state is base-ui's, not a
+ * visual-only cue.
+ */
+export function MenuRadioItem({
+  className,
+  children,
+  ...props
+}: ComponentProps<typeof BaseMenu.RadioItem>): JSX.Element {
+  return (
+    <BaseMenu.RadioItem
+      className={cn(
+        'flex cursor-default select-none items-center gap-2 px-3 py-1.5 outline-none',
+        'data-[highlighted]:bg-accent data-[highlighted]:text-on-accent',
+        className,
+      )}
+      {...props}
+    >
+      <span className="flex size-4 shrink-0 items-center justify-center">
+        <BaseMenu.RadioItemIndicator>
+          <Check className="size-4" aria-hidden />
+        </BaseMenu.RadioItemIndicator>
+      </span>
+      <span className="flex-1">{children}</span>
+    </BaseMenu.RadioItem>
+  )
+}


### PR DESCRIPTION
Closes #129. Follow-up to #113/#128 (design-system sidebar).

## What
- **Removed the sidebar "Open project" `Button`** from `sidebarTop` (kept the settings gear + `Environment` — the gear moves to the account menu in #130). The separate first-run `EmptyState` "Open project" CTA is untouched.
- **Projects header is now a row:** the "Projects" label left; on the right a **new-project `+` `IconButton`** (→ the existing `openProject()`, disabled + spinner while `opening`) and an **options "…" menu**.
- **Options menu = a display-only sort order** for the project switcher: **Recent** (default) / **Name (A–Z)**, persisted to `localStorage`. Grouping is deferred (t3code-specific).

## Behavior preserved
- `openProject()` byte-for-byte unchanged — only its trigger moved to the `+`. Selection/switcher/thread-list/background-attention/Show-more/pin/empty-states all unchanged (`nav-reducer`/`unified-threads`/`first-run`/`background-attention` untouched).
- **Sort is presentation-only:** the switcher maps a sorted COPY (`sortWorkspaces` returns a new array; the `workspaces` prop is never mutated), and every row still selects by `w.id` — so ordering can't change which project is active or the threads shown. TDD'd (`workspace-sort.ts`, 10 tests incl. no-mutation + throw-tolerant storage).
- The `+` stays available with zero workspaces (first project still openable); the switcher is what's hidden when empty.

## Review fold
Adversarial verdict was SHIP; I folded its one SHOULD-FIX (a11y): the sort options conveyed the active choice only visually. They're now a base-ui **`MenuRadioGroup`/`MenuRadioItem`** (`role="menuitemradio"` + `aria-checked`), so a screen reader announces the selected order — added as reusable parts to the Menu primitive + barrel.

## Gates
`bun run lint && bun run typecheck && bun run build && bun run test` — all green, **528 tests** (518 + 10 new). No new BEM.

## Needs a live smoke
Header row spacing/alignment of `+`/`…`; the `+` spinner during a real connect; the options menu opens/positions + the radio check reflects/persists across reload; the sorted switcher still selects the right project on click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)