### PR TITLE
sidebar: drag-to-resize the sidebar width (bounded + persisted)

### DIFF
--- a/src/renderer/src/shell/Shell.tsx
+++ b/src/renderer/src/shell/Shell.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type JSX, type ReactNode } from 'react'
+import { useEffect, useRef, useState, type JSX, type PointerEvent, type ReactNode } from 'react'
 import {
   Archive,
   ArchiveRestore,
@@ -27,6 +27,12 @@ import {
   type UnifiedThreadRow,
 } from './unified-threads'
 import { getOpenProjects, setOpenProjects } from './project-open-store'
+import {
+  clampSidebarWidth,
+  DEFAULT_SIDEBAR_WIDTH,
+  getSidebarWidth,
+  setSidebarWidth,
+} from './sidebar-width-store'
 import { getSortOrder, setSortOrder, sortWorkspaces, type WorkspaceSortOrder } from './workspace-sort'
 import { Badge } from '../ui/badge'
 import { cn } from '../lib/utils'
@@ -132,27 +138,77 @@ export function Shell({
   /** Open the routed Settings page (#130) — from the account chip's menu. */
   onOpenSettings: () => void
 }): JSX.Element {
+  // The sidebar's EXPANDED width (#drag-to-resize): renderer-only UI state, seeded from
+  // localStorage (clamped) and persisted on drag-release. `dragging` disables the
+  // collapse width-transition so the aside tracks the pointer 1:1 with no lag, and
+  // suppresses text selection while the pointer is captured.
+  const [width, setWidth] = useState(() => getSidebarWidth(window.localStorage))
+  const [dragging, setDragging] = useState(false)
+  // The drag origin, captured on pointer-down so the move handler reads no stale state.
+  const dragOrigin = useRef({ startX: 0, startWidth: DEFAULT_SIDEBAR_WIDTH })
+
+  function onHandlePointerDown(e: PointerEvent<HTMLDivElement>): void {
+    e.preventDefault()
+    dragOrigin.current = { startX: e.clientX, startWidth: width }
+    setDragging(true)
+    e.currentTarget.setPointerCapture(e.pointerId)
+  }
+  function onHandlePointerMove(e: PointerEvent<HTMLDivElement>): void {
+    if (!dragging) return
+    const { startX, startWidth } = dragOrigin.current
+    setWidth(clampSidebarWidth(startWidth + (e.clientX - startX)))
+  }
+  function endDrag(e: PointerEvent<HTMLDivElement>): void {
+    if (!dragging) return
+    setDragging(false)
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId)
+    }
+    // Persist the settled EXPANDED width (best-effort). Read from state via the setter to
+    // avoid a stale closure — setWidth's identity update returns the current value.
+    setWidth((current) => {
+      setSidebarWidth(window.localStorage, current)
+      return current
+    })
+  }
+  function resetWidth(): void {
+    setWidth(DEFAULT_SIDEBAR_WIDTH)
+    setSidebarWidth(window.localStorage, DEFAULT_SIDEBAR_WIDTH)
+  }
+  // Collapsing unmounts the handle, so a drag in flight would never get its pointerup
+  // (→ `dragging` stuck true: stuck `select-none`, suppressed transition, and — worst —
+  // the re-expanded handle resizing on mere hover off a stale origin). Clear it on collapse.
+  useEffect(() => {
+    if (collapsed) setDragging(false)
+  }, [collapsed])
+
   return (
-    <div className="flex min-h-0 flex-1">
+    <div className={cn('flex min-h-0 flex-1', dragging && 'select-none')}>
       {/* The sidebar stays MOUNTED when collapsed (#127) — its state (open projects,
           scroll, the #138 fold list) survives, so re-expanding is instant. The OUTER
-          <aside> animates only its width (0 ↔ 338px) and clips (`overflow-hidden`); the
-          INNER holds a FIXED 338px width so the content SLIDES under the clip cleanly
-          instead of squishing as the container shrinks. `aria-hidden`/`inert` take the
-          now-hidden controls out of the tab order + a11y tree while collapsed. The
-          <main> outlet is `flex-1`, so it reclaims the freed space automatically. */}
+          <aside> animates only its width (0 ↔ the resized width) and clips
+          (`overflow-hidden`); the INNER holds a FIXED (resized) width so the content
+          SLIDES under the clip cleanly instead of squishing as the container shrinks.
+          `aria-hidden`/`inert` take the now-hidden controls out of the tab order + a11y
+          tree while collapsed. The <main> outlet is `flex-1`, so it reclaims the freed
+          space automatically. The width is inline (dynamic #drag-to-resize); the
+          transition is disabled WHILE DRAGGING so the aside tracks the pointer with no
+          lag, but kept for the collapse animation. */}
       <aside
         aria-hidden={collapsed || undefined}
         inert={collapsed || undefined}
+        style={{ width: collapsed ? 0 : width }}
         className={cn(
           'flex flex-none overflow-hidden border-border bg-sidebar transition-[width] duration-200',
-          collapsed ? 'w-0 border-r-0' : 'w-[338px] border-r',
+          collapsed ? 'border-r-0' : 'border-r',
+          dragging && 'transition-none',
         )}
       >
         {/* Three-band sidebar: a PINNED top (logo + primary nav) and a PINNED bottom
             (account) sandwich the ONLY scroll region — the Projects list — so the nav
-            and account stay put while just the projects scroll. */}
-        <div className="flex h-full w-[338px] flex-none flex-col gap-3 p-3">
+            and account stay put while just the projects scroll. The INNER holds the
+            resized width (not shrinking) so content slides under the clip on collapse. */}
+        <div className="flex h-full flex-none flex-col gap-3 p-3" style={{ width }}>
           <div className="flex flex-none flex-col gap-3">
             <SidebarHeader />
             <PrimaryNav canCreateThread={canCreateThread} onNewThread={onNewThread} />
