### PR TITLE
sidebar: pin top nav + account, scroll only the projects list

### DIFF
--- a/src/renderer/src/shell/Shell.tsx
+++ b/src/renderer/src/shell/Shell.tsx
@@ -141,23 +141,29 @@ export function Shell({
           collapsed ? 'w-0 border-r-0' : 'w-[338px] border-r',
         )}
       >
-        <div className="flex h-full w-[338px] flex-none flex-col gap-3 overflow-y-auto p-3">
-          <SidebarHeader />
-          <PrimaryNav canCreateThread={canCreateThread} onNewThread={onNewThread} />
-          <WorkspaceNav
-            workspaces={workspaces}
-            nav={nav}
-            workspaceFlags={workspaceFlags}
-            rows={rows}
-            protectedThreadId={protectedThreadId}
-            opening={opening}
-            onOpenProject={onOpenProject}
-            onSelectThread={onSelectThread}
-            onNewThreadInWorkspace={onNewThreadInWorkspace}
-            onDeleteThread={onDeleteThread}
-            onSetThreadFlags={onSetThreadFlags}
-          />
-          <div className="flex-1" />
+        {/* Three-band sidebar: a PINNED top (logo + primary nav) and a PINNED bottom
+            (account) sandwich the ONLY scroll region — the Projects list — so the nav
+            and account stay put while just the projects scroll. */}
+        <div className="flex h-full w-[338px] flex-none flex-col gap-3 p-3">
+          <div className="flex flex-none flex-col gap-3">
+            <SidebarHeader />
+            <PrimaryNav canCreateThread={canCreateThread} onNewThread={onNewThread} />
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            <WorkspaceNav
+              workspaces={workspaces}
+              nav={nav}
+              workspaceFlags={workspaceFlags}
+              rows={rows}
+              protectedThreadId={protectedThreadId}
+              opening={opening}
+              onOpenProject={onOpenProject}
+              onSelectThread={onSelectThread}
+              onNewThreadInWorkspace={onNewThreadInWorkspace}
+              onDeleteThread={onDeleteThread}
+              onSetThreadFlags={onSetThreadFlags}
+            />
+          </div>
           <AccountChip onOpenSettings={onOpenSettings} />
         </div>
       </aside>


### PR DESCRIPTION
Small UI change (user request). Makes the sidebar's **top nav** (logo + New chat + Search/Scheduled/Plugins) and **account chip** stay pinned while **only the Projects list scrolls** between them — previously the whole column scrolled together.

## What
Split the inner sidebar column into three flex bands:
- **Pinned top** (`flex-none`): `SidebarHeader` + `PrimaryNav`.
- **Scrolling middle** (`flex-1 min-h-0 overflow-y-auto`): `WorkspaceNav` (the Projects list) — the only scroll region now.
- **Pinned bottom** (`flex-none`): `AccountChip`.

Layout-only — the `flex-1` spacer is gone (the middle fills the space), the collapse-to-width-0 animation (#127) and all sidebar behavior are unchanged.

## Gates
`bun run lint && bun run typecheck && bun run build && bun run test` — all green, **569 tests** (no logic change).

## Smoke
With enough projects/threads to overflow: the top nav + account stay put; only the Projects list scrolls between them. (The scrollbar sits inside the 12px padding — easy to nudge to the edge if you'd prefer.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)