### PR TITLE
#157: eager primary ACP session at connect, reused by first prompt (ADR-0012)

### DIFF
--- a/docs/adr/0012-eager-primary-session-at-connect-reused-by-first-prompt.md
+++ b/docs/adr/0012-eager-primary-session-at-connect-reused-by-first-prompt.md
@@ -1,0 +1,124 @@
+# Open one primary ACP session per Workspace at connect, reused by the first prompt
+
+**Status: ACCEPTED** (2026-07-01). Amends **ADR-0011** — reverses its decision #2 ("No eager
+`session/new`") while preserving its core invariant (#1: no persisted Thread/transcript residue until the
+first prompt). Builds on **ADR-0006** (warm agent pool) and **ADR-0007** (agent controls are Vibe-owned,
+surfaced only by `session/new`/`session/load`).
+
+## Context
+
+The composer's **Mode / Model / Reasoning-effort** pickers are empty on a fresh Draft — they only appear
+after the first prompt. Root cause is protocol-shaped and confirmed against ground truth: vibe-acp
+advertises the control option lists ONLY in the `session/new` / `session/load` response, never at
+`initialize` (`docs/acp-capture.md:23-35`). We are a **thin orchestrator (ADR-0002)** and deliberately
+keep **no** client-side model/mode registry — so with no session there is nothing to populate the picker
+from. (Contrast t3code, which shows its pickers pre-prompt precisely because it *owns* a client-side
+provider/model registry — `ServerProviderModel[]` from its contracts layer — a design we rejected under
+ADR-0002 because Vibe owns the lists and they are per-account, e.g. vision only on `mistral-medium-3.5`.)
+
+ADR-0011 anticipated this exact gap and deferred it: "the very first Thread (no session yet) is
+unavoidable." **#153** shipped the enhancement it predicted — a per-Workspace controls cache — which makes
+the picker appear on drafts **after** a Workspace has bound at least once. But the **first-ever draft** in a
+Workspace (or after a cache-clear) is still bare, and that is the moment a user most often meets the app.
+This ADR closes that last gap by giving every Draft a real session's controls to read from, immediately.
+
+## Decision
+
+1. **One primary ACP session per Workspace, opened at connect.** When a Workspace connects and its agent
+   is warm (ADR-0006), open a single `session/new` and keep its `sessionId` + reported controls on the
+   connection as the Workspace's **primary session**. This seeds `connectionControlsOf(conn)` with real,
+   account-accurate option lists, so a Draft's picker renders on the first paint — no prompt required.
+
+2. **The first prompt REUSES the primary session; it does not mint a second.** A Draft's first prompt
+   binds to the Workspace's unconsumed primary session (marking it consumed) instead of calling a fresh
+   `session/new`. In the common case (the user does prompt) the eager session is *the* session the Thread
+   uses — not waste. If the primary session is already consumed (a second concurrent Draft, or the first
+   Thread already bound), the next first-prompt mints a new session exactly as today.
+
+3. **ADR-0011's residue invariant is preserved unchanged.** First prompt remains the single durability
+   trigger: **no metadata record and no transcript file** is written for a Thread until it binds. An idle
+   primary ACP session is an in-memory protocol handle on `vibe-acp`, **not** persisted state — the
+   metadata Thread list still contains only prompted Threads. Opening/clicking Workspaces still writes zero
+   Threads to `metadata.json`.
+
+4. **The connection retains the option lists for the Workspace's lifetime**, independent of which session
+   provided them. Once learned (from the primary session, or restored from the #153 cache before it
+   responds), every subsequent Draft AND every not-yet-resumed Continue in that Workspace shows the picker —
+   not just the first Draft. This also closes the identical picker gap on the Continue flow that ADR-0011
+   left open (`continueConnection` hard-codes null controls until the lazy resume).
+
+5. **#153's cache becomes the fast path, not the mechanism.** The cache still seeds the picker instantly on
+   connect (surviving restarts, covering the window before the primary `session/new` returns) and the
+   eager primary session provides the authoritative, live values that the cache is then refreshed from.
+   Belt and suspenders; neither is removed.
+
+6. **Bounded lifetime.** A primary session for a Workspace the user opens but never prompts is torn down
+   when its agent is idle-evicted / LRU-capped (ADR-0006) — the same bound that already governs warm
+   agents. At most one idle session per warm Workspace.
+
+## Why
+
+The value that was "not worth it" when ADR-0011 was written now is: the app has a final design whose
+composer shows the controls up front, and the empty-first-draft picker reads as broken (it prompted this
+ADR). The two reasons ADR-0011 gave for rejecting eager `session/new` are answered rather than ignored:
+
+- **"Session churn / usually-abandoned sessions."** ADR-0011's rejected option opened a session on *every*
+  Workspace click and *deferred only the record*, so the session was pure overhead. Decision #2 here makes
+  the eager session **the first Thread's session** (reuse), so in the prompted case there is no extra
+  session at all — the handshake simply moves from first-prompt to connect. Only the opened-but-never-
+  prompted Workspace leaves one idle session, and #6 bounds that. Churn is per-Workspace-connect, not
+  per-click.
+- **"Two entry points diverge at the protocol layer."** They still converge: a Draft from either door (the
+  + button or Workspace-open) reuses the same per-Workspace primary session on its first prompt. One
+  session rule, one persistence rule, both doors.
+
+Net: the first-prompt latency *improves* (session already open), the picker is populated everywhere, and
+the only new cost is a bounded idle session in the abandon case — which is strictly less residue than the
+pre-ADR-0011 world (no empty Thread, no metadata write).
+
+## Considered options
+
+- **Keep ADR-0011 + the #153 cache only (status quo)** — rejected as insufficient: the first-ever draft in
+  a Workspace stays bare, which is the exact complaint. The cache cannot invent options with no session.
+- **Client-side model/mode registry (the t3code approach)** — rejected: violates ADR-0002 (thin
+  orchestrator; Vibe owns the lists) and would drift from Vibe's real, per-account, per-version option sets
+  (models differ by account; modes/effort can change across vibe-acp versions). A hardcoded list would lie.
+- **Eager session at connect, WITHOUT reuse (mint a fresh one on first prompt anyway)** — rejected: that is
+  ADR-0011's rejected "defer only the record" option verbatim — real churn, an abandoned session every
+  connect. Reuse (#2) is what makes this defensible.
+- **Eager `initialize`-only probe for controls** — impossible: `initialize` carries no model/mode data
+  (`acp-capture.md:23-35`).
+- **Open the primary session lazily on first *Workspace select* rather than connect** — folded in: "at
+  connect" here means when the agent is warm and the Workspace is selected; a background/never-selected
+  Workspace need not pay it. Implementation may open it on first select of a connected Workspace.
+
+## Consequences
+
+- **`thread-binding.ts` gains a reuse branch.** A Draft's first prompt checks for the Workspace's unconsumed
+  primary `sessionId` and binds to it (persist + `mintAndBind` semantics unchanged apart from the session
+  source); absent/consumed → mint as today. A "consumed" flag lives on the connection/primary-session state.
+- **Connect grows a `session/new`.** Selecting a connected Workspace opens one session and threads its
+  controls onto the connection (App seeds `configFor`/draft controls from it, same shape #75/#153 already
+  consume). One extra round-trip on connect, on an already-warm process (a handshake, not a spawn).
+- **The first draft's picker is populated on first paint** (from the #153 cache if present, then reconciled
+  to the primary session's live values). The first-ever Draft in a never-prompted Workspace now shows the
+  picker too — the case ADR-0011 called "unavoidable" becomes avoidable, at the cost of one bounded session.
+- **Continue-flow picker gap also closes:** a reopened, not-yet-resumed Thread shows the Workspace's option
+  lists instead of null controls.
+- **One idle ACP session per opened-but-never-prompted Workspace**, torn down on agent eviction (ADR-0006).
+  This is the entire new cost, and it is bounded by the existing warm-agent policy.
+- **Eviction / re-warm:** when an evicted Workspace is re-selected, the primary session is re-opened on
+  re-warm (transparent, like agent re-warm today). The #153 cache covers the picker during the gap.
+- **Supersedes ADR-0011 decision #2 only.** ADR-0011 decisions #1 (first-prompt durability trigger), #3
+  (both entry points identical), and #4 (Workspace metadata persists on open) remain in force. ADR-0005
+  (storage engine) and ADR-0006 (warm pool) are unaffected.
+
+## Rollout
+
+A single tracer-bullet slice (renderer + main): (1) open the primary session on connect and thread its
+controls onto the connection; (2) `thread-binding` reuse branch + consumed flag; (3) keep #153 as the
+instant-paint cache. Behavior-identical to today except the picker now shows pre-prompt and the first
+prompt reuses the primary session. Gates: `bun run lint && bun run typecheck && bun run build && bun run test`.
+Live-smoke: open a never-prompted Workspace → New chat → pickers present immediately; send first prompt →
+it reuses the primary session (no second `session/new`); open a second concurrent Draft → its first prompt
+mints its own session.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -363,14 +363,20 @@ function draftConnection(
 ): ThreadConnection {
   const threadId = randomUUID()
   transcriptThreads.set(agentId, threadId)
+  // Seed the picker from the Workspace's eager primary session (ADR-0012) so a
+  // fresh draft shows Mode/Model/effort on first paint. `sessionId` stays null —
+  // the draft is still a renderer-only unbound Thread (ADR-0011); the primary
+  // sessionId is a main-side detail its first prompt claims. Null-safe -> today's
+  // all-null behavior when no primary session opened (best-effort failure).
+  const controls = agent.primarySessionControls
   return {
     agentId,
     workspaceDir: agent.workspaceDir,
     sessionId: null,
     title: null,
-    modes: null,
-    models: null,
-    reasoningEffort: null,
+    modes: controls?.modes ?? null,
+    models: controls?.models ?? null,
+    reasoningEffort: controls?.reasoningEffort ?? null,
     threadId,
     workspaceId: workspaceId ?? randomUUID(),
     signOutAvailable: agent.signOutAvailable,
@@ -400,12 +406,18 @@ async function bindThreadSession(
   // prompt (last-write-wins, and only the active Thread prompts at a time).
   transcriptThreads.set(args.agentId, args.threadId)
   if (metadataStore) {
+    // A draft's first prompt (sessionId null) claims the Workspace's eager primary
+    // session (ADR-0012), so it binds to that instead of minting a SECOND
+    // `session/new`; consumed once, so a second concurrent draft mints its own.
+    // Never claimed for a reopened/already-bound Thread (those aren't case (i)).
+    const preopened = args.sessionId === null ? (agent.consumePrimarySession() ?? undefined) : undefined
     const bound = await ensureBoundSession({
       agent,
       store: metadataStore,
       threadId: args.threadId,
       workspaceId: args.workspaceId,
       sessionId: args.sessionId,
+      preopened,
     })
     return { sessionId: bound.sessionId, minted: bound.minted, rebound: bound.rebound, controls: bound.controls }
   }
@@ -458,14 +470,19 @@ function continueConnection(
   const target = resolveContinueTarget(metadataStore, threadId)
   if (!target) return null
   transcriptThreads.set(agentId, target.threadId)
+  // Seed the picker from the Workspace's eager primary session (ADR-0012 #4), closing
+  // the Continue-flow gap ADR-0011 left open: a reopened, not-yet-resumed Thread shows
+  // the Workspace's option lists instead of null controls until its lazy `session/load`
+  // reports its own. Null-safe -> today's all-null when no primary session opened.
+  const controls = agent.primarySessionControls
   return {
     agentId,
     workspaceDir: agent.workspaceDir,
     sessionId: target.sessionId,
     title: target.title,
-    modes: null,
-    models: null,
-    reasoningEffort: null,
+    modes: controls?.modes ?? null,
+    models: controls?.models ?? null,
+    reasoningEffort: controls?.reasoningEffort ?? null,
     threadId: target.threadId,
     workspaceId: target.workspaceId,
     signOutAvailable: agent.signOutAvailable,
@@ -686,6 +703,18 @@ function registerIpc(): void {
         return { ok: false, kind: 'not-signed-in', agentId, workspaceDir: args.workspaceDir, authMethods: agent.authMethods }
       }
 
+      // Open the Workspace's eager primary session (ADR-0012) so a draft's/continue's
+      // picker reads real controls pre-prompt, and the first prompt REUSES it (no
+      // second `session/new`). Best-effort: a `session/new` failure must NOT break
+      // connect — fall back to a null-controls draft (the #153 cache still covers the
+      // picker). Signed-in was just checked, so a -32000 shouldn't happen; catch
+      // defensively anyway. A no-op on a re-select whose agent already opened one.
+      try {
+        await agent.openPrimarySession()
+      } catch {
+        // Swallow: connect proceeds with a null-controls draft/continue connection.
+      }
+
       // Continue from the cold launch list (TB4 #33): connect to the EXISTING
       // Thread (its first prompt drives the lazy `session/load` resume) without
       // opening — and persisting — a throwaway empty Thread. Falls through to a
@@ -714,6 +743,14 @@ function registerIpc(): void {
     if (!agent) return { ok: false, kind: 'error', error: `No active agent for id ${args.agentId}.`, hint: null }
     pool.touch(args.agentId) // landing in a Thread is activity — outrank idle peers (TB5 #50)
     const workspaceId = await recordWorkspaceOpen(agent.workspaceDir)
+    // Open the eager primary session (ADR-0012) for this post-sign-in draft too, so
+    // its picker reads real controls and its first prompt reuses it. Best-effort —
+    // a failure falls back to a null-controls draft. No-op if one is already open.
+    try {
+      await agent.openPrimarySession()
+    } catch {
+      // Swallow: the draft connection is still returned (null-controls fallback).
+    }
     return { ok: true, thread: draftConnection(args.agentId, agent, workspaceId) }
   })
 

--- a/src/main/thread-binding.test.ts
+++ b/src/main/thread-binding.test.ts
@@ -122,6 +122,65 @@ describe('ensureBoundSession', () => {
     expect(second.sessionId).toBe('sess-1')
   })
 
+  it('reuses a preopened primary session on first prompt — binds it, NO session/new (ADR-0012)', async () => {
+    const store = new MetadataStore({ filePath: join(dir, 'reuse.json') })
+    await store.load()
+    const ws = await store.upsertWorkspace({ dir: '/proj/reuse' })
+    const threadId = randomUUID()
+    const agent = fakeOpener()
+    // The Workspace's eager primary session, opened at connect (its controls seeded
+    // the draft's picker). Its `session/new` already ran — the first prompt reuses it.
+    const preopened: ThreadInfo = {
+      sessionId: 'primary-1',
+      title: 'Primary',
+      modes: { currentModeId: 'default', availableModes: [] },
+      models: null,
+      reasoningEffort: null,
+    }
+
+    const bound = await ensureBoundSession({
+      agent,
+      store,
+      threadId,
+      workspaceId: ws.id,
+      sessionId: null,
+      preopened,
+    })
+
+    expect(agent.calls).toBe(0) // the eager session is reused — no SECOND session/new
+    expect(bound.minted).toBe(true) // this call newly bound the Thread to a session
+    expect(bound.sessionId).toBe('primary-1')
+    // The reused session's controls flow to the renderer's `thread:bound` (#153 cache).
+    expect(bound.controls).toEqual({ modes: preopened.modes, models: null, reasoningEffort: null })
+
+    // Bound onto the SAME Thread id, carrying the primary sessionId as the resume cursor.
+    const threads = store.snapshot().threads
+    expect(threads).toHaveLength(1)
+    expect(threads[0]?.id).toBe(threadId)
+    expect(threads[0]?.sessionId).toBe('primary-1')
+  })
+
+  it('mints a fresh session/new for a draft when NO preopened primary session is supplied', async () => {
+    const store = new MetadataStore({ filePath: join(dir, 'no-preopen.json') })
+    await store.load()
+    const ws = await store.upsertWorkspace({ dir: '/proj/no-preopen' })
+    const agent = fakeOpener()
+
+    // A second concurrent draft (primary already consumed) passes no preopened session.
+    const bound = await ensureBoundSession({
+      agent,
+      store,
+      threadId: randomUUID(),
+      workspaceId: ws.id,
+      sessionId: null,
+      preopened: undefined,
+    })
+
+    expect(agent.calls).toBe(1) // mints its own session
+    expect(bound.minted).toBe(true)
+    expect(bound.sessionId).toBe('sess-1')
+  })
+
   it('binds two drafts under one agent to two distinct sessions (multi-Thread per Workspace)', async () => {
     const store = new MetadataStore({ filePath: join(dir, 'multi.json') })
     await store.load()

--- a/src/main/thread-binding.ts
+++ b/src/main/thread-binding.ts
@@ -123,6 +123,12 @@ export interface BoundSession {
  * This is the fix for the reopened-Thread bug: before TB4, case (ii) returned the
  * stored sessionId untouched, so `agent.prompt` threw `No open Thread` because the
  * fresh agent's session map was empty (it never resumed the session).
+ *
+ * `preopened` (ADR-0012) is the Workspace's unconsumed PRIMARY session — opened
+ * eagerly at connect. When a draft (case i) has one, the first prompt BINDS to it
+ * instead of minting a second `session/new` (the eager session IS this Thread's
+ * session). Only case (i) reads it; the caller passes it only for a draft and only
+ * once (it claims it via `consumePrimarySession`).
  */
 export async function ensureBoundSession(args: {
   agent: SessionBinder
@@ -130,9 +136,14 @@ export async function ensureBoundSession(args: {
   threadId: string
   workspaceId: string
   sessionId: string | null
+  preopened?: ThreadInfo
 }): Promise<BoundSession> {
-  // (i) draft: mint a fresh session and bind it.
-  if (!args.sessionId) return mintAndBind(args)
+  // (i) draft: bind the Workspace's unconsumed primary session if one was opened at
+  // connect (ADR-0012 — no second session/new), else mint a fresh one. Either way
+  // the session is bound onto THIS Thread id.
+  if (!args.sessionId) {
+    return args.preopened ? bindThread(args, args.preopened) : mintAndBind(args)
+  }
 
   // (iii) already hosted this run: reuse with no load/new — no fresh result, so no
   // controls to hand the renderer (it keeps whatever it already holds for this Thread).
@@ -163,7 +174,19 @@ async function mintAndBind(args: {
   threadId: string
   workspaceId: string
 }): Promise<BoundSession> {
-  const thread = await args.agent.openThread()
+  return bindThread(args, await args.agent.openThread())
+}
+
+/**
+ * Bind an ALREADY-OPEN session (a fresh `session/new`, or ADR-0012's reused primary
+ * session) onto the Thread id: upsert the record by id (preserving `createdAt`) and
+ * report the bind as `minted` with the session's reported controls. No agent call —
+ * the session/new already ran (at mint or eagerly at connect).
+ */
+async function bindThread(
+  args: { store: ThreadBindStore; threadId: string; workspaceId: string },
+  thread: ThreadInfo,
+): Promise<BoundSession> {
   await args.store.upsertThread({
     id: args.threadId,
     workspaceId: args.workspaceId,

--- a/src/main/workspace-agent.test.ts
+++ b/src/main/workspace-agent.test.ts
@@ -1441,3 +1441,100 @@ describe('WorkspaceAgent agent controls (#66, acp-capture §10)', () => {
     expect(info.reasoningEffort).toBeNull()
   })
 })
+
+/**
+ * Eager primary session (ADR-0012): one `session/new` opened at connect, whose
+ * controls seed a Draft's picker and whose session the first prompt reuses.
+ * Consume-once semantics keep a second concurrent Draft minting its own session.
+ */
+describe('WorkspaceAgent primary session (ADR-0012)', () => {
+  const PRIMARY_ID = 'primary-0001'
+
+  /** Drive start() to a ready, signed-in agent WITHOUT opening a Thread. */
+  async function startReady(fake: CapturingFake): Promise<WorkspaceAgent> {
+    const agent = new WorkspaceAgent({ workspaceDir: '/abs/workspace', spawn: () => fake.child })
+    const started = agent.start()
+    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: 1, result: { protocolVersion: 1 } }) + '\n')
+    await new Promise((r) => setTimeout(r, 0))
+    fake.feed(
+      JSON.stringify({ jsonrpc: '2.0', id: 2, result: { authenticated: true, authState: 'os_keyring' } }) + '\n',
+    )
+    await started
+    return agent
+  }
+
+  it('opens ONE primary session, exposes its controls, and consumes it exactly once', async () => {
+    const fake = makeCapturingFake()
+    const agent = await startReady(fake)
+
+    // Nothing before the eager open: no controls, nothing to consume.
+    expect(agent.primarySessionControls).toBeNull()
+    expect(agent.consumePrimarySession()).toBeNull()
+
+    const opening = agent.openPrimarySession()
+    // The eager session/new (id 3) — answer with a real Mode control.
+    fake.feed(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 3,
+        result: { sessionId: PRIMARY_ID, modes: { currentModeId: 'default', availableModes: [] } },
+      }) + '\n',
+    )
+    await opening
+
+    // Controls readable from the primary session (seed a Draft's picker pre-prompt).
+    expect(agent.primarySessionControls).toEqual({
+      modes: { currentModeId: 'default', availableModes: [] },
+      models: null,
+      reasoningEffort: null,
+    })
+    // Hosted — so the bound Thread's later prompts reuse it (already-hosted path).
+    expect(agent.hasSession(PRIMARY_ID)).toBe(true)
+
+    // Idempotent: a second openPrimarySession sends NO second session/new.
+    await agent.openPrimarySession()
+    expect(sent(fake).filter((m) => m.method === 'session/new')).toHaveLength(1)
+
+    // Consume once: returns the ThreadInfo, then null on any later claim.
+    expect(agent.consumePrimarySession()?.sessionId).toBe(PRIMARY_ID)
+    expect(agent.consumePrimarySession()).toBeNull()
+
+    // Controls stay readable after consume (learned lists for the connection's life).
+    expect(agent.primarySessionControls).not.toBeNull()
+  })
+
+  it('two concurrent openPrimarySession calls share ONE session/new (ADR-0012, no race)', async () => {
+    const fake = makeCapturingFake()
+    const agent = await startReady(fake)
+
+    // Overlapping connects on the SAME agent (e.g. Workspace double-click): both call
+    // openPrimarySession before either resolves. They must dedupe to one session/new.
+    const first = agent.openPrimarySession()
+    const second = agent.openPrimarySession()
+    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: 3, result: { sessionId: PRIMARY_ID } }) + '\n')
+    await Promise.all([first, second])
+
+    expect(sent(fake).filter((m) => m.method === 'session/new')).toHaveLength(1)
+    expect(agent.hasSession(PRIMARY_ID)).toBe(true)
+    // Exactly one session to consume, then null.
+    expect(agent.consumePrimarySession()?.sessionId).toBe(PRIMARY_ID)
+    expect(agent.consumePrimarySession()).toBeNull()
+  })
+
+  it('drops the primary session on stop() (eviction) — a re-warm re-opens one', async () => {
+    const fake = makeCapturingFake()
+    const agent = await startReady(fake)
+
+    const opening = agent.openPrimarySession()
+    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: 3, result: { sessionId: PRIMARY_ID } }) + '\n')
+    await opening
+    expect(agent.primarySessionControls).not.toBeNull()
+
+    agent.stop()
+
+    // Torn down with the process (ADR-0012 #6 / ADR-0006): no lingering session.
+    expect(agent.primarySessionControls).toBeNull()
+    expect(agent.consumePrimarySession()).toBeNull()
+    expect(agent.hasSession(PRIMARY_ID)).toBe(false)
+  })
+})

--- a/src/main/workspace-agent.ts
+++ b/src/main/workspace-agent.ts
@@ -9,6 +9,7 @@ import type {
   AuthState,
   PromptImage,
   PromptResult,
+  ThreadAgentControls,
   ThreadInfo,
   ThreadModes,
   ThreadModels,
@@ -28,6 +29,16 @@ import type {
 
 const PROTOCOL_VERSION = 1
 const CLIENT_INFO = { name: 'vibe-mistro', version: '0.0.1' } as const
+
+/**
+ * How long connect will WAIT for the eager primary `session/new` (ADR-0012) before
+ * returning without it. `AcpClient.request` has no timeout of its own, so a live-but-
+ * unresponsive agent would otherwise wedge connect at "Launching…"; this caps that.
+ * The session still resolves in the background and seeds later drafts + the first-
+ * prompt reuse, and the #153 cache covers the picker meanwhile. The handshake replies
+ * in ~1s (acp-capture), so this is generous headroom, not a normal-path wait.
+ */
+const PRIMARY_SESSION_OPEN_TIMEOUT_MS = 5000
 
 export const AUTH_HINT =
   'Run `vibe` to sign in, or `vibe --setup` to configure your Mistral Vibe account.'
@@ -122,6 +133,18 @@ export class WorkspaceAgent extends EventEmitter {
   private readonly openUrl?: (url: string) => void
   /** Threads hosted by this agent, keyed by their ACP `sessionId`. */
   private readonly threads = new Map<string, ThreadInfo>()
+  /**
+   * The Workspace's single primary ACP session (ADR-0012): one `session/new`
+   * opened eagerly at connect so a Draft's picker can read real, account-accurate
+   * control option lists BEFORE its first prompt — and REUSED by that first prompt
+   * (no second `session/new`). In-memory only (NOT persisted — ADR-0011's residue
+   * invariant holds); dropped on teardown (`stop()`), so eviction frees it and a
+   * re-warm re-opens one. `primaryConsumed` gives the reuse consume-once semantics.
+   */
+  private primarySessionValue: ThreadInfo | null = null
+  private primaryConsumed = false
+  /** The single in-flight primary `session/new`, shared by concurrent openers. */
+  private primaryOpening: Promise<void> | null = null
   private initialized = false
   /** Sign-in state detected via `_auth/status` during start(). */
   private authStateValue: AuthState = 'unknown'
@@ -485,6 +508,71 @@ export class WorkspaceAgent extends EventEmitter {
   }
 
   /**
+   * Open the Workspace's single primary ACP session (ADR-0012), if none is open
+   * yet — one `session/new` whose reported controls seed a Draft's picker pre-prompt
+   * and whose session the first prompt REUSES (via `consumePrimarySession`) instead
+   * of minting a second. Idempotent: a no-op once a primary session exists, so the
+   * two connect entry points (Workspace-open, post-sign-in openThread) never open two.
+   * Best-effort at the caller — a failure must not break connect, so callers wrap
+   * this in try/catch and fall back to a null-controls draft.
+   *
+   * Concurrency-safe: overlapping connects on the SAME agent share one in-flight
+   * `session/new` (never mint two — ADR-0012's "exactly one"). And the wait is BOUNDED
+   * by `PRIMARY_SESSION_OPEN_TIMEOUT_MS` so a slow/unresponsive agent can't wedge
+   * connect; a late-resolving session is still stored in the background for later
+   * drafts + the first-prompt reuse.
+   */
+  async openPrimarySession(): Promise<void> {
+    if (this.primarySessionValue) return
+    if (!this.primaryOpening) {
+      this.primaryOpening = this.openThread()
+        .then((info) => {
+          this.primarySessionValue = info
+        })
+        .catch(() => {
+          // Best-effort: leave the value null so a later connect retries the open.
+        })
+        .finally(() => {
+          this.primaryOpening = null
+        })
+    }
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const bound = new Promise<void>((resolve) => {
+      timer = setTimeout(resolve, PRIMARY_SESSION_OPEN_TIMEOUT_MS)
+    })
+    try {
+      await Promise.race([this.primaryOpening, bound])
+    } finally {
+      if (timer) clearTimeout(timer)
+    }
+  }
+
+  /**
+   * The primary session's agent-controls (#70), for seeding a Draft's / Continue's
+   * connection picker (ADR-0012 #4) — the learned option lists for the Workspace's
+   * lifetime, readable even after the session is consumed by a first prompt. Null
+   * until `openPrimarySession` succeeds (and again after an eviction re-warm, until
+   * it re-opens).
+   */
+  get primarySessionControls(): ThreadAgentControls | null {
+    const s = this.primarySessionValue
+    return s ? { modes: s.modes, models: s.models, reasoningEffort: s.reasoningEffort } : null
+  }
+
+  /**
+   * Claim the unconsumed primary session for a Draft's FIRST prompt (ADR-0012 #2),
+   * marking it consumed so a second concurrent Draft mints its own session instead.
+   * Returns the primary `ThreadInfo` exactly once, then null (none open, or already
+   * claimed). The session stays hosted (`hasSession` stays true), so the bound
+   * Thread's later prompts reuse it via the already-hosted path — no re-mint.
+   */
+  consumePrimarySession(): ThreadInfo | null {
+    if (!this.primarySessionValue || this.primaryConsumed) return null
+    this.primaryConsumed = true
+    return this.primarySessionValue
+  }
+
+  /**
    * Resume a prior Thread's ACP session via `session/load` (TB4 #33, acp-capture
    * §9). Params mirror `session/new` but carry the stored `sessionId`; the success
    * result has NO `sessionId` (the caller already knows the id it loaded), so we
@@ -710,6 +798,11 @@ export class WorkspaceAgent extends EventEmitter {
   stop(): void {
     this.client.stop()
     this.threads.clear()
+    // Drop the primary session with the process (ADR-0012 #6 / ADR-0006): an
+    // idle un-prompted session dies on eviction, and a re-warm re-opens a fresh one.
+    this.primarySessionValue = null
+    this.primaryConsumed = false
+    this.primaryOpening = null
     this.initialized = false
   }
 


### PR DESCRIPTION
Closes #157. Implements **ADR-0012** (accepted; amends ADR-0011). Fixes the composer's Mode/Model/Reasoning pickers being empty on a **first-ever draft** — the case #153's cache can't cover because there's no session yet to learn the option lists from (Vibe surfaces them only via `session/new`/`session/load`; `initialize` carries none — `acp-capture.md:23-35`).

## What it does
- **Opens one primary ACP session per Workspace at connect** (`WorkspaceAgent.openPrimarySession`, best-effort). Its controls seed `draftConnection` / `continueConnection`, so the picker renders on first paint with no prompt.
- **The first prompt REUSES that session** instead of minting a second: `ensureBoundSession` case (i) binds the unconsumed primary (`consumePrimarySession`) via the new shared `bindThread` helper — no second `session/new`. A second concurrent draft mints its own.
- **ADR-0011 invariant preserved:** the primary session is an in-memory ACP handle, not persisted state — `draftConnection` still returns `sessionId: null`, no metadata/transcript write until the first prompt. Sidebar still lists only prompted Threads.
- **Bounded lifetime:** dropped in `stop()`, so eviction frees it and a re-warm re-opens one (ADR-0006).
- Also closes the Continue-flow picker gap (a reopened, not-yet-resumed Thread shows the Workspace's option lists).
- **No renderer change** — the renderer already consumes connection controls for a draft (#75/#153).

## Review folds (both SHOULD-FIX from adversarial review)
- **S1 — concurrency race:** `openPrimarySession`'s guard/assignment straddled an `await`, so two overlapping connects could mint two sessions. Now a single shared in-flight promise (`primaryOpening`) dedupes concurrent opens to one `session/new` (+ regression test).
- **S2 — connect-wedge risk:** `AcpClient.request` has no timeout, so awaiting the primary `session/new` on the connect critical path could wedge connect at "Launching…" against a live-but-unresponsive agent. The wait is now **bounded** (`PRIMARY_SESSION_OPEN_TIMEOUT_MS = 5s`); a slow session still resolves in the background for later drafts + the reuse, and the #153 cache covers the picker meanwhile.

## Verification
- Gates green: **617 tests** (`lint && typecheck && build && test`). Reuse ("exactly one `session/new`") and eviction-cleanup are asserted directly; concurrency dedupe covered.
- Independent lead verify (read all diffs, traced multi-draft / continue / degraded / best-effort-failure paths) + adversarial review (verdict fix-then-ship → S1/S2 folded).

## Accepted, non-blocking (documented in review)
- **N1 consume-then-fail orphan** (draft prompt consumes the primary then `upsertThread` throws → orphaned session): eviction-bounded, residue-invariant intact, same class as pre-#157 `mintAndBind`.
- **N2 degraded mode** (no metadataStore): primary opened but not reused → draft mints its own (2 sessions, orphan). Picker still works; rare best-effort path, eviction-bounded.

## Live smoke recommended
Open a never-prompted Workspace → New chat → pickers present immediately; send first prompt → it reuses the primary (no second `session/new`); open a second concurrent draft → its prompt mints its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)