### PR TITLE
#153: cache per-Workspace agent controls so a draft's picker shows before the first prompt

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -45,6 +45,11 @@ import {
   type ThreadStatusMap,
 } from './conversation/thread-status'
 import { clearDraft } from './conversation/composer-draft-store'
+import {
+  getWorkspaceControls,
+  setWorkspaceControls,
+  workspaceControlsKey,
+} from './connection/workspace-controls-store'
 import { ArrowLeft, ArrowRight, Maximize2, PanelLeft, PanelRight, Terminal } from 'lucide-react'
 import { Button } from './ui/button'
 import { IconButton } from './ui/icon-button'
@@ -629,8 +634,18 @@ export function App(): JSX.Element {
             // self-corrects. We don't eagerly resume to learn it (#33 defers load to the
             // first prompt); Model isn't trust-relevant (it doesn't gate writes), so the
             // transient pre-prompt mismatch is accepted.
+            // A never-bound draft's connection advertises all-null controls (ADR-0011
+            // opens no session until the first prompt), so before falling back to the
+            // connection we try the per-Workspace cache (#153) — the last bound session's
+            // option lists — so the picker shows immediately instead of after send.
             configFor(workspaceThreads, conn.workspaceId, activeThread.id) ??
-            draftControls(connectionControlsOf(conn), selectedFor(workspaceThreads, conn.workspaceId, activeThread.id))
+            draftControls(
+              getWorkspaceControls(
+                window.localStorage,
+                workspaceControlsKey(conn.workspaceId, conn.workspaceDir),
+              ) ?? connectionControlsOf(conn),
+              selectedFor(workspaceThreads, conn.workspaceId, activeThread.id),
+            )
           }
           onSetConfig={(axis, value, sessionId) => {
             // A real session => the bound IPC path (#70); a null session => a draft
@@ -643,7 +658,16 @@ export function App(): JSX.Element {
             // re-assert the user's cached selection over them (#72) — a resume reports
             // defaults, so this restores a prior non-default Mode/Model/effort.
             wtDispatch({ type: 'bind', workspaceId: conn.workspaceId, threadId: activeThread.id, sessionId, controls })
-            if (controls) reassertAfterResume(conn.workspaceId, conn.agentId, activeThread.id, sessionId, controls)
+            if (controls) {
+              reassertAfterResume(conn.workspaceId, conn.agentId, activeThread.id, sessionId, controls)
+              // Cache the bound session's option lists per Workspace (#153) so the NEXT
+              // never-bound draft here shows the picker before its own first prompt binds.
+              setWorkspaceControls(
+                window.localStorage,
+                workspaceControlsKey(conn.workspaceId, conn.workspaceDir),
+                controls,
+              )
+            }
           }}
           onContinue={() => {
             wtDispatch({ type: 'open', workspaceId: conn.workspaceId, threadId: activeThread.id })

--- a/src/renderer/src/connection/workspace-controls-store.test.ts
+++ b/src/renderer/src/connection/workspace-controls-store.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect } from 'vitest'
+import {
+  WORKSPACE_CONTROLS_STORAGE_KEY,
+  getWorkspaceControls,
+  setWorkspaceControls,
+  workspaceControlsKey,
+  type WorkspaceControlsStorage,
+} from './workspace-controls-store'
+import type { ThreadAgentControls } from '../../../shared/ipc'
+
+/**
+ * Per-Workspace agent-controls cache (#153): the last session-reported option lists
+ * (+ current values) for a Workspace, cached so a never-bound draft's picker can show
+ * BEFORE the first prompt mints a session (ADR-0011 lazy binding). The module is pure
+ * over an injected storage seam, so here we feed it a Map-backed fake — round-trip,
+ * per-Workspace isolation, the key fallback, and the never-throw tolerance paths.
+ */
+
+/** A Map-backed fake satisfying the injected `WorkspaceControlsStorage` seam. */
+function fakeStorage(): WorkspaceControlsStorage & { map: Map<string, string> } {
+  const map = new Map<string, string>()
+  return {
+    map,
+    getItem: (k) => (map.has(k) ? (map.get(k) as string) : null),
+    setItem: (k, v) => {
+      map.set(k, v)
+    },
+    removeItem: (k) => {
+      map.delete(k)
+    },
+  }
+}
+
+/** A full three-axis controls bundle for round-trip assertions. */
+function sampleControls(): ThreadAgentControls {
+  return {
+    modes: {
+      currentModeId: 'default',
+      availableModes: [
+        { id: 'default', name: 'Default' },
+        { id: 'plan', name: 'Plan' },
+      ],
+    },
+    models: {
+      currentModelId: 'mistral-large',
+      availableModels: [
+        { modelId: 'mistral-large', name: 'Mistral Large' },
+        { modelId: 'mistral-small', name: 'Mistral Small' },
+      ],
+    },
+    reasoningEffort: {
+      current: 'high',
+      options: [{ value: 'low' }, { value: 'high', name: 'High' }],
+    },
+  }
+}
+
+describe('workspaceControlsKey', () => {
+  it('prefers the persisted workspaceId', () => {
+    expect(workspaceControlsKey('ws-1', '/home/me/project')).toBe('ws-1')
+  })
+
+  it('falls back to the workspaceDir when workspaceId is null (degraded / no-store draft)', () => {
+    expect(workspaceControlsKey(null, '/home/me/project')).toBe('/home/me/project')
+  })
+
+  it('falls back to the workspaceDir for an empty workspaceId', () => {
+    expect(workspaceControlsKey('', '/home/me/project')).toBe('/home/me/project')
+  })
+})
+
+describe('get / set round-trip', () => {
+  it('stores and reads back a Workspace bundle keyed by its key', () => {
+    const storage = fakeStorage()
+    const controls = sampleControls()
+    setWorkspaceControls(storage, 'ws-1', controls)
+    expect(getWorkspaceControls(storage, 'ws-1')).toEqual(controls)
+  })
+
+  it('returns null for an absent Workspace', () => {
+    expect(getWorkspaceControls(fakeStorage(), 'never')).toBeNull()
+  })
+
+  it('overwrites (patches) one Workspace without disturbing another', () => {
+    const storage = fakeStorage()
+    const a = sampleControls()
+    const b: ThreadAgentControls = {
+      modes: { currentModeId: 'default', availableModes: [{ id: 'default', name: 'Default' }] },
+      models: null,
+      reasoningEffort: null,
+    }
+    setWorkspaceControls(storage, 'ws-1', a)
+    setWorkspaceControls(storage, 'ws-2', b)
+    // Re-write ws-1 with a different bundle; ws-2 must stay intact.
+    const a2: ThreadAgentControls = {
+      modes: { currentModeId: 'plan', availableModes: [{ id: 'plan', name: 'Plan' }] },
+      models: null,
+      reasoningEffort: null,
+    }
+    setWorkspaceControls(storage, 'ws-1', a2)
+    expect(getWorkspaceControls(storage, 'ws-1')).toEqual(a2)
+    expect(getWorkspaceControls(storage, 'ws-2')).toEqual(b)
+  })
+})
+
+describe('per-Workspace isolation', () => {
+  it('keeps two Workspaces independent', () => {
+    const storage = fakeStorage()
+    const a = sampleControls()
+    const b: ThreadAgentControls = {
+      modes: { currentModeId: 'default', availableModes: [{ id: 'default', name: 'Default' }] },
+      models: null,
+      reasoningEffort: null,
+    }
+    setWorkspaceControls(storage, 'ws-1', a)
+    setWorkspaceControls(storage, 'ws-2', b)
+    expect(getWorkspaceControls(storage, 'ws-1')).toEqual(a)
+    expect(getWorkspaceControls(storage, 'ws-2')).toEqual(b)
+  })
+
+  it('normalizes a stored entry to the three-axis shape, defaulting missing axes to null', () => {
+    const storage = fakeStorage()
+    // A partial blob (e.g. from an older shape) still yields a valid bundle.
+    storage.map.set(WORKSPACE_CONTROLS_STORAGE_KEY, JSON.stringify({ 'ws-1': { modes: null } }))
+    expect(getWorkspaceControls(storage, 'ws-1')).toEqual({
+      modes: null,
+      models: null,
+      reasoningEffort: null,
+    })
+  })
+
+  it('nulls out an axis whose list field is missing or not an array (S1: picker maps it unguarded)', () => {
+    const storage = fakeStorage()
+    // A tampered/older blob: each axis is an object but its list field is absent or a
+    // non-array. Passing these through would throw `undefined.map()` in AgentControls.
+    storage.map.set(
+      WORKSPACE_CONTROLS_STORAGE_KEY,
+      JSON.stringify({
+        'ws-1': {
+          modes: { currentModeId: 'default' }, // no availableModes
+          models: { currentModelId: 'm', availableModels: 'nope' }, // non-array list
+          reasoningEffort: { current: 'high', options: [{ value: 'high' }] }, // valid → kept
+        },
+      }),
+    )
+    expect(getWorkspaceControls(storage, 'ws-1')).toEqual({
+      modes: null,
+      models: null,
+      reasoningEffort: { current: 'high', options: [{ value: 'high' }] },
+    })
+  })
+})
+
+describe('monotonic caching (N1: an all-null bundle never clobbers a good cache)', () => {
+  it('does not write an all-null bundle', () => {
+    const storage = fakeStorage()
+    setWorkspaceControls(storage, 'ws-1', { modes: null, models: null, reasoningEffort: null })
+    expect(getWorkspaceControls(storage, 'ws-1')).toBeNull()
+    expect(storage.map.has(WORKSPACE_CONTROLS_STORAGE_KEY)).toBe(false)
+  })
+
+  it('a later all-null bind leaves an existing good cache intact', () => {
+    const storage = fakeStorage()
+    const good = sampleControls()
+    setWorkspaceControls(storage, 'ws-1', good)
+    // A degraded resume reports no axes — must NOT clobber the cached bundle.
+    setWorkspaceControls(storage, 'ws-1', { modes: null, models: null, reasoningEffort: null })
+    expect(getWorkspaceControls(storage, 'ws-1')).toEqual(good)
+  })
+})
+
+describe('malformed / missing tolerance (never throws into render)', () => {
+  it('treats malformed JSON as absent', () => {
+    const storage = fakeStorage()
+    storage.map.set(WORKSPACE_CONTROLS_STORAGE_KEY, '{not json')
+    expect(getWorkspaceControls(storage, 'ws-1')).toBeNull()
+  })
+
+  it('treats a non-object blob as absent', () => {
+    const storage = fakeStorage()
+    storage.map.set(WORKSPACE_CONTROLS_STORAGE_KEY, '"a string"')
+    expect(getWorkspaceControls(storage, 'ws-1')).toBeNull()
+  })
+
+  it('treats an array blob as absent', () => {
+    const storage = fakeStorage()
+    storage.map.set(WORKSPACE_CONTROLS_STORAGE_KEY, '[1,2,3]')
+    expect(getWorkspaceControls(storage, 'ws-1')).toBeNull()
+  })
+
+  it('treats a non-object entry value as absent', () => {
+    const storage = fakeStorage()
+    storage.map.set(WORKSPACE_CONTROLS_STORAGE_KEY, JSON.stringify({ 'ws-1': 42 }))
+    expect(getWorkspaceControls(storage, 'ws-1')).toBeNull()
+  })
+
+  it('returns null for an absent key', () => {
+    expect(getWorkspaceControls(fakeStorage(), 'ws-1')).toBeNull()
+  })
+
+  it('overwrites a malformed blob on the next set', () => {
+    const storage = fakeStorage()
+    storage.map.set(WORKSPACE_CONTROLS_STORAGE_KEY, '{not json')
+    const controls = sampleControls()
+    setWorkspaceControls(storage, 'ws-1', controls)
+    expect(getWorkspaceControls(storage, 'ws-1')).toEqual(controls)
+  })
+})
+
+describe('best-effort writes (a throwing storage does not propagate)', () => {
+  it('swallows a setItem exception on set', () => {
+    const throwing: WorkspaceControlsStorage = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error('quota exceeded')
+      },
+      removeItem: () => {},
+    }
+    expect(() => setWorkspaceControls(throwing, 'ws-1', sampleControls())).not.toThrow()
+  })
+
+  it('swallows a getItem exception on read', () => {
+    const throwing: WorkspaceControlsStorage = {
+      getItem: () => {
+        throw new Error('SecurityError')
+      },
+      setItem: () => {},
+      removeItem: () => {},
+    }
+    expect(getWorkspaceControls(throwing, 'ws-1')).toBeNull()
+  })
+})
+
+describe('absent storage guard', () => {
+  it('getWorkspaceControls returns null when storage is null/undefined', () => {
+    expect(getWorkspaceControls(null, 'ws-1')).toBeNull()
+    expect(getWorkspaceControls(undefined, 'ws-1')).toBeNull()
+  })
+
+  it('setWorkspaceControls is a no-op when storage is null/undefined', () => {
+    expect(() => setWorkspaceControls(null, 'ws-1', sampleControls())).not.toThrow()
+    expect(() => setWorkspaceControls(undefined, 'ws-1', sampleControls())).not.toThrow()
+  })
+})

