### PR TITLE
#132/#133: pin + archive threads (shared per-thread flags surface)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -30,6 +30,8 @@ import {
   type CheckAuthStatusResult,
   type SetThreadConfigArgs,
   type SetThreadConfigResult,
+  type SetThreadFlagsArgs,
+  type SetThreadFlagsResult,
   type SignInArgs,
   type SignInResult,
   type SignOutArgs,
@@ -852,6 +854,32 @@ function registerIpc(): void {
     })
     return { ok: true }
   })
+
+  ipcMain.handle(
+    IPC.setThreadFlags,
+    async (_event, args: SetThreadFlagsArgs): Promise<SetThreadFlagsResult> => {
+      // Toggle a Thread's persisted per-Thread flags (#132 pin / #133 archive) on OUR
+      // metadata record. A SAFE metadata op — no ACP session teardown — so unlike
+      // delete it has no streaming guard. Best-effort per ADR-0005: an absent store or
+      // a failed persist returns `{ok:false}` (never throws into the live flow); the
+      // renderer then leaves the list unchanged. `setThreadFlags` is a no-op for an
+      // unknown id. Persisting the metadata index is not agent activity → no `pool.touch`.
+      if (!metadataStore) return { ok: false }
+      try {
+        await metadataStore.setThreadFlags(args.threadId, {
+          pinned: args.pinned,
+          archived: args.archived,
+        })
+        return { ok: true }
+      } catch (err) {
+        console.error(
+          `[vibe-mistro:metadata] setThreadFlags failed (${args.threadId}): ` +
+            `${err instanceof Error ? err.message : String(err)}`,
+        )
+        return { ok: false }
+      }
+    },
+  )
 
   ipcMain.handle(
     IPC.setThreadConfig,

--- a/src/main/persistence/metadata-store.test.ts
+++ b/src/main/persistence/metadata-store.test.ts
@@ -234,6 +234,105 @@ describe('MetadataStore.deleteThread (TB6 #35)', () => {
   })
 })
 
