### PR TITLE
sidebar: branded pixel-M snake loading spinner (+ fold-only project spinner)

### DIFF
--- a/src/renderer/src/shell/Shell.tsx
+++ b/src/renderer/src/shell/Shell.tsx
@@ -35,6 +35,7 @@ import { Menu, MenuContent, MenuItem, MenuRadioGroup, MenuRadioItem, MenuTrigger
 import { NavItem } from '../ui/nav-item'
 import { Spinner } from '../ui/spinner'
 import { Logo } from './logo'
+import { LogoSnakeSpinner } from './logo-snake-spinner'
 import { formatRelativeTime } from './relative-time'
 import { visibleRows } from './show-more'
 
@@ -499,10 +500,12 @@ function ProjectRow({
           <span className="flex-1 truncate" title={workspace.dir}>
             {workspace.displayName}
           </span>
-          {/* Rolled-up live status — visible EVEN WHEN FOLDED (a background permission
-              prompt must not be hidden). */}
-          {flags?.streaming && (
-            <Spinner className="size-3.5 text-accent-text" aria-label="This project is working" />
+          {/* Rolled-up live status. The needs-attention badge stays visible even when
+              FOLDED (a background permission prompt must not be hidden). The streaming
+              snake shows ONLY when FOLDED — expanded, the thread rows carry their own,
+              so this avoids a redundant project-level + thread-level spinner. */}
+          {!open && flags?.streaming && (
+            <LogoSnakeSpinner size={15} label="This project is working" />
           )}
           {flags?.needsAttention && (
             <Badge variant="destructive" title="A thread in this project needs your attention">
@@ -690,9 +693,7 @@ function NavThread({
         />
         {pinned && <Pin className="size-3 shrink-0 text-muted" aria-label="Pinned" />}
         <span className="flex-1 truncate">{threadLabel(row)}</span>
-        {row.streaming && (
-          <Spinner className="size-3.5 text-accent-text" aria-label="Streaming" />
-        )}
+        {row.streaming && <LogoSnakeSpinner size={15} label="Streaming" />}
         {row.needsAttention && (
           <Badge variant="destructive" title="Awaiting your response">
             !

--- a/src/renderer/src/shell/logo-snake-spinner.tsx
+++ b/src/renderer/src/shell/logo-snake-spinner.tsx
@@ -1,0 +1,69 @@
+import type { JSX } from 'react'
+import { cn } from '../lib/utils'
+
+/** The mark's intrinsic aspect ratio (viewBox 191×135), same as {@link Logo}. */
+const LOGO_RATIO = 191 / 135
+
+/** How long one full lap of the snake takes. */
+const SNAKE_DURATION_S = 1.1
+
+/**
+ * The Vibe Mistro "M" mark's 8 cells, ORDERED as a snake path that traces the
+ * letter — top-left → down the left side → across the middle bar → the three legs →
+ * up the right side → top-right — so the phased highlight reads as a light snaking
+ * around the M rather than a flat shimmer. Each cell keeps its own brand fill
+ * (yellow → orange → red), revealed as the bright "head" passes over it.
+ */
+const SNAKE_PATH: ReadonlyArray<{ d: string; fill: string }> = [
+  { d: 'M54.3221 0H27.1531V27.0892H54.3221V0Z', fill: '#FFD800' }, // top-left
+  { d: 'M81.4823 27.0918H27.1531V54.181H81.4823V27.0918Z', fill: '#FFAF00' }, // upper-left
+  { d: 'M162.972 54.168H27.1531V81.2572H162.972V54.168Z', fill: '#FF8205' }, // middle bar
+  { d: 'M54 81H27V135H54V81Z', fill: '#FA500F' }, // left leg
+  { d: 'M108.661 81.2598H81.4917V108.349H108.661V81.2598Z', fill: '#FA500F' }, // center leg
+  { d: 'M163 81H136V135H163V81Z', fill: '#FA500F' }, // right leg
+  { d: 'M162.99 27.0918H108.661V54.181H162.99V27.0918Z', fill: '#FFAF00' }, // upper-right
+  { d: 'M162.984 0H135.815V27.0892H162.984V0Z', fill: '#FFD800' }, // top-right
+]
+
+/**
+ * A branded loading indicator (the "funky" spinner): a light snakes around the
+ * Vibe Mistro "M", a port of the vibe-acp CLI's `SnakeSpinner` in our brand palette.
+ * Pure CSS — each cell runs the shared `vmSnake` keyframe (styles.css) phased by a
+ * negative `animationDelay` along {@link SNAKE_PATH}, so a bright head + short trail
+ * chase through the mark. `prefers-reduced-motion` freezes it to a static dim M.
+ * `size` is the HEIGHT in px (width scales to the 191:135 ratio); drop-in for the
+ * old lucide spinner at the sidebar's streaming indicators.
+ */
+export function LogoSnakeSpinner({
+  size = 14,
+  className,
+  label = 'Working',
+}: {
+  size?: number
+  className?: string
+  /** Accessible name — the streaming context ("Streaming", "This project is working"). */
+  label?: string
+}): JSX.Element {
+  return (
+    <svg
+      role="img"
+      aria-label={label}
+      className={cn('shrink-0', className)}
+      width={Math.round(size * LOGO_RATIO)}
+      height={size}
+      viewBox="0 0 191 135"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      {SNAKE_PATH.map((cell, i) => (
+        <path
+          key={cell.d}
+          d={cell.d}
+          fill={cell.fill}
+          className="vm-snake-cell"
+          style={{ animationDelay: `${-(i / SNAKE_PATH.length) * SNAKE_DURATION_S}s` }}
+        />
+      ))}
+    </svg>
+  )
+}

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -221,6 +221,34 @@ body {
   }
 }
 
+/* Branded "snake" loading indicator (LogoSnakeSpinner): each of the M's cells runs
+   this keyframe, phased by a per-cell `animation-delay` along the snake path, so a
+   bright head (0%) with a short fading trail (25%) chases through the mark while the
+   rest sits dim. Respects reduced-motion by freezing to a static, legible M. */
+@keyframes vmSnake {
+  0% {
+    opacity: 1;
+  }
+  25% {
+    opacity: 0.45;
+  }
+  50%,
+  100% {
+    opacity: 0.15;
+  }
+}
+
+.vm-snake-cell {
+  animation: vmSnake 1.1s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vm-snake-cell {
+    animation: none;
+    opacity: 0.85;
+  }
+}
+
 .hint {
   color: var(--muted);
   font-size: 13px;


### PR DESCRIPTION
Follow-up to the sidebar cluster (user-requested): a **funky loading indicator** — a light **snakes around the Vibe Mistro "M"** in its brand palette — replacing the plain lucide spinner in the sidebar. A port of the vibe-acp CLI's `SnakeSpinner`, in our colors.

## What
- **`shell/logo-snake-spinner.tsx`** — a `LogoSnakeSpinner`: the M's 8 cells ordered along a path that traces the letter; a shared **`vmSnake`** keyframe (styles.css) runs on each cell, phased by a per-cell negative `animation-delay`, so a bright **head + short trail chase** through the mark while the rest sits dim. Pure CSS (GPU-friendly opacity), each cell keeps its brand fill (yellow→orange→red). `prefers-reduced-motion` freezes it to a static, legible M. `role="img"` + a contextual `aria-label`.
- Swapped the sidebar's two **streaming** indicators (thread rows + project headers) to it. (The Projects-header **+** button's connect micro-spinner stays lucide — different context.)
- **Bundled tweak (your earlier question):** the project-header rolled-up spinner now shows **only when the project is FOLDED** — when it's expanded, the thread rows already carry their own snake, so this removes the redundant project-level + thread-level double spinner.

## Not here (by your call)
The **shimmer** variant is reserved for the composer / conversation section — I'll build it there in the conversation slices.

## Gates
`bun run lint && bun run typecheck && bun run build && bun run test` — all green, **569 tests** (no new tests — it's a data array + SVG + CSS, no branching logic, like `logo.tsx`). Confirmed `vmSnake`/`vm-snake-cell`/`prefers-reduced-motion` emit in the built CSS.

## Smoke it + easy to tune
Ask an agent → the thread row (and, when its project is folded, the project header) shows the M with a light snaking around it. All easily tuned if you want a different feel: **speed** (`1.1s`), **trail length/contrast** (the `vmSnake` keyframe stops), **direction**, or **size** (`15`). Tell me and I'll adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)