### PR TITLE
#130: settings page + account menu (move CLI/env status off the sidebar)

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -45,14 +45,14 @@ import {
   type ThreadStatusMap,
 } from './conversation/thread-status'
 import { clearDraft } from './conversation/composer-draft-store'
-import { ArrowLeft, ArrowRight, Maximize2, PanelLeft, PanelRight, Settings, Terminal } from 'lucide-react'
+import { ArrowLeft, ArrowRight, Maximize2, PanelLeft, PanelRight, Terminal } from 'lucide-react'
 import { Button } from './ui/button'
 import { IconButton } from './ui/icon-button'
 import { Shell, type WorkspaceFlags } from './shell/Shell'
 import { Logo } from './shell/logo'
 import { heroHeadline } from './shell/hero-headline'
 import { firstRunState, type FirstRunState } from './shell/first-run'
-import { findSelectedThread, initialNavState, navReducer } from './shell/nav-reducer'
+import { findSelectedThread, initialNavState, navReducer, type NavState } from './shell/nav-reducer'
 import {
   getSidebarCollapsed,
   setSidebarCollapsed as setSidebarCollapsedStore,
@@ -83,10 +83,6 @@ export function App(): JSX.Element {
   const [detect, setDetect] = useState<VibeDetectResult | null>(null)
   const [loading, setLoading] = useState(true)
   const [opening, setOpening] = useState(false)
-  // Whether the on-demand environment/settings panel is open in the sidebar. The
-  // env check is no longer a permanent top-level card (#49) — it's reachable here,
-  // and surfaced prominently in the outlet only when it matters (first-run).
-  const [showSettings, setShowSettings] = useState(false)
   // Whether the left sidebar is collapsed (#127): renderer-only UI chrome, seeded
   // from localStorage (default expanded) and persisted best-effort on toggle. It
   // never touches nav/selection/connections — the <aside> stays mounted, its width
@@ -506,29 +502,6 @@ export function App(): JSX.Element {
     connDispatch({ type: 'set', workspaceId, state: { status: 'not-signed-in', agentId, workspaceDir, authMethods } })
   }
 
-  // The sidebar's pinned top: a settings affordance that reveals the environment
-  // status on demand (#49). The Open-project control now lives in the Projects
-  // header's new-project + (#129); the env card is no longer pinned permanently — it
-  // lives behind this gear once everything's installed, and is surfaced prominently in
-  // the outlet's first-run state when something's missing.
-  const sidebarTop = (
-    <div className="flex flex-col gap-2">
-      <div className="flex items-center justify-end gap-2">
-        <IconButton
-          aria-label="Environment & settings"
-          title="Environment & settings"
-          aria-expanded={showSettings}
-          onClick={() => setShowSettings((s) => !s)}
-        >
-          <Settings className="size-4" aria-hidden />
-        </IconButton>
-      </div>
-      {showSettings && (
-        <Environment detect={detect} loading={loading} onRecheck={() => void runDetect()} />
-      )}
-    </div>
-  )
-
   const connectedIds = connectedWorkspaceIds(connections)
   const selectedWs = nav.selectedWorkspaceId
   const selected = selectedConnection(connections, selectedWs)
@@ -659,20 +632,33 @@ export function App(): JSX.Element {
   // longer depend on that: main pushes per-Thread `streaming`/`needsAttention` for
   // ALL live Threads (#53), so a NON-active live sibling's in-flight turn or blocked
   // permission surfaces in the sidebar (and its delete gate) without a mounted view.
+  // The on-demand Settings page (#130): a top-level outlet view, routed by the nav
+  // reducer (`nav.view === 'settings'`), that hosts the env/CLI detection status the
+  // sidebar gear used to toggle (reusing the same `Environment` component + `detect`).
+  // It swaps the conversation/cold/empty outlet WITHOUT unmounting the connected
+  // Workspaces — they stay mounted-but-hidden so a background turn keeps streaming, and
+  // closing Settings (or picking a project/thread) returns to exactly the same view.
+  const inSettings = nav.view === 'settings'
   const outlet = (
     <>
       {connectedIds.map((wid) => {
         const conn = connections[wid]
         if (conn.status !== 'connected') return null
         return (
-          <div key={wid} hidden={wid !== selectedWs}>
-            {renderConnected(conn.thread, wid === selectedWs, wsFlags[wid]?.streaming ?? false)}
+          <div key={wid} hidden={inSettings || wid !== selectedWs}>
+            {renderConnected(conn.thread, !inSettings && wid === selectedWs, wsFlags[wid]?.streaming ?? false)}
           </div>
         )
       })}
-      {selected.status === 'connected'
-        ? null // rendered (visible) in the keep-mounted map above
-        : selected.status !== 'idle'
+      {inSettings ? (
+        <SettingsView
+          detect={detect}
+          loading={loading}
+          onRecheck={() => void runDetect()}
+          onClose={() => navDispatch({ type: 'close-settings' })}
+        />
+      ) : selected.status === 'connected' ? null : ( // connected: rendered (visible) in the keep-mounted map above
+        selected.status !== 'idle'
           ? renderTransientOutlet(selected, {
               continueToThread: (agentId) => void continueToThread(selectedWs ?? '', agentId),
               onRetry: () => selectedWs && void connectWorkspace(selectedWs),
@@ -693,7 +679,8 @@ export function App(): JSX.Element {
                 onRecheck={() => void runDetect()}
                 onOpenProject={() => void openProject()}
               />,
-            )}
+            )
+      )}
     </>
   )
 
@@ -750,7 +737,6 @@ export function App(): JSX.Element {
       <Shell
         collapsed={sidebarCollapsed}
         workspaces={recents}
-        sidebarTop={sidebarTop}
         nav={nav}
         workspaceFlags={wsFlags}
         rows={rows}
@@ -764,6 +750,7 @@ export function App(): JSX.Element {
         onNewThreadInWorkspace={newThreadInWorkspace}
         onDeleteThread={deleteThread}
         onSetThreadFlags={setThreadFlags}
+        onOpenSettings={() => navDispatch({ type: 'open-settings' })}
       />
     </div>
   )
@@ -889,7 +876,7 @@ function renderTransientOutlet(
  */
 function renderColdOutlet(
   recents: ListMetadataResult,
-  nav: { selectedWorkspaceId: string | null; selectedThreadId: string | null },
+  nav: NavState,
   handlers: { onClose: () => void; onContinue: (thread: ThreadMeta) => void },
   empty: ReactNode,
 ): ReactNode {
@@ -969,6 +956,41 @@ function EmptyState({
       <p className="hint">
         Select a thread from the sidebar to view it, or open a project to start a live agent.
       </p>
+    </div>
+  )
+}
+
+/**
+ * The Settings page (#130): an on-demand, nav-routed outlet view that replaces the
+ * old sidebar gear. A titled panel with a back/close affordance (`onClose` dispatches
+ * `close-settings`, so you can leave even with nothing selected) hosting the existing
+ * `Environment` env/CLI status. Future settings land here. This is an ADDITIONAL place
+ * to check the toolchain — NOT a replacement for the first-run `EmptyState`, which still
+ * surfaces a missing toolchain prominently in the outlet when nothing's installed.
+ */
+function SettingsView({
+  detect,
+  loading,
+  onRecheck,
+  onClose,
+}: {
+  detect: VibeDetectResult | null
+  loading: boolean
+  onRecheck: () => void
+  onClose: () => void
+}): JSX.Element {
+  return (
+    <div className="mx-auto flex w-full max-w-[560px] flex-col gap-5">
+      <div className="flex items-center gap-2">
+        <IconButton aria-label="Back" title="Back" onClick={onClose}>
+          <ArrowLeft className="size-4" aria-hidden />
+        </IconButton>
+        <h1 className="text-[19px] font-semibold tracking-tight text-text-strong">Settings</h1>
+      </div>
+      <section className="flex flex-col gap-2">
+        <h2 className="text-[13px] font-semibold text-faint">Environment</h2>
+        <Environment detect={detect} loading={loading} onRecheck={onRecheck} />
+      </section>
     </div>
   )
 }

--- a/src/renderer/src/shell/Shell.tsx
+++ b/src/renderer/src/shell/Shell.tsx
@@ -12,6 +12,7 @@ import {
   PinOff,
   Plus,
   Search,
+  Settings,
   SquarePen,
   Trash2,
 } from 'lucide-react'
@@ -74,7 +75,6 @@ const NO_STATUSES = {} as const
 export function Shell({
   collapsed,
   workspaces,
-  sidebarTop,
   nav,
   workspaceFlags,
   rows,
@@ -88,13 +88,12 @@ export function Shell({
   onNewThreadInWorkspace,
   onDeleteThread,
   onSetThreadFlags,
+  onOpenSettings,
 }: {
   /** Whether the left sidebar is collapsed (#127) — animate its width to 0 (still mounted). */
   collapsed: boolean
   /** Persisted Workspaces (cold metadata) for the switcher rows + display names. */
   workspaces: ListMetadataResult
-  /** App-owned controls pinned above the list (environment status; the gear). */
-  sidebarTop: ReactNode
   /** The current navigation selection (controlled by App). */
   nav: NavState
   /** Per-Workspace rolled-up live status, keyed by Workspace id (switcher badges). */
@@ -121,6 +120,8 @@ export function Shell({
   onDeleteThread: (thread: ThreadMeta) => Promise<void>
   /** Pin/archive a Thread (#132/#133) — a safe metadata toggle on any row. */
   onSetThreadFlags: SetThreadFlags
+  /** Open the routed Settings page (#130) — from the account chip's menu. */
+  onOpenSettings: () => void
 }): JSX.Element {
   return (
     <div className="flex min-h-0 flex-1">
@@ -141,7 +142,6 @@ export function Shell({
       >
         <div className="flex h-full w-[338px] flex-none flex-col gap-3 overflow-y-auto p-3">
           <SidebarHeader />
-          {sidebarTop}
           <PrimaryNav canCreateThread={canCreateThread} onNewThread={onNewThread} />
           <WorkspaceNav
             workspaces={workspaces}
@@ -157,7 +157,7 @@ export function Shell({
             onSetThreadFlags={onSetThreadFlags}
           />
           <div className="flex-1" />
-          <AccountChip />
+          <AccountChip onOpenSettings={onOpenSettings} />
         </div>
       </aside>
 
@@ -220,30 +220,40 @@ function PrimaryNav({
 }
 
 /**
- * The account chip pinned to the sidebar's bottom — a gradient avatar + a name +
- * a tier. STATIC placeholder chrome (#future): Vibe exposes no account identity
- * (see ADR-0003 / the SignedInBar), so these are fixed strings, not live data.
+ * The account chip pinned to the sidebar's bottom — a gradient avatar + a name + a
+ * tier, now the TRIGGER of an account dropdown (#130). The chip's chrome stays a
+ * STATIC placeholder (#future): Vibe exposes no account identity (see ADR-0003 / the
+ * SignedInBar), so the avatar/name/tier are fixed strings, not live data. The menu
+ * holds a real "Settings" item (→ the routed Settings page that now hosts the env/CLI
+ * status the sidebar gear used to toggle) plus room for future account actions.
  */
-function AccountChip(): JSX.Element {
-  // placeholder — account identity + tier (#future); no live account API exists yet.
+function AccountChip({ onOpenSettings }: { onOpenSettings: () => void }): JSX.Element {
   return (
-    <button
-      type="button"
-      className="flex items-center gap-2.5 rounded-[9px] px-2 py-2 text-left outline-none transition-colors hover:bg-accent/10"
-    >
-      <span
-        aria-hidden
-        className="flex size-8 shrink-0 items-center justify-center rounded-md text-sm font-semibold text-white"
-        style={{ backgroundImage: 'var(--accent-grad-avatar)' }}
-      >
-        V
-      </span>
-      <span className="flex min-w-0 flex-1 flex-col">
-        <span className="truncate text-[14px] font-semibold text-text-strong">Your account</span>
-        <span className="truncate text-[12px] text-faint">Mistral Vibe</span>
-      </span>
-      <ChevronDown className="size-4 shrink-0 text-muted" aria-hidden />
-    </button>
+    <Menu>
+      <MenuTrigger className="flex items-center gap-2.5 rounded-[9px] px-2 py-2 text-left outline-none transition-colors hover:bg-accent/10 focus-visible:bg-accent/10 data-[popup-open]:bg-accent/10">
+        {/* placeholder — account identity + tier (#future); no live account API exists yet. */}
+        <span
+          aria-hidden
+          className="flex size-8 shrink-0 items-center justify-center rounded-md text-sm font-semibold text-white"
+          style={{ backgroundImage: 'var(--accent-grad-avatar)' }}
+        >
+          V
+        </span>
+        <span className="flex min-w-0 flex-1 flex-col">
+          <span className="truncate text-[14px] font-semibold text-text-strong">Your account</span>
+          <span className="truncate text-[12px] text-faint">Mistral Vibe</span>
+        </span>
+        <ChevronDown className="size-4 shrink-0 text-muted" aria-hidden />
+      </MenuTrigger>
+      <MenuContent align="start" className="min-w-[200px]">
+        <MenuItem onClick={onOpenSettings}>
+          <Settings className="size-3.5" aria-hidden />
+          Settings
+        </MenuItem>
+        {/* room for future account actions (profile, sign-out, tier) — #future;
+            no live account API exists yet (ADR-0003). */}
+      </MenuContent>
+    </Menu>
   )
 }
 

--- a/src/renderer/src/shell/nav-reducer.test.ts
+++ b/src/renderer/src/shell/nav-reducer.test.ts
@@ -14,30 +14,77 @@ function thread(id: string, workspaceId: string): ThreadMeta {
 }
 
 describe('navReducer', () => {
-  it('starts with nothing selected', () => {
-    expect(initialNavState).toEqual({ selectedWorkspaceId: null, selectedThreadId: null })
+  it('starts with nothing selected, in the conversation view', () => {
+    expect(initialNavState).toEqual({ selectedWorkspaceId: null, selectedThreadId: null, view: 'conversation' })
   })
 
   it('select-thread pins both the Thread and its Workspace', () => {
     const next = navReducer(initialNavState, { type: 'select-thread', workspaceId: 'w1', threadId: 't1' })
-    expect(next).toEqual({ selectedWorkspaceId: 'w1', selectedThreadId: 't1' })
+    expect(next).toEqual({ selectedWorkspaceId: 'w1', selectedThreadId: 't1', view: 'conversation' })
   })
 
   it('switching to a different Workspace drops the now-foreign Thread selection', () => {
-    const start: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 't1' }
+    const start: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 't1', view: 'conversation' }
     const next = navReducer(start, { type: 'select-workspace', workspaceId: 'w2' })
-    expect(next).toEqual({ selectedWorkspaceId: 'w2', selectedThreadId: null })
+    expect(next).toEqual({ selectedWorkspaceId: 'w2', selectedThreadId: null, view: 'conversation' })
   })
 
-  it('re-selecting the same Workspace is a no-op (keeps the Thread selection)', () => {
-    const start: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 't1' }
+  it('re-selecting the same Workspace while in the conversation view is a no-op (same reference)', () => {
+    const start: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 't1', view: 'conversation' }
     const next = navReducer(start, { type: 'select-workspace', workspaceId: 'w1' })
     expect(next).toBe(start) // same reference: no spurious re-render or cleared Thread
   })
 
-  it('clear resets to nothing selected', () => {
-    const start: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 't1' }
+  it('clear resets to nothing selected in the conversation view', () => {
+    const start: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 't1', view: 'settings' }
     expect(navReducer(start, { type: 'clear' })).toEqual(initialNavState)
+  })
+
+  describe('Settings view (#130)', () => {
+    it('open-settings switches to the settings view, preserving the selection', () => {
+      const start: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 't1', view: 'conversation' }
+      expect(navReducer(start, { type: 'open-settings' })).toEqual({
+        selectedWorkspaceId: 'w1',
+        selectedThreadId: 't1',
+        view: 'settings',
+      })
+    })
+
+    it('open-settings works with nothing selected', () => {
+      expect(navReducer(initialNavState, { type: 'open-settings' })).toEqual({
+        selectedWorkspaceId: null,
+        selectedThreadId: null,
+        view: 'settings',
+      })
+    })
+
+    it('close-settings returns to the conversation view, PRESERVING the selection', () => {
+      const start: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 't1', view: 'settings' }
+      expect(navReducer(start, { type: 'close-settings' })).toEqual({
+        selectedWorkspaceId: 'w1',
+        selectedThreadId: 't1',
+        view: 'conversation',
+      })
+    })
+
+    it('selecting a Thread while in Settings leaves Settings (resets view)', () => {
+      const start: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 't1', view: 'settings' }
+      const next = navReducer(start, { type: 'select-thread', workspaceId: 'w1', threadId: 't2' })
+      expect(next).toEqual({ selectedWorkspaceId: 'w1', selectedThreadId: 't2', view: 'conversation' })
+    })
+
+    it('selecting a DIFFERENT Workspace while in Settings leaves Settings', () => {
+      const start: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 't1', view: 'settings' }
+      const next = navReducer(start, { type: 'select-workspace', workspaceId: 'w2' })
+      expect(next).toEqual({ selectedWorkspaceId: 'w2', selectedThreadId: null, view: 'conversation' })
+    })
+
+    it('re-selecting the SAME Workspace while in Settings leaves Settings (keeps selection)', () => {
+      const start: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 't1', view: 'settings' }
+      const next = navReducer(start, { type: 'select-workspace', workspaceId: 'w1' })
+      expect(next).toEqual({ selectedWorkspaceId: 'w1', selectedThreadId: 't1', view: 'conversation' })
+      expect(next).not.toBe(start) // not a no-op here: it must exit Settings
+    })
   })
 })
 
@@ -48,21 +95,23 @@ describe('findSelectedThread (cold-outlet derivation)', () => {
   ]
 
   it('resolves the selected Thread to its cold metadata', () => {
-    const state: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 't2' }
+    const state: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 't2', view: 'conversation' }
     expect(findSelectedThread(workspaces, state)?.id).toBe('t2')
   })
 
   it('returns null when no Thread is selected', () => {
-    expect(findSelectedThread(workspaces, { selectedWorkspaceId: 'w1', selectedThreadId: null })).toBeNull()
+    expect(
+      findSelectedThread(workspaces, { selectedWorkspaceId: 'w1', selectedThreadId: null, view: 'conversation' }),
+    ).toBeNull()
   })
 
   it('returns null when the selected Thread no longer exists (e.g. after a delete refreshed the list)', () => {
-    const state: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 'gone' }
+    const state: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 'gone', view: 'conversation' }
     expect(findSelectedThread(workspaces, state)).toBeNull()
   })
 
   it('scopes the lookup to the selected Workspace (a Thread id under another Workspace is not matched)', () => {
-    const state: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 't3' }
+    const state: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 't3', view: 'conversation' }
     expect(findSelectedThread(workspaces, state)).toBeNull()
   })
 })

--- a/src/renderer/src/shell/nav-reducer.ts
+++ b/src/renderer/src/shell/nav-reducer.ts
@@ -13,29 +13,52 @@ import type { ListMetadataResult, ThreadMeta } from '../../../shared/ipc'
 export interface NavState {
   selectedWorkspaceId: string | null
   selectedThreadId: string | null
+  /**
+   * WHICH top-level outlet view is showing (#130). `'settings'` swaps the outlet for
+   * the on-demand Settings page (env/CLI status + future settings), leaving the
+   * Workspace/Thread selection intact so closing it returns to the same conversation.
+   * Any `select-workspace` / `select-thread` (picking a project or thread from the
+   * sidebar) resets it to `'conversation'` — navigating leaves Settings.
+   */
+  view: 'conversation' | 'settings'
 }
 
 export type NavAction =
   | { type: 'select-workspace'; workspaceId: string }
   | { type: 'select-thread'; workspaceId: string; threadId: string }
+  | { type: 'open-settings' }
+  | { type: 'close-settings' }
   | { type: 'clear' }
 
 export const initialNavState: NavState = {
   selectedWorkspaceId: null,
   selectedThreadId: null,
+  view: 'conversation',
 }
 
 export function navReducer(state: NavState, action: NavAction): NavState {
   switch (action.type) {
     case 'select-workspace':
-      // Re-selecting the SAME Workspace is a no-op (keeps any Thread selection);
-      // switching to a different one drops the now-foreign Thread selection so the
-      // two can never disagree.
-      if (state.selectedWorkspaceId === action.workspaceId) return state
-      return { selectedWorkspaceId: action.workspaceId, selectedThreadId: null }
+      // Re-selecting the SAME Workspace keeps any Thread selection; switching to a
+      // different one drops the now-foreign Thread selection so the two can never
+      // disagree. Either way this leaves Settings (resets `view` to conversation) —
+      // but the same-Workspace path stays a referential no-op when ALREADY in the
+      // conversation view, so re-selecting the current project never re-renders.
+      if (state.selectedWorkspaceId === action.workspaceId) {
+        return state.view === 'conversation' ? state : { ...state, view: 'conversation' }
+      }
+      return { selectedWorkspaceId: action.workspaceId, selectedThreadId: null, view: 'conversation' }
     case 'select-thread':
-      // Selecting a Thread pins its Workspace too, so the two never disagree.
-      return { selectedWorkspaceId: action.workspaceId, selectedThreadId: action.threadId }
+      // Selecting a Thread pins its Workspace too, so the two never disagree — and
+      // leaves Settings (picking a thread returns to the conversation view).
+      return { selectedWorkspaceId: action.workspaceId, selectedThreadId: action.threadId, view: 'conversation' }
+    case 'open-settings':
+      // Swap the outlet for the Settings page, PRESERVING the current selection.
+      // Referential no-op when already in Settings (uniform with select-workspace).
+      return state.view === 'settings' ? state : { ...state, view: 'settings' }
+    case 'close-settings':
+      // Return to the conversation view, PRESERVING the current selection.
+      return state.view === 'conversation' ? state : { ...state, view: 'conversation' }
     case 'clear':
       return initialNavState
   }


### PR DESCRIPTION
Closes #130. Last of the sidebar cluster.

## What
Moves the vibe-CLI/env status out of the sidebar into the **account menu** + a nav-routed **Settings page**.
- **Nav reducer** (`shell/nav-reducer.ts`): `NavState` gains `view: 'conversation' | 'settings'`; `open-settings`/`close-settings` (preserve selection), and `select-workspace`/`select-thread` reset `view` to conversation (picking a project/thread leaves Settings). The same-workspace path stays a **referential no-op** when already in conversation (and `open/close-settings` are now no-op-preserving too). TDD'd (+6 cases).
- **App**: removed the sidebar settings-gear + inline `Environment` + the now-empty `sidebarTop` + `showSettings`. The outlet branches on `nav.view === 'settings'` → a new `SettingsView` (titled panel + back button → `close-settings`, hosting the existing `Environment`); connected workspaces stay **mounted-but-hidden** while in Settings (background turns keep streaming; the selected agent stays eviction-protected).
- **Shell**: the placeholder `AccountChip` is now a real base-ui **Menu** — the chip is the trigger, the content holds a **Settings** item (→ `open-settings`) + room for future account actions.

## Behavior preserved
First-run env-missing flow unchanged (`EmptyState`/`firstRunState` still surfaces a missing toolchain in the outlet). Selecting a project/thread while in Settings returns to conversation. Active-agent eviction protection + per-thread status are unaffected during Settings. `nav-reducer`/`first-run` otherwise intact.

## Review fold
Adversarial verdict **SHIP** (routing + keep-mounted streaming + eviction protection all verified). Folded its one NIT: `open-settings`/`close-settings` are now referential-no-op-preserving, uniform with the `select-workspace` guard.

## Gates
`bun run lint && bun run typecheck && bun run build && bun run test` — all green, **566 tests** (560 + 6 new nav-reducer).

## Needs a live smoke
Account chip → Settings routes the outlet to the Settings page (Environment + Re-check); back returns to the prior view (works with nothing selected); sidebar shows no gear/env; a background turn keeps streaming while Settings is open; picking a project/thread exits Settings; first-run install prompt still shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)