### PR TITLE
menu: inset item highlight so it stops touching the popup edges

### DIFF
--- a/src/renderer/src/ui/menu.tsx
+++ b/src/renderer/src/ui/menu.tsx
@@ -38,7 +38,7 @@ export function MenuContent({
       <BaseMenu.Positioner sideOffset={sideOffset} align={align}>
         <BaseMenu.Popup
           className={cn(
-            'min-w-32 rounded-md border border-border bg-panel py-1 text-sm text-text shadow-md outline-none',
+            'min-w-32 rounded-md border border-border bg-panel p-1 text-sm text-text shadow-md outline-none',
             className,
           )}
           {...props}
@@ -56,7 +56,7 @@ export function MenuItem({
   return (
     <BaseMenu.Item
       className={cn(
-        'flex cursor-default select-none items-center gap-2 px-3 py-1.5 outline-none',
+        'flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 outline-none',
         'data-[highlighted]:bg-accent data-[highlighted]:text-on-accent',
         className,
       )}
@@ -89,7 +89,7 @@ export function MenuRadioItem({
   return (
     <BaseMenu.RadioItem
       className={cn(
-        'flex cursor-default select-none items-center gap-2 px-3 py-1.5 outline-none',
+        'flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 outline-none',
         'data-[highlighted]:bg-accent data-[highlighted]:text-on-accent',
         className,
       )}


### PR DESCRIPTION
## What you saw
In the thread-row menu (pin / archive / delete), the hover highlight **spanned edge-to-edge, touching the popup border** with square corners — looked unpolished.

## Cause
`src/renderer/src/ui/menu.tsx`: the popup had only *vertical* padding (`py-1`), so a highlighted item filled the full width flush against the border, and items had no corner rounding.

## Fix
- Popup: `py-1` → **`p-1`** (adds 4px horizontal padding).
- Items (`MenuItem` + `MenuRadioItem`): add **`rounded-sm`**, `px-3` → `px-2`.

Net: the accent highlight now floats **inset from the border with rounded corners**. Text inset is unchanged (4px popup + 8px item = the same 12px as the old `px-3`).

Applies to **every** menu that shares these components: the thread-row pin/archive/delete menu, the account menu, and the composer Mode/Model/reasoning-effort radio pickers — so they stay consistent.

## Gates
`lint && typecheck && build && test` — all green, **659 tests**. One-file diff (`menu.tsx`, +3/−3).

## Smoke
Open a thread's ⋯ menu → hovering an item shows a rounded highlight with a small gap to the popup border, not a full-bleed bar. Same in the account menu and composer dropdowns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)