### PR TITLE
#115: conversation B — tool rows, reasoning collapsible, shimmer working indicator

### DIFF
--- a/src/renderer/src/conversation/ColdThread.tsx
+++ b/src/renderer/src/conversation/ColdThread.tsx
@@ -65,7 +65,10 @@ export function ColdThread({
         ) : view.items.length === 0 ? (
           <p className="hint">This thread has no saved conversation yet.</p>
         ) : (
-          view.items.map((item) => <Item key={item.id} item={item} onPermission={noPermission} />)
+          view.items.map((item) => (
+            // Read-only reopened history: no live turn, so reasoning renders collapsed.
+            <Item key={item.id} item={item} streaming={false} onPermission={noPermission} />
+          ))
         )}
       </div>
 

--- a/src/renderer/src/conversation/Conversation.tsx
+++ b/src/renderer/src/conversation/Conversation.tsx
@@ -16,12 +16,34 @@ import type {
   ThreadModels,
   ThreadReasoningEffort,
 } from '../../../shared/ipc'
-import { ArrowUp, Mic, Plus, Square, X } from 'lucide-react'
+import {
+  ArrowUp,
+  Brain,
+  Check,
+  ChevronDown,
+  Eye,
+  Globe,
+  Loader2,
+  Mic,
+  Move,
+  Plus,
+  Search,
+  Square,
+  SquarePen,
+  Terminal,
+  Trash2,
+  Wrench,
+  X,
+} from 'lucide-react'
 import { AgentControls } from './AgentControls'
 import { Card } from '../ui/card'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../ui/collapsible'
 import { IconButton } from '../ui/icon-button'
 import { Textarea } from '../ui/textarea'
 import { cn } from '../lib/utils'