@@ -176,6 +232,31 @@ export function Shell({
           <AccountChip onOpenSettings={onOpenSettings} />
         </div>
       </aside>
+
+      {/* Resize handle (#drag-to-resize): a SIBLING of the <aside> (so it lives OUTSIDE
+          the aside's `overflow-hidden`/collapse clip) rendered only when expanded — a
+          collapsed sidebar can't be resized. A 0-width relative wrapper on the border
+          carries a WIDER (8px) invisible hit strip (`absolute -left-1 w-2`) with a thin
+          visible line on hover/drag, so the grab target is forgiving but the affordance
+          is a 1px seam. Pointer-capture keeps the drag tracking outside the strip and
+          auto-cleans (no leaked window listener). Double-click resets to the default. */}
+      {!collapsed && (
+        <div className="relative z-10 w-0 flex-none">
+          <div
+            aria-hidden
+            onPointerDown={onHandlePointerDown}
+            onPointerMove={onHandlePointerMove}
+            onPointerUp={endDrag}
+            onPointerCancel={endDrag}
+            onDoubleClick={resetWidth}
+            className={cn(
+              'absolute -left-1 top-0 h-full w-2 cursor-col-resize [-webkit-app-region:no-drag]',
+              'after:absolute after:inset-y-0 after:left-1 after:w-px after:bg-transparent after:transition-colors after:content-[""] hover:after:bg-accent/40',
+              dragging && 'after:bg-accent/60',
+            )}
+          />
+        </div>
+      )}
 
       <main className="min-w-0 flex-1 overflow-y-auto p-6">{outlet}</main>
     </div>

--- a/src/renderer/src/shell/sidebar-width-store.test.ts
+++ b/src/renderer/src/shell/sidebar-width-store.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  clampSidebarWidth,
+  DEFAULT_SIDEBAR_WIDTH,
+  getSidebarWidth,
+  MAX_SIDEBAR_WIDTH,
+  MIN_SIDEBAR_WIDTH,
+  SIDEBAR_WIDTH_STORAGE_KEY,
+  setSidebarWidth,
+  type SidebarWidthStorage,
+} from './sidebar-width-store'
+
+/** A throwaway in-memory Storage seam for the tests. */
+function fakeStorage(
+  seed?: Record<string, string>,
+): SidebarWidthStorage & { map: Map<string, string> } {
+  const map = new Map<string, string>(Object.entries(seed ?? {}))
+  return {
+    map,
+    getItem: (k) => map.get(k) ?? null,
+    setItem: (k, v) => void map.set(k, v),
+  }
+}
+
+describe('clampSidebarWidth', () => {
+  it('passes an in-range width through unchanged', () => {
+    expect(clampSidebarWidth(338)).toBe(338)
+    expect(clampSidebarWidth(300)).toBe(300)
+  })
+
+  it('clamps below the minimum up to MIN', () => {
+    expect(clampSidebarWidth(MIN_SIDEBAR_WIDTH - 100)).toBe(MIN_SIDEBAR_WIDTH)
+    expect(clampSidebarWidth(0)).toBe(MIN_SIDEBAR_WIDTH)
+    expect(clampSidebarWidth(-50)).toBe(MIN_SIDEBAR_WIDTH)
+  })
+
+  it('clamps above the maximum down to MAX', () => {
+    expect(clampSidebarWidth(MAX_SIDEBAR_WIDTH + 100)).toBe(MAX_SIDEBAR_WIDTH)
+    expect(clampSidebarWidth(10_000)).toBe(MAX_SIDEBAR_WIDTH)
+  })
+
+  it('keeps the exact bounds', () => {
+    expect(clampSidebarWidth(MIN_SIDEBAR_WIDTH)).toBe(MIN_SIDEBAR_WIDTH)
+    expect(clampSidebarWidth(MAX_SIDEBAR_WIDTH)).toBe(MAX_SIDEBAR_WIDTH)
+  })
+
+  it('falls back to DEFAULT for NaN / non-finite inputs', () => {
+    expect(clampSidebarWidth(NaN)).toBe(DEFAULT_SIDEBAR_WIDTH)
+    expect(clampSidebarWidth(Infinity)).toBe(DEFAULT_SIDEBAR_WIDTH)
+    expect(clampSidebarWidth(-Infinity)).toBe(DEFAULT_SIDEBAR_WIDTH)
+  })
+})
+
+describe('getSidebarWidth', () => {
+  it('defaults to DEFAULT_SIDEBAR_WIDTH when nothing is stored', () => {
+    expect(getSidebarWidth(fakeStorage())).toBe(DEFAULT_SIDEBAR_WIDTH)
+  })
+
+  it('defaults to DEFAULT_SIDEBAR_WIDTH for a null/undefined store', () => {
+    expect(getSidebarWidth(null)).toBe(DEFAULT_SIDEBAR_WIDTH)
+    expect(getSidebarWidth(undefined)).toBe(DEFAULT_SIDEBAR_WIDTH)
+  })
+
+  it('reads a stored in-range width', () => {
+    expect(getSidebarWidth(fakeStorage({ [SIDEBAR_WIDTH_STORAGE_KEY]: '300' }))).toBe(300)
+  })
+
+  it('clamps an out-of-range stored width', () => {
+    expect(getSidebarWidth(fakeStorage({ [SIDEBAR_WIDTH_STORAGE_KEY]: '100' }))).toBe(
+      MIN_SIDEBAR_WIDTH,
+    )
+    expect(getSidebarWidth(fakeStorage({ [SIDEBAR_WIDTH_STORAGE_KEY]: '9999' }))).toBe(
+      MAX_SIDEBAR_WIDTH,
+    )
+  })
+
+  it('defaults on a corrupt (non-numeric) payload', () => {
+    expect(getSidebarWidth(fakeStorage({ [SIDEBAR_WIDTH_STORAGE_KEY]: 'wide' }))).toBe(
+      DEFAULT_SIDEBAR_WIDTH,
+    )
+    expect(getSidebarWidth(fakeStorage({ [SIDEBAR_WIDTH_STORAGE_KEY]: '{not json' }))).toBe(
+      DEFAULT_SIDEBAR_WIDTH,
+    )
+  })
+
+  it('round-trips a value through setSidebarWidth', () => {
+    const storage = fakeStorage()
+    setSidebarWidth(storage, 400)
+    expect(getSidebarWidth(storage)).toBe(400)
+  })
+
+  it('never throws when the store throws on read', () => {
+    const storage: SidebarWidthStorage = {
+      getItem: () => {
+        throw new Error('blocked')
+      },
+      setItem: () => {},
+    }
+    expect(getSidebarWidth(storage)).toBe(DEFAULT_SIDEBAR_WIDTH)
+  })
+})
+
+describe('setSidebarWidth', () => {
+  it('stores the CLAMPED value (out-of-range in → bound stored)', () => {
+    const storage = fakeStorage()
+    setSidebarWidth(storage, 9999)
+    expect(storage.map.get(SIDEBAR_WIDTH_STORAGE_KEY)).toBe(String(MAX_SIDEBAR_WIDTH))
+    setSidebarWidth(storage, 10)
+    expect(storage.map.get(SIDEBAR_WIDTH_STORAGE_KEY)).toBe(String(MIN_SIDEBAR_WIDTH))
+  })
+
+  it('no-ops for a null/undefined store', () => {
+    expect(() => setSidebarWidth(null, 300)).not.toThrow()
+    expect(() => setSidebarWidth(undefined, 300)).not.toThrow()
+  })
+
+  it('swallows a throwing store (quota/security) without propagating', () => {
+    const setItem = vi.fn(() => {
+      throw new Error('quota exceeded')
+    })
+    const storage: SidebarWidthStorage = { getItem: () => null, setItem }
+    expect(() => setSidebarWidth(storage, 300)).not.toThrow()
+    expect(setItem).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/shell/sidebar-width-store.ts
+++ b/src/renderer/src/shell/sidebar-width-store.ts
@@ -1,0 +1,72 @@
+/**
+ * The left sidebar's EXPANDED width in pixels (#drag-to-resize): a renderer-only,
+ * display-only number. Resizing the sidebar is pure UI chrome — it never spawns an
+ * agent, changes the active Workspace, or touches nav/persistence — so (like the
+ * collapsed flag #127, the project fold state #138, and the sort order #129) it lives
+ * in localStorage alone: no IPC, no main, no persistence store.
+ *
+ * The width is always CLAMPED to [MIN_SIDEBAR_WIDTH, MAX_SIDEBAR_WIDTH] so a corrupt
+ * or out-of-range stored value (or a drag past the bounds) can never wedge the sidebar
+ * too narrow to use or too wide to fit. A missing/NaN/non-finite value falls back to
+ * DEFAULT_SIDEBAR_WIDTH.
+ *
+ * The storage seam is INJECTED so tests pass a fake and render code passes
+ * `window.localStorage`; every path tolerates an unavailable/throwing/corrupt store and
+ * falls back to the default so a blocked store never traps the sidebar at a bad width.
+ */
+
+/** Narrowest the sidebar may be dragged (px). */
+export const MIN_SIDEBAR_WIDTH = 240
+/** Widest the sidebar may be dragged (px). */
+export const MAX_SIDEBAR_WIDTH = 480
+/** The default (and double-click reset) sidebar width (px) — the historical `w-[338px]`. */
+export const DEFAULT_SIDEBAR_WIDTH = 338
+
+/** The single localStorage key holding the sidebar's expanded width. */
+export const SIDEBAR_WIDTH_STORAGE_KEY = 'vibe-mistro:sidebar-width:v1'
+
+/** The slice of the Web Storage API we depend on — `window.localStorage` satisfies it. */
+export interface SidebarWidthStorage {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+}
+
+/**
+ * Clamp a width to [MIN, MAX]. A NaN/non-finite input (e.g. a corrupt parse) falls back
+ * to {@link DEFAULT_SIDEBAR_WIDTH}. Pure — the single source of truth for "a valid width".
+ */
+export function clampSidebarWidth(px: number): number {
+  if (!Number.isFinite(px)) return DEFAULT_SIDEBAR_WIDTH
+  if (px < MIN_SIDEBAR_WIDTH) return MIN_SIDEBAR_WIDTH
+  if (px > MAX_SIDEBAR_WIDTH) return MAX_SIDEBAR_WIDTH
+  return px
+}
+
+/**
+ * The persisted (clamped) sidebar width, or {@link DEFAULT_SIDEBAR_WIDTH} when
+ * absent/unknown/unavailable. Never throws — a blocked/throwing/corrupt store must not
+ * trap the sidebar at a bad width.
+ */
+export function getSidebarWidth(storage: SidebarWidthStorage | null | undefined): number {
+  if (!storage) return DEFAULT_SIDEBAR_WIDTH
+  try {
+    const raw = storage.getItem(SIDEBAR_WIDTH_STORAGE_KEY)
+    if (!raw) return DEFAULT_SIDEBAR_WIDTH
+    return clampSidebarWidth(Number(raw))
+  } catch {
+    return DEFAULT_SIDEBAR_WIDTH
+  }
+}
+
+/** Persist the sidebar width (clamped) best-effort; a quota/security exception is swallowed. */
+export function setSidebarWidth(
+  storage: SidebarWidthStorage | null | undefined,
+  px: number,
+): void {
+  if (!storage) return
+  try {
+    storage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(clampSidebarWidth(px)))
+  } catch {
+    // Best-effort: a full/blocked storage must never throw from a resize drag.
+  }
+}


### PR DESCRIPTION
User request. Drag the sidebar's right edge to resize it within bounds; the width persists and coexists with the collapse toggle.

## What
- **Drag handle** — a `col-resize` grab strip (8px hit area, 1px seam that highlights on hover/drag) sitting on the sidebar's right border, as a sibling of `<aside>` so it's outside the collapse clip. **Hidden when collapsed** (can't resize a collapsed sidebar). Double-click resets to the default width.
- **Bounds + persistence** — width clamped to **240–480px** (default **338**), persisted to `localStorage` via a new TDD'd `sidebar-width-store.ts` (`clampSidebarWidth` + throw-tolerant get/set, mirroring `sidebar-collapsed-store`).
- **Drag mechanics** — pointer-capture (routes moves off the handle, auto-cleans), origin in a ref (no stale start), width = `clamp(startWidth + dx)`, persist on release. `transition-none` while dragging (1:1 tracking); `select-none` on the shell root so text isn't selected.
- **Collapse coexistence** — the `<aside>` width is inline `style={{ width: collapsed ? 0 : width }}` (keeps the #127 collapse animation); the inner band stays at `width` so content still slides under the clip on collapse. Collapse doesn't touch the width, so collapse→expand restores the resized width.

## Review folds
Adversarial verdict SHIP-WITH-FIXES; folded its one real SHOULD-FIX: if the handle unmounts mid-drag (collapse during a drag), `dragging` would get stuck (→ hover-resizes from a stale origin) — added `useEffect(() => { if (collapsed) setDragging(false) }, [collapsed])`. Also dropped the self-cancelling `role="separator"`+`aria-hidden` markup (it's an honest mouse affordance).

## Gates
`bun run lint && bun run typecheck && bun run build && bun run test` — all green, **591 tests** (+15 new store/clamp). Rebased onto latest `main` (includes #117 composer); the diff is Shell.tsx + the store only.

## Smoke
Drag the edge (clamps at 240/480), release → persists across reload, double-click the handle → resets to 338, and collapse/expand still animates to your chosen width. Bounds are one constant each if you want a wider max.

🤖 Generated with [Claude Code](https://claude.com/claude-code)