### PR TITLE
#127: collapsible sidebar (toggle in the window chrome)

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -45,7 +45,7 @@ import {
   type ThreadStatusMap,
 } from './conversation/thread-status'
 import { clearDraft } from './conversation/composer-draft-store'
-import { ArrowLeft, ArrowRight, Maximize2, PanelRight, Settings, Terminal } from 'lucide-react'
+import { ArrowLeft, ArrowRight, Maximize2, PanelLeft, PanelRight, Settings, Terminal } from 'lucide-react'
 import { Button } from './ui/button'
 import { IconButton } from './ui/icon-button'
 import { Shell, type WorkspaceFlags } from './shell/Shell'
@@ -53,6 +53,10 @@ import { Logo } from './shell/logo'
 import { heroHeadline } from './shell/hero-headline'
 import { firstRunState, type FirstRunState } from './shell/first-run'
 import { findSelectedThread, initialNavState, navReducer } from './shell/nav-reducer'
+import {
+  getSidebarCollapsed,
+  setSidebarCollapsed as setSidebarCollapsedStore,
+} from './shell/sidebar-collapsed-store'
 import { deriveUnifiedThreads, workspaceFlags, type UnifiedThreadRow } from './shell/unified-threads'
 
 /** A stable empty live-set for Workspaces with no live-state yet (no re-alloc). */