+import { describeToolStatus, type ToolStatusGlyph } from './tool-status'
+import { toolKindIcon, type ToolIconName } from './tool-icon'
+import { formatElapsed } from './working-time'
 import {
   conversationReducer,
   initialConversationState,
@@ -540,13 +562,16 @@ export function Conversation({
   }
 
   const title = state.title ?? thread.title ?? 'Untitled Thread'
+  // The current turn is everything AFTER the last user message; used to scope
+  // reasoning auto-open to the live turn only (#115 review S1).
+  const lastUserIndex = state.items.map((i) => i.kind).lastIndexOf('user')
 
   return (
     <div className="conv">
       <div className="conv__head">
         <span className="dot dot--ok" aria-hidden />
         <span className="conv__title">{title}</span>
-        <span className="badge">{state.isProcessing ? 'thinking…' : 'connected'}</span>
+        <span className="badge">connected</span>
       </div>
 
       <UsageBar state={state} />
@@ -555,9 +580,21 @@ export function Conversation({
         {state.items.length === 0 && (
           <p className="hint">Send a prompt to start the conversation.</p>
         )}
-        {state.items.map((item) => (
-          <Item key={item.id} item={item} onPermission={respondPermission} />
+        {state.items.map((item, idx) => (
+          <Item
+            key={item.id}
+            item={item}
+            // Auto-open reasoning only for the CURRENT turn — items AFTER the last
+            // user message — so sending a new prompt doesn't re-expand the whole
+            // history's "Thinking" blocks (they belong to prior, settled turns).
+            streaming={state.isProcessing && idx > lastUserIndex}
+            onPermission={respondPermission}
+          />
         ))}
+        {/* Working indicator (#115): while a turn is in flight, a self-ticking
+            "Working for …" row after the transcript. It mounts when the turn opens
+            and unmounts on completion, so its timer starts at turn start. */}
+        {state.isProcessing && <WorkingRow />}
       </MessageScroller>
 
       {state.isProcessing && (
@@ -783,16 +820,19 @@ export function UsageBar({ state }: { state: { usage: { used: number; size: numb
 
 export function Item({
   item,
+  streaming,
   onPermission,
 }: {
   item: ConversationItem
+  /** True while this Thread's turn is in flight (#115) — drives reasoning auto-open. */
+  streaming: boolean
   onPermission: (item: PermissionItem, option: PermissionOption) => void
 }): JSX.Element {
   switch (item.kind) {
     case 'user':
       return <UserRow item={item} />
     case 'reasoning':
-      return <ReasoningRow item={item} />
+      return <ReasoningRow item={item} streaming={streaming} />
     case 'assistant':
       return <AssistantRow item={item} />
     case 'tool':
@@ -838,29 +878,189 @@ function AssistantRow({ item }: { item: AssistantItem }): JSX.Element {
   return <Response className="text-[15px] leading-relaxed text-text-body" text={item.text} />
 }
 
-function ReasoningRow({ item }: { item: ReasoningItem }): JSX.Element {
-  // Reasoning container stays as-is (#115 owns its restyle); only its markdown body
-  // now flows through the new Response primitive.
+function ReasoningRow({ item, streaming }: { item: ReasoningItem; streaming: boolean }): JSX.Element {
+  // Reasoning (#115): a Collapsible "thinking" block, auto-open while THIS Thread's
+  // turn streams and collapsed once it settles (ADR-0010). Kept toggleable in
+  // between — the effect only re-syncs `open` when `streaming` itself flips, so a
+  // manual toggle mid-turn isn't fought. Body flows through the Response primitive.
+  const [open, setOpen] = useState(streaming)
+  useEffect(() => setOpen(streaming), [streaming])
   return (
-    <details className="reasoning" open>
-      <summary className="reasoning__summary">Reasoning</summary>
-      <Response className="reasoning__body" text={item.text} />
-    </details>
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger className="flex items-center gap-1.5 rounded-md px-0.5 py-0.5 text-[12px] text-muted outline-none transition-colors hover:bg-accent/10 focus-visible:bg-accent/10">
+        <Brain className="size-3.5 shrink-0" aria-hidden />
+        <span className="font-medium">Thinking</span>
+        <ChevronDown
+          className={cn('size-3.5 shrink-0 opacity-70 transition-transform duration-200', open && 'rotate-180')}
+          aria-hidden
+        />
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <Response
+          className="mt-1 ms-2 border-s border-border ps-3 text-[13px] leading-relaxed text-muted"
+          text={item.text}
+        />
+      </CollapsibleContent>
+    </Collapsible>
   )
 }
 
+/** Map a resolved tool-kind icon name (pure `tool-icon.ts`) to a lucide element. */
+function ToolKindIcon({ name, className }: { name: ToolIconName; className?: string }): JSX.Element {
+  switch (name) {
+    case 'eye':
+      return <Eye className={className} aria-hidden />
+    case 'square-pen':
+      return <SquarePen className={className} aria-hidden />
+    case 'terminal':
+      return <Terminal className={className} aria-hidden />
+    case 'globe':
+      return <Globe className={className} aria-hidden />
+    case 'brain':
+      return <Brain className={className} aria-hidden />
+    case 'trash':
+      return <Trash2 className={className} aria-hidden />
+    case 'move':
+      return <Move className={className} aria-hidden />
+    case 'search':
+      return <Search className={className} aria-hidden />
+    case 'wrench':
+      return <Wrench className={className} aria-hidden />
+  }
+}
+
+/** The right-hand status glyph (pure `tool-status.ts` → lucide): spinner while live,
+ *  a muted check when completed, a destructive X on failure. */
+function ToolStatusGlyph({ glyph }: { glyph: ToolStatusGlyph }): JSX.Element {
+  switch (glyph) {
+    case 'check':
+      return <Check className="size-4 text-muted" aria-hidden />
+    case 'x':
+      return <X className="size-4 text-bad" aria-hidden />
+    case 'spinner':
+      return <Loader2 className="size-4 animate-spin text-muted" aria-hidden />
+  }
+}
+
+/** Stringify a raw tool field for the expanded `<pre>` detail. */
+function stringifyToolDetail(value: unknown): string {
+  return typeof value === 'string' ? value : JSON.stringify(value, null, 2)
+}
+
+/** The expandable detail body: rawInput / rawOutput / content, or null if none. */
+function toolDetail(item: ToolItem): string | null {
+  const parts: string[] = []
+  if (item.rawInput !== undefined && item.rawInput !== null) parts.push(stringifyToolDetail(item.rawInput))
+  if (item.rawOutput !== undefined && item.rawOutput !== null) parts.push(stringifyToolDetail(item.rawOutput))
+  if (Array.isArray(item.content) && item.content.length > 0) parts.push(stringifyToolDetail(item.content))
+  return parts.length > 0 ? parts.join('\n\n') : null
+}
+
+/** The dimmed inline preview (a touched path, else a short string rawInput),
+ *  suppressed when it merely duplicates the heading. */
+function toolPreview(item: ToolItem, heading: string): string | null {
+  const raw = item.locations.find((l) => l.path)?.path ?? (typeof item.rawInput === 'string' ? item.rawInput : null)
+  if (!raw) return null
+  return raw.trim().toLowerCase() === heading.trim().toLowerCase() ? null : raw
+}
+
 function ToolRow({ item }: { item: ToolItem }): JSX.Element {
-  const done = item.status === 'completed'
-  const label = item.title ?? item.toolKind ?? 'tool'
-  const path = item.locations.find((l) => l.path)?.path
+  // Tool call (#115, adapted from t3code SimpleWorkEntryRow): a compact row —
+  // leading tone-icon (kind→lucide) + heading + dimmed preview + a rotating chevron
+  // (only when there's detail) + a right status glyph (ACP status→display). Clicking
+  // an expandable row toggles an indented `<pre>` of the raw input/output/content.
+  const [expanded, setExpanded] = useState(false)
+  const status = describeToolStatus(item.status)
+  const heading = item.title ?? item.toolKind ?? 'tool'
+  const preview = toolPreview(item, heading)
+  const detail = toolDetail(item)
+  const canExpand = detail !== null
+
+  const toggleProps = canExpand
+    ? {
+        role: 'button' as const,
+        tabIndex: 0,
+        'aria-expanded': expanded,
+        onClick: () => setExpanded((v) => !v),
+        onKeyDown: (e: KeyboardEvent<HTMLDivElement>) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            setExpanded((v) => !v)
+          }
+        },
+      }
+    : {}
+
   return (
-    <div className="tool">
-      <div className="tool__head">
-        <span className={done ? 'dot dot--ok' : 'dot dot--pending'} aria-hidden />
-        <span className="tool__name">{label}</span>
-        <span className="tool__status">{item.status}</span>
+    <div
+      className={cn(
+        'flex flex-col rounded-md px-0.5 py-0.5 transition-colors',
+        canExpand && 'cursor-pointer hover:bg-accent/10 focus-visible:bg-accent/10 outline-none',
+      )}
+      {...toggleProps}
+    >
+      <div className="flex items-center gap-1.5 select-none">
+        <span className="flex size-5 shrink-0 items-center justify-center text-muted">
+          <ToolKindIcon name={toolKindIcon(item.toolKind)} className="size-3.5 shrink-0 stroke-[1.8]" />
+        </span>
+        <p className="flex min-w-0 flex-1 items-baseline gap-1.5 text-[13px] leading-5">
+          <span className="min-w-0 shrink truncate font-medium text-text-body">{heading}</span>
+          {preview && <span className="min-w-0 flex-1 truncate text-muted">{preview}</span>}
+        </p>
+        <span className="flex shrink-0 items-center gap-px">
+          {canExpand && (
+            <ChevronDown
+              className={cn(
+                'size-3.5 shrink-0 text-muted opacity-70 transition-transform duration-200',
+                expanded && 'rotate-180',
+              )}
+              aria-hidden
+            />
+          )}
+          <span className="flex size-4 shrink-0 items-center justify-center">
+            <ToolStatusGlyph glyph={status.glyph} />
+          </span>
+        </span>
       </div>
-      {path && <div className="tool__path mono">{path}</div>}
+      {expanded && detail && (
+        <pre
+          className="mt-1 ms-7 max-h-64 cursor-default overflow-auto border-s border-border ps-3 font-mono text-[11px] whitespace-pre-wrap"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {detail}
+        </pre>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Working indicator (#115): a self-ticking "Working for 12s" label that SHIMMERS
+ * through the Mistral "M" palette — a web port of the vibe CLI's LoadingWidget (which
+ * sweeps yellow→orange→red across its status text). The `.vm-shimmer` class rides a
+ * background-clip:text gradient (styles.css); the whole label lives in ONE text node
+ * (clip:text doesn't span nested colored children), updated via `setInterval` so the
+ * timer never triggers a React re-render. The row mounts only while a turn is in
+ * flight, so mount ≈ turn start.
+ */
+function WorkingRow(): JSX.Element {
+  const startRef = useRef(Date.now())
+  const textRef = useRef<HTMLSpanElement>(null)
+  useEffect(() => {
+    const tick = (): void => {
+      if (textRef.current) {
+        textRef.current.textContent = `Working for ${formatElapsed((Date.now() - startRef.current) / 1000)}`
+      }
+    }
+    tick()
+    const id = window.setInterval(tick, 1000)
+    return () => window.clearInterval(id)
+  }, [])
+  return (
+    <div className="flex items-center px-0.5 py-0.5 text-[12px] tabular-nums">
+      <span ref={textRef} className="vm-shimmer font-medium">
+        Working for 0s
+      </span>
     </div>
   )
 }

--- a/src/renderer/src/conversation/tool-icon.test.ts
+++ b/src/renderer/src/conversation/tool-icon.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { toolKindIcon } from './tool-icon'
+
+/**
+ * ToolRow tone-icon name resolution (#115): ACP tool `kind` → lucide icon name.
+ * Pure — the JSX switch that turns a name into a component isn't tested here.
+ */
+describe('toolKindIcon', () => {
+  it('maps the core ACP kinds', () => {
+    expect(toolKindIcon('read')).toBe('eye')
+    expect(toolKindIcon('edit')).toBe('square-pen')
+    expect(toolKindIcon('execute')).toBe('terminal')
+    expect(toolKindIcon('fetch')).toBe('globe')
+    expect(toolKindIcon('think')).toBe('brain')
+    expect(toolKindIcon('delete')).toBe('trash')
+    expect(toolKindIcon('move')).toBe('move')
+    expect(toolKindIcon('search')).toBe('search')
+  })
+
+  it('accepts loose synonyms Vibe may emit', () => {
+    expect(toolKindIcon('command')).toBe('terminal')
+    expect(toolKindIcon('web')).toBe('globe')
+  })
+
+  it('falls back to wrench for `other`, unknown, or missing kinds', () => {
+    expect(toolKindIcon('other')).toBe('wrench')
+    expect(toolKindIcon('mcp_custom_thing')).toBe('wrench')
+    expect(toolKindIcon(null)).toBe('wrench')
+    expect(toolKindIcon(undefined)).toBe('wrench')
+  })
+})

--- a/src/renderer/src/conversation/tool-icon.ts
+++ b/src/renderer/src/conversation/tool-icon.ts
@@ -1,0 +1,45 @@
+/**
+ * ToolRow leading tone-icon (#115) — the PURE resolution from an ACP tool `kind`
+ * (docs/acp-capture §7: `read` / `edit` / `delete` / `move` / `search` /
+ * `execute` / `think` / `fetch` / `other`, plus loose synonyms Vibe may emit) to
+ * a lucide icon NAME. Kept name-only (no JSX) so it's unit-tested as data
+ * (`tool-icon.test.ts`); the tsx maps the name to a lucide component via an
+ * explicit switch (NO dynamic import). Unknown/missing kinds fall back to
+ * `wrench` — a generic "tool" affordance.
+ */
+export type ToolIconName =
+  | 'eye'
+  | 'square-pen'
+  | 'terminal'
+  | 'globe'
+  | 'brain'
+  | 'trash'
+  | 'move'
+  | 'search'
+  | 'wrench'
+
+export function toolKindIcon(kind: string | null | undefined): ToolIconName {
+  switch (kind) {
+    case 'read':
+      return 'eye'
+    case 'edit':
+      return 'square-pen'
+    case 'execute':
+    case 'command':
+      return 'terminal'
+    case 'fetch':
+    case 'web':
+      return 'globe'
+    case 'think':
+      return 'brain'
+    case 'delete':
+      return 'trash'
+    case 'move':
+      return 'move'
+    case 'search':
+      return 'search'
+    default:
+      // `other`, unknown, or missing → the generic tool glyph.
+      return 'wrench'
+  }
+}

--- a/src/renderer/src/conversation/tool-status.test.ts
+++ b/src/renderer/src/conversation/tool-status.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { describeToolStatus } from './tool-status'
+
+/**
+ * ToolRow status mapping (#115): OUR ACP tool `status` string → the four display
+ * buckets + trailing glyph. Pure/DOM-free — exercised as data.
+ */
+describe('describeToolStatus', () => {
+  it('maps completed → done/check', () => {
+    expect(describeToolStatus('completed')).toEqual({ state: 'done', glyph: 'check' })
+  })
+
+  it('maps failed → failed/x', () => {
+    expect(describeToolStatus('failed')).toEqual({ state: 'failed', glyph: 'x' })
+  })
+
+  it('maps in_progress → running/spinner (live, no terminal check)', () => {
+    expect(describeToolStatus('in_progress')).toEqual({ state: 'running', glyph: 'spinner' })
+  })
+
+  it('maps pending → pending/spinner', () => {
+    expect(describeToolStatus('pending')).toEqual({ state: 'pending', glyph: 'spinner' })
+  })
+
+  it('defaults an unknown status to pending/spinner', () => {
+    expect(describeToolStatus('weird-status')).toEqual({ state: 'pending', glyph: 'spinner' })
+  })
+
+  it('defaults a missing (null/undefined/empty) status to pending/spinner', () => {
+    expect(describeToolStatus(null)).toEqual({ state: 'pending', glyph: 'spinner' })
+    expect(describeToolStatus(undefined)).toEqual({ state: 'pending', glyph: 'spinner' })
+    expect(describeToolStatus('')).toEqual({ state: 'pending', glyph: 'spinner' })
+  })
+})

--- a/src/renderer/src/conversation/tool-status.ts
+++ b/src/renderer/src/conversation/tool-status.ts
@@ -1,0 +1,38 @@
+/**
+ * ToolRow status mapping (#115) — the PURE bridge from OUR ACP tool `status`
+ * string (docs/acp-capture §4/§7: `pending` → `in_progress` → `completed`, or
+ * `failed`) to the compact right-hand status glyph the row renders. Kept DOM-free
+ * so it's unit-tested as data (`tool-status.test.ts`); the tsx just switches the
+ * returned `glyph` to a lucide component.
+ *
+ * `state` collapses the protocol lifecycle to four display buckets; `glyph`
+ * selects the trailing indicator — a spinner while the call is live (pending or
+ * in-progress: "absence of a terminal check"), a `Check` once completed, a
+ * destructive `X` on failure. An unknown/missing status defaults to `pending`
+ * (spinner) — a freshly-created `tool_call` with no status yet is still "live".
+ */
+export type ToolDisplayState = 'pending' | 'running' | 'done' | 'failed'
+
+export type ToolStatusGlyph = 'spinner' | 'check' | 'x'
+
+export interface ToolStatusDisplay {
+  state: ToolDisplayState
+  glyph: ToolStatusGlyph
+}
+
+export function describeToolStatus(status: string | null | undefined): ToolStatusDisplay {
+  switch (status) {
+    case 'completed':
+      return { state: 'done', glyph: 'check' }
+    case 'failed':
+      return { state: 'failed', glyph: 'x' }
+    case 'in_progress':
+      return { state: 'running', glyph: 'spinner' }
+    case 'pending':
+      return { state: 'pending', glyph: 'spinner' }
+    default:
+      // Unknown or missing status (e.g. a just-minted `tool_call`) is treated as
+      // still-live: show the spinner, never a false "done".
+      return { state: 'pending', glyph: 'spinner' }
+  }
+}

--- a/src/renderer/src/conversation/working-time.test.ts
+++ b/src/renderer/src/conversation/working-time.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { formatElapsed } from './working-time'
+
+/**
+ * Working-indicator elapsed formatting (#115): seconds → "12s" / "1m 05s". Pure.
+ */
+describe('formatElapsed', () => {
+  it('renders sub-minute durations as bare seconds', () => {
+    expect(formatElapsed(0)).toBe('0s')
+    expect(formatElapsed(12)).toBe('12s')
+    expect(formatElapsed(59)).toBe('59s')
+  })
+
+  it('renders a minute or more as `Nm SSs` with zero-padded seconds', () => {
+    expect(formatElapsed(60)).toBe('1m 00s')
+    expect(formatElapsed(65)).toBe('1m 05s')
+    expect(formatElapsed(600)).toBe('10m 00s')
+    expect(formatElapsed(3599)).toBe('59m 59s')
+  })
+
+  it('floors fractional seconds and clamps negatives to 0s', () => {
+    expect(formatElapsed(12.9)).toBe('12s')
+    expect(formatElapsed(-5)).toBe('0s')
+  })
+})

--- a/src/renderer/src/conversation/working-time.ts
+++ b/src/renderer/src/conversation/working-time.ts
@@ -1,0 +1,15 @@
+/**
+ * Working-indicator elapsed formatting (#115) — the PURE seconds → label used by
+ * the self-ticking "Working for …" timer (adapted from t3code's WorkingTimer, but
+ * with OUR zero-padded `m ss` shape). Under a minute reads as bare seconds
+ * (`0s`, `12s`); a minute or more reads `Nm SSs` with two-digit seconds
+ * (`1m 05s`, `10m 00s`). DOM-free so it's unit-tested as data
+ * (`working-time.test.ts`); the component only pushes this string into a text node.
+ */
+export function formatElapsed(totalSeconds: number): string {
+  const seconds = Math.max(0, Math.floor(totalSeconds))
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  const rem = seconds % 60
+  return `${minutes}m ${String(rem).padStart(2, '0')}s`
+}

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -278,6 +278,48 @@ body {
   }
 }
 
+/* Working-indicator SHIMMER (#115) — port of the vibe CLI's LoadingWidget, which
+   sweeps the Mistral "M" palette (yellow → orange → red) across the status text.
+   Here the same palette rides a background-clip:text gradient that sweeps L→R, so
+   "Working for 12s" shimmers through the brand ramp. Reduced-motion freezes it to a
+   static, legible orange. Palette = CLI MistralColors (constants.py). */
+@keyframes vmShimmer {
+  from {
+    background-position: 200% 50%;
+  }
+  to {
+    background-position: 0% 50%;
+  }
+}
+
+.vm-shimmer {
+  background-image: linear-gradient(
+    90deg,
+    #ffd800,
+    #ffaf00,
+    #ff8205,
+    #fa500f,
+    #e10500,
+    #fa500f,
+    #ff8205,
+    #ffaf00,
+    #ffd800
+  );
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: vmShimmer 2.4s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vm-shimmer {
+    animation: none;
+    background: none;
+    color: var(--accent-text);
+  }
+}
+
 .hint {
   color: var(--muted);
   font-size: 13px;
@@ -496,28 +538,13 @@ body {
   padding: 4px 2px;
 }
 
-.reasoning {
-  border-left: 2px solid var(--border);
-  padding-left: 10px;
-}
-
-.reasoning__summary,
+/* Reasoning is now the Collapsible "thinking" block, styled inline via tokens in
+   Conversation.tsx (#115) — its old `.reasoning*` BEM rules were retired here. */
 .fallback__summary {
   cursor: pointer;
   font-size: 12px;
   color: var(--muted);
   user-select: none;
-}
-
-.reasoning__body {
-  margin-top: 6px;
-  font-size: 13px;
-  line-height: 1.5;
-  color: var(--muted);
-  /* No `white-space: pre-wrap`: this now hosts block markdown via <Response>, which
-     manages its own whitespace — pre-wrap would turn source soft-newlines into hard
-     breaks. (The old .chat-md wrapper normalized this; #115 owns the fuller restyle.) */
-  word-break: break-word;
 }
 
 .fallback {
@@ -534,39 +561,9 @@ body {
   word-break: break-word;
 }
 
-/* --- Tool cards + permission prompt (TB3) --- */
-
-.tool {
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 8px 12px;
-  background: var(--panel);
-}
-
-.tool__head {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.tool__name {
-  flex: 1;
-  font-size: 13px;
-  font-weight: 600;
-}
-
-.tool__status {
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--muted);
-}
-
-.tool__path {
-  margin-top: 4px;
-  color: var(--muted);
-  word-break: break-all;
-}
+/* --- Permission prompt (TB3) --- */
+/* The tool row is now the compact design-system ToolRow, styled inline via tokens
+   in Conversation.tsx (#115) — its old `.tool*` BEM rules were retired here. */
 
 .permission {
   border: 1px solid var(--accent-tint-border);


### PR DESCRIPTION
Closes #115 (design-system epic, conversation B). Behavior-identical restyle of the agent-work items on the #114 baseline. Reducer/event-routing/replay UNCHANGED; **659 tests** green. **Live design-reviewed with the user — all 4 points approved (incl. the shimmer).**

## What changed
- **ToolRow** (adapted from t3code `SimpleWorkEntryRow`): compact row — kind tone-icon + heading + dimmed path/preview + rotating chevron (only when there's detail) + right status glyph; click expands an indented `<pre>` of rawInput/rawOutput/content. Accessible (role=button, Enter/Space, aria-expanded).
- **Reasoning**: native `<details>` → the `Collapsible` primitive, a "Thinking" block that **auto-opens while the current turn streams** and collapses once settled. Body still flows through the #114 `Response`.
- **Working indicator**: a self-ticking "Working for 12s" label that **shimmers through the Mistral M palette** — a web port of the vibe CLI's `LoadingWidget` (sweeps yellow→orange→red across its status text). `@keyframes vmShimmer` + `.vm-shimmer` (background-clip:text gradient sweep) with a reduced-motion fallback; timer updates via `textContent` (no per-tick re-render).
- Retired `.tool*` + `.reasoning*` BEM (grep-proven zero consumers); kept shared `.dot*`/`.mono`/`.status*`/`.permission*` (permission is #116).

## New pure logic (TDD'd)
- `tool-status.ts` — ACP status (`pending`/`in_progress`/`completed`/`failed`/unknown) → `{state, glyph}` (spinner/check/x); unknown→spinner (never a false "done").
- `tool-icon.ts` — toolKind → closed lucide-name union (exhaustive switch; default→wrench).
- `working-time.ts` — seconds → "12s" / "1m 05s".
- (`ColdThread.tsx` passes `streaming={false}` — required call-site update for the new `Item` prop.)

## Review fold (adversarial review: fix-then-ship)
- **S1** — auto-open was scoped to the *global* `isProcessing`, so sending a new prompt re-expanded **every prior turn's** reasoning. Fixed: only the current turn's reasoning (items after the last user message) auto-opens.
- Deferred **#164** (stuck-spinner if ACP omits a terminal `tool_call_update` — edge case, not the documented flow).

## Verification
- Gates: `lint && typecheck && build && test` → **659** (+12 new). Independent lead verify + adversarial review + **live `bun run dev` design review (user-approved all 4 points + shimmer)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)