### PR TITLE
docs: refresh HANDOFF + NEXT-SESSION for the remaining epic slices

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -3,9 +3,12 @@
 > You are picking up an in-flight project. Read this top to bottom once, then keep it open.
 > It tells you **what this is**, **how we work**, **what exists**, **what's next**, and **where the
 > authoritative information lives** (in-repo docs + the local reference repos in §4). Last updated
-> 2026-07-01, `main` @ `65c23a5`, **495 tests**. The **design-system epic is SCOPED AND FILED**: grilled →
-> **ADR-0010** + `docs/design-tokens.md` + `docs/design-system-components.md` → **PRD #109** → tracer-bullet
-> issues **#110–#119**. **Start with #110 (token layer)** — see §6/§8. `$`/`@` autocomplete stays paused.
+> 2026-07-01, `main` @ `0197b5a`, **569 tests**. The **design-system epic (PRD #109) is ~half DONE**: its
+> **foundation (#110 tokens, #111 primitives, #112 streamdown spike, #113 shell) and the entire SIDEBAR
+> cluster (#127–#134, #138) shipped**; **REMAINING = #114/#115/#116 conversation · #117 composer · #118 auth ·
+> #119 git panel** (see §6). **`docs/NEXT-SESSION.md` is the copy-paste kickoff for the next session.**
+> Values live in ADR-0010 + `docs/design-tokens.md` + `docs/design-system-components.md` + `docs/streamdown-spike.md`.
+> `$`/`@` autocomplete stays paused.
 
 ---
 
@@ -315,31 +318,33 @@ review round):** the in-flight latch MUST be module-level per-Thread (`sending` 
 
 ## 6. What's next
 
-**The DESIGN-SYSTEM epic is scoped, ADR'd, and filed as issues #110–#119** (parent PRD #109, all
-`ready-for-agent`). Pipeline done: `/grill-with-docs` → **ADR-0010** + `docs/design-tokens.md` (exact token
-values) + `docs/design-system-components.md` (what to lift from shadcn/t3code + how to adapt) → PRD #109 →
-`/to-issues`. **START HERE: issue #110 (token layer)** — no blockers, highest-impact/lowest-risk (the whole
-app repaints toward the design with zero structural change). Slice order + deps:
-- **#110** token layer (—) → **#111** primitives (base-ui+CVA, #110) → **#113** shell (#110,#111)
-- **#112** streamdown spike (#110) → **#114** conversation A / Response+Message+Bubble+scroll **[HITL]**
-  (#111,#112) → **#115** conversation B / tool+reasoning+working (#114) → **#116** conversation C /
-  approval-inline+actions+file-links (#114)
-- **#117** composer (#111,#113) · **#118** auth (#111) · **#119** git panel (#111) — parallel after #110/#111
-Each issue carries `/tdd` build instructions; each is a **behavior-identical restyle** (existing ~495 tests
-MUST stay green) that retires its area's BEM from `styles.css`. Reference `docs/design-system-components.md`
-for the shadcn (`/Users/abdullahatrash/mistral/ui` `bases/base`) + t3code component-adaptation details.
+**The DESIGN-SYSTEM epic (PRD #109) is ~HALF DONE — `docs/NEXT-SESSION.md` is the copy-paste kickoff for the
+next session.** Pipeline was: `/grill-with-docs` → **ADR-0010** + `docs/design-tokens.md` +
+`docs/design-system-components.md` → PRD #109 → `/to-issues` (#110–#119).
 
-**The chosen next intermediate epic (context):** a DESIGN-SYSTEM pass — establish layouts + a component
-library NOW, before the app grows and refactors get expensive.
+**► SHIPPED (all merged to `main`):**
+- **Foundation:** #110 token layer (warm/rounded/soft-orange in `styles.css`) · #111 primitive library
+  (`src/renderer/src/ui/` — base-ui + Tailwind + **CVA**; Button/Menu/Dialog/Popover/Tooltip/Collapsible/Select/
+  ScrollArea/… + `MenuRadioGroup`) · #112 **streamdown ADOPT** verdict (`docs/streamdown-spike.md`) · #113 shell.
+- **Full SIDEBAR cluster** (a follow-up wave beyond the original #110–119): collapsible all-visible project list
+  (#138, base-ui Collapsible, peek-only) · Projects header +new-project/sort (#129) · pin + archive threads
+  (#132/#133 — `ThreadMeta.pinned?`/`archived?` + `thread:set-flags` IPC + `MetadataStore.setThreadFlags`;
+  `orderByPin`/`partitionArchived`) · settings page + account menu (#130, nav-reducer `view` route) · collapsible
+  sidebar (#127) · official SVG logo (#134) · branded **snake loading spinner** · sticky top-nav/bottom-account.
+  Also parallel: #125 persistence hardening (ADR-0011, draft-persist-on-first-prompt).
 
-**► NEXT: Design-system pass (layouts + components).** Goal: lock in a coherent design system (tokens,
-primitives, layout shells) and migrate the per-area UI onto it, on the #61 foundation (Tailwind v4 +
-base-ui + lucide already in place — `docs/adr` / CONTEXT for that stack). This is the user's priority to
-"get out of the way before the system starts to grow and be complex to change." Scope it as its own
-**grill-with-docs → ADR → tracer-bullet slices** (likely: audit current UI + tokens → design-token/theme
-layer → shared primitives (Button/Menu/Input/Panel/Dialog) → per-area migration (composer / sidebar /
-conversation / auth / git panel), area by area, keeping behavior identical). Reference: t3code +
-CodexMonitor UIs (both local), base-ui docs. START by grilling the scope with the user.
+**► REMAINING slices (build order + deps):**
+- **#114** conversation A / Response(=streamdown)+Message+Bubble+autoscroll **[HITL]** (#111,#112 ✓) → **#115**
+  conversation B / tool+reasoning+working (#114) → **#116** conversation C / approval-inline+actions+file-links (#114)
+- **#117** composer (#111,#113 ✓) · **#118** auth (#111 ✓) · **#119** git panel (#111 ✓) — parallel, AFK-able.
+- Recommended: knock out the AFK area slices **#117 → #119 → #118** first, then **#114 → #115 → #116** with the
+  human in the loop. Each is a **behavior-identical restyle** (569 tests MUST stay green) that retires its area's
+  BEM from `styles.css`. **Reference sources for the conversation work** (copy-adapt & OWN, never a dep):
+  `docs/design-system-components.md §2` (THE lift-from guide) · **streamdown** (`docs/streamdown-spike.md`) ·
+  **shadcn/ui** `bases/base/ui/` (`message`/`bubble`/`message-scroller`/`marker`) · **shadcn AI Elements / ai-sdk
+  Elements** (web: `ai-sdk.dev/elements` — Conversation/Message/Response/Reasoning/Tool/Actions patterns; structure
+  only, feed our ACP reducer) · **t3code** `apps/web/src/components/chat/*` + `ChatMarkdown.tsx` · base-ui docs.
+  Full list + how-to-drive-it in **`docs/NEXT-SESSION.md`**.
 
 **Composer-extras — remaining (RESOLVED from the Vibe CLI source `/Users/abdullahatrash/mistral/mistral-vibe`):**
 - **`$` skills — DROP; already covered by `/`.** vibe-acp has NO `$`/`skills/list` surface: skills are

--- a/docs/NEXT-SESSION.md
+++ b/docs/NEXT-SESSION.md
@@ -1,40 +1,91 @@
-# Next session — kickoff for the design-system epic
+# Next session — design-system epic: conversation + composer + auth + git
 
-Open a fresh Claude Code session **in `/Users/abdullahatrash/mistral/vibe-mistro`** (so `main` is the cwd) and
-paste the block below as the first message. It auto-loads `CLAUDE.md` + the memory index on launch.
+The epic's **foundation is DONE** (tokens, primitives, streamdown decision, shell) and the **entire sidebar
+cluster is DONE**. What remains is the **conversation view**, the **composer**, and the **auth** + **git**
+panels. Open a fresh Claude Code session **in `/Users/abdullahatrash/mistral/vibe-mistro`** (so `main` is the
+cwd — it auto-loads `CLAUDE.md` + the memory index) and paste the block below as the first message.
 
 ## Paste this
 
-> Read `HANDOFF.md`, then `docs/adr/0010-design-system-tokens-primitives-migration.md` +
-> `docs/design-tokens.md` + `docs/design-system-components.md`. We're building the **design-system epic**
-> (issues #110–#119, parent PRD #109). First confirm the baseline: on `main`, run the four gates
-> (`export PATH="$HOME/.nvm/versions/node/v22.22.1/bin:$HOME/.local/bin:$PATH"; bun run lint && bun run
-> typecheck && bun run build && bun run test`) → expect **495 tests green**. Then **start issue #110 (token
-> layer)**: `GH_HOST=github.com gh issue view 110`, and build it via the **team loop in HANDOFF §3** —
-> manual worktree with a **real `bun install`** (never a node_modules symlink), an implementer agent (the
-> issue carries `/tdd`), your own **independent verification** (re-run all four gates + read the diff), an
-> **adversarial review**, fold fixes, **targeted `git add` (never `-A`)**, push, and **I'll merge**. It's a
-> **behavior-identical restyle** — the 495 tests must stay green.
+> Read `HANDOFF.md`, then `docs/adr/0010-design-system-tokens-primitives-migration.md` + `docs/design-tokens.md`
+> + `docs/design-system-components.md` + `docs/streamdown-spike.md`. We're continuing the **design-system epic**
+> (parent PRD #109). Its **foundation (#110 tokens, #111 primitives, #112 streamdown spike, #113 shell) and the
+> whole SIDEBAR cluster (#127–#134, #138) are already SHIPPED to `main`.** What's LEFT: **#114/#115/#116
+> conversation, #117 composer, #118 auth, #119 git panel.** First confirm the baseline: on `main`, run the four
+> gates (`export PATH="$HOME/.nvm/versions/node/v22.22.1/bin:$HOME/.local/bin:$PATH"; bun run lint && bun run
+> typecheck && bun run build && bun run test`) → expect **569 tests green** (`main` @ `0197b5a` or later). Then
+> build the next slice via the **team loop in HANDOFF §3**: a manual worktree with a **real `bun install`**
+> (never a `node_modules` symlink), an implementer agent (the issue carries `/tdd`), your own **independent
+> verification** (re-run all four gates + read the diff), an **adversarial review** agent, fold fixes, **targeted
+> `git add <paths>` (never `-A`)**, push, and **I'll merge**. Each is a **behavior-identical restyle** — the 569
+> tests must stay green. **START with the slice I name** (or, if I just say "continue", start **#117 composer** —
+> it's unblocked and AFK-able — and ask me before starting **#114**, which is HITL). For the CONVERSATION slices
+> (#114–#116) mine the reference sources below HARD; the Response/markdown layer is **streamdown** (adopted in
+> #112 — `docs/streamdown-spike.md` has the exact wiring + the security sign-off you must surface to me).
 
-## Slice order & dependencies
+## What's already shipped (this epic, all on `main`)
+- **Foundation:** #110 token layer (warm neutrals / rounded / softer gradient-orange in `styles.css`), #111
+  primitive library (`src/renderer/src/ui/` — base-ui + Tailwind + **CVA**: Button/Menu/Dialog/Popover/Tooltip/
+  Collapsible/Select/ScrollArea/etc. + `MenuRadioGroup`), #112 **streamdown ADOPT** verdict (`docs/streamdown-spike.md`),
+  #113 shell/sidebar restyle.
+- **Sidebar cluster:** all-visible **collapsible project list** (#138 — base-ui Collapsible, peek-only: folding
+  never spawns an agent; active project shows live rows, others show cold), Projects header **+new-project + sort**
+  (#129), **pin + archive** threads (#132/#133 — `ThreadMeta.pinned?`/`archived?` + `thread:set-flags` IPC +
+  `MetadataStore.setThreadFlags`; `orderByPin`/`partitionArchived` in `unified-threads.ts`), **settings page +
+  account menu** (#130 — nav-reducer `view: 'conversation'|'settings'` route), **collapsible sidebar** (#127 —
+  `panel-left` toggle + `sidebar-collapsed-store`), official **SVG logo** (#134), a branded **snake loading spinner**
+  (`shell/logo-snake-spinner.tsx` + `vmSnake` keyframe), and sticky top-nav/bottom-account (only the Projects list
+  scrolls). Renderer-only UI state uses the injected-storage throw-tolerant store pattern
+  (`project-open-store`/`workspace-sort`/`sidebar-collapsed-store`).
+- **Persistence (parallel, not this epic):** #125 ADR-0011 — draft threads persist + bind on first prompt (no
+  eager `session/new`; no empty-thread-on-open).
 
-`#110` token layer (—) → `#111` primitives (base-ui+CVA, needs #110) → `#113` shell (#110,#111).
-`#112` streamdown spike (#110) → `#114` conversation A **[HITL — live-smoke + iterate on the chat]**
-(#111,#112) → `#115` conversation B (#114) / `#116` conversation C (#114).
-`#117` composer (#111,#113) · `#118` auth (#111) · `#119` git panel (#111) — parallel once #110/#111 land.
+## Remaining slices + dependencies
+- **#114 conversation A — [HITL]** — Response (=streamdown) / Message / Bubble / autoscroll. The hard core and the
+  biggest visual jump. Needs live `bun run dev` iteration AND a sign-off on streamdown's **HTML-sanitize security
+  posture** (streamdown `rehype-sanitize`+`rehype-harden` vs today's escape-everything `ChatMarkdown` — see
+  `docs/streamdown-spike.md`). Depends on #111 + #112 (both done).
+- **#115 conversation B** (needs #114) — tool rows (t3code `SimpleWorkEntryRow`), a **Collapsible** reasoning block
+  (auto-open while streaming), a self-ticking "Working…" indicator.
+- **#116 conversation C** (needs #114) — inline approval (restyle `PermissionRow`), a hover actions bar
+  (copy/👍/👎/retry), file-path **chip links** (new pure logic — TDD it).
+- **#117 composer** (needs #111/#113 — done) · **#118 auth** (needs #111) · **#119 git panel** (needs #111) —
+  parallel, AFK-able area restyles onto the primitives.
+- Recommended order: knock out the AFK area slices **#117 → #119 → #118** first (visible wins, no HITL), then do
+  **#114 → #115 → #116** with the human in the loop. Or start #114 first if the human wants the chat sooner.
+
+## Reference sources for the CONVERSATION work — copy-adapt & OWN in-repo, NEVER add as deps
+1. **`docs/design-system-components.md` §2** — THE build reference (exactly what to lift from shadcn + t3code for
+   Message/Bubble/Response/ToolRow/Reasoning/Approval/Actions/file-links, and what to STRIP). Read it first.
+2. **streamdown** (+ `@streamdown/code`) — the ADOPTED Response/markdown layer (#112). `docs/streamdown-spike.md`
+   has the locked #114 plan: `@source '…/streamdown/dist'` + the `@theme inline` shadcn-token map, the `muted`
+   token-collision fix, the shiki-dedup lever, and the HTML-sanitize security decision. It's streaming-native +
+   shiki + copy built in; it's what shadcn/AI-Elements' `Response` uses.
+3. **shadcn/ui** — `/Users/abdullahatrash/mistral/ui/apps/v4/registry/bases/base/ui/`: `message.tsx`, `bubble.tsx`,
+   `message-scroller.tsx` (the autoscroll engine — replaces our naive `scrollTop=scrollHeight`), `marker.tsx`. This
+   is the **base-ui** variant = our exact stack; swap its `cn-*` theme tokens for our inline Tailwind (the #111 gotcha).
+4. **shadcn AI Elements / ai-sdk Elements** (external — WebFetch `https://ai-sdk.dev/elements/overview` if useful):
+   the canonical chat-component patterns — Conversation, Message, Response, Reasoning, Tool, Actions, PromptInput.
+   Structure only: a discriminated **part-switch** (matches our `ConversationState.items` reducer, ADR-0001). Do
+   NOT adopt the AI-SDK message shape — feed our **ACP reducer** data (renderer owns conversation state, ADR-0001).
+5. **t3code** — `/Users/abdullahatrash/mistral/t3code/apps/web/src/components/chat/*` + `ChatMarkdown.tsx`: the rich
+   chat aesthetic — `SimpleWorkEntryRow` (tool rows), `WorkingTimelineRow` + `WorkingTimer`, `MarkdownFileLink`,
+   message bubbles. STRIP its coupling (worktree/checkpoint diffs, Pierre file icons → lucide, `session-logic`
+   derivation, `@legendapp/list` virtualization) — see components doc §2.
+6. **base-ui** (`https://base-ui.com`) — Collapsible (reasoning), ScrollArea, Tooltip, etc. Our primitives in
+   `src/renderer/src/ui/` already wrap these; extend them rather than reaching for base-ui directly in feature code.
 
 ## How the human drives it
-- After each slice PR: **"merge it then start `<next unblocked #>`"** (same cadence as the composer epic).
-- **#114 is HITL** — live-smoke (`bun run dev`) and iterate on the conversation aesthetic (the pixel-perfect
-  part that matters most). The rest are AFK to the mockups with a quick smoke.
-- Net-new features (Search/Scheduled/Plugins, terminal, view modes, dock, git Environment/Sources) stay
-  **static placeholders** — don't let the agent build their functionality.
+- After each slice PR: **"merge it then start `<next #>`"** (same tight cadence as the whole epic so far).
+- **#114 is HITL** — live-smoke (`bun run dev`) and iterate on the conversation aesthetic; get the security sign-off.
+- Net-new features (Search/Scheduled/Plugins nav, terminal, view modes, multi-tool dock, git Environment/Sources)
+  stay **static placeholders** — do NOT build their functionality (ADR-0010 scope boundary).
 
 ## Guardrails (also in HANDOFF/CLAUDE.md)
-- Branch first, never commit to `main`; **targeted `git add <paths>`, never `-A`**; **user merges**.
-- Worktrees use a **real `bun install`**, NOT a `node_modules` symlink (it broke the build once).
-- `docs/design-tokens.md` **supersedes** the old `docs/design/brand.md` (softer orange + rounded, reversing
-  `#fa500f` + zero-radius). Use the tokens doc for anything visual.
-- Reference repos (HANDOFF §4) are **copy-adapt-and-own** — never add as npm deps: t3code + shadcn `ui/`
-  (`/Users/abdullahatrash/mistral/ui`, `apps/v4/registry/bases/base/`) + mistral-vibe (`vibe/acp/`).
+- Branch first, never commit to `main`; **targeted `git add <paths>`, never `-A`**; **the user merges**.
+- Worktrees use a **real `bun install`**, NOT a `node_modules` symlink (it broke the build once, #64).
+- `docs/design-tokens.md` **supersedes** `docs/design/brand.md` (softer orange + rounded, reversing `#fa500f` +
+  zero-radius). Use the tokens doc for anything visual.
+- Reference repos are **copy-adapt-and-own** — never add t3code/shadcn/AI-Elements as npm deps. New deps this epic:
+  `class-variance-authority` (shipped, #111); `streamdown` + `@streamdown/code` (add in #114 per the spike).
 - Gates before any slice is done: `bun run lint && bun run typecheck && bun run build && bun run test`.


### PR DESCRIPTION
Hand-off prep for the next Claude Code session.

## What
- **`HANDOFF.md`** — updated the header (`main` @ `0197b5a`, **569 tests**) and §6 "What's next": the design-system epic is **~half done** — foundation (#110 tokens, #111 primitives, #112 streamdown spike, #113 shell) + the **entire sidebar cluster** (#127–#134, #138) are shipped; **remaining = #114/#115/#116 conversation · #117 composer · #118 auth · #119 git panel**.
- **`docs/NEXT-SESSION.md`** — rewritten as the **copy-paste kickoff** for the next session: the paste-in first message, what's shipped, the remaining slice order/deps, how the human drives it, guardrails, and — per request — the **inspiration/reference sources** for the conversation work: `docs/design-system-components.md §2`, **streamdown** (`docs/streamdown-spike.md`), **shadcn/ui** `bases/base/ui/` (message/bubble/message-scroller/marker), **shadcn AI Elements / ai-sdk Elements** (Conversation/Message/Response/Reasoning/Tool/Actions patterns), **t3code** chat (`components/chat/*` + `ChatMarkdown.tsx`), and base-ui.

Docs-only. The paste prompt tells the next agent to confirm the 569-test baseline, run the team loop (worktree → implementer `/tdd` → independent verify → adversarial review → fold → user merges), and keep each slice behavior-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)