### PR TITLE
design: adopt Geist (Vercel) as the app font

### DIFF
--- a/docs/design-tokens.md
+++ b/docs/design-tokens.md
@@ -64,9 +64,9 @@ bridged into Tailwind v4 via `@theme inline`. **Warm neutrals · softer gradient
 Bridge into `@theme` so `rounded-md`/`rounded-2xl` map to these (undo the current all-zero override).
 
 ## Typography
-- **UI stack:** `-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', system-ui, sans-serif`
-- **Mono stack:** `'SF Mono', ui-monospace, 'Menlo', monospace` (code, terminal)
-- No webfont loaded — system fonts.
+- **UI stack (`--font-sans`):** `'Geist Variable', -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', system-ui, sans-serif`
+- **Mono stack (`--font-mono`):** `'Geist Mono Variable', ui-monospace, SFMono-Regular, 'Menlo', monospace` (code, terminal)
+- **Geist (Vercel)** is now the app font — bundled OFFLINE via `@fontsource-variable/geist` + `@fontsource-variable/geist-mono` (imported in `main.tsx`), defined as `--font-sans`/`--font-mono` in `@theme` (so Tailwind `font-sans`/`font-mono` utilities resolve to them too). System fonts remain the fallback if Geist ever fails to load. CSP allows the bundled woff2 via `font-src 'self' data:`.
 
 | Role | size | weight | line-height | tracking |
 |---|---|---|---|---|

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
+    "@fontsource-variable/geist": "^5.2.9",
+    "@fontsource-variable/geist-mono": "^5.2.8",
     "@pierre/diffs": "^1.2.12",
     "@tailwindcss/vite": "^4",
     "chokidar": "^5.0.0",

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' data:"
     />
     <title>Vibe Mistro</title>
   </head>

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -1,6 +1,10 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { App } from './App'
+// Geist (Vercel) — bundled offline via @fontsource-variable, before styles.css so the
+// @font-face rules (and their bundled woff2) are registered when the tokens reference them.
+import '@fontsource-variable/geist'
+import '@fontsource-variable/geist-mono'
 import './styles.css'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -75,7 +75,7 @@
      generated --spacing (4px-based) already covers this range via `p-*`/`gap-*`
      utilities — intentionally NOT redefining a parallel spacing var scheme here. */
 
-  font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', system-ui, sans-serif;
+  font-family: var(--font-sans);
 }
 
 /* Bridge the brand tokens into Tailwind v4's theme so utilities resolve to the
@@ -111,6 +111,16 @@
    self-reference against the :root token of the same name (TRAP 1: that
    collision silently resolves to invalid → border-radius falls back to 0). */
 @theme {
+  /* Fonts — Geist (Vercel), bundled OFFLINE via @fontsource-variable (imported in
+     main.tsx; variable weight 100–900). Defined in `@theme` so `font-sans`/`font-mono`
+     utilities resolve to them (the streamdown Response layer #114 uses `font-mono`),
+     and `var(--font-sans)`/`var(--font-mono)` drive the base + `.mono`/code rules.
+     System fonts stay as the fallback if Geist ever fails to load. */
+  --font-sans:
+    'Geist Variable', -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', system-ui,
+    sans-serif;
+  --font-mono: 'Geist Mono Variable', ui-monospace, SFMono-Regular, Menlo, monospace;
+
   --radius-sm: 7px; /* icon buttons / window controls */
   --radius-md: 10px; /* nav items */
   --radius-lg: 12px; /* pill */
@@ -257,7 +267,7 @@ body {
 
 .hint code,
 .mono {
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: var(--font-mono);
   font-size: 12px;
 }
 
@@ -676,7 +686,7 @@ body {
 }
 
 .chat-md code {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 0.9em;
   background: var(--accent-tint);
   border: 1px solid var(--border);


### PR DESCRIPTION
Swaps the app off system fonts onto **Geist** (Vercel) — **Geist Sans** for UI, **Geist Mono** for code/terminal.

## What
- Added **`@fontsource-variable/geist`** + **`@fontsource-variable/geist-mono`** (variable, weight 100–900), imported in `main.tsx` before `styles.css`. **Bundled OFFLINE** — no CDN, so it fits our strict CSP (11 woff2 subsets ship in `out/renderer/assets/`, verified in the build).
- Defined **`--font-sans`** / **`--font-mono`** in `@theme` (Geist first, system fonts as fallback). Pointed the base `:root` font + the `.mono`/code rules at `var(--font-sans)`/`var(--font-mono)`. Since they're `@theme` keys, Tailwind's `font-sans`/`font-mono` utilities also resolve to Geist — which the streamdown Response layer (#114) will use.
- CSP: added `font-src 'self' data:` for the bundled woff2.
- Updated `docs/design-tokens.md` typography.

## Notes
- For reference: **t3code** uses DM Sans + JetBrains Mono (via `@fontsource`); we went with **Geist**. The `geist` npm package is Next-only (`next/font`), so `@fontsource-variable/geist` is the right one for our Electron/Vite app.
- Reversible: system fonts remain the fallback; removing the two imports + reverting the stacks restores SF.

## Gates
`bun run lint && bun run typecheck && bun run build && bun run test` — all green, **617 tests**. Build bundles the Geist woff2; the built CSS carries the `@font-face` + `--font-sans`/`--font-mono`.

## Smoke (needs your eye)
The whole app should render in **Geist** (rounder, more geometric than SF), code/mono in **Geist Mono**. I can't run `bun run dev` headless — confirm the fonts actually load (no CSP block in the console) and you like the look. Easy to tune weights or fall back if not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)