+describe('MetadataStore.setThreadFlags (#132 pin / #133 archive)', () => {
+  it('patches only the passed flag, leaving the other untouched, and round-trips', async () => {
+    const file = 'flags-roundtrip.json'
+    const store = storeAt(file)
+    await store.load()
+    const ws = await store.upsertWorkspace({ dir: '/proj/flags' })
+    const t = await store.upsertThread({ workspaceId: ws.id, sessionId: 's1' })
+
+    // Pin only: archived stays absent (undefined = false).
+    await store.setThreadFlags(t.id, { pinned: true })
+    let rec = store.snapshot().threads.find((x) => x.id === t.id)
+    expect(rec?.pinned).toBe(true)
+    expect(rec?.archived).toBeUndefined()
+
+    // Archive only: pin is preserved (only the passed field changes).
+    await store.setThreadFlags(t.id, { archived: true })
+    rec = store.snapshot().threads.find((x) => x.id === t.id)
+    expect(rec?.pinned).toBe(true)
+    expect(rec?.archived).toBe(true)
+
+    // Durable across a fresh instance over the SAME file (survives reopen/eviction).
+    const reopened = storeAt(file)
+    await reopened.load()
+    const back = reopened.snapshot().threads.find((x) => x.id === t.id)
+    expect(back?.pinned).toBe(true)
+    expect(back?.archived).toBe(true)
+
+    // Unpin clears just that flag.
+    await reopened.setThreadFlags(t.id, { pinned: false })
+    expect(reopened.snapshot().threads.find((x) => x.id === t.id)?.pinned).toBe(false)
+    expect(reopened.snapshot().threads.find((x) => x.id === t.id)?.archived).toBe(true)
+  })
+
+  it('holds the record list POSITION (a flag toggle is not activity)', async () => {
+    let clock = 1000
+    const store = new MetadataStore({ filePath: join(dir, 'flags-order.json'), now: () => clock })
+    await store.load()
+    const ws = await store.upsertWorkspace({ dir: '/proj/flags-order' })
+    clock = 1100
+    const t1 = await store.upsertThread({ workspaceId: ws.id })
+    clock = 1200
+    const t2 = await store.upsertThread({ workspaceId: ws.id })
+
+    // t2 leads (most recent). Pinning t1 must NOT re-order the stored list.
+    await store.setThreadFlags(t1.id, { pinned: true })
+    expect(store.snapshot().threads.map((t) => t.id)).toEqual([t2.id, t1.id])
+  })
+
+  it('is a no-op for an unknown id (no throw, no write)', async () => {
+    const events: string[] = []
+    const store = new MetadataStore({
+      filePath: join(dir, 'flags-unknown.json'),
+      readFile: async () => {
+        throw new Error('ENOENT')
+      },
+      writeFile: async (path) => {
+        events.push(`write:${path}`)
+      },
+      rename: async () => {},
+    })
+    await store.load()
+    await expect(store.setThreadFlags('no-such-thread', { pinned: true })).resolves.toBeUndefined()
+    expect(events).toEqual([]) // no disk write for an unknown id
+  })
+
+  it('upsertThread PRESERVES pinned/archived across a routine activity re-target', async () => {
+    const store = storeAt('flags-preserve.json')
+    await store.load()
+    const ws = await store.upsertWorkspace({ dir: '/proj/flags-preserve' })
+    const t = await store.upsertThread({ workspaceId: ws.id })
+    await store.setThreadFlags(t.id, { pinned: true, archived: true })
+
+    // A normal activity-upsert (new turn: same id, fresh sessionId) must NOT clear them.
+    const again = await store.upsertThread({ id: t.id, workspaceId: ws.id, sessionId: 's-new' })
+    expect(again.pinned).toBe(true)
+    expect(again.archived).toBe(true)
+  })
+
+  it('coerces a stored non-boolean flag to undefined on load (defensive)', async () => {
+    const file = join(dir, 'flags-coerce.json')
+    writeFileSync(
+      file,
+      JSON.stringify({
+        schemaVersion: METADATA_SCHEMA_VERSION,
+        workspaces: [{ id: 'w1', dir: '/c', displayName: 'c', lastOpenedAt: 1 }],
+        threads: [
+          // pinned is a truthy STRING, archived is a real boolean — only the boolean survives.
+          { id: 't1', workspaceId: 'w1', sessionId: null, title: null, createdAt: 1, lastActiveAt: 1, pinned: 'yes', archived: true },
+        ],
+      }),
+    )
+    const store = new MetadataStore({ filePath: file })
+    await store.load()
+    const rec = store.snapshot().threads.find((t) => t.id === 't1')
+    expect(rec?.pinned).toBeUndefined() // non-boolean coerced away (not truthy-pinned)
+    expect(rec?.archived).toBe(true)
+  })
+})
+
 describe('MetadataStore atomic persist', () => {
   it('writes to a temp file then renames it over the target (crash-safe)', async () => {
     const events: string[] = []

--- a/src/main/persistence/metadata-store.ts
+++ b/src/main/persistence/metadata-store.ts
@@ -74,6 +74,10 @@ export interface ThreadInput {
   title?: string | null
   createdAt?: number
   lastActiveAt?: number
+  /** Pin flag (#132) — may be seeded here, but the primary toggle is `setThreadFlags`. */
+  pinned?: boolean
+  /** Archive flag (#133) — may be seeded here, but the primary toggle is `setThreadFlags`. */
+  archived?: boolean
 }
 
 /**
@@ -170,7 +174,9 @@ export class MetadataStore {
       workspaces: (Array.isArray(parsed.workspaces) ? parsed.workspaces : []).filter(
         isWorkspaceRecord,
       ),
-      threads: (Array.isArray(parsed.threads) ? parsed.threads : []).filter(isThreadRecord),
+      threads: (Array.isArray(parsed.threads) ? parsed.threads : [])
+        .filter(isThreadRecord)
+        .map(normalizeThreadFlags),
     }
   }
 
@@ -204,7 +210,11 @@ export class MetadataStore {
   /**
    * Add or update a Thread. A matching `id` re-targets the existing Thread —
    * preserving its `createdAt` while refreshing `lastActiveAt` (and the
-   * `sessionId` resume cursor) — instead of creating a second record.
+   * `sessionId` resume cursor) — instead of creating a second record. The
+   * per-Thread flags (`pinned`/`archived`, #132/#133) are PRESERVED across a
+   * re-target too, so a routine activity-upsert never clears a pin/archive; they
+   * change only when explicitly passed here or (the primary path) via
+   * `setThreadFlags`.
    */
   async upsertThread(input: ThreadInput): Promise<ThreadRecord> {
     const ts = this.now()
@@ -216,10 +226,32 @@ export class MetadataStore {
       title: input.title ?? existing?.title ?? null,
       createdAt: input.createdAt ?? existing?.createdAt ?? ts,
       lastActiveAt: input.lastActiveAt ?? ts,
+      pinned: input.pinned ?? existing?.pinned,
+      archived: input.archived ?? existing?.archived,
     }
     this.state.threads = [record, ...this.state.threads.filter((t) => t.id !== record.id)]
     await this.persist()
     return record
+  }
+
+  /**
+   * Toggle a Thread's per-Thread flags (#132 pin / #133 archive) on its metadata
+   * record, keyed by minted `id`. Patches ONLY the provided flag(s) — the other is
+   * left untouched — and holds the record's list POSITION (a flag change is not
+   * activity, so it does not re-order like an upsert). An unknown id is a no-op
+   * with NO write. Persisted atomically like the upserts; flags round-trip through
+   * `load`, so a pin/archive survives reopen/eviction (ADR-0005).
+   */
+  async setThreadFlags(id: string, flags: { pinned?: boolean; archived?: boolean }): Promise<void> {
+    const existing = this.state.threads.find((t) => t.id === id)
+    if (!existing) return // unknown id — nothing to patch, no disk write
+    const updated: ThreadRecord = {
+      ...existing,
+      ...(flags.pinned !== undefined ? { pinned: flags.pinned } : {}),
+      ...(flags.archived !== undefined ? { archived: flags.archived } : {}),
+    }
+    this.state.threads = this.state.threads.map((t) => (t.id === id ? updated : t))
+    await this.persist()
   }
 
   /**
@@ -305,6 +337,20 @@ function isThreadRecord(value: unknown): value is ThreadRecord {
     typeof t.createdAt === 'number' &&
     typeof t.lastActiveAt === 'number'
   )
+}
+
+/**
+ * Coerce a loaded Thread's optional flags (#132/#133) to strict booleans: a stored
+ * `pinned`/`archived` that isn't literally `true` (a stale non-boolean, or absent)
+ * normalizes to `undefined` (= false). Keeps the in-memory shape honest so the
+ * renderer's `orderByPin`/`partitionArchived` never see a truthy non-boolean.
+ */
+function normalizeThreadFlags(t: ThreadRecord): ThreadRecord {
+  return {
+    ...t,
+    pinned: t.pinned === true ? true : undefined,
+    archived: t.archived === true ? true : undefined,
+  }
 }
 
 /**

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -29,6 +29,8 @@ import {
   type CheckAuthStatusResult,
   type SetThreadConfigArgs,
   type SetThreadConfigResult,
+  type SetThreadFlagsArgs,
+  type SetThreadFlagsResult,
   type SignInArgs,
   type SignInResult,
   type SignOutArgs,
@@ -65,6 +67,8 @@ const api = {
   getThreadStatuses: (): Promise<ThreadStatusEvent[]> => ipcRenderer.invoke(IPC.getThreadStatuses),
   setThreadConfig: (args: SetThreadConfigArgs): Promise<SetThreadConfigResult> =>
     ipcRenderer.invoke(IPC.setThreadConfig, args),
+  setThreadFlags: (args: SetThreadFlagsArgs): Promise<SetThreadFlagsResult> =>
+    ipcRenderer.invoke(IPC.setThreadFlags, args),
   readTranscript: (threadId: string): Promise<ReadTranscriptResult> =>
     ipcRenderer.invoke(IPC.readTranscript, threadId),
   gitSubscribeStatus: (args: GitStatusSubscriptionArgs): Promise<void> =>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -184,6 +184,22 @@ export function App(): JSX.Element {
   }
 
   /**
+   * Toggle a Thread's persisted per-Thread flags (#132 pin / #133 archive). A SAFE
+   * metadata op — no session teardown — so it runs on any row (active or cold-peek).
+   * Best-effort in main (ADR-0005); we refresh the recents list so the new flag
+   * reflects in the sidebar's derivation (`orderByPin` / `partitionArchived`). A
+   * `{ok:false}` (store failure) leaves the list as-is — the toggle is a no-op.
+   */
+  async function setThreadFlags(
+    threadId: string,
+    flags: { pinned?: boolean; archived?: boolean },
+  ): Promise<void> {
+    const result = await window.api.setThreadFlags({ threadId, ...flags })
+    if (!result.ok) return
+    await refreshRecents()
+  }
+
+  /**
    * Record a Workspace connect outcome: set its ConnectState and, when connected,
    * (re)seed its per-session live-state with the agent's auto-opened Thread. Pull
    * focus to that Thread when the user is still on this Workspace (`focus`, or the
@@ -747,6 +763,7 @@ export function App(): JSX.Element {
         onNewThread={() => selectedWs && newThread(selectedWs)}
         onNewThreadInWorkspace={newThreadInWorkspace}
         onDeleteThread={deleteThread}
+        onSetThreadFlags={setThreadFlags}
       />
     </div>
   )

--- a/src/renderer/src/shell/Shell.tsx
+++ b/src/renderer/src/shell/Shell.tsx
@@ -1,11 +1,15 @@
 import { useState, type JSX, type ReactNode } from 'react'
 import {
+  Archive,
+  ArchiveRestore,
   Atom,
   ChevronDown,
   Clock,
   Ellipsis,
   Folder,
   MoreVertical,
+  Pin,
+  PinOff,
   Plus,
   Search,
   SquarePen,
@@ -13,7 +17,13 @@ import {
 } from 'lucide-react'
 import type { ListMetadataResult, ThreadMeta } from '../../../shared/ipc'
 import type { NavState } from './nav-reducer'
-import { deriveUnifiedThreads, isThreadDeletable, type UnifiedThreadRow } from './unified-threads'
+import {
+  deriveUnifiedThreads,
+  isThreadDeletable,
+  orderByPin,
+  partitionArchived,
+  type UnifiedThreadRow,
+} from './unified-threads'
 import { getOpenProjects, setOpenProjects } from './project-open-store'
 import { getSortOrder, setSortOrder, sortWorkspaces, type WorkspaceSortOrder } from './workspace-sort'
 import { Badge } from '../ui/badge'
@@ -32,6 +42,9 @@ export interface WorkspaceFlags {
   streaming: boolean
   needsAttention: boolean
 }
+
+/** Toggle a Thread's persisted per-Thread flags (#132 pin / #133 archive). */
+type SetThreadFlags = (threadId: string, flags: { pinned?: boolean; archived?: boolean }) => void
 
 /** How many thread rows each project shows before "Show more" (#113/#138). */
 const THREAD_CAP = 5
@@ -74,6 +87,7 @@ export function Shell({
   onNewThread,
   onNewThreadInWorkspace,
   onDeleteThread,
+  onSetThreadFlags,
 }: {
   /** Whether the left sidebar is collapsed (#127) — animate its width to 0 (still mounted). */
   collapsed: boolean
@@ -105,6 +119,8 @@ export function Shell({
   onNewThreadInWorkspace: (workspaceId: string) => void
   /** Delete a Thread (TB6) — main tears down any live session, then the list refreshes. */
   onDeleteThread: (thread: ThreadMeta) => Promise<void>
+  /** Pin/archive a Thread (#132/#133) — a safe metadata toggle on any row. */
+  onSetThreadFlags: SetThreadFlags
 }): JSX.Element {
   return (
     <div className="flex min-h-0 flex-1">
@@ -138,6 +154,7 @@ export function Shell({
             onSelectThread={onSelectThread}
             onNewThreadInWorkspace={onNewThreadInWorkspace}
             onDeleteThread={onDeleteThread}
+            onSetThreadFlags={onSetThreadFlags}
           />
           <div className="flex-1" />
           <AccountChip />
@@ -264,6 +281,7 @@ function WorkspaceNav({
   onSelectThread,
   onNewThreadInWorkspace,
   onDeleteThread,
+  onSetThreadFlags,
 }: {
   workspaces: ListMetadataResult
   nav: NavState
@@ -275,6 +293,7 @@ function WorkspaceNav({
   onSelectThread: (workspaceId: string, threadId: string) => void
   onNewThreadInWorkspace: (workspaceId: string) => void
   onDeleteThread: (thread: ThreadMeta) => Promise<void>
+  onSetThreadFlags: SetThreadFlags
 }): JSX.Element {
   // The DISPLAY-ONLY sort order (#129): renderer-only UI state seeded from
   // localStorage (default 'recent'), persisted on change. It reorders the project
@@ -385,6 +404,7 @@ function WorkspaceNav({
               onNewThread={onNewThreadInWorkspace}
               onSelectThread={onSelectThread}
               onDeleteThread={onDeleteThread}
+              onSetThreadFlags={onSetThreadFlags}
             />
           )
         })
@@ -416,6 +436,7 @@ function ProjectRow({
   onNewThread,
   onSelectThread,
   onDeleteThread,
+  onSetThreadFlags,
 }: {
   workspace: ListMetadataResult[number]
   rows: UnifiedThreadRow[]
@@ -430,20 +451,26 @@ function ProjectRow({
   onNewThread: (workspaceId: string) => void
   onSelectThread: (workspaceId: string, threadId: string) => void
   onDeleteThread: (thread: ThreadMeta) => Promise<void>
+  onSetThreadFlags: SetThreadFlags
 }): JSX.Element {
   const [expandedThreads, setExpandedThreads] = useState(false)
-  // Cap this project's list, PINNING the selected row so opening a thread that sorts
-  // below the cap never hides its (highlighted) row (#113 review). Only the active
-  // project has a selected row in its list (thread ids are globally unique).
+  // Split archived rows out (#133) then float pinned rows to the top of the active
+  // list (#132) — both pure post-processing over the derived rows (deriveUnifiedThreads
+  // stays flag-agnostic). Archived rows fold into a collapsible section at the bottom.
+  const { active: activeRows, archived: archivedRows } = partitionArchived(rows)
+  const mainRows = orderByPin(activeRows)
+  // Cap the main list, PINNING the selected row so opening a thread that sorts below
+  // the cap never hides its (highlighted) row (#113 review). Only the active project
+  // has a selected row in its list (thread ids are globally unique).
   const capped = visibleRows(
-    rows,
+    mainRows,
     THREAD_CAP,
     expandedThreads,
     (r) => r.thread.id === selectedThreadId,
   )
-  const hiddenCount = rows.length - capped.length
+  const hiddenCount = mainRows.length - capped.length
   const cappedIds = new Set(capped.map((r) => r.thread.id))
-  const hiddenNeedsAttention = rows.some((r) => !cappedIds.has(r.thread.id) && r.needsAttention)
+  const hiddenNeedsAttention = mainRows.some((r) => !cappedIds.has(r.thread.id) && r.needsAttention)
 
   return (
     <Collapsible open={open} onOpenChange={(next) => onToggleOpen(workspace.id, next)}>
@@ -490,7 +517,7 @@ function ProjectRow({
       </div>
 
       <CollapsibleContent>
-        {rows.length > 0 ? (
+        {mainRows.length > 0 ? (
           <ul className="flex flex-col gap-0.5">
             {capped.map((row) => (
               <NavThread
@@ -503,10 +530,12 @@ function ProjectRow({
                 // delete to the active project — else a background-connected project's
                 // mid-turn thread would look cold-and-deletable and tear its session.
                 // Within the active project the pure gate decides (cold always; the
-                // primary never; any other live row when idle).
+                // primary never; any other live row when idle). Pin/archive are SAFE
+                // metadata ops (no session teardown), so the kebab shows on every row.
                 deletable={isActive && isThreadDeletable(row, protectedThreadId)}
                 onOpen={() => onSelectThread(workspace.id, row.thread.id)}
                 onDelete={onDeleteThread}
+                onSetThreadFlags={onSetThreadFlags}
               />
             ))}
             {(expandedThreads || hiddenCount > 0) && (
@@ -527,9 +556,84 @@ function ProjectRow({
               </button>
             )}
           </ul>
-        ) : (
+        ) : archivedRows.length === 0 ? (
           <div className="px-3 py-1 pl-[42px] text-[13px] text-muted">No threads yet</div>
+        ) : null}
+
+        {/* Archived section (#133): a collapsible "Archived (N)" fold at the BOTTOM,
+            default-collapsed, hidden entirely when N=0. Same NavThread rows (open /
+            unarchive / delete). */}
+        {archivedRows.length > 0 && (
+          <ArchivedSection
+            rows={archivedRows}
+            isActive={isActive}
+            protectedThreadId={protectedThreadId}
+            selectedThreadId={selectedThreadId}
+            nowMs={nowMs}
+            workspaceId={workspace.id}
+            onSelectThread={onSelectThread}
+            onDeleteThread={onDeleteThread}
+            onSetThreadFlags={onSetThreadFlags}
+          />
         )}
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}
+
+/**
+ * The per-project "Archived (N)" collapsible (#133): a nested, default-collapsed fold
+ * at the bottom of a project's panel listing its archived Threads. Uses the SAME
+ * NavThread row (so archived rows keep open / unarchive / delete), with the same
+ * active-project delete gate as the main list.
+ */
+function ArchivedSection({
+  rows,
+  isActive,
+  protectedThreadId,
+  selectedThreadId,
+  nowMs,
+  workspaceId,
+  onSelectThread,
+  onDeleteThread,
+  onSetThreadFlags,
+}: {
+  rows: UnifiedThreadRow[]
+  isActive: boolean
+  protectedThreadId: string | null
+  selectedThreadId: string | null
+  nowMs: number
+  workspaceId: string
+  onSelectThread: (workspaceId: string, threadId: string) => void
+  onDeleteThread: (thread: ThreadMeta) => Promise<void>
+  onSetThreadFlags: SetThreadFlags
+}): JSX.Element {
+  const [open, setOpen] = useState(false)
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className="mt-0.5">
+      <CollapsibleTrigger className="flex w-full items-center gap-2 rounded-md px-3 py-1 pl-[26px] text-left text-[13px] text-faint outline-none transition-colors hover:bg-accent/10 focus-visible:bg-accent/10">
+        <ChevronDown
+          className={cn('size-3.5 shrink-0 text-muted transition-transform', !open && '-rotate-90')}
+          aria-hidden
+        />
+        <Archive className="size-3.5 shrink-0 text-muted" aria-hidden />
+        <span className="flex-1 truncate">Archived ({rows.length})</span>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <ul className="flex flex-col gap-0.5">
+          {rows.map((row) => (
+            <NavThread
+              key={row.thread.id}
+              row={row}
+              nowMs={nowMs}
+              selected={row.thread.id === selectedThreadId}
+              deletable={isActive && isThreadDeletable(row, protectedThreadId)}
+              onOpen={() => onSelectThread(workspaceId, row.thread.id)}
+              onDelete={onDeleteThread}
+              onSetThreadFlags={onSetThreadFlags}
+            />
+          ))}
+        </ul>
       </CollapsibleContent>
     </Collapsible>
   )
@@ -550,6 +654,7 @@ function NavThread({
   deletable,
   onOpen,
   onDelete,
+  onSetThreadFlags,
 }: {
   row: UnifiedThreadRow
   nowMs: number
@@ -557,8 +662,11 @@ function NavThread({
   deletable: boolean
   onOpen: () => void
   onDelete: (thread: ThreadMeta) => Promise<void>
+  onSetThreadFlags: SetThreadFlags
 }): JSX.Element {
   const timestamp = formatRelativeTime(row.thread.lastActiveAt, nowMs)
+  const pinned = row.thread.pinned === true
+  const archived = row.thread.archived === true
   return (
     <li className="group/thread relative">
       <NavItem active={selected} onClick={onOpen} className="py-[7px] pr-2 pl-[42px] text-[14.5px]">
@@ -570,6 +678,7 @@ function NavThread({
           }
           aria-hidden
         />
+        {pinned && <Pin className="size-3 shrink-0 text-muted" aria-label="Pinned" />}
         <span className="flex-1 truncate">{threadLabel(row)}</span>
         {row.streaming && (
           <Spinner className="size-3.5 text-accent-text" aria-label="Streaming" />
@@ -581,23 +690,38 @@ function NavThread({
         )}
         {timestamp && <span className="shrink-0 text-[13px] text-faint">{timestamp}</span>}
       </NavItem>
-      {deletable && (
-        <Menu>
-          <MenuTrigger
-            aria-label="Thread actions"
-            title="Thread actions"
-            className="absolute top-1/2 right-1 inline-flex size-6 -translate-y-1/2 items-center justify-center rounded-sm text-muted opacity-0 outline-none transition-opacity hover:bg-accent/10 hover:text-text focus-visible:opacity-100 group-hover/thread:opacity-100 data-[popup-open]:opacity-100"
-          >
-            <MoreVertical className="size-3.5" aria-hidden />
-          </MenuTrigger>
-          <MenuContent>
+      {/* Kebab shows on EVERY row now (#132/#133): pin/archive are SAFE metadata ops
+          (no session teardown), so they're always available; only Delete stays gated to
+          `deletable` (the #138 active-project safety). */}
+      <Menu>
+        <MenuTrigger
+          aria-label="Thread actions"
+          title="Thread actions"
+          className="absolute top-1/2 right-1 inline-flex size-6 -translate-y-1/2 items-center justify-center rounded-sm text-muted opacity-0 outline-none transition-opacity hover:bg-accent/10 hover:text-text focus-visible:opacity-100 group-hover/thread:opacity-100 data-[popup-open]:opacity-100"
+        >
+          <MoreVertical className="size-3.5" aria-hidden />
+        </MenuTrigger>
+        <MenuContent>
+          <MenuItem onClick={() => onSetThreadFlags(row.thread.id, { pinned: !pinned })}>
+            {pinned ? <PinOff className="size-3.5" aria-hidden /> : <Pin className="size-3.5" aria-hidden />}
+            {pinned ? 'Unpin' : 'Pin'}
+          </MenuItem>
+          <MenuItem onClick={() => onSetThreadFlags(row.thread.id, { archived: !archived })}>
+            {archived ? (
+              <ArchiveRestore className="size-3.5" aria-hidden />
+            ) : (
+              <Archive className="size-3.5" aria-hidden />
+            )}
+            {archived ? 'Unarchive' : 'Archive'}
+          </MenuItem>
+          {deletable && (
             <MenuItem className="text-bad" onClick={() => void onDelete(row.thread)}>
               <Trash2 className="size-3.5" aria-hidden />
               Delete
             </MenuItem>
-          </MenuContent>
-        </Menu>
-      )}
+          )}
+        </MenuContent>
+      </Menu>
     </li>
   )
 }

--- a/src/renderer/src/shell/unified-threads.test.ts
+++ b/src/renderer/src/shell/unified-threads.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { deriveUnifiedThreads, isThreadDeletable, workspaceFlags, type UnifiedThreadRow } from './unified-threads'
+import {
+  deriveUnifiedThreads,
+  isThreadDeletable,
+  orderByPin,
+  partitionArchived,
+  workspaceFlags,
+  type UnifiedThreadRow,
+} from './unified-threads'
 import type { ThreadStatusMap } from '../conversation/thread-status'
 import type { ThreadMeta } from '../../../shared/ipc'
 
@@ -108,6 +115,86 @@ describe('workspaceFlags (background Workspace roll-up)', () => {
   it('ignores statuses of Threads not in this Workspace live set', () => {
     const statuses: ThreadStatusMap = { other: { streaming: true, needsAttention: true } }
     expect(workspaceFlags(new Set(['a']), statuses)).toEqual({ streaming: false, needsAttention: false })
+  })
+})
+
+describe('orderByPin (#132 pinned-first, stable)', () => {
+  function row(id: string, pinned?: boolean): UnifiedThreadRow {
+    return {
+      thread: { ...thread(id), pinned },
+      live: false,
+      streaming: false,
+      needsAttention: false,
+    }
+  }
+
+  it('returns the same order when nothing is pinned', () => {
+    const rows = [row('a'), row('b'), row('c')]
+    expect(orderByPin(rows).map((r) => r.thread.id)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('keeps order when every row is pinned', () => {
+    const rows = [row('a', true), row('b', true), row('c', true)]
+    expect(orderByPin(rows).map((r) => r.thread.id)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('floats pinned rows to the top, preserving each group order (stable)', () => {
+    // Incoming most-recent-first: a, b(pin), c, d(pin), e. Pinned keep b,d order;
+    // rest keep a,c,e order — appended after.
+    const rows = [row('a'), row('b', true), row('c'), row('d', true), row('e')]
+    expect(orderByPin(rows).map((r) => r.thread.id)).toEqual(['b', 'd', 'a', 'c', 'e'])
+  })
+
+  it('does not mutate its input', () => {
+    const rows = [row('a'), row('b', true)]
+    const snapshot = rows.map((r) => r.thread.id)
+    orderByPin(rows)
+    expect(rows.map((r) => r.thread.id)).toEqual(snapshot)
+  })
+
+  it('handles an empty list', () => {
+    expect(orderByPin([])).toEqual([])
+  })
+})
+
+describe('partitionArchived (#133 split, order-preserving)', () => {
+  function row(id: string, archived?: boolean): UnifiedThreadRow {
+    return {
+      thread: { ...thread(id), archived },
+      live: false,
+      streaming: false,
+      needsAttention: false,
+    }
+  }
+
+  it('puts everything in active when nothing is archived', () => {
+    const { active, archived } = partitionArchived([row('a'), row('b')])
+    expect(active.map((r) => r.thread.id)).toEqual(['a', 'b'])
+    expect(archived).toEqual([])
+  })
+
+  it('splits archived out, preserving both groups order', () => {
+    const rows = [row('a'), row('b', true), row('c'), row('d', true)]
+    const { active, archived } = partitionArchived(rows)
+    expect(active.map((r) => r.thread.id)).toEqual(['a', 'c'])
+    expect(archived.map((r) => r.thread.id)).toEqual(['b', 'd'])
+  })
+
+  it('puts everything in archived when all are archived', () => {
+    const { active, archived } = partitionArchived([row('a', true), row('b', true)])
+    expect(active).toEqual([])
+    expect(archived.map((r) => r.thread.id)).toEqual(['a', 'b'])
+  })
+
+  it('does not mutate its input', () => {
+    const rows = [row('a'), row('b', true)]
+    const snapshot = rows.map((r) => r.thread.id)
+    partitionArchived(rows)
+    expect(rows.map((r) => r.thread.id)).toEqual(snapshot)
+  })
+
+  it('handles an empty list', () => {
+    expect(partitionArchived([])).toEqual({ active: [], archived: [] })
   })
 })
 

--- a/src/renderer/src/shell/unified-threads.ts
+++ b/src/renderer/src/shell/unified-threads.ts
@@ -62,6 +62,41 @@ export function deriveUnifiedThreads(args: {
 }
 
 /**
+ * Stable reorder that floats a Workspace's PINNED rows (#132) to the top while
+ * preserving each group's incoming order — so within the pinned group and within the
+ * rest, the most-recent-first order the caller passed is untouched. Pure: returns a
+ * NEW array (never mutates the input), applied as post-processing over
+ * `deriveUnifiedThreads` (which stays flag-agnostic).
+ */
+export function orderByPin(rows: UnifiedThreadRow[]): UnifiedThreadRow[] {
+  const pinned: UnifiedThreadRow[] = []
+  const rest: UnifiedThreadRow[] = []
+  for (const row of rows) {
+    if (row.thread.pinned) pinned.push(row)
+    else rest.push(row)
+  }
+  return [...pinned, ...rest]
+}
+
+/**
+ * Split a Workspace's rows into `active` (shown in the main list) and `archived`
+ * (#133 — folded into a collapsible "Archived" section), keyed off `thread.archived`.
+ * Both halves preserve the incoming order; pure (no mutation of the input array).
+ */
+export function partitionArchived(rows: UnifiedThreadRow[]): {
+  active: UnifiedThreadRow[]
+  archived: UnifiedThreadRow[]
+} {
+  const active: UnifiedThreadRow[] = []
+  const archived: UnifiedThreadRow[] = []
+  for (const row of rows) {
+    if (row.thread.archived) archived.push(row)
+    else active.push(row)
+  }
+  return { active, archived }
+}
+
+/**
  * Whether a unified row may be deleted (pure — the safe-delete gate, TB6 / #48 /
  * #53). The hazard is tearing a session out from under a mid-turn agent. Now that
  * main pushes real per-Thread `streaming` for ALL live Threads (#53, not just the

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -90,6 +90,16 @@ export const IPC = {
    */
   setThreadConfig: 'thread:set-config',
   /**
+   * Renderer -> main: toggle a Thread's persisted per-Thread FLAGS (#132 pin, #133
+   * archive) on its metadata record. ONE channel drives both flags — pin sends
+   * `{threadId, pinned}`, archive sends `{threadId, archived}`; only the passed
+   * field(s) change. These are SAFE metadata ops (no session teardown), so they're
+   * available on every row. Best-effort per ADR-0005: a store failure returns
+   * `{ok:false}` and never breaks the live flow. Flags survive reopen/eviction (they
+   * live in the MetadataStore), so a pinned/archived Thread stays so across launches.
+   */
+  setThreadFlags: 'thread:set-flags',
+  /**
    * Renderer -> main: subscribe to the active Workspace's STREAMED git status
    * (#84, ADR-0008). Ref-counted per `workspaceDir` in main — the first subscribe
    * starts one fs watcher + one background fetch and emits a `snapshot`; later
@@ -547,6 +557,26 @@ export interface SetThreadConfigArgs {
 export type SetThreadConfigResult = { ok: true } | { ok: false; error: string }
 
 /**
+ * Toggle a Thread's persisted per-Thread flags (#132 pin / #133 archive). ONE
+ * payload drives either flag: a pin toggle sends `{threadId, pinned}`, an archive
+ * toggle sends `{threadId, archived}`; each is optional so only the passed field(s)
+ * change on the metadata record (`setThreadFlags` patches, never clears the other).
+ */
+export interface SetThreadFlagsArgs {
+  /** OUR durable Thread id whose flags to patch. */
+  threadId: string
+  pinned?: boolean
+  archived?: boolean
+}
+
+/**
+ * The `setThreadFlags` reply. `{ok:true}` once the flag is persisted; `{ok:false}`
+ * when the best-effort store write failed (ADR-0005 — the renderer keeps the list as
+ * it was and the toggle is a no-op rather than throwing into the live flow).
+ */
+export type SetThreadFlagsResult = { ok: true } | { ok: false }
+
+/**
  * Persisted Workspace metadata (ADR-0005): a project dir the user has opened.
  * The renderer lists these on launch with NO agent spawned and no transcript
  * loaded — opening for content is a later slice (TB3).
@@ -574,6 +604,18 @@ export interface ThreadMeta {
   title: string | null
   createdAt: number
   lastActiveAt: number
+  /**
+   * Pinned to the top of the unified list (#132). Optional/additive — `undefined`
+   * reads as false, so legacy records (and every never-pinned Thread) need no
+   * migration. Toggled via `setThreadFlags`; sorted by `orderByPin`.
+   */
+  pinned?: boolean
+  /**
+   * Archived — hidden from the main list into a collapsible "Archived" section
+   * (#133). Optional/additive like `pinned` (`undefined` = not archived). Toggled
+   * via `setThreadFlags`; split out by `partitionArchived`.
+   */
+  archived?: boolean
 }
 
 /** A Workspace with its Threads nested, both most-recent-first — the cold list. */


### PR DESCRIPTION
Closes #132 and #133. Both built together on ONE shared per-thread flags surface.

## What
Threads can be **pinned to the top** (#132) and **archived** (#133) from their sidebar row menu; both flags persist in the metadata store and survive reopen/eviction.

**Cross-layer, one flags surface:**
- **Schema/IPC** (`src/shared/ipc.ts`): optional `pinned?`/`archived?` on `ThreadMeta` (additive — no schema bump); one `thread:set-flags` channel + `SetThreadFlagsArgs`/`SetThreadFlagsResult`.
- **Main** (`metadata-store.ts` + handler): `setThreadFlags(id, {pinned?, archived?})` patches only the passed flag(s), **holds list position** (a flag toggle isn't activity → `lastActiveAt` untouched, so the renderer floats pins up), unknown-id no-op-no-write. `upsertThread` **preserves** existing flags (a routine activity-upsert never clears a pin). `load` normalizes non-boolean flags. The `ipcMain.handle` is **best-effort (ADR-0005)** — an absent store or failed persist returns `{ok:false}` and never throws into the live flow.
- **Renderer** (pure, TDD'd): `orderByPin` (stable, pinned-first) + `partitionArchived` (`{active, archived}`); `deriveUnifiedThreads` stays unchanged. `ProjectRow` applies both, then the existing cap/"Show more". The `NavThread` kebab now shows on **every** row — Pin/Unpin + Archive/Unarchive are safe metadata ops, with **Delete still gated to the active project** (#138 safety intact). Archived threads fold into a per-project, default-collapsed **"Archived (N)"** section (hidden at N=0). App's `setThreadFlags` refreshes recents on success, no-ops on `{ok:false}`.

## Invariants
Best-effort persistence (never breaks the live flow); flags round-trip through reopen (test) and survive activity-upserts; delete safety unchanged; `deriveUnifiedThreads`/nav-reducer/first-run untouched.

## Gates
`bun run lint && bun run typecheck && bun run build && bun run test` — all green, **560 tests** (545 + 15 new: store setThreadFlags/preserve/round-trip/coerce, `orderByPin`, `partitionArchived`).

## Known minor (adversarial review NITs, intended/cosmetic — not folded)
- Archiving the thread you're *currently viewing* moves its (still-selected) row into the default-collapsed "Archived" fold — the conversation stays open in the main pane. This is the intended "move it out of the way" semantics; say the word if you'd rather the archived fold auto-expand to keep the open thread's row visible.
- With >5 pinned threads, pins 6+ fall under "Show more" (pins still get first priority within the cap).

## Needs a live smoke
Pin a lower thread → jumps to top (pin glyph shows); unpin restores order. Archive → leaves main list into "Archived (N)"; unarchive returns it. Flags persist across relaunch + agent eviction. Delete still only on active-project idle/cold rows; kebab (pin/archive) shows on every row incl. peeked projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)