### PR TITLE
sidebar: New chat always actionable + Search/Scheduled/Plugins marked "Soon"

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -377,6 +377,19 @@ export function App(): JSX.Element {
     else selectWorkspace(workspaceId)
   }
 
+  /**
+   * The sidebar's primary "New chat" — always actionable (no longer greyed out until a
+   * project happens to be connected). Targets the selected project, else the most-recent
+   * one (`recents` is most-recent-first); if there are NO projects yet, opens the project
+   * picker. Reuses `newThreadInWorkspace` (connect-if-needed), so a fresh app can start a
+   * chat in one click.
+   */
+  function startNewChat(): void {
+    const target = nav.selectedWorkspaceId ?? recents[0]?.id ?? null
+    if (target) newThreadInWorkspace(target)
+    else void openProject()
+  }
+
   useEffect(() => {
     void runDetect()
     void refreshRecents()
@@ -568,7 +581,6 @@ export function App(): JSX.Element {
   // cold/idle one lists its persisted Threads (clicking replays them, no agent).
   let rows: UnifiedThreadRow[] = []
   let protectedThreadId: string | null = null
-  let canCreateThread = false
   if (selectedWs) {
     const cold = threadsForWorkspace(recents, selectedWs)
     if (selected.status === 'connected') {
@@ -581,7 +593,6 @@ export function App(): JSX.Element {
         statuses,
       })
       protectedThreadId = conn.threadId
-      canCreateThread = true
     } else {
       rows = deriveUnifiedThreads({ cold, live: [], liveThreadIds: NO_LIVE, statuses })
     }
@@ -812,12 +823,11 @@ export function App(): JSX.Element {
         workspaceFlags={wsFlags}
         rows={rows}
         protectedThreadId={protectedThreadId}
-        canCreateThread={canCreateThread}
         outlet={outlet}
         opening={opening}
         onOpenProject={() => void openProject()}
         onSelectThread={selectThreadInWorkspace}
-        onNewThread={() => selectedWs && newThread(selectedWs)}
+        onNewThread={startNewChat}
         onNewThreadInWorkspace={newThreadInWorkspace}
         onDeleteThread={deleteThread}
         onSetThreadFlags={setThreadFlags}

--- a/src/renderer/src/shell/Shell.tsx
+++ b/src/renderer/src/shell/Shell.tsx
@@ -91,7 +91,6 @@ export function Shell({
   workspaceFlags,
   rows,
   protectedThreadId,
-  canCreateThread,
   outlet,
   opening,
   onOpenProject,
@@ -115,8 +114,6 @@ export function Shell({
   rows: UnifiedThreadRow[]
   /** The connection's primary Thread (never deletable mid-connection), or null. */
   protectedThreadId: string | null
-  /** Whether New-thread is available (the selected Workspace is connected). */
-  canCreateThread: boolean
   /** The fully-computed conversation outlet (connection views / cold replay). */
   outlet: ReactNode
   /** Whether an Open-project connect is in flight — busies the header's new-project +. */
@@ -211,7 +208,7 @@ export function Shell({
         <div className="flex h-full flex-none flex-col gap-3 p-3" style={{ width }}>
           <div className="flex flex-none flex-col gap-3">
             <SidebarHeader />
-            <PrimaryNav canCreateThread={canCreateThread} onNewThread={onNewThread} />
+            <PrimaryNav busy={opening} onNewThread={onNewThread} />
           </div>
           <div className="min-h-0 flex-1 overflow-y-auto">
             <WorkspaceNav
@@ -275,15 +272,17 @@ function SidebarHeader(): JSX.Element {
 
 /**
  * The primary nav: the peach-tinted "New chat" pill (the ONE filled tint,
- * `--accent-fill`) which mints a draft on the selected connected Workspace
- * (`onNewThread`, gated by `canCreateThread` — behavior unchanged from the old
- * "+ New thread"), plus static placeholder rows for Search / Scheduled / Plugins.
+ * `--accent-fill`). It's ALWAYS actionable now — `onNewThread` (App's `startNewChat`)
+ * targets the selected/most-recent project (connect-if-needed) or opens the picker when
+ * there are none — so it's only disabled while a connect is in flight (`busy`). Below it,
+ * Search / Scheduled / Plugins are net-new features (ADR-0010) shown as disabled "Soon"
+ * rows until their own epics land, so they read as intentional rather than broken.
  */
 function PrimaryNav({
-  canCreateThread,
+  busy,
   onNewThread,
 }: {
-  canCreateThread: boolean
+  busy: boolean
   onNewThread: () => void
 }): JSX.Element {
   return (
@@ -291,28 +290,31 @@ function PrimaryNav({
       <button
         type="button"
         onClick={onNewThread}
-        disabled={!canCreateThread}
+        disabled={busy}
         className="flex w-full items-center gap-2.5 rounded-lg bg-[var(--accent-fill)] px-3 py-2 text-left text-[14px] font-semibold text-accent-text outline-none transition-[filter] hover:brightness-[0.98] disabled:pointer-events-none disabled:opacity-50"
       >
         <SquarePen className="size-[18px]" aria-hidden />
         New chat
       </button>
-      {/* placeholder — Search (#future) */}
-      <NavItem>
-        <Search className="size-[18px]" aria-hidden />
-        Search
-      </NavItem>
-      {/* placeholder — Scheduled (#future) */}
-      <NavItem>
-        <Clock className="size-[18px]" aria-hidden />
-        Scheduled
-      </NavItem>
-      {/* placeholder — Plugins (#future) */}
-      <NavItem>
-        <Atom className="size-[18px]" aria-hidden />
-        Plugins
-      </NavItem>
+      <PlaceholderNav icon={<Search className="size-[18px]" aria-hidden />}>Search</PlaceholderNav>
+      <PlaceholderNav icon={<Clock className="size-[18px]" aria-hidden />}>Scheduled</PlaceholderNav>
+      <PlaceholderNav icon={<Atom className="size-[18px]" aria-hidden />}>Plugins</PlaceholderNav>
     </nav>
+  )
+}
+
+/**
+ * A not-yet-built primary-nav entry (Search / Scheduled / Plugins — each its own future
+ * epic, ADR-0010): a disabled `NavItem` with a muted "Soon" tag, so it reads as
+ * intentionally-coming rather than a broken no-op.
+ */
+function PlaceholderNav({ icon, children }: { icon: JSX.Element; children: ReactNode }): JSX.Element {
+  return (
+    <NavItem disabled title="Coming soon" className="cursor-default opacity-60">
+      {icon}
+      <span className="flex-1">{children}</span>
+      <span className="text-[11px] font-medium text-faint">Soon</span>
+    </NavItem>
   )
 }
 


### PR DESCRIPTION
Two sidebar fixes you flagged.

## 1. New chat is always actionable
It was disabled unless a project was already **connected** — confusing on a fresh open (since #138 made folding a project *peek-only*, nothing's connected by default, so the app's most prominent action sat greyed out).

Now `onNewThread` = a new `startNewChat`:
- **A project is selected** → new thread in it (connect-if-needed, via the existing `newThreadInWorkspace`).
- **Nothing selected but you have projects** → the **most-recent** one (`recents[0]`).
- **No projects at all** → opens the **project picker** (`openProject`).

So it's one click from a new conversation, and only disabled **while a connect is in flight** (`opening`). Double-clicks are safe — `selectWorkspace`'s existing in-flight guard prevents a double-spawn. Retired the now-unused `canCreateThread` gate/prop.

## 2. Search / Scheduled / Plugins → "Soon"
These are net-new feature epics (ADR-0010 scope boundary), previously rendered as focusable no-op rows. Now they're **disabled `NavItem`s with a muted "Soon" tag** (+ "Coming soon" tooltip), so they read as intentionally-upcoming rather than broken. (Search is the natural next real feature per our chat.)

## Gates
`bun run lint && bun run typecheck && bun run build && bun run test` — all green, **617 tests**. Scope: App.tsx + Shell.tsx. Reuses the already-reviewed `newThreadInWorkspace`/`selectWorkspace` logic.

## Smoke
Fresh open (nothing connected) → New chat is enabled; click it → opens/connects your most-recent project (or the picker if none) and starts a chat. With a project active → New chat starts a fresh draft in it. Search/Scheduled/Plugins show a "Soon" tag and don't respond to clicks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)