### PR TITLE
sidebar: Remove project — Codex-style workspace removal (no disk delete)

### DIFF
--- a/src/main/agent-pool.test.ts
+++ b/src/main/agent-pool.test.ts
@@ -105,6 +105,17 @@ describe('AgentPool — lookups', () => {
     expect(pool.getByWorkspace('/proj/unknown')).toBeNull()
   })
 
+  it('resolves the warm agentId for a Workspace dir (null for unknown / after dispose)', () => {
+    const { pool } = makePool()
+    const { agentId } = pool.acquire('/proj/a')
+
+    expect(pool.agentIdForWorkspace('/proj/a')).toBe(agentId)
+    expect(pool.agentIdForWorkspace('/proj/unknown')).toBeNull()
+
+    pool.dispose(agentId)
+    expect(pool.agentIdForWorkspace('/proj/a')).toBeNull()
+  })
+
   it('lists every warm agent (for fan-out like best-effort session close)', () => {
     const { pool } = makePool()
     const a = pool.acquire('/proj/a').agent

--- a/src/main/agent-pool.ts
+++ b/src/main/agent-pool.ts
@@ -205,6 +205,16 @@ export class AgentPool<A extends PoolAgent = WorkspaceAgent> {
     return this.byId.get(agentId)?.agent ?? null
   }
 
+  /**
+   * The minted `agentId` currently warm for a Workspace dir, or null when none is
+   * (never selected, evicted, or disposed). A thin reverse-index read used by
+   * "Remove project" to find the warm agent to stop before removing our records —
+   * distinct from `getByWorkspace` in returning just the handle (no agent).
+   */
+  agentIdForWorkspace(workspaceDir: string): string | null {
+    return this.byWorkspace.get(workspaceDir) ?? null
+  }
+
   /** The warm agent + id for a Workspace dir, or null when none is warm. */
   getByWorkspace(workspaceDir: string): PooledAgent<A> | null {
     const agentId = this.byWorkspace.get(workspaceDir)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -25,6 +25,7 @@ import {
   type RevealPathArgs,
   type OpenThreadArgs,
   type ReadTranscriptResult,
+  type RemoveWorkspaceResult,
   type RespondPermissionArgs,
   type SendPromptArgs,
   type SendPromptResult,
@@ -69,6 +70,7 @@ import { AgentPool } from './agent-pool'
 import { isProtected } from './agent-protection'
 import { controlsOf, ensureBoundSession, resolveContinueTarget } from './thread-binding'
 import { deleteThread } from './persistence/delete-thread'
+import { removeWorkspace } from './persistence/remove-workspace'
 import { permissionRequestIdOf, ThreadStatusTracker, type ThreadStatusChange } from './thread-status'
 import { gitFetch, readGitStatus } from './git/status'
 import { readGitDiff } from './git/diff'
@@ -311,6 +313,20 @@ let transcriptStore: TranscriptStore | null = null
  */
 const transcriptThreads = new Map<string, string>()
 
+/**
+ * Thread ids whose JSONL has been (or is being) removed and must NEVER be re-created
+ * ("Remove project" — a Workspace can be removed MID-TURN). `TranscriptStore.delete`
+ * only drops the tail of the append chain; it can't cancel a tee that arrives AFTER
+ * the unlink — notably the `turn-error` teed from `runPromptTurn`'s catch when the
+ * disposed agent rejects its in-flight prompt (that tee uses `args.threadId` directly,
+ * bypassing the bridge). Without this guard `append` would start a FRESH chain and
+ * re-write a header + line, leaking an orphaned transcript no metadata references.
+ * We tombstone a Workspace's Thread ids BEFORE removal so every such late tee is
+ * suppressed at the choke point below. Thread ids are unique-and-never-reused, so the
+ * set is monotonic and bounded by removals this session — no cleanup needed.
+ */
+const tombstonedThreadIds = new Set<string>()
+
 /** Resolve the Thread id for a chokepoint, or null to skip the tee (best-effort). */
 function threadIdForTee(agentId: string, sessionId?: string | null): string | null {
   return (
@@ -320,11 +336,13 @@ function threadIdForTee(agentId: string, sessionId?: string | null): string | nu
 
 /**
  * Tee one conversation INPUT to the active Thread's JSONL (ADR-0005). Best-effort
- * and fire-and-forget, guarded exactly like `recordWorkspaceOpen`: an absent store or an
- * unresolved Thread id skips the write; the append itself swallows I/O errors.
+ * and fire-and-forget, guarded exactly like `recordWorkspaceOpen`: an absent store, an
+ * unresolved Thread id, or a TOMBSTONED (removed) Thread skips the write; the append
+ * itself swallows I/O errors. The tombstone check is what makes mid-turn "Remove
+ * project" safe — see `tombstonedThreadIds`.
  */
 function teeTranscript(threadId: string | null, entry: TranscriptEntry): void {
-  if (!transcriptStore || !threadId) return
+  if (!transcriptStore || !threadId || tombstonedThreadIds.has(threadId)) return
   void transcriptStore.append(threadId, entry)
 }
 
@@ -935,6 +953,48 @@ function registerIpc(): void {
     })
     return { ok: true }
   })
+
+  ipcMain.handle(
+    IPC.removeWorkspace,
+    async (_event, workspaceId: string): Promise<RemoveWorkspaceResult> => {
+      // Remove a Workspace end-to-end ("Remove project", ADR-0005): stop its warm
+      // agent cleanly (if any — allowed even mid-turn), then remove OUR records — the
+      // Workspace + Thread metadata and their JSONL transcripts. NEVER deletes files
+      // on disk. A thin wrapper: all real logic lives in the pure `removeWorkspace`
+      // orchestrator + `MetadataStore.removeWorkspace`. Best-effort throughout, so a
+      // missing store / cold Workspace just no-ops — never a throw.
+      if (!metadataStore) return { ok: true }
+      const snapshot = metadataStore.snapshot()
+      // Resolve the Workspace dir → its warm agentId (null when cold). The dir is the
+      // pool's key, so a warm agent for this Workspace is found here before removal.
+      const dir = snapshot.workspaces.find((w) => w.id === workspaceId)?.dir
+      const agentId = dir ? pool.agentIdForWorkspace(dir) : null
+      // Tombstone this Workspace's Thread ids BEFORE anything tears down, so a late
+      // tee from the disposed agent's rejected in-flight turn (or a straggling event)
+      // can't re-create a just-deleted JSONL. Safe for a mid-turn removal — see
+      // `tombstonedThreadIds`. Done first: dispose (below) rejects the pending prompt.
+      for (const t of snapshot.threads) {
+        if (t.workspaceId === workspaceId) tombstonedThreadIds.add(t.id)
+      }
+      await removeWorkspace({
+        workspaceId,
+        store: metadataStore,
+        transcript: transcriptStore ?? { delete: () => Promise.resolve() },
+        // When a warm agent hosts this Workspace, stop it via the SAME path the
+        // sweep/stop uses: `pool.dispose` (graceful teardown of hosted sessions) plus
+        // `notifyAgentsEvicted` (clears inFlightTurns + transcript bridge + per-Thread
+        // status AND tells the renderer to drop the now-dead connection). Order mirrors
+        // `stopAgent`/the sweep: dispose the child, then broadcast the eviction cleanup.
+        stopAgent: agentId
+          ? () => {
+              pool.dispose(agentId)
+              notifyAgentsEvicted([agentId])
+            }
+          : undefined,
+      })
+      return { ok: true }
+    },
+  )
 
   ipcMain.handle(
     IPC.setThreadFlags,

--- a/src/main/persistence/metadata-store.test.ts
+++ b/src/main/persistence/metadata-store.test.ts
@@ -302,6 +302,65 @@ describe('MetadataStore.deleteThread (TB6 #35)', () => {
   })
 })
 
+describe('MetadataStore.removeWorkspace ("Remove project")', () => {
+  it('removes the Workspace + all its Threads and returns their ids', async () => {
+    const file = 'remove-ws.json'
+    const store = storeAt(file)
+    await store.load()
+    const ws = await store.upsertWorkspace({ dir: '/proj/rm' })
+    const t1 = await store.upsertThread({ workspaceId: ws.id, sessionId: 's1' })
+    const t2 = await store.upsertThread({ workspaceId: ws.id, sessionId: 's2' })
+
+    const removed = await store.removeWorkspace(ws.id)
+
+    expect(removed).toEqual(expect.arrayContaining([t1.id, t2.id]))
+    expect(removed).toHaveLength(2)
+    expect(store.snapshot().workspaces).toEqual([])
+    expect(store.snapshot().threads).toEqual([])
+
+    // Durable: a fresh instance over the SAME file must not see the removed records.
+    const reopened = storeAt(file)
+    await reopened.load()
+    expect(reopened.snapshot().workspaces).toEqual([])
+    expect(reopened.snapshot().threads).toEqual([])
+  })
+
+  it('leaves other Workspaces and their Threads intact', async () => {
+    const store = storeAt('remove-ws-siblings.json')
+    await store.load()
+    const drop = await store.upsertWorkspace({ dir: '/proj/drop' })
+    const keep = await store.upsertWorkspace({ dir: '/proj/keep' })
+    const dropThread = await store.upsertThread({ workspaceId: drop.id })
+    const keepThread = await store.upsertThread({ workspaceId: keep.id })
+
+    const removed = await store.removeWorkspace(drop.id)
+
+    expect(removed).toEqual([dropThread.id])
+    expect(store.snapshot().workspaces.map((w) => w.id)).toEqual([keep.id])
+    expect(store.snapshot().threads.map((t) => t.id)).toEqual([keepThread.id])
+  })
+
+  it('is a no-op for an unknown id — returns [] and writes NOTHING', async () => {
+    const writes: string[] = []
+    const store = new MetadataStore({
+      filePath: join(dir, 'remove-ws-unknown.json'),
+      readFile: async () => {
+        throw new Error('ENOENT')
+      },
+      writeFile: async (path) => {
+        writes.push(`write:${path}`)
+      },
+      rename: async () => {},
+    })
+    await store.load()
+    await store.upsertWorkspace({ dir: '/proj/present' })
+    const writesAfterSetup = writes.length
+
+    await expect(store.removeWorkspace('no-such-workspace')).resolves.toEqual([])
+    expect(writes.length).toBe(writesAfterSetup) // unknown id → no disk write
+  })
+})
+
 describe('MetadataStore.setThreadFlags (#132 pin / #133 archive)', () => {
   it('patches only the passed flag, leaving the other untouched, and round-trips', async () => {
     const file = 'flags-roundtrip.json'

--- a/src/main/persistence/metadata-store.ts
+++ b/src/main/persistence/metadata-store.ts
@@ -287,6 +287,27 @@ export class MetadataStore {
   }
 
   /**
+   * Remove a Workspace record AND every Thread under it ("Remove project"). Returns
+   * the removed Thread ids so the caller can drop THEIR JSONL transcripts (best-
+   * effort, ADR-0005) — the store owns only our metadata, not the transcript files.
+   * Idempotent: an unknown id (or an already-removed Workspace with no threads)
+   * matches nothing, returns `[]`, and writes NOTHING — so removing twice never
+   * throws. Persisted atomically like the other mutations, and only when something
+   * actually changed (an unknown-id removal needs no disk write). Files on disk are
+   * never touched here; this is purely our index.
+   */
+  async removeWorkspace(id: string): Promise<string[]> {
+    const removedThreadIds = this.state.threads.filter((t) => t.workspaceId === id).map((t) => t.id)
+    const hadWorkspace = this.state.workspaces.some((w) => w.id === id)
+    // Nothing to do — no record write for an unknown/already-removed Workspace.
+    if (!hadWorkspace && removedThreadIds.length === 0) return []
+    this.state.workspaces = this.state.workspaces.filter((w) => w.id !== id)
+    this.state.threads = this.state.threads.filter((t) => t.workspaceId !== id)
+    await this.persist()
+    return removedThreadIds
+  }
+
+  /**
    * Resolve a Thread's minted `id` from its bound ACP `sessionId` (TB2 transcript
    * routing). Events flow keyed by `sessionId`, but the JSONL is keyed by the
    * minted Thread `id`; this bridges the two. A null/unmatched session is `null`

--- a/src/main/persistence/remove-workspace.test.ts
+++ b/src/main/persistence/remove-workspace.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest'
+import { removeWorkspace } from './remove-workspace'
+
+/**
+ * The "Remove project" orchestration (ADR-0005): stop the Workspace's live warm
+ * agent (if any), then remove OUR records — the Workspace + Thread metadata and each
+ * Thread's JSONL transcript. Per ADR-0005 a stop failure (or no warm agent) and a
+ * store/transcript failure must NEVER block the removal or surface as a hard error.
+ * Exercised with injected fakes for the store / transcript / stop seams — no real
+ * `vibe-acp`, no `userData`, no files on disk touched.
+ */
+
+type RemoveWs = (id: string) => Promise<string[]>
+type DeleteFn = (threadId: string) => Promise<void>
+
+function fakes(threadIds: string[]): {
+  store: { removeWorkspace: ReturnType<typeof vi.fn<RemoveWs>> }
+  transcript: { delete: ReturnType<typeof vi.fn<DeleteFn>> }
+} {
+  return {
+    store: { removeWorkspace: vi.fn<RemoveWs>(async () => threadIds) },
+    transcript: { delete: vi.fn<DeleteFn>(async () => {}) },
+  }
+}
+
+describe('removeWorkspace ("Remove project")', () => {
+  it('removes the Workspace records and deletes every returned Thread transcript', async () => {
+    const { store, transcript } = fakes(['t1', 't2'])
+
+    await removeWorkspace({ workspaceId: 'w1', store, transcript })
+
+    expect(store.removeWorkspace).toHaveBeenCalledWith('w1')
+    expect(transcript.delete).toHaveBeenCalledWith('t1')
+    expect(transcript.delete).toHaveBeenCalledWith('t2')
+    expect(transcript.delete).toHaveBeenCalledTimes(2)
+  })
+
+  it('stops the agent BEFORE touching the store when a warm agent is present', async () => {
+    const { store, transcript } = fakes(['t1'])
+    const order: string[] = []
+    const stopAgent = vi.fn(async () => {
+      order.push('stop')
+    })
+    store.removeWorkspace.mockImplementation(async () => {
+      order.push('store')
+      return ['t1']
+    })
+    transcript.delete.mockImplementation(async () => {
+      order.push('transcript')
+    })
+
+    await removeWorkspace({ workspaceId: 'w1', store, transcript, stopAgent })
+
+    expect(stopAgent).toHaveBeenCalledOnce()
+    expect(order).toEqual(['stop', 'store', 'transcript'])
+  })
+
+  it('is fine with NO stopAgent (a cold Workspace) — still removes records + transcripts', async () => {
+    const { store, transcript } = fakes(['t1'])
+
+    await expect(removeWorkspace({ workspaceId: 'w1', store, transcript })).resolves.toBeUndefined()
+    expect(store.removeWorkspace).toHaveBeenCalledWith('w1')
+    expect(transcript.delete).toHaveBeenCalledWith('t1')
+  })
+
+  it('RESOLVES even when the store removal rejects, and skips transcript cleanup (nothing removed)', async () => {
+    const { store, transcript } = fakes(['t1'])
+    store.removeWorkspace.mockRejectedValue(new Error('EROFS: read-only file system'))
+
+    await expect(removeWorkspace({ workspaceId: 'w1', store, transcript })).resolves.toBeUndefined()
+    // A throw is treated as "nothing removed", so no transcript is deleted.
+    expect(transcript.delete).not.toHaveBeenCalled()
+  })
+
+  it('one transcript-delete rejecting does NOT skip the others', async () => {
+    const { store, transcript } = fakes(['t1', 't2', 't3'])
+    transcript.delete.mockImplementation(async (id: string) => {
+      if (id === 't2') throw new Error('EACCES: permission denied')
+    })
+
+    await expect(removeWorkspace({ workspaceId: 'w1', store, transcript })).resolves.toBeUndefined()
+    // All three attempted despite t2 rejecting.
+    expect(transcript.delete).toHaveBeenCalledWith('t1')
+    expect(transcript.delete).toHaveBeenCalledWith('t2')
+    expect(transcript.delete).toHaveBeenCalledWith('t3')
+    expect(transcript.delete).toHaveBeenCalledTimes(3)
+  })
+
+  it('still removes records when the best-effort stop REJECTS (no error surfaced)', async () => {
+    const { store, transcript } = fakes(['t1'])
+    const stopAgent = vi.fn(async () => {
+      throw new Error('dispose failed — agent gone')
+    })
+
+    await expect(
+      removeWorkspace({ workspaceId: 'w1', store, transcript, stopAgent }),
+    ).resolves.toBeUndefined()
+    expect(store.removeWorkspace).toHaveBeenCalledWith('w1')
+    expect(transcript.delete).toHaveBeenCalledWith('t1')
+  })
+})

--- a/src/main/persistence/remove-workspace.ts
+++ b/src/main/persistence/remove-workspace.ts
@@ -1,0 +1,71 @@
+/**
+ * Remove a Workspace end-to-end ("Remove project", Codex-style; ADR-0005). Vibe owns
+ * agent context; WE own the visible history, so removing a Workspace tears down OUR
+ * records — its metadata entry, every Thread metadata entry under it, and each of
+ * those Threads' JSONL transcripts — and, when the Workspace has a LIVE warm agent,
+ * stops that agent cleanly FIRST. It NEVER deletes files on disk: the project
+ * directory is untouched; only our index + transcripts come down.
+ *
+ * Best-effort is the whole point (mirrors `deleteThread`): a stop failure, a cold
+ * Workspace with no warm agent, or a store/transcript unlink failure must NEVER block
+ * the removal or surface as a hard error. EVERY step is guarded so the orchestration
+ * always RESOLVES: the agent stop is swallowed (belt-and-suspenders — the stop seam
+ * is itself best-effort), the metadata removal is swallowed (its `persist()` rejects
+ * on a full / read-only `userData`, and an unguarded reject would bubble out the
+ * `workspace:remove` IPC to the renderer's `.catch`-less onClick), and EACH transcript
+ * removal is attempted independently so one failing unlink can't skip the rest. This
+ * mirrors `recordWorkspaceOpen`'s guard — a failing persist never rejects the UI flow.
+ */
+
+/** The store surface needed to drop a Workspace + its Threads (returns removed Thread ids). */
+export interface RemoveWorkspaceStore {
+  removeWorkspace(id: string): Promise<string[]>
+}
+
+/** The transcript surface needed to drop one Thread's JSONL (missing = no-op). */
+export interface RemoveWorkspaceTranscript {
+  delete(threadId: string): Promise<void>
+}
+
+export interface RemoveWorkspaceArgs {
+  workspaceId: string
+  store: RemoveWorkspaceStore
+  transcript: RemoveWorkspaceTranscript
+  /**
+   * Best-effort clean stop of the Workspace's LIVE warm agent, when one is warm.
+   * Omitted for a cold Workspace (nothing to stop). Any rejection is swallowed — a
+   * Vibe-side teardown failure must not block the record removal below.
+   */
+  stopAgent?: () => void | Promise<void>
+}
+
+export async function removeWorkspace(args: RemoveWorkspaceArgs): Promise<void> {
+  // 1. Best-effort stop FIRST, while the warm agent handle is still resolvable.
+  //    Swallow any failure (or absence) — Vibe-side cleanup never gates ours.
+  if (args.stopAgent) {
+    try {
+      await args.stopAgent()
+    } catch {
+      // A failed/unavailable stop is non-fatal — proceed to remove our records.
+    }
+  }
+  // 2. Remove our metadata records (the Workspace + all its Threads), guarded so a
+  //    persist failure (full / read-only userData) can't reject the orchestration.
+  //    A throw is treated as "nothing removed" so the transcript loop below no-ops.
+  let removedThreadIds: string[] = []
+  try {
+    removedThreadIds = await args.store.removeWorkspace(args.workspaceId)
+  } catch {
+    // A metadata persist failure is non-fatal — leave the transcript cleanup to no-op.
+  }
+  // 3. Drop each removed Thread's JSONL, EACH guarded independently so one failing
+  //    unlink can't skip the others (the store already swallows ENOENT; this guards
+  //    the injected/no-op seam and any unexpected reject too).
+  for (const threadId of removedThreadIds) {
+    try {
+      await args.transcript.delete(threadId)
+    } catch {
+      // A transcript unlink failure is non-fatal — continue with the rest.
+    }
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -22,6 +22,7 @@ import {
   type GitStatusSubscriptionArgs,
   type ListMetadataResult,
   type ReadTranscriptResult,
+  type RemoveWorkspaceResult,
   type RespondPermissionArgs,
   type OpenThreadArgs,
   type SendPromptArgs,
@@ -68,6 +69,8 @@ const api = {
   listMetadata: (): Promise<ListMetadataResult> => ipcRenderer.invoke(IPC.listMetadata),
   deleteThread: (threadId: string): Promise<DeleteThreadResult> =>
     ipcRenderer.invoke(IPC.deleteThread, threadId),
+  removeWorkspace: (workspaceId: string): Promise<RemoveWorkspaceResult> =>
+    ipcRenderer.invoke(IPC.removeWorkspace, workspaceId),
   getThreadStatuses: (): Promise<ThreadStatusEvent[]> => ipcRenderer.invoke(IPC.getThreadStatuses),
   setThreadConfig: (args: SetThreadConfigArgs): Promise<SetThreadConfigResult> =>
     ipcRenderer.invoke(IPC.setThreadConfig, args),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -185,6 +185,36 @@ export function App(): JSX.Element {
   }
 
   /**
+   * Remove a Workspace from the sidebar ("Remove project", Codex-style). Main stops
+   * its warm agent (if any — allowed even mid-turn) and removes OUR records (the
+   * Workspace + Thread metadata + JSONL); it NEVER deletes files on disk. Here we
+   * reconcile local state so the project disappears cleanly:
+   *  - If it was the selected Workspace, clear the nav selection (lands on the empty
+   *    state); leave the selection untouched when removing a non-selected project.
+   *  - Drop its connection and per-Workspace live-state. Both are idempotent: for a
+   *    CONNECTED project main disposed the agent and pushed `agent:evicted`, whose
+   *    handler already dropped the connection by agentId — so `clear` is a no-op then
+   *    (no double-removal), and it covers the cold/unconnected case that evict misses.
+   *  - Drop each removed Thread's persisted composer draft + renderer status, mirroring
+   *    `deleteThread` — so a removed project leaves no orphaned localStorage/status keys.
+   *  - `refreshRecents()` LAST, dropping it from the persisted list the sidebar renders.
+   */
+  async function removeWorkspace(workspaceId: string): Promise<void> {
+    await window.api.removeWorkspace(workspaceId)
+    // Snapshot the removed Workspace's Thread ids from the CURRENT list, before the
+    // refresh drops it, so we can clear their renderer-local residue below.
+    const removedThreadIds = recents.find((w) => w.id === workspaceId)?.threads.map((t) => t.id) ?? []
+    if (nav.selectedWorkspaceId === workspaceId) navDispatch({ type: 'clear' })
+    connDispatch({ type: 'clear', workspaceId })
+    wtDispatch({ type: 'remove-workspace', workspaceId })
+    if (removedThreadIds.length > 0) {
+      setStatuses((prev) => removedThreadIds.reduce((acc, id) => clearThreadStatus(acc, id), prev))
+      for (const id of removedThreadIds) clearDraft(window.localStorage, id)
+    }
+    await refreshRecents()
+  }
+
+  /**
    * Toggle a Thread's persisted per-Thread flags (#132 pin / #133 archive). A SAFE
    * metadata op — no session teardown — so it runs on any row (active or cold-peek).
    * Best-effort in main (ADR-0005); we refresh the recents list so the new flag
@@ -833,6 +863,7 @@ export function App(): JSX.Element {
         onNewThread={startNewChat}
         onNewThreadInWorkspace={newThreadInWorkspace}
         onDeleteThread={deleteThread}
+        onRemoveWorkspace={removeWorkspace}
         onSetThreadFlags={setThreadFlags}
         onRenameThread={renameThread}
         onOpenSettings={() => navDispatch({ type: 'open-settings' })}

--- a/src/renderer/src/connection/workspace-threads.test.ts
+++ b/src/renderer/src/connection/workspace-threads.test.ts
@@ -183,6 +183,31 @@ describe('workspaceThreadsReducer', () => {
     expect(workspaceThreadsReducer(s, { type: 'remove', workspaceId: 'w1', threadId: 'cold' })).toBe(s)
   })
 
+  it('remove-workspace drops the whole Workspace entry, leaving siblings intact', () => {
+    let s = workspaceThreadsReducer(initialWorkspaceThreads, {
+      type: 'connect',
+      workspaceId: 'w1',
+      threadId: 't1',
+      sessionId: 's1',
+      controls: null,
+    })
+    s = workspaceThreadsReducer(s, { type: 'connect', workspaceId: 'w2', threadId: 't2', sessionId: 's2', controls: null })
+    s = workspaceThreadsReducer(s, { type: 'remove-workspace', workspaceId: 'w1' })
+    expect(workspaceThreadStateFor(s, 'w1')).toBeNull()
+    expect(workspaceThreadStateFor(s, 'w2')).not.toBeNull()
+  })
+
+  it('remove-workspace on an unconnected Workspace returns the same state reference', () => {
+    const s = workspaceThreadsReducer(initialWorkspaceThreads, {
+      type: 'connect',
+      workspaceId: 'w1',
+      threadId: 't1',
+      sessionId: null,
+      controls: null,
+    })
+    expect(workspaceThreadsReducer(s, { type: 'remove-workspace', workspaceId: 'w-none' })).toBe(s)
+  })
+
   it('keeps Workspaces independent (one connect does not disturb another)', () => {
     let s = workspaceThreadsReducer(initialWorkspaceThreads, {
       type: 'connect',

--- a/src/renderer/src/connection/workspace-threads.ts
+++ b/src/renderer/src/connection/workspace-threads.ts
@@ -72,6 +72,11 @@ export type WorkspaceThreadsAction =
   // A live Thread was deleted (TB6): drop it from the live set + its bound session
   // + its config entry.
   | { type: 'remove'; workspaceId: string; threadId: string }
+  // A whole Workspace was removed ("Remove project"): drop its ENTIRE live-state
+  // entry (live set, bound sessions, active, config, selection cache). Idempotent —
+  // a Workspace never connected this session has no entry, so this returns the SAME
+  // ref and drives no re-render.
+  | { type: 'remove-workspace'; workspaceId: string }
   // Optimistically reflect a per-Thread agent-control change (#70, ADR-0007): a
   // change emits no notification, so the renderer updates THIS Thread's displayed
   // current value the instant the user picks, then reverts (re-dispatching the prior
@@ -153,6 +158,14 @@ export function workspaceThreadsReducer(
       // `active` is left to the caller: deleting the active Thread is paired with a
       // `select` back to the connection's primary Thread (which is never deletable).
       return { ...state, [action.workspaceId]: { ...cur, live, bound, config, selected } }
+    }
+    case 'remove-workspace': {
+      // Drop the removed Workspace's entire entry. Same-ref discipline: a Workspace
+      // with no live-state (never connected this session) returns the SAME ref.
+      if (!(action.workspaceId in state)) return state
+      const next = { ...state }
+      delete next[action.workspaceId]
+      return next
     }
     case 'set-config': {
       // Optimistic per-Thread update (#70, ADR-0007). Same-ref-on-noop discipline:

--- a/src/renderer/src/shell/Shell.tsx
+++ b/src/renderer/src/shell/Shell.tsx
@@ -35,8 +35,18 @@ import {
 } from './sidebar-width-store'
 import { getSortOrder, setSortOrder, sortWorkspaces, type WorkspaceSortOrder } from './workspace-sort'
 import { Badge } from '../ui/badge'
+import { Button } from '../ui/button'
 import { cn } from '../lib/utils'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../ui/collapsible'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog'
 import { IconButton } from '../ui/icon-button'
 import { Menu, MenuContent, MenuItem, MenuRadioGroup, MenuRadioItem, MenuTrigger } from '../ui/menu'
 import { NavItem } from '../ui/nav-item'
@@ -98,6 +108,7 @@ export function Shell({
   onNewThread,
   onNewThreadInWorkspace,
   onDeleteThread,
+  onRemoveWorkspace,
   onSetThreadFlags,
   onRenameThread,
   onOpenSettings,
@@ -128,6 +139,8 @@ export function Shell({
   onNewThreadInWorkspace: (workspaceId: string) => void
   /** Delete a Thread (TB6) — main tears down any live session, then the list refreshes. */
   onDeleteThread: (thread: ThreadMeta) => Promise<void>
+  /** Remove a Workspace ("Remove project") — main stops its agent + drops our records (no disk delete). */
+  onRemoveWorkspace: (workspaceId: string) => void | Promise<void>
   /** Pin/archive a Thread (#132/#133) — a safe metadata toggle on any row. */
   onSetThreadFlags: SetThreadFlags
   /** Rename a Thread (#) — inline sidebar edit; App persists + syncs vibe-acp if live. */
@@ -222,6 +235,7 @@ export function Shell({
               onSelectThread={onSelectThread}
               onNewThreadInWorkspace={onNewThreadInWorkspace}
               onDeleteThread={onDeleteThread}
+              onRemoveWorkspace={onRemoveWorkspace}
               onSetThreadFlags={onSetThreadFlags}
               onRenameThread={onRenameThread}
             />
@@ -390,6 +404,7 @@ function WorkspaceNav({
   onSelectThread,
   onNewThreadInWorkspace,
   onDeleteThread,
+  onRemoveWorkspace,
   onSetThreadFlags,
   onRenameThread,
 }: {
@@ -403,6 +418,7 @@ function WorkspaceNav({
   onSelectThread: (workspaceId: string, threadId: string) => void
   onNewThreadInWorkspace: (workspaceId: string) => void
   onDeleteThread: (thread: ThreadMeta) => Promise<void>
+  onRemoveWorkspace: (workspaceId: string) => void | Promise<void>
   onSetThreadFlags: SetThreadFlags
   onRenameThread: RenameThread
 }): JSX.Element {
@@ -515,6 +531,7 @@ function WorkspaceNav({
               onNewThread={onNewThreadInWorkspace}
               onSelectThread={onSelectThread}
               onDeleteThread={onDeleteThread}
+              onRemoveWorkspace={onRemoveWorkspace}
               onSetThreadFlags={onSetThreadFlags}
               onRenameThread={onRenameThread}
             />
@@ -548,6 +565,7 @@ function ProjectRow({
   onNewThread,
   onSelectThread,
   onDeleteThread,
+  onRemoveWorkspace,
   onSetThreadFlags,
   onRenameThread,
 }: {
@@ -564,10 +582,14 @@ function ProjectRow({
   onNewThread: (workspaceId: string) => void
   onSelectThread: (workspaceId: string, threadId: string) => void
   onDeleteThread: (thread: ThreadMeta) => Promise<void>
+  onRemoveWorkspace: (workspaceId: string) => void | Promise<void>
   onSetThreadFlags: SetThreadFlags
   onRenameThread: RenameThread
 }): JSX.Element {
   const [expandedThreads, setExpandedThreads] = useState(false)
+  // The "Remove project" confirmation dialog (Codex-style): a destructive, controlled
+  // modal opened from this project's ⋯ menu. Confirming calls `onRemoveWorkspace`.
+  const [confirmRemoveOpen, setConfirmRemoveOpen] = useState(false)
   // Split archived rows out (#133) then float pinned rows to the top of the active
   // list (#132) — both pure post-processing over the derived rows (deriveUnifiedThreads
   // stays flag-agnostic). Archived rows fold into a collapsible section at the bottom.
@@ -630,7 +652,50 @@ function ProjectRow({
         >
           <Plus className="size-4" aria-hidden />
         </IconButton>
+        {/* Per-project ⋯ actions menu (a SIBLING of the trigger, so opening it never
+            toggles the fold). Hover-revealed like the ＋; holds the destructive
+            "Remove project" action, which opens the confirm dialog. */}
+        <Menu>
+          <MenuTrigger
+            aria-label={`${workspace.displayName} project actions`}
+            title="Project actions"
+            className="inline-flex size-6 shrink-0 items-center justify-center rounded-sm text-muted opacity-0 outline-none transition-opacity hover:bg-accent/10 hover:text-text focus-visible:opacity-100 group-hover/proj:opacity-100 data-[popup-open]:opacity-100"
+          >
+            <MoreVertical className="size-3.5" aria-hidden />
+          </MenuTrigger>
+          <MenuContent>
+            <MenuItem className="text-bad" onClick={() => setConfirmRemoveOpen(true)}>
+              <Trash2 className="size-3.5" aria-hidden />
+              Remove project
+            </MenuItem>
+          </MenuContent>
+        </Menu>
       </div>
+
+      {/* Confirm dialog for "Remove project" — controlled, destructive. It removes the
+          project from vibe-mistro (our records + its agent), never files on disk. */}
+      <Dialog open={confirmRemoveOpen} onOpenChange={setConfirmRemoveOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Remove {workspace.displayName}?</DialogTitle>
+            <DialogDescription>
+              This removes the project from vibe-mistro. Files on disk will not be deleted.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <DialogClose render={<Button variant="secondary" />}>Cancel</DialogClose>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                setConfirmRemoveOpen(false)
+                void onRemoveWorkspace(workspace.id)
+              }}
+            >
+              Remove
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <CollapsibleContent>
         {mainRows.length > 0 ? (

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -81,6 +81,15 @@ export const IPC = {
    */
   deleteThread: 'thread:delete',
   /**
+   * Remove a Workspace (Codex-style "Remove project"): stop/dispose its warm agent
+   * (if any), then remove OUR records — the Workspace metadata entry + every Thread
+   * metadata entry under it + their JSONL transcripts. It NEVER deletes files on
+   * disk (the project directory is untouched). Allowed even mid-turn — the agent is
+   * stopped cleanly. Best-effort per ADR-0005: every step is guarded so the removal
+   * always resolves, and the Workspace vanishes from the next `listMetadata`.
+   */
+  removeWorkspace: 'workspace:remove',
+  /**
    * Renderer -> main: the current NON-default per-Thread statuses (#53), pulled
    * once on mount so a renderer that loads (or dev-reloads) MID-turn re-seeds its
    * status registry instead of waiting for the next flip. Main only pushes on a
@@ -486,6 +495,15 @@ export type SendPromptResult =
  * through just as a turn began; the renderer leaves the row in place.
  */
 export type DeleteThreadResult = { ok: true } | { ok: false; reason: 'streaming' }
+
+/**
+ * The `removeWorkspace` reply. Always `{ ok: true }` — the removal is fully
+ * best-effort (ADR-0005): stopping the agent and dropping our records/transcripts
+ * are each guarded so nothing can reject the live flow, and an unknown/already-gone
+ * Workspace is a harmless no-op. There is no failure signal for the renderer to
+ * branch on; it just refreshes the list.
+ */
+export type RemoveWorkspaceResult = { ok: true }
 
 /**
  * Interrupt a Thread's active turn (#103, ADR-0009). Fired by the Stop button,


### PR DESCRIPTION
Adds the Codex-style **Remove project** you asked about — there was previously no project-level removal at all (only thread delete).

## UX
- Each project header gets a hover-revealed **⋯ menu** (sibling of the ＋, so it never toggles the fold) with a destructive **Remove project** item.
- Clicking it opens a confirm modal: **"Remove {name}? This removes the project from vibe-mistro. Files on disk will not be deleted."** — Cancel / Remove.
- Confirming: stops/disposes that workspace's warm agent (allowed even mid-turn — decided "allow, stop cleanly"), removes **our** records (Workspace + Thread metadata + their JSONL transcripts), deselects it if active, and refreshes the list. **The project directory on disk is never touched.**

## Shape (mirrors thread-delete end-to-end)
`workspace:remove` shared channel → preload passthrough → **thin** main handler → pure best-effort orchestrator `remove-workspace.ts` + `MetadataStore.removeWorkspace` (returns removed thread ids) + `pool.agentIdForWorkspace`. Renderer reconciles via existing idempotent reducer actions (`nav clear`, `connections clear`, new `workspace-threads remove-workspace`) and clears each removed thread's composer draft + status. All best-effort per ADR-0005 — nothing can reject the live flow.

## Reviewed adversarially — one MUST-fix found and folded
A mid-turn removal could **re-create an orphaned JSONL**: `TranscriptStore.delete` only drops the append-chain tail, so the `turn-error` teed when the disposed agent rejects its in-flight prompt (that tee uses `args.threadId` directly, bypassing the bridge) would start a fresh chain and re-write a header + line — a leaked transcript no metadata references. The store's own docstring flags this exact call site as unsafe for live threads.

**Fix:** a session-scoped **tombstone set** of removed thread ids, populated *before* teardown and checked at the single `teeTranscript` choke point — every late tee (rejected turn or straggling event) is suppressed. Also cleaned up orphaned renderer-local draft/status keys (review NIT #2). The remaining review points were verified correct (idempotency, ordering/no-double-removal, best-effort discipline, `inFlightTurns` cleanup on mid-turn dispose).

## Gates
`lint && typecheck && build && test` — all green, **687 tests (+12 new)**: orchestrator best-effort (6), `MetadataStore.removeWorkspace` (3), `pool.agentIdForWorkspace` (1), `workspace-threads remove-workspace` (2).

Note: the tombstone/tee guard lives in `index.ts` app wiring (like the existing untested `transcriptThreads`/`threadIdForTee` tee plumbing), covered by reasoning + the orchestrator tests rather than a new unit test — the risk is in the wiring order (tombstone before dispose), not a pure function.

## Smoke
Hover a project → ⋯ → Remove project → confirm. It disappears from the sidebar; disk files remain. Remove a project mid-turn → agent stops, no orphaned transcript reappears on reopen. Remove a non-selected project → your current selection is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)