--- a/src/renderer/src/connection/workspace-controls-store.ts
+++ b/src/renderer/src/connection/workspace-controls-store.ts
@@ -1,0 +1,146 @@
+/**
+ * Per-Workspace agent-controls cache (#153): the option lists (+ current values) for
+ * a Workspace's Mode / Model / Reasoning-effort pickers, as the LAST bound session
+ * reported them. The picker option lists are Vibe-owned and surfaced ONLY by
+ * `session/new` / `session/load`; by ADR-0011's lazy binding we open NO ACP session
+ * until a Thread's first prompt, so a never-prompted draft's connection advertises
+ * all-null controls and `AgentControls` renders nothing. Caching the last bound
+ * bundle lets a fresh draft show the picker immediately, standing in until its own
+ * first prompt binds and the REAL session values self-correct (the bound path wins;
+ * this cache is read only in the draft branch, before `configFor` is seeded).
+ *
+ * Like the composer drafts (#60), open-projects (#138), and sidebar-collapsed state,
+ * this is renderer-only display state, so it lives in localStorage alone: no IPC, no
+ * main, no persistence store, no new ACP session. A pure module over an INJECTED
+ * storage seam — tests pass a fake and render code passes `window.localStorage`.
+ * Reading must never throw into a render and writing must never throw from a bind, so
+ * both paths swallow a malformed blob, an absent key, and a quota/security exception.
+ */
+
+import type { ThreadAgentControls } from '../../../shared/ipc'
+
+/** The single localStorage key holding the `workspaceKey -> controls` map. */
+export const WORKSPACE_CONTROLS_STORAGE_KEY = 'vibe-mistro:workspace-controls:v1'
+
+/** The slice of the Web Storage API we depend on — `window.localStorage` satisfies it. */
+export interface WorkspaceControlsStorage {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+  removeItem(key: string): void
+}
+
+/** The persisted shape: a workspace key -> its cached agent-controls bundle. */
+type ControlsMap = Record<string, ThreadAgentControls>
+
+/**
+ * The map key for a Workspace's cached controls: prefer the persisted `workspaceId`,
+ * but fall back to the `workspaceDir` when `workspaceId` is absent — a draft opened in
+ * degraded / no-store mode has no minted id yet. A Workspace uses one or the other for
+ * a session, so a mid-flight id/dir switch is at worst a cache miss (acceptable — a
+ * miss just falls back to today's cold behavior).
+ */
+export function workspaceControlsKey(workspaceId: string | null, workspaceDir: string): string {
+  return workspaceId ? workspaceId : workspaceDir
+}
+
+/**
+ * Read one axis from a raw entry, keeping it ONLY when it's an object whose list field
+ * (the array `AgentControls` maps over) is actually an array. A stale/older-shaped/
+ * tampered axis like `{}` (object but no `availableModes`) is nulled out rather than
+ * passed through — the picker calls `.map()` on that list unguarded, so an axis missing
+ * its array would throw in render. `listKey` is the axis's array field name.
+ */
+function readAxis(v: Record<string, unknown>, key: string, listKey: string): unknown {
+  const raw = v[key]
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) return null
+  return Array.isArray((raw as Record<string, unknown>)[listKey]) ? raw : null
+}
+
+/**
+ * Normalize an unknown stored entry to a valid three-axis bundle: a non-object entry
+ * is rejected (null), and any missing/non-object/list-less axis defaults to null. Keeps
+ * a stale or older-shaped blob from ever surfacing a malformed control to the picker.
+ */
+function normalizeControls(value: unknown): ThreadAgentControls | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null
+  const v = value as Record<string, unknown>
+  return {
+    modes: readAxis(v, 'modes', 'availableModes') as ThreadAgentControls['modes'],
+    models: readAxis(v, 'models', 'availableModels') as ThreadAgentControls['models'],
+    reasoningEffort: readAxis(v, 'reasoningEffort', 'options') as ThreadAgentControls['reasoningEffort'],
+  }
+}
+
+/**
+ * Read + parse the controls map, tolerating everything: an unavailable storage, an
+ * absent key, a parse error, or a non-object blob all yield an empty map. Never throws
+ * — a corrupt entry must not break a draft's render.
+ */
+function readMap(storage: WorkspaceControlsStorage | null | undefined): ControlsMap {
+  if (!storage) return {}
+  let raw: string | null
+  try {
+    raw = storage.getItem(WORKSPACE_CONTROLS_STORAGE_KEY)
+  } catch {
+    return {}
+  }
+  if (raw === null) return {}
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {}
+    return parsed as ControlsMap
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * Persist the controls map best-effort: a quota/security exception is swallowed. When
+ * the map is empty the whole key is REMOVED (not stored as `'{}'`), so an emptied store
+ * leaves no dangling blob behind.
+ */
+function writeMap(storage: WorkspaceControlsStorage, map: ControlsMap): void {
+  try {
+    if (Object.keys(map).length === 0) {
+      storage.removeItem(WORKSPACE_CONTROLS_STORAGE_KEY)
+      return
+    }
+    storage.setItem(WORKSPACE_CONTROLS_STORAGE_KEY, JSON.stringify(map))
+  } catch {
+    // Best-effort: a full/blocked storage must never throw from a bind.
+  }
+}
+
+/**
+ * The cached controls for a Workspace, or null when absent/malformed. Never throws —
+ * the draft branch reads this to stand in for the not-yet-bound session's controls.
+ */
+export function getWorkspaceControls(
+  storage: WorkspaceControlsStorage | null | undefined,
+  key: string,
+): ThreadAgentControls | null {
+  const entry = readMap(storage)[key]
+  return entry === undefined ? null : normalizeControls(entry)
+}
+
+/**
+ * Cache a Workspace's controls (patching just that key, leaving other Workspaces
+ * intact) — called on `thread:bound` when the session reports a non-null bundle so the
+ * next draft in this Workspace shows the picker. Best-effort; a store failure is a
+ * silent no-op (the picker just stays cold until the next bind).
+ */
+export function setWorkspaceControls(
+  storage: WorkspaceControlsStorage | null | undefined,
+  key: string,
+  controls: ThreadAgentControls,
+): void {
+  if (!storage) return
+  // Skip an all-null bundle so caching stays MONOTONIC: a degraded bind/resume that
+  // reports no axes must not clobber a Workspace's already-good cache (which would send
+  // the next draft back to a cold, picker-less state). An all-null bundle caches nothing
+  // useful anyway — the draft branch renders nothing from it.
+  if (!controls.modes && !controls.models && !controls.reasoningEffort) return
+  const map = readMap(storage)
+  map[key] = controls
+  writeMap(storage, map)
+}


### PR DESCRIPTION
Closes #153. The composer's **Mode / Model / Reasoning-effort** pickers (`AgentControls`, ADR-0007) only appeared **after** the user's first message. Root cause: a draft opens no ACP session (ADR-0011 lazy binding), so its connection advertises all-null controls → `AgentControls` renders nothing until `session/new` reports the option lists on `thread:bound`.

## Fix (renderer-only, no protocol change)
Cache the last bound session's control **option lists** per Workspace and project them onto a draft via the existing `draftControls`, so the picker shows immediately.

- **New store** `src/renderer/src/connection/workspace-controls-store.ts` (+ 21 tests) — pure module over an injected `Storage` seam, mirroring `composer-draft-store` / `project-open-store`. Versioned key `vibe-mistro:workspace-controls:v1`, map `{ [workspaceKey]: ThreadAgentControls }`. Throw / malformed / absent / non-object / array tolerant (never throws into render or the bind callback). `workspaceControlsKey(workspaceId, workspaceDir)` = `workspaceId || workspaceDir`.
- **App.tsx wiring** (+28/−2) — WRITE in `onBound` when a bind reports non-null controls; READ in the draft branch: `getWorkspaceControls(…) ?? connectionControlsOf(conn)` fed to `draftControls`. `draftControls` logic unchanged.

## Why it's safe
- **Live values always win.** The cache is read ONLY in the draft branch, gated behind `configFor(...) ?? …`. Once a session binds, `configFor` is non-null and short-circuits before the cache is ever consulted — the real session's Mode/Model/effort override it. Pure pre-bind stand-in.
- **No eager session.** Nothing creates an ACP `session/new` any earlier than today (ADR-0011 boundary intact). No new IPC, no main/preload/ipc.ts change, no JSONL/metadata writes.
- **Cold case (accepted):** a brand-new Workspace never prompted before shows no pickers until its first message (no cache yet).

## Review folds (both defense-in-depth)
- **S1** — `normalizeControls` now nulls out any axis whose list field (`availableModes`/`availableModels`/`options`) isn't an array, so a tampered / version-skewed blob can't reach `AgentControls`'s unguarded `.map()` and crash the render (honors the module's own docstring).
- **N1** — `setWorkspaceControls` skips an all-null bundle, so a degraded bind/resume can't clobber a Workspace's already-good cache (caching is now monotonic).

## Verification
- Gates green: `bun run lint && bun run typecheck && bun run build && bun run test` → **612 passed** (+21 new).
- Independent lead verify (read store + wiring, re-ran gates) + adversarial review (verdict: ship; live-values-win / cross-workspace isolation / store hygiene all confirmed safe).
- Live `bun run dev` smoke recommended: open a previously-prompted Workspace → New chat → picker present pre-prompt; pre-pick a non-default Mode → first turn runs in it; picker self-corrects to the real session values after bind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)