### PR TITLE
#116: conversation C — inline approval + actions bar + (reveal-ready) file chips

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, dialog, ipcMain, shell, type WebContents } from 'electron'
-import { mkdir } from 'node:fs/promises'
+import { mkdir, realpath, stat } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
+import { homedir } from 'node:os'
 import { basename, join } from 'node:path'
 import {
   IPC,
@@ -21,6 +22,7 @@ import {
   type GitStatusEvent,
   type GitStatusSubscriptionArgs,
   type ListMetadataResult,
+  type RevealPathArgs,
   type OpenThreadArgs,
   type ReadTranscriptResult,
   type RespondPermissionArgs,
@@ -46,6 +48,8 @@ import {
   type ThreadTitleEvent,
 } from '../shared/ipc'
 import { detectVibe } from './vibe-detect'
+import { resolveWorkspacePath } from './resolve-workspace-path'
+import { isWithinDir } from './open-target'
 import { getShellEnv } from './shell-env'
 import { groupThreadsByWorkspace, MetadataStore } from './persistence/metadata-store'
 import {
@@ -1127,6 +1131,36 @@ function registerIpc(): void {
     const result = await ghCreatePr(args.workspaceDir, { title: args.title, body: args.body })
     if (!result.ok) console.error(`[vibe-mistro:gh] create-pr failed (${args.workspaceDir}): ${result.error}`)
     return result
+  })
+
+  ipcMain.handle(IPC.revealPath, async (_event, args: RevealPathArgs): Promise<void> => {
+    // REVEAL a file behind a clickable file-path chip (#116). The href is AGENT-AUTHORED
+    // (untrusted), so a click must never OPEN/execute it — we use `shell.showItemInFolder`,
+    // which only highlights the file in the OS file manager (no Launch Services, no code
+    // execution, no matter the file type). We still CONFINE it so a click can't disclose
+    // the location of an out-of-tree file:
+    //   1. Resolve the (possibly relative) path against the agent's Workspace cwd.
+    //   2. Require a regular FILE (blocks dirs / missing paths), then symlink-resolve
+    //      (`realpath`) and confine to the realpath'd Workspace — an in-tree symlink can't
+    //      escape, and a `..`/absolute target outside the root is refused (`/etc/passwd`,
+    //      `~/.ssh/*`). No file-TYPE gate is needed: reveal never runs anything.
+    // Best-effort throughout: any refusal or fs failure is a logged no-op, never thrown.
+    const agent = pool.get(args.agentId)
+    if (!agent) return
+    const requested = resolveWorkspacePath(agent.workspaceDir, args.path, homedir())
+    try {
+      const [realRoot, stats] = await Promise.all([realpath(agent.workspaceDir), stat(requested)])
+      if (!stats.isFile()) return // a dir or missing path — refuse
+      const realTarget = await realpath(requested)
+      if (!isWithinDir(realRoot, realTarget)) {
+        console.error(`[vibe-mistro:reveal-path] refused (outside Workspace): ${realTarget}`)
+        return
+      }
+      shell.showItemInFolder(realTarget) // reveal only — never opens/executes
+    } catch (err) {
+      // Missing path / stat / realpath failure — swallow (best-effort, never throws).
+      console.error(`[vibe-mistro:reveal-path] ${requested}: ${String(err)}`)
+    }
   })
 }
 

--- a/src/main/open-target.test.ts
+++ b/src/main/open-target.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { isWithinDir } from './open-target'
+
+const ROOT = '/Users/dev/project'
+
+describe('isWithinDir', () => {
+  it('accepts a file directly inside the dir', () => {
+    expect(isWithinDir(ROOT, '/Users/dev/project/src/app.ts')).toBe(true)
+  })
+
+  it('accepts the dir itself', () => {
+    expect(isWithinDir(ROOT, ROOT)).toBe(true)
+  })
+
+  it('rejects a path outside the dir', () => {
+    expect(isWithinDir(ROOT, '/etc/passwd')).toBe(false)
+    expect(isWithinDir(ROOT, '/Users/dev/.ssh/id_rsa')).toBe(false)
+  })
+
+  it('rejects a parent-directory escape', () => {
+    expect(isWithinDir(ROOT, '/Users/dev/sibling/file.ts')).toBe(false)
+  })
+
+  it('rejects a sibling dir that shares a name prefix', () => {
+    expect(isWithinDir(ROOT, '/Users/dev/project-evil/file.ts')).toBe(false)
+  })
+
+  it('rejects everything for an empty dir', () => {
+    expect(isWithinDir('', '/anything')).toBe(false)
+  })
+})

--- a/src/main/open-target.ts
+++ b/src/main/open-target.ts
@@ -1,0 +1,24 @@
+import { sep } from 'node:path'
+
+/**
+ * Security helper for the `shell:reveal-path` handler (#116). A file-link chip is
+ * agent-authored (UNTRUSTED), so its click is an UNPERMISSIONED path into the OS file
+ * manager. We never OPEN/execute the target (the handler uses `shell.showItemInFolder`,
+ * which only REVEALS it in Finder — no Launch Services, no code execution). We still
+ * CONFINE the revealed target to the Workspace so a click can't disclose the location
+ * of an out-of-tree file (`/etc/…`, `~/.ssh/…`, a `..` escape). Pure so it's unit-tested
+ * here; the caller collapses symlinks (`realpath`) before calling this.
+ */
+
+/**
+ * True when `target` sits inside `dir`, or IS `dir`. Both must already be
+ * realpath-resolved absolute paths (the caller collapses symlinks first) so this is a
+ * plain lexical containment test — no `..` or symlink can slip past it. The trailing
+ * separator on `dir` stops the classic sibling-prefix escape (`/a/proj` vs `/a/proj-evil`).
+ */
+export function isWithinDir(dir: string, target: string): boolean {
+  if (dir.length === 0) return false
+  if (target === dir) return true
+  const base = dir.endsWith(sep) ? dir : dir + sep
+  return target.startsWith(base)
+}

--- a/src/main/resolve-workspace-path.test.ts
+++ b/src/main/resolve-workspace-path.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { resolveWorkspacePath } from './resolve-workspace-path'
+
+const WORKSPACE = '/Users/dev/project'
+const HOME = '/Users/dev'
+
+describe('resolveWorkspacePath', () => {
+  it('passes an absolute path through unchanged', () => {
+    expect(resolveWorkspacePath(WORKSPACE, '/etc/hosts', HOME)).toBe('/etc/hosts')
+  })
+
+  it('resolves a bare relative path against the Workspace cwd', () => {
+    expect(resolveWorkspacePath(WORKSPACE, 'src/index.ts', HOME)).toBe(
+      '/Users/dev/project/src/index.ts',
+    )
+  })
+
+  it('resolves a `./`-prefixed path against the Workspace cwd', () => {
+    expect(resolveWorkspacePath(WORKSPACE, './README.md', HOME)).toBe(
+      '/Users/dev/project/README.md',
+    )
+  })
+
+  it('normalizes `..` segments against the Workspace cwd', () => {
+    expect(resolveWorkspacePath(WORKSPACE, '../sibling/file.ts', HOME)).toBe(
+      '/Users/dev/sibling/file.ts',
+    )
+  })
+
+  it('expands a `~/`-prefixed path against the home directory', () => {
+    expect(resolveWorkspacePath(WORKSPACE, '~/notes/todo.md', HOME)).toBe(
+      '/Users/dev/notes/todo.md',
+    )
+  })
+
+  it('expands a bare `~` to the home directory', () => {
+    expect(resolveWorkspacePath(WORKSPACE, '~', HOME)).toBe(HOME)
+  })
+
+  it('trims surrounding whitespace before resolving', () => {
+    expect(resolveWorkspacePath(WORKSPACE, '  src/app.ts  ', HOME)).toBe(
+      '/Users/dev/project/src/app.ts',
+    )
+  })
+})

--- a/src/main/resolve-workspace-path.ts
+++ b/src/main/resolve-workspace-path.ts
@@ -1,0 +1,26 @@
+import { isAbsolute, join, resolve } from 'node:path'
+
+/**
+ * Resolve a (possibly relative) file path from an agent's markdown into an absolute
+ * CANDIDATE path (#116, clickable file links). The renderer has no fs, so this runs in
+ * MAIN against the agent's Workspace cwd. Pure — the OS-touching realpath/confinement +
+ * `shell.showItemInFolder` (reveal) stay in the handler; homeDir is injected so this
+ * stays testable. This only RESOLVES; the handler CONFINES the result to the Workspace
+ * (an absolute or `~` path may resolve outside — the handler rejects that).
+ *
+ * Rules: an absolute path passes through; a `~` / `~/…` path expands against `homeDir`;
+ * anything else resolves against `workspaceDir` (the agent's cwd). Any `:line:col`
+ * position has already been stripped by `parseFileLink` before the path reaches us —
+ * reveal can't deep-link a line anyway, so clicking just reveals the file.
+ */
+export function resolveWorkspacePath(
+  workspaceDir: string,
+  inputPath: string,
+  homeDir: string,
+): string {
+  const trimmed = inputPath.trim()
+  if (trimmed === '~') return homeDir
+  if (trimmed.startsWith('~/')) return join(homeDir, trimmed.slice(2))
+  if (isAbsolute(trimmed)) return trimmed
+  return resolve(workspaceDir, trimmed)
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -17,6 +17,7 @@ import {
   type GhCreateResult,
   type GhCurrentPrArgs,
   type GhPrResult,
+  type RevealPathArgs,
   type GitStatusEvent,
   type GitStatusSubscriptionArgs,
   type ListMetadataResult,
@@ -92,6 +93,7 @@ const api = {
     ipcRenderer.invoke(IPC.ghCurrentPr, args),
   ghCreatePr: (args: GhCreatePrArgs): Promise<GhCreateResult> =>
     ipcRenderer.invoke(IPC.ghCreatePr, args),
+  revealPath: (args: RevealPathArgs): Promise<void> => ipcRenderer.invoke(IPC.revealPath, args),
   onAcpEvent: (listener: (event: AcpEvent) => void): (() => void) => {
     const handler = (_e: unknown, payload: AcpEvent): void => listener(payload)
     ipcRenderer.on(IPC.acpEvent, handler)

--- a/src/renderer/src/conversation/Conversation.tsx
+++ b/src/renderer/src/conversation/Conversation.tsx
@@ -1,4 +1,5 @@
 import {
+  useCallback,
   useEffect,
   useReducer,
   useRef,
@@ -21,26 +22,35 @@ import {
   Brain,
   Check,
   ChevronDown,
+  Copy,
   Eye,
   Globe,
   Loader2,
   Mic,
   Move,
   Plus,
+  RotateCcw,
   Search,
+  ShieldAlert,
   Square,
   SquarePen,
   Terminal,
+  ThumbsDown,
+  ThumbsUp,
   Trash2,
   Wrench,
   X,
 } from 'lucide-react'
 import { AgentControls } from './AgentControls'
+import { Button } from '../ui/button'
 import { Card } from '../ui/card'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../ui/collapsible'
 import { IconButton } from '../ui/icon-button'
 import { Textarea } from '../ui/textarea'
 import { cn } from '../lib/utils'
+import { FileOpenProvider } from './file-open-context'
+import { isRejectOption } from './permission-option'
+import type { FileLink } from './file-link'
 import { describeToolStatus, type ToolStatusGlyph } from './tool-status'
 import { toolKindIcon, type ToolIconName } from './tool-icon'
 import { formatElapsed } from './working-time'
@@ -425,6 +435,19 @@ export function Conversation({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [followUps.sending, followUps.queued])
 
+  // Reveal a file behind a clickable file-path chip (#116) in the OS file manager.
+  // Provided to the deeply-nested FileChip via context so we don't prop-drill through
+  // Response/Streamdown. Fire-and-forget: main resolves the (possibly relative) path
+  // against THIS Thread's Workspace cwd, confines it, and reveals it (never opens/
+  // executes — the chip text is untrusted agent output). Memoized on agentId so a
+  // keystroke-driven re-render doesn't re-render every chip under the provider.
+  const openFile = useCallback(
+    (link: FileLink): void => {
+      void window.api.revealPath({ agentId: thread.agentId, path: link.path })
+    },
+    [thread.agentId],
+  )
+
   // Answer a pending permission request: relay the choice to the agent and mark
   // the prompt resolved so it stops asking (state stays renderer-owned).
   function respondPermission(item: PermissionItem, option: PermissionOption): void {
@@ -448,8 +471,7 @@ export function Conversation({
   function recover(): void {
     for (const item of state.items) {
       if (item.kind !== 'permission' || item.chosenOptionId !== null) continue
-      const deny =
-        item.options.find((o) => o.kind.startsWith('reject')) ?? item.options[item.options.length - 1]
+      const deny = item.options.find(isRejectOption) ?? item.options[item.options.length - 1]
       if (!deny) continue
       void window.api.respondPermission({
         agentId: thread.agentId,
@@ -567,6 +589,9 @@ export function Conversation({
   const lastUserIndex = state.items.map((i) => i.kind).lastIndexOf('user')
 
   return (
+    // Chip clicks (#116) open files through main; provided here (agentId closed over)
+    // for the FileChips streamdown renders far below in the assistant markdown.
+    <FileOpenProvider value={openFile}>
     <div className="conv">
       <div className="conv__head">
         <span className="dot dot--ok" aria-hidden />
@@ -796,6 +821,7 @@ export function Conversation({
         </Card>
       </div>
     </div>
+    </FileOpenProvider>
   )
 }
 
@@ -834,7 +860,7 @@ export function Item({
     case 'reasoning':
       return <ReasoningRow item={item} streaming={streaming} />
     case 'assistant':
-      return <AssistantRow item={item} />
+      return <AssistantRow item={item} streaming={streaming} />
     case 'tool':
       return <ToolRow item={item} />
     case 'permission':
@@ -872,10 +898,90 @@ function UserRow({ item }: { item: UserItem }): JSX.Element {
   )
 }
 
-function AssistantRow({ item }: { item: AssistantItem }): JSX.Element {
+function AssistantRow({ item, streaming }: { item: AssistantItem; streaming: boolean }): JSX.Element {
   // Assistant turn (#114): no bubble — full-width flowing markdown via the Response
-  // primitive (streamdown), so tables/code/lists get room to breathe.
-  return <Response className="text-[15px] leading-relaxed text-text-body" text={item.text} />
+  // primitive (streamdown), so tables/code/lists get room to breathe. Wrapped in a
+  // `group` so the #116 actions bar reveals on hover of the whole answer.
+  return (
+    <div className="group flex flex-col gap-1.5">
+      <Response className="text-[15px] leading-relaxed text-text-body" text={item.text} />
+      {/* Actions bar (#116): a hover-reveal row under the answer. Copy is the only
+          FUNCTIONAL action (clipboard + anchored toast); thumbs up/down + retry are
+          designed affordances from the mockup — present + styled but not yet wired to
+          any backend (no feedback store, no re-submit) so we don't invent behavior.
+          Hidden while the answer streams (a half-written reply isn't copyable) and for
+          an empty item. `focus-within` also reveals it for keyboard users. */}
+      {!streaming && item.text.trim().length > 0 && (
+        <div className="flex items-center gap-0.5 opacity-0 transition-opacity duration-150 group-hover:opacity-100 focus-within:opacity-100">
+          <MessageCopyButton text={item.text} />
+          <IconButton size="icon-xs" className="text-muted hover:text-text" aria-label="Good response" title="Good response">
+            <ThumbsUp className="size-3.5" aria-hidden />
+          </IconButton>
+          <IconButton size="icon-xs" className="text-muted hover:text-text" aria-label="Bad response" title="Bad response">
+            <ThumbsDown className="size-3.5" aria-hidden />
+          </IconButton>
+          <IconButton size="icon-xs" className="text-muted hover:text-text" aria-label="Retry" title="Retry">
+            <RotateCcw className="size-3.5" aria-hidden />
+          </IconButton>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * The copy control on the assistant actions bar (#116, mirrors t3code `MessageCopyButton`).
+ * Writes the answer to the clipboard, flips the icon to a check, and floats an ANCHORED
+ * "Copied!" toast above the button (a popover positioned on the button, NOT an inline
+ * label) that clears after a beat. Self-contained: no toast manager, just local state +
+ * a positioned span. The timer is cleared on unmount so a fast switch-away can't set
+ * state on a dead component.
+ */
+function MessageCopyButton({ text }: { text: string }): JSX.Element {
+  const [copied, setCopied] = useState(false)
+  const timeoutRef = useRef<number | null>(null)
+  const mountedRef = useRef(true)
+  useEffect(
+    () => () => {
+      mountedRef.current = false
+      if (timeoutRef.current !== null) window.clearTimeout(timeoutRef.current)
+    },
+    [],
+  )
+  function onCopy(): void {
+    void navigator.clipboard.writeText(text).then(() => {
+      // The clipboard write is async — bail if we unmounted between click and resolve.
+      if (!mountedRef.current) return
+      setCopied(true)
+      if (timeoutRef.current !== null) window.clearTimeout(timeoutRef.current)
+      timeoutRef.current = window.setTimeout(() => setCopied(false), 1200)
+    })
+  }
+  return (
+    <span className="relative inline-flex">
+      <IconButton
+        size="icon-xs"
+        className="text-muted hover:text-text"
+        aria-label="Copy message"
+        title="Copy"
+        onClick={onCopy}
+      >
+        {copied ? (
+          <Check className="size-3.5 text-accent-text" aria-hidden />
+        ) : (
+          <Copy className="size-3.5" aria-hidden />
+        )}
+      </IconButton>
+      {copied && (
+        <span
+          role="status"
+          className="pointer-events-none absolute bottom-full left-1/2 mb-1 -translate-x-1/2 rounded-sm bg-text px-2 py-1 text-xs whitespace-nowrap text-bg shadow-md"
+        >
+          Copied!
+        </span>
+      )}
+    </span>
+  )
 }
 
 function ReasoningRow({ item, streaming }: { item: ReasoningItem; streaming: boolean }): JSX.Element {
@@ -1072,23 +1178,34 @@ function PermissionRow({
   item: PermissionItem
   onPermission: (item: PermissionItem, option: PermissionOption) => void
 }): JSX.Element {
+  // Permission request (#116): kept INLINE in the transcript (not the composer footer),
+  // restyled onto the Button primitive over the accent-tint card. Allow actions read as
+  // the primary (default) Button; reject actions (kind starts with `reject`) as an
+  // outline — the same classification `recover()` uses to auto-deny a wedged turn. The
+  // settled "You chose: …" state is unchanged; the wiring (`onPermission`, `item.options`,
+  // `chosenName`) is behaviour-identical to the retired BEM version.
   return (
-    <div className="permission">
-      <div className="permission__title">
-        Permission request{item.toolCallId ? ` · ${item.toolCallId}` : ''}
+    <div className="flex flex-col gap-2.5 rounded-lg border border-[var(--accent-tint-border)] bg-[var(--accent-tint)] p-3">
+      <div className="flex items-center gap-1.5 text-[13px] font-semibold text-accent-text">
+        <ShieldAlert className="size-4 shrink-0" aria-hidden />
+        <span>Permission request{item.toolCallId ? ` · ${item.toolCallId}` : ''}</span>
       </div>
       {item.chosenName ? (
-        <div className="permission__chosen">You chose: {item.chosenName}</div>
+        <div className="flex items-center gap-1.5 text-[13px] text-muted">
+          <Check className="size-3.5 shrink-0" aria-hidden />
+          <span>You chose: {item.chosenName}</span>
+        </div>
       ) : (
-        <div className="permission__options">
+        <div className="flex flex-wrap gap-2">
           {item.options.map((option) => (
-            <button
+            <Button
               key={option.optionId}
-              className={option.kind.startsWith('reject') ? 'btn btn--ghost' : 'btn'}
+              size="sm"
+              variant={isRejectOption(option) ? 'outline' : 'default'}
               onClick={() => onPermission(item, option)}
             >
               {option.name}
-            </button>
+            </Button>
           ))}
         </div>
       )}

--- a/src/renderer/src/conversation/FileChip.tsx
+++ b/src/renderer/src/conversation/FileChip.tsx
@@ -2,14 +2,20 @@ import type { JSX } from 'react'
 import { File } from 'lucide-react'
 import { cn } from '../lib/utils'
 import type { FileLink } from './file-link'
+import { useOpenFile } from './file-open-context'
 
 /**
  * The orange file-path chip rendered inline in agent markdown (#114) — a file icon,
  * a (disambiguated) label, and an optional `L12:C3` line ref. A thin, DOM-free
- * consumer of the pure `parseFileLink` result: we deliberately DON'T port t3code's
- * editor-open / `localApi` plumbing, so the chip is a non-navigating affordance
- * (a plain `<span>`, not an `<a>`, so a click can't drive the Electron window). The
- * full path lives in the native `title` tooltip.
+ * consumer of the pure `parseFileLink` result.
+ *
+ * Clickability (#116) is context-driven: when a Conversation provides an `openFile`
+ * handler (via {@link useOpenFile}), the chip is a real `<button>` that opens the file
+ * (main resolves the path against the Workspace cwd + confines it + `shell.showItemInFolder`); with no
+ * handler it degrades to the original non-navigating `<span>` (#114), so the chip stays
+ * safe outside a Conversation and we still DON'T port t3code's editor-open/`localApi`
+ * plumbing. reveal can't deep-link a line, so the `Lx:Cy` ref is display-only;
+ * the full path lives in the native `title` tooltip.
  */
 export function FileChip({
   link,
@@ -20,19 +26,40 @@ export function FileChip({
   label: string
   className?: string
 }): JSX.Element {
+  const openFile = useOpenFile()
   const position = link.line ? `L${link.line}${link.column ? `:C${link.column}` : ''}` : null
-  return (
-    <span
-      data-file-chip
-      title={link.path}
-      className={cn(
-        'inline-flex items-center gap-1 rounded-md border border-[var(--accent-tint-border)] bg-[var(--accent-tint)] px-1.5 py-0.5 align-text-bottom font-mono text-[0.85em] leading-none text-accent-text',
-        className,
-      )}
-    >
+  const inner = (
+    <>
       <File className="size-3.5 shrink-0 text-accent-text" aria-hidden />
       <span>{label}</span>
       {position && <span className="text-muted">{position}</span>}
+    </>
+  )
+  const chipClass = cn(
+    'inline-flex items-center gap-1 rounded-md border border-[var(--accent-tint-border)] bg-[var(--accent-tint)] px-1.5 py-0.5 align-text-bottom font-mono text-[0.85em] leading-none text-accent-text',
+    className,
+  )
+
+  if (openFile) {
+    return (
+      <button
+        type="button"
+        data-file-chip
+        title={link.path}
+        onClick={() => openFile(link)}
+        className={cn(
+          chipClass,
+          'cursor-pointer outline-none transition-colors hover:bg-[var(--accent-tint-border)] focus-visible:ring-2 focus-visible:ring-accent/40',
+        )}
+      >
+        {inner}
+      </button>
+    )
+  }
+
+  return (
+    <span data-file-chip title={link.path} className={chipClass}>
+      {inner}
     </span>
   )
 }

--- a/src/renderer/src/conversation/file-open-context.ts
+++ b/src/renderer/src/conversation/file-open-context.ts
@@ -1,0 +1,23 @@
+import { createContext, useContext } from 'react'
+import type { FileLink } from './file-link'
+
+/**
+ * Handler that opens the file behind a clickable file-path chip (#116). Provided at
+ * the `Conversation` level (with the Thread's `agentId` closed over) and consumed by
+ * the deeply-nested `FileChip` — which streamdown renders inside its `a` override, far
+ * below the conversation — WITHOUT prop-drilling through `Response`/`Streamdown`.
+ *
+ * `null` (the default) means "no opener wired": the chip then renders as the original
+ * non-navigating `<span>` (#114), so `FileChip`/`Response` stay usable outside a
+ * Conversation. Main does the relative→absolute resolution + confinement + `shell.showItemInFolder` (reveal).
+ */
+export type OpenFileHandler = ((link: FileLink) => void) | null
+
+const FileOpenContext = createContext<OpenFileHandler>(null)
+
+export const FileOpenProvider = FileOpenContext.Provider
+
+/** The current chip opener, or `null` when no Conversation provides one. */
+export function useOpenFile(): OpenFileHandler {
+  return useContext(FileOpenContext)
+}

--- a/src/renderer/src/conversation/permission-option.test.ts
+++ b/src/renderer/src/conversation/permission-option.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { isRejectOption } from './permission-option'
+
+describe('isRejectOption', () => {
+  it('classifies reject_once / reject_always as reject actions', () => {
+    expect(isRejectOption({ kind: 'reject_once' })).toBe(true)
+    expect(isRejectOption({ kind: 'reject_always' })).toBe(true)
+  })
+
+  it('classifies allow_* kinds as non-reject (allow) actions', () => {
+    expect(isRejectOption({ kind: 'allow_once' })).toBe(false)
+    expect(isRejectOption({ kind: 'allow_always' })).toBe(false)
+  })
+
+  it('treats an unknown kind as a non-reject action', () => {
+    expect(isRejectOption({ kind: 'proceed' })).toBe(false)
+    expect(isRejectOption({ kind: '' })).toBe(false)
+  })
+})

--- a/src/renderer/src/conversation/permission-option.ts
+++ b/src/renderer/src/conversation/permission-option.ts
@@ -1,0 +1,13 @@
+import type { PermissionOption } from './reducer'
+
+/**
+ * Classify a permission option as reject/deny vs. allow/approve (#116). Vibe's ACP
+ * `request_permission` options carry a `kind` — the deny actions are the ones whose
+ * kind starts with `reject` (`reject_once`, `reject_always`); everything else
+ * (`allow_once`, `allow_always`, …) is an allow action. Drives BOTH the button styling
+ * (allow = primary, reject = outline) and `recover()`'s auto-deny of a wedged turn, so
+ * the two stay in lockstep. Pure/DOM-free — takes just the `kind` it reads.
+ */
+export function isRejectOption(option: Pick<PermissionOption, 'kind'>): boolean {
+  return option.kind.startsWith('reject')
+}

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -561,36 +561,11 @@ body {
   word-break: break-word;
 }
 
-/* --- Permission prompt (TB3) --- */
+/* --- Permission prompt --- */
 /* The tool row is now the compact design-system ToolRow, styled inline via tokens
-   in Conversation.tsx (#115) — its old `.tool*` BEM rules were retired here. */
-
-.permission {
-  border: 1px solid var(--accent-tint-border);
-  background: var(--accent-tint);
-  border-radius: var(--radius);
-  padding: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.permission__title {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--accent-text);
-}
-
-.permission__chosen {
-  font-size: 13px;
-  color: var(--muted);
-}
-
-.permission__options {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
+   in Conversation.tsx (#115), and the permission prompt is the design-system
+   PermissionRow (Button primitives over the accent-tint card, #116) — both retired
+   their old BEM rules here. */
 
 .btn--ghost {
   background: transparent;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -192,6 +192,18 @@ export const IPC = {
    * affordance on the branch having an upstream). NOT agent activity, so no `pool.touch`.
    */
   ghCreatePr: 'gh:create-pr',
+  /**
+   * Renderer -> main: REVEAL a file referenced by a clickable file-path chip (#116) in
+   * the OS file manager. Fire-and-forget (invoke → `Promise<void>`, like `respondPermission`).
+   * The chip text is AGENT-AUTHORED (untrusted), so main never OPENS/executes the target —
+   * it resolves the (possibly relative) path against the hosting agent's Workspace cwd,
+   * CONFINES it to the Workspace (symlink-resolved), and calls `shell.showItemInFolder`
+   * (highlight only, no Launch Services / code execution). Best-effort — an out-of-Workspace
+   * or bad path is a logged no-op, never thrown. Reveal can't deep-link a line, so the
+   * chip's `Lx:Cy` ref stays display-only. (Do NOT switch this to `shell.openPath` — that
+   * would execute `.app`/`.command`/installers from untrusted markdown on one click.)
+   */
+  revealPath: 'shell:reveal-path',
 } as const
 
 /**
@@ -885,4 +897,16 @@ export interface GhCreatePrArgs {
   workspaceDir: string
   title: string
   body: string
+}
+
+/**
+ * Args for `revealPath` (#116): reveal a file referenced by a clickable file-path chip.
+ * `agentId` identifies the hosting Workspace agent so main can resolve `path`'s
+ * Workspace cwd (the renderer has no fs, so relative→absolute resolution is main's
+ * job) and confine it. `path` is the `FileLink.path` from the chip — already stripped
+ * of any `:line:col` position.
+ */
+export interface RevealPathArgs {
+  agentId: string
+  path: string
 }


### PR DESCRIPTION
Closes #116 (design-system epic, conversation C — the last conversation slice). **675 tests** green.

## What changed
- **Inline approval** — `PermissionRow` restyled onto `Button` primitives (allow = solid, reject = outline), kept INLINE in the conversation. Behavior identical: same `onPermission`/`item.options`/`chosenName` wiring. `permission-option.ts` (`isRejectOption`, TDD'd) is a shared extraction used by both the button styling AND `recover()`'s auto-deny, so they stay in lockstep.
- **Actions bar** — hover-reveal row under assistant answers: functional **copy** (clipboard + anchored "Copied!" toast, hidden while streaming / for empty text, unmount-guarded) + thumbs-up/down + retry as designed affordances (no invented backend). `group-hover`/`focus-within` reveal.
- **File-path chips → reveal-in-Finder** — new `IPC.revealPath` (`shell:reveal-path`): resolves the path against the Workspace cwd, **confines** it (symlink-resolved `realpath` + `isWithinDir`, rejecting absolute-outside / `../`-escape / sibling-prefix tricks), and `shell.showItemInFolder` — **reveals only, never opens/executes** untrusted agent-authored paths. Pure logic TDD'd: `resolveWorkspacePath`, `isWithinDir`.
- Retired `.permission*` BEM.

## Security (user-decided: confine + reveal)
Adversarial review found the original impl handed agent-authored paths to `shell.openPath` (executes `.app`/`.command`/installers) with no confinement — a 1-click code-exec vector. Per the user's decision, switched to **`shell.showItemInFolder`** (reveal, never executes — no denylist to keep leak-free) + Workspace confinement, and **renamed the IPC `openPath`→`revealPath`** with a "do NOT switch back to openPath" guard-comment so it can't regress into an executor.

## KNOWN: file chips don't render yet → follow-up #168
Live testing surfaced that streamdown's `harden` blocks relative/file link hrefs (`[test.txt](test.txt)` → `[blocked]`) BEFORE our chip override runs — so file chips have never rendered (a #114-era issue, not introduced here). The reveal IPC + FileChip are correct and **ready**; **#168** fixes streamdown's harden config (with its own XSS re-verification) to make them live. Shipping #116 for the working approval + actions bar per user decision.

## Verification
- Gates: **675** (+16 new). Independent lead verify + adversarial review (security → confine+reveal folded; implementer's out-of-scope App.tsx window-chrome change dropped — it would've double-rendered macOS traffic lights). Live design pass with the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)