### PR TITLE
Fix rename input corner radius (rounded-sm is 7px here)

### DIFF
--- a/src/renderer/src/shell/Shell.tsx
+++ b/src/renderer/src/shell/Shell.tsx
@@ -753,7 +753,7 @@ function NavThread({
               else if (e.key === 'Escape') cancelRename()
             }}
             onBlur={(e) => submitRename(e.currentTarget.value)}
-            className="min-w-0 flex-1 rounded-sm bg-transparent px-1 text-[13.5px] text-text outline-none ring-1 ring-accent"
+            className="min-w-0 flex-1 rounded-[3px] bg-transparent px-1 text-[13.5px] text-text outline-none ring-1 ring-accent"
           />
         </div>
       </li>


### PR DESCRIPTION
Follow-up to #151. This design system overrides the radius scale — `--radius-sm` is **7px** here (not Tailwind's default 2px), so `rounded-sm` on the small rename input read as too rounded. Dropped it to an explicit `rounded-[3px]` for a crisp edit box.

One-line change; missed #151 because that PR was merged just before this commit was pushed to its branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)