### PR TITLE
sidebar: tighten row font sizes for a denser feel

### DIFF
--- a/docs/design-tokens.md
+++ b/docs/design-tokens.md
@@ -73,12 +73,16 @@ Bridge into `@theme` so `rounded-md`/`rounded-2xl` map to these (undo the curren
 | Hero H1 | 37px | 600 | — | -0.6px |
 | Workspace title | 20px | 600 | — | -0.2px |
 | Composer placeholder | 17px | 400 | — | — |
-| Nav label / New chat | 15.5px | 400 / 600 | — | — |
-| Body / project row / chip | 15px | 400 | 1.25 | — |
-| Thread row / context chip | 14.5px | 400 | — | — |
+| Nav label / New chat | 14px | 400 / 600 | — | — |
+| Body / project row / chip | 14px | 400 | 1.25 | — |
+| Thread row / context chip | 13.5px | 400 | — | — |
 | Section header ("Projects") | 13px | 500 | — | — |
 | Timestamp / plan / small | 13px | 400 | — | — |
 | Code / terminal body | 13px | 400 | 1.7 | — |
+
+> Sidebar rows were **tightened from the prototype** (nav/New-chat 15.5→14, project row 15→14, thread row
+> 14.5→13.5) for a denser, more desktop-app feel — the prototype ran a touch large. Hierarchy preserved
+> (nav ≥ project ≥ thread ≥ meta). Applied in `ui/nav-item.tsx` + `shell/Shell.tsx`.
 
 ## Spacing scale
 `2 · 4 · 6 · 8 · 10 · 12 · 14 · 16 · 18 · 20 · 22 · 24 · 40 · 42 · 44` (micro 2–12; macro 14–24; hero 40–44).

--- a/src/renderer/src/shell/Shell.tsx
+++ b/src/renderer/src/shell/Shell.tsx
@@ -187,7 +187,7 @@ function SidebarHeader(): JSX.Element {
   return (
     <div className="flex items-center gap-2.5 px-1 pt-1">
       <Logo size={30} />
-      <span className="text-[15px] font-semibold tracking-tight text-text-strong">vibe mistro</span>
+      <span className="text-[14.5px] font-semibold tracking-tight text-text-strong">vibe mistro</span>
     </div>
   )
 }
@@ -211,7 +211,7 @@ function PrimaryNav({
         type="button"
         onClick={onNewThread}
         disabled={!canCreateThread}
-        className="flex w-full items-center gap-2.5 rounded-lg bg-[var(--accent-fill)] px-3 py-2 text-left text-[15.5px] font-semibold text-accent-text outline-none transition-[filter] hover:brightness-[0.98] disabled:pointer-events-none disabled:opacity-50"
+        className="flex w-full items-center gap-2.5 rounded-lg bg-[var(--accent-fill)] px-3 py-2 text-left text-[14px] font-semibold text-accent-text outline-none transition-[filter] hover:brightness-[0.98] disabled:pointer-events-none disabled:opacity-50"
       >
         <SquarePen className="size-[18px]" aria-hidden />
         New chat
@@ -508,7 +508,7 @@ function ProjectRow({
       {/* Header row: the fold trigger + a SIBLING ＋ (outside the trigger button, so
           clicking ＋ starts a thread rather than toggling the fold). */}
       <div className="group/proj flex items-center gap-0.5 rounded-md pr-1 transition-colors hover:bg-accent/10">
-        <CollapsibleTrigger className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-3 py-[7px] text-left text-[15px] text-text-body outline-none focus-visible:bg-accent/10">
+        <CollapsibleTrigger className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-3 py-[7px] text-left text-[14px] text-text-body outline-none focus-visible:bg-accent/10">
           <ChevronDown
             className={cn(
               'size-4 shrink-0 text-muted transition-transform',
@@ -742,7 +742,7 @@ function NavThread({
             else if (e.key === 'Escape') cancelRename()
           }}
           onBlur={(e) => submitRename(e.currentTarget.value)}
-          className="w-full rounded-md border border-accent bg-transparent py-[7px] pr-2 pl-[42px] text-[14.5px] text-text outline-none"
+          className="w-full rounded-md border border-accent bg-transparent py-[7px] pr-2 pl-[42px] text-[13.5px] text-text outline-none"
         />
       </li>
     )
@@ -753,7 +753,7 @@ function NavThread({
   const archived = row.thread.archived === true
   return (
     <li className="group/thread relative">
-      <NavItem active={selected} onClick={onOpen} className="py-[7px] pr-2 pl-[42px] text-[14.5px]">
+      <NavItem active={selected} onClick={onOpen} className="py-[7px] pr-2 pl-[42px] text-[13.5px]">
         <span
           className={
             row.live

--- a/src/renderer/src/ui/nav-item.tsx
+++ b/src/renderer/src/ui/nav-item.tsx
@@ -20,7 +20,7 @@ export function NavItem({
       data-slot="nav-item"
       data-active={active || undefined}
       className={cn(
-        'flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-left text-[15.5px] text-text-body outline-none transition-colors',
+        'flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-left text-[14px] text-text-body outline-none transition-colors',
         '[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:text-muted',
         'hover:bg-accent/10 focus-visible:bg-accent/10',
         active && 'bg-accent/15 font-semibold text-text-strong [&_svg]:text-text-strong',


### PR DESCRIPTION
Small UI tweak (user felt the sidebar text was a bit big). Dials the interactive rows down ~1–1.5px for a tighter, more desktop-app feel — the prototype's type scale ran a touch large.

| Element | Was | Now |
|---|---|---|
| Nav items (New chat / Search / Scheduled / Plugins) | 15.5 | **14** |
| Project row (switcher/header) | 15 | **14** |
| Thread row + inline-rename input | 14.5 | **13.5** |
| "vibe mistro" wordmark | 15 | **14.5** |
| Projects label · timestamps · account · meta | — | unchanged (13 / 14 / 12) |

Hierarchy preserved (nav ≥ project ≥ thread ≥ meta). Changed in `ui/nav-item.tsx` (default; NavItem is sidebar-only) + `shell/Shell.tsx`, and updated `docs/design-tokens.md`'s type scale + a note so the spec matches the code.

## Gates
`bun run lint && bun run typecheck && bun run build && bun run test` — all green, **576 tests** (layout-only, no logic).

Easy to tune further — if 14 still reads big we can drop to 13.5, or I can do a couple of variants to compare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)