@@ -83,6 +87,20 @@ export function App(): JSX.Element {
   // env check is no longer a permanent top-level card (#49) — it's reachable here,
   // and surfaced prominently in the outlet only when it matters (first-run).
   const [showSettings, setShowSettings] = useState(false)
+  // Whether the left sidebar is collapsed (#127): renderer-only UI chrome, seeded
+  // from localStorage (default expanded) and persisted best-effort on toggle. It
+  // never touches nav/selection/connections — the <aside> stays mounted, its width
+  // just animates to 0 so the outlet reclaims the space.
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(() =>
+    getSidebarCollapsed(window.localStorage),
+  )
+  function toggleSidebar(): void {
+    setSidebarCollapsed((prev) => {
+      const next = !prev
+      setSidebarCollapsedStore(window.localStorage, next)
+      return next
+    })
+  }
   // Navigation (decision 2): WHICH Workspace/Thread the user is looking at —
   // lifted here so the connect flow (Open project, Continue, sign-in) can drive it.
   const [nav, navDispatch] = useReducer(navReducer, initialNavState)
@@ -685,6 +703,19 @@ export function App(): JSX.Element {
             <ArrowRight className="size-4" aria-hidden />
           </IconButton>
         </div>
+        {/* Sidebar collapse toggle (#127): controls the left sidebar, so it sits in the
+            header's LEFT region. Always visible (the header never hides), usable in both
+            states; opts out of the drag region like every other header control. */}
+        <div className="ml-2 flex items-center [-webkit-app-region:no-drag]">
+          <IconButton
+            size="icon-sm"
+            aria-label={sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            title={sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            onClick={toggleSidebar}
+          >
+            <PanelLeft className="size-4" aria-hidden />
+          </IconButton>
+        </div>
         <div className="flex-1" />
         {/* placeholder — layout / view modes (#future) */}
         <div className="flex items-center gap-0.5 [-webkit-app-region:no-drag]">
@@ -701,6 +732,7 @@ export function App(): JSX.Element {
       </header>
 
       <Shell
+        collapsed={sidebarCollapsed}
         workspaces={recents}
         sidebarTop={sidebarTop}
         nav={nav}

--- a/src/renderer/src/shell/Shell.tsx
+++ b/src/renderer/src/shell/Shell.tsx
@@ -59,6 +59,7 @@ const NO_STATUSES = {} as const
  * badge, and an inline (safe) delete. Selection is the nav reducer's alone.
  */
 export function Shell({
+  collapsed,
   workspaces,
   sidebarTop,
   nav,
@@ -74,6 +75,8 @@ export function Shell({
   onNewThreadInWorkspace,
   onDeleteThread,
 }: {
+  /** Whether the left sidebar is collapsed (#127) — animate its width to 0 (still mounted). */
+  collapsed: boolean
   /** Persisted Workspaces (cold metadata) for the switcher rows + display names. */
   workspaces: ListMetadataResult
   /** App-owned controls pinned above the list (environment status; the gear). */
@@ -105,24 +108,40 @@ export function Shell({
 }): JSX.Element {
   return (
     <div className="flex min-h-0 flex-1">
-      <aside className="flex w-[338px] flex-none flex-col gap-3 overflow-y-auto border-r border-border bg-sidebar p-3">
-        <SidebarHeader />
-        {sidebarTop}
-        <PrimaryNav canCreateThread={canCreateThread} onNewThread={onNewThread} />
-        <WorkspaceNav
-          workspaces={workspaces}
-          nav={nav}
-          workspaceFlags={workspaceFlags}
-          rows={rows}
-          protectedThreadId={protectedThreadId}
-          opening={opening}
-          onOpenProject={onOpenProject}
-          onSelectThread={onSelectThread}
-          onNewThreadInWorkspace={onNewThreadInWorkspace}
-          onDeleteThread={onDeleteThread}
-        />
-        <div className="flex-1" />
-        <AccountChip />
+      {/* The sidebar stays MOUNTED when collapsed (#127) — its state (open projects,
+          scroll, the #138 fold list) survives, so re-expanding is instant. The OUTER
+          <aside> animates only its width (0 ↔ 338px) and clips (`overflow-hidden`); the
+          INNER holds a FIXED 338px width so the content SLIDES under the clip cleanly
+          instead of squishing as the container shrinks. `aria-hidden`/`inert` take the
+          now-hidden controls out of the tab order + a11y tree while collapsed. The
+          <main> outlet is `flex-1`, so it reclaims the freed space automatically. */}
+      <aside
+        aria-hidden={collapsed || undefined}
+        inert={collapsed || undefined}
+        className={cn(
+          'flex flex-none overflow-hidden border-border bg-sidebar transition-[width] duration-200',
+          collapsed ? 'w-0 border-r-0' : 'w-[338px] border-r',
+        )}
+      >
+        <div className="flex h-full w-[338px] flex-none flex-col gap-3 overflow-y-auto p-3">
+          <SidebarHeader />
+          {sidebarTop}
+          <PrimaryNav canCreateThread={canCreateThread} onNewThread={onNewThread} />
+          <WorkspaceNav
+            workspaces={workspaces}
+            nav={nav}
+            workspaceFlags={workspaceFlags}
+            rows={rows}
+            protectedThreadId={protectedThreadId}
+            opening={opening}
+            onOpenProject={onOpenProject}
+            onSelectThread={onSelectThread}
+            onNewThreadInWorkspace={onNewThreadInWorkspace}
+            onDeleteThread={onDeleteThread}
+          />
+          <div className="flex-1" />
+          <AccountChip />
+        </div>
       </aside>
 
       <main className="min-w-0 flex-1 overflow-y-auto p-6">{outlet}</main>

--- a/src/renderer/src/shell/sidebar-collapsed-store.test.ts
+++ b/src/renderer/src/shell/sidebar-collapsed-store.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  getSidebarCollapsed,
+  SIDEBAR_COLLAPSED_STORAGE_KEY,
+  setSidebarCollapsed,
+  type SidebarCollapsedStorage,
+} from './sidebar-collapsed-store'
+
+/** A throwaway in-memory Storage seam for the tests. */
+function fakeStorage(
+  seed?: Record<string, string>,
+): SidebarCollapsedStorage & { map: Map<string, string> } {
+  const map = new Map<string, string>(Object.entries(seed ?? {}))
+  return {
+    map,
+    getItem: (k) => map.get(k) ?? null,
+    setItem: (k, v) => void map.set(k, v),
+  }
+}
+
+describe('getSidebarCollapsed', () => {
+  it('defaults to false (expanded) when nothing is stored', () => {
+    expect(getSidebarCollapsed(fakeStorage())).toBe(false)
+  })
+
+  it('defaults to false for a null/undefined store', () => {
+    expect(getSidebarCollapsed(null)).toBe(false)
+    expect(getSidebarCollapsed(undefined)).toBe(false)
+  })
+
+  it('reads true when the flag is stored as "true"', () => {
+    expect(getSidebarCollapsed(fakeStorage({ [SIDEBAR_COLLAPSED_STORAGE_KEY]: 'true' }))).toBe(true)
+  })
+
+  it('reads false when the flag is stored as "false"', () => {
+    expect(getSidebarCollapsed(fakeStorage({ [SIDEBAR_COLLAPSED_STORAGE_KEY]: 'false' }))).toBe(
+      false,
+    )
+  })
+
+  it('round-trips both values through setSidebarCollapsed', () => {
+    const storage = fakeStorage()
+    setSidebarCollapsed(storage, true)
+    expect(getSidebarCollapsed(storage)).toBe(true)
+    setSidebarCollapsed(storage, false)
+    expect(getSidebarCollapsed(storage)).toBe(false)
+  })
+
+  it('treats any other/corrupt payload as absent → default false', () => {
+    expect(getSidebarCollapsed(fakeStorage({ [SIDEBAR_COLLAPSED_STORAGE_KEY]: 'TRUE' }))).toBe(false)
+    expect(getSidebarCollapsed(fakeStorage({ [SIDEBAR_COLLAPSED_STORAGE_KEY]: '1' }))).toBe(false)
+    expect(getSidebarCollapsed(fakeStorage({ [SIDEBAR_COLLAPSED_STORAGE_KEY]: '{not json' }))).toBe(
+      false,
+    )
+  })
+
+  it('never throws when the store throws on read', () => {
+    const storage: SidebarCollapsedStorage = {
+      getItem: () => {
+        throw new Error('blocked')
+      },
+      setItem: () => {},
+    }
+    expect(getSidebarCollapsed(storage)).toBe(false)
+  })
+})
+
+describe('setSidebarCollapsed', () => {
+  it('no-ops for a null/undefined store', () => {
+    expect(() => setSidebarCollapsed(null, true)).not.toThrow()
+    expect(() => setSidebarCollapsed(undefined, true)).not.toThrow()
+  })
+
+  it('swallows a throwing store (quota/security) without propagating', () => {
+    const setItem = vi.fn(() => {
+      throw new Error('quota exceeded')
+    })
+    const storage: SidebarCollapsedStorage = { getItem: () => null, setItem }
+    expect(() => setSidebarCollapsed(storage, true)).not.toThrow()
+    expect(setItem).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/shell/sidebar-collapsed-store.ts
+++ b/src/renderer/src/shell/sidebar-collapsed-store.ts
@@ -1,0 +1,48 @@
+/**
+ * Whether the left sidebar is COLLAPSED (#127): a renderer-only, display-only boolean.
+ * Collapsing the sidebar is pure UI chrome — it never spawns an agent, changes the
+ * active Workspace, or touches nav/persistence — so (like the project fold state #138,
+ * the sort order #129, and composer drafts #60) it lives in localStorage alone: no IPC,
+ * no main, no persistence store.
+ *
+ * The storage seam is INJECTED so tests pass a fake and render code passes
+ * `window.localStorage`; every path tolerates an unavailable/throwing/corrupt store
+ * and falls back to the default (EXPANDED = `false`) so a blocked store never traps the
+ * sidebar shut. The value is the string `"true"`/`"false"`; anything else is treated as
+ * absent → default.
+ */
+
+/** The single localStorage key holding the sidebar-collapsed flag. */
+export const SIDEBAR_COLLAPSED_STORAGE_KEY = 'vibe-mistro:sidebar-collapsed:v1'
+
+/** The slice of the Web Storage API we depend on — `window.localStorage` satisfies it. */
+export interface SidebarCollapsedStorage {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+}
+
+/**
+ * The persisted collapsed flag, or `false` (expanded) when absent/unknown/unavailable.
+ * Never throws — a blocked/throwing/corrupt store must not trap the sidebar shut.
+ */
+export function getSidebarCollapsed(storage: SidebarCollapsedStorage | null | undefined): boolean {
+  if (!storage) return false
+  try {
+    return storage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+/** Persist the collapsed flag best-effort; a quota/security exception is swallowed. */
+export function setSidebarCollapsed(
+  storage: SidebarCollapsedStorage | null | undefined,
+  collapsed: boolean,
+): void {
+  if (!storage) return
+  try {
+    storage.setItem(SIDEBAR_COLLAPSED_STORAGE_KEY, collapsed ? 'true' : 'false')
+  } catch {
+    // Best-effort: a full/blocked storage must never throw from a collapse toggle.
+  }
+}


### PR DESCRIPTION
Closes #127. Follow-up to #113 (shell).

## What
A `panel-left` toggle in the window-chrome bar collapses/expands the whole left sidebar; the conversation outlet reflows to full width. Collapsed state persists across reload.

- **App owns the state:** `sidebarCollapsed` seeded from a new localStorage store, flipped by `toggleSidebar` (persist on toggle). The `PanelLeft` `IconButton` sits in the header's left region (`[-webkit-app-region:no-drag]`, dynamic "Collapse/Expand sidebar" label), usable in both states.
- **The `<aside>` stays MOUNTED** when collapsed (open-projects/scroll/#138 fold state survive → instant re-expand). The OUTER aside animates only its width (`w-[338px] ↔ w-0`, `transition-[width]`) and clips (`overflow-hidden`); an INNER fixed-338px wrapper holds the content so it **slides under the clip cleanly** rather than squishing. `<main>` (`flex-1`) reclaims the space. `aria-hidden`+`inert` drop the hidden controls from the tab order + a11y tree while collapsed.
- **New store** `shell/sidebar-collapsed-store.ts` — pure, injected-storage, throw-tolerant (default = expanded, so a blocked store never traps the sidebar shut). Mirrors `project-open-store.ts`. TDD'd (9 tests).

## Behavior preserved
Expanded is byte-equivalent to before (338px, same border/bg/padding/scroll). No nav/persistence/pool/reducer changes — purely additive.

## Review fold
Adversarial verdict was SHIP; I folded its SHOULD-FIX (and both NITs): the collapse now uses an inner fixed-width wrapper so it slides cleanly instead of squishing the content, and the transition is scoped to `width` (no theme-swap lag / no `overflow` conflict).

## Gates
`bun run lint && bun run typecheck && bun run build && bun run test` — all green, **545 tests** (536 + 9 new store tests).

## Needs a live smoke
Toggle collapses/expands (clean slide, outlet widens); label flips; collapse + reload persists; window doesn't drag when clicking the toggle; re-expand restores projects/scroll/folds intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)