### PR TITLE
docs: refresh HANDOFF + NEXT-SESSION — design-system epic complete

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -3,11 +3,12 @@
 > You are picking up an in-flight project. Read this top to bottom once, then keep it open.
 > It tells you **what this is**, **how we work**, **what exists**, **what's next**, and **where the
 > authoritative information lives** (in-repo docs + the local reference repos in §4). Last updated
-> 2026-07-01, `main` @ `0197b5a`, **569 tests**. The **design-system epic (PRD #109) is ~half DONE**: its
-> **foundation (#110 tokens, #111 primitives, #112 streamdown spike, #113 shell) and the entire SIDEBAR
-> cluster (#127–#134, #138) shipped**; **REMAINING = #114/#115/#116 conversation · #117 composer · #118 auth ·
-> #119 git panel** (see §6). **`docs/NEXT-SESSION.md` is the copy-paste kickoff for the next session.**
-> Values live in ADR-0010 + `docs/design-tokens.md` + `docs/design-system-components.md` + `docs/streamdown-spike.md`.
+> 2026-07-01, `main` @ `3485094` or later, **675 tests**. 🎉 **The design-system epic (PRD #109) is COMPLETE** —
+> ALL slices shipped (#110 tokens · #111 primitives · #112 streamdown spike · #113 shell · #114–#116 conversation
+> core · #117 composer · #118 auth · #119 git panel, plus the sidebar cluster #127–#134/#138). Every UI area now
+> runs on tokens + primitives. **There is NO active epic — the next one is the user's call** (see §6 for the
+> roadmap + a small open follow-up backlog). `docs/NEXT-SESSION.md` is the copy-paste kickoff. Values live in
+> ADR-0010..0012 + `docs/design-tokens.md` + `docs/design-system-components.md` + `docs/streamdown-spike.md`.
 > `$`/`@` autocomplete stays paused.
 
 ---

--- a/docs/NEXT-SESSION.md
+++ b/docs/NEXT-SESSION.md
@@ -1,91 +1,66 @@
-# Next session — design-system epic: conversation + composer + auth + git
+# Next session — design-system epic COMPLETE; pick the next epic (or clear the follow-up backlog)
 
-The epic's **foundation is DONE** (tokens, primitives, streamdown decision, shell) and the **entire sidebar
-cluster is DONE**. What remains is the **conversation view**, the **composer**, and the **auth** + **git**
-panels. Open a fresh Claude Code session **in `/Users/abdullahatrash/mistral/vibe-mistro`** (so `main` is the
-cwd — it auto-loads `CLAUDE.md` + the memory index) and paste the block below as the first message.
+🎉 The **design-system epic (PRD #109) is fully shipped** — every UI area (tokens → primitives → shell →
+sidebar → conversation → composer → auth → git panel) now runs on the design tokens + primitive library.
+Baseline is **675 tests** green on `main`. There is **no active epic**; the next one is your call.
+
+Open a fresh Claude Code session **in `/Users/abdullahatrash/mistral/vibe-mistro`** (so `main` is the cwd — it
+auto-loads `CLAUDE.md` + the memory index) and paste the block below as the first message.
 
 ## Paste this
 
-> Read `HANDOFF.md`, then `docs/adr/0010-design-system-tokens-primitives-migration.md` + `docs/design-tokens.md`
-> + `docs/design-system-components.md` + `docs/streamdown-spike.md`. We're continuing the **design-system epic**
-> (parent PRD #109). Its **foundation (#110 tokens, #111 primitives, #112 streamdown spike, #113 shell) and the
-> whole SIDEBAR cluster (#127–#134, #138) are already SHIPPED to `main`.** What's LEFT: **#114/#115/#116
-> conversation, #117 composer, #118 auth, #119 git panel.** First confirm the baseline: on `main`, run the four
-> gates (`export PATH="$HOME/.nvm/versions/node/v22.22.1/bin:$HOME/.local/bin:$PATH"; bun run lint && bun run
-> typecheck && bun run build && bun run test`) → expect **569 tests green** (`main` @ `0197b5a` or later). Then
-> build the next slice via the **team loop in HANDOFF §3**: a manual worktree with a **real `bun install`**
-> (never a `node_modules` symlink), an implementer agent (the issue carries `/tdd`), your own **independent
-> verification** (re-run all four gates + read the diff), an **adversarial review** agent, fold fixes, **targeted
-> `git add <paths>` (never `-A`)**, push, and **I'll merge**. Each is a **behavior-identical restyle** — the 569
-> tests must stay green. **START with the slice I name** (or, if I just say "continue", start **#117 composer** —
-> it's unblocked and AFK-able — and ask me before starting **#114**, which is HITL). For the CONVERSATION slices
-> (#114–#116) mine the reference sources below HARD; the Response/markdown layer is **streamdown** (adopted in
-> #112 — `docs/streamdown-spike.md` has the exact wiring + the security sign-off you must surface to me).
+> Read `HANDOFF.md` (esp. §3 the team loop, §6 what's next) and skim the `design-system-epic` memory. The
+> **design-system epic (PRD #109) is COMPLETE** — all of #110–#119 + the sidebar cluster shipped; every area is
+> on tokens + primitives. First confirm the baseline: on `main`, run the four gates
+> (`export PATH="$HOME/.nvm/versions/node/v22.22.1/bin:$HOME/.local/bin:$PATH"; bun run lint && bun run typecheck
+> && bun run build && bun run test`) → expect **675 tests green** (`main` @ `3485094` or later). Then we pick the
+> next thing to work on — either a **new epic** (see the roadmap below) or **clearing the follow-up backlog**
+> below. When we build, follow the **team loop in HANDOFF §3**: a manual worktree with a **real `bun install`**
+> (never a `node_modules` symlink), an implementer agent (issues carry `/tdd`), your own **independent
+> verification** (re-run all four gates + read the diff — always `git diff <commit>^..<commit>` for scope, since
+> `main` moves fast in parallel), an **adversarial review** agent, fold fixes, **targeted `git add <paths>`
+> (never `-A`)**, push, and **I merge**. For anything touching **auth, security, or a new IPC**, surface the
+> decision to me (HITL) before committing. **Ask me which of the two lists below to start**; don't assume.
 
-## What's already shipped (this epic, all on `main`)
-- **Foundation:** #110 token layer (warm neutrals / rounded / softer gradient-orange in `styles.css`), #111
-  primitive library (`src/renderer/src/ui/` — base-ui + Tailwind + **CVA**: Button/Menu/Dialog/Popover/Tooltip/
-  Collapsible/Select/ScrollArea/etc. + `MenuRadioGroup`), #112 **streamdown ADOPT** verdict (`docs/streamdown-spike.md`),
-  #113 shell/sidebar restyle.
-- **Sidebar cluster:** all-visible **collapsible project list** (#138 — base-ui Collapsible, peek-only: folding
-  never spawns an agent; active project shows live rows, others show cold), Projects header **+new-project + sort**
-  (#129), **pin + archive** threads (#132/#133 — `ThreadMeta.pinned?`/`archived?` + `thread:set-flags` IPC +
-  `MetadataStore.setThreadFlags`; `orderByPin`/`partitionArchived` in `unified-threads.ts`), **settings page +
-  account menu** (#130 — nav-reducer `view: 'conversation'|'settings'` route), **collapsible sidebar** (#127 —
-  `panel-left` toggle + `sidebar-collapsed-store`), official **SVG logo** (#134), a branded **snake loading spinner**
-  (`shell/logo-snake-spinner.tsx` + `vmSnake` keyframe), and sticky top-nav/bottom-account (only the Projects list
-  scrolls). Renderer-only UI state uses the injected-storage throw-tolerant store pattern
-  (`project-open-store`/`workspace-sort`/`sidebar-collapsed-store`).
-- **Persistence (parallel, not this epic):** #125 ADR-0011 — draft threads persist + bind on first prompt (no
-  eager `session/new`; no empty-thread-on-open).
+## ⚠️ Two gotchas that bit us this epic (read these)
+- **NO LOCKFILE.** The repo tracks no `bun.lock`. Any PR that ADDS a dependency (this epic added streamdown,
+  `@streamdown/code`, `use-stick-to-bottom`, CVA, `@fontsource-variable/geist`) means **you MUST `bun install`
+  after every `git pull` on `main`** — otherwise `bun run dev`/build fail to resolve the new package. This bit
+  the user twice.
+- **`main` moves fast in parallel.** Judge an implementer's scope with **`git diff <commit>^..<commit>`** (against
+  the commit's PARENT), NOT `git diff origin/main` — a moved `origin/main` shows phantom "out-of-scope" files.
+  When a merge conflicts because `main` advanced mid-slice, rebuild clean: `git reset --hard origin/main` then
+  `git checkout <impl-sha> -- <only the in-scope files>`, recommit (real bug we hit on #117/#153/#114).
 
-## Remaining slices + dependencies
-- **#114 conversation A — [HITL]** — Response (=streamdown) / Message / Bubble / autoscroll. The hard core and the
-  biggest visual jump. Needs live `bun run dev` iteration AND a sign-off on streamdown's **HTML-sanitize security
-  posture** (streamdown `rehype-sanitize`+`rehype-harden` vs today's escape-everything `ChatMarkdown` — see
-  `docs/streamdown-spike.md`). Depends on #111 + #112 (both done).
-- **#115 conversation B** (needs #114) — tool rows (t3code `SimpleWorkEntryRow`), a **Collapsible** reasoning block
-  (auto-open while streaming), a self-ticking "Working…" indicator.
-- **#116 conversation C** (needs #114) — inline approval (restyle `PermissionRow`), a hover actions bar
-  (copy/👍/👎/retry), file-path **chip links** (new pure logic — TDD it).
-- **#117 composer** (needs #111/#113 — done) · **#118 auth** (needs #111) · **#119 git panel** (needs #111) —
-  parallel, AFK-able area restyles onto the primitives.
-- Recommended order: knock out the AFK area slices **#117 → #119 → #118** first (visible wins, no HITL), then do
-  **#114 → #115 → #116** with the human in the loop. Or start #114 first if the human wants the chat sooner.
+## Open follow-up backlog (small, tracked issues — good warm-up work)
+- **#168** — file-path chips NEVER render: streamdown's `harden` blocks relative/file link hrefs (`[x](path)` →
+  `[blocked]`) before our chip override runs (a #114-era issue). The reveal IPC + `FileChip` are built + secure
+  and READY; this fixes the harden config (SECURITY-SENSITIVE — must re-verify `javascript:` stays blocked). Also
+  the place to consider auto-linkifying bare file paths in prose (agents rarely emit markdown file-links).
+- **#164** — a tool row spins forever if ACP omits a terminal `tool_call_update` (thread `streaming` into
+  `ToolRow`; show a static glyph once settled).
+- **#162** — streamdown table `<thead>` renders dark-grey (the `muted` token-collision, tables only). Override
+  `th`/`thead` in `Response.tsx`'s `components` (mirror the `inlineCode` fix).
+- **#159** — shiki grammars duplicated (streamdown 3.x vs `@pierre/diffs` 4.x, ~+10MB lazy). Pin one shiki via
+  package.json `overrides` WITH a `@pierre/diffs` highlighting regression check.
+- **Verification debt:** #80 sign-in re-check + #87/#88 git branches/PR were static-verified only — live-smoke
+  when convenient.
 
-## Reference sources for the CONVERSATION work — copy-adapt & OWN in-repo, NEVER add as deps
-1. **`docs/design-system-components.md` §2** — THE build reference (exactly what to lift from shadcn + t3code for
-   Message/Bubble/Response/ToolRow/Reasoning/Approval/Actions/file-links, and what to STRIP). Read it first.
-2. **streamdown** (+ `@streamdown/code`) — the ADOPTED Response/markdown layer (#112). `docs/streamdown-spike.md`
-   has the locked #114 plan: `@source '…/streamdown/dist'` + the `@theme inline` shadcn-token map, the `muted`
-   token-collision fix, the shiki-dedup lever, and the HTML-sanitize security decision. It's streaming-native +
-   shiki + copy built in; it's what shadcn/AI-Elements' `Response` uses.
-3. **shadcn/ui** — `/Users/abdullahatrash/mistral/ui/apps/v4/registry/bases/base/ui/`: `message.tsx`, `bubble.tsx`,
-   `message-scroller.tsx` (the autoscroll engine — replaces our naive `scrollTop=scrollHeight`), `marker.tsx`. This
-   is the **base-ui** variant = our exact stack; swap its `cn-*` theme tokens for our inline Tailwind (the #111 gotcha).
-4. **shadcn AI Elements / ai-sdk Elements** (external — WebFetch `https://ai-sdk.dev/elements/overview` if useful):
-   the canonical chat-component patterns — Conversation, Message, Response, Reasoning, Tool, Actions, PromptInput.
-   Structure only: a discriminated **part-switch** (matches our `ConversationState.items` reducer, ADR-0001). Do
-   NOT adopt the AI-SDK message shape — feed our **ACP reducer** data (renderer owns conversation state, ADR-0001).
-5. **t3code** — `/Users/abdullahatrash/mistral/t3code/apps/web/src/components/chat/*` + `ChatMarkdown.tsx`: the rich
-   chat aesthetic — `SimpleWorkEntryRow` (tool rows), `WorkingTimelineRow` + `WorkingTimer`, `MarkdownFileLink`,
-   message bubbles. STRIP its coupling (worktree/checkpoint diffs, Pierre file icons → lucide, `session-logic`
-   derivation, `@legendapp/list` virtualization) — see components doc §2.
-6. **base-ui** (`https://base-ui.com`) — Collapsible (reasoning), ScrollArea, Tooltip, etc. Our primitives in
-   `src/renderer/src/ui/` already wrap these; extend them rather than reaching for base-ui directly in feature code.
+## Next-epic roadmap (CodexMonitor parity — user picks one; grill-with-docs → ADR → tracer-bullet issues)
+- **File tree + prompt library** — a file browser in the side panel. Unblocks BOTH the paused **`@` file-path
+  autocomplete** (needs a main-side file-listing IPC; the agent expands `@path` itself server-side — see
+  `HANDOFF.md` §6) AND a cleaner path for #168's chips.
+- **Terminal dock** — node-pty embedded terminal (see `opencode` for the Electron mechanics). The design mockups
+  already reserve chrome for it (a 230px dock; the shimmer/snake-spinner brand palette is in place).
+- **Settings / usage meter / in-app updates / packaging** — electron-updater + electron-builder (see `opencode`).
+  The Settings page shell already exists (#130).
+- **Git/GitHub follow-ups** (ADR-0008 deferred tier) — multi-repo, a full PR/issue browser, "Ask PR",
+  worktree-per-Thread isolation.
+- **Composer extras — final piece** — `@` file-path autocomplete (see file-tree above); `$` skills already
+  covered by `/`.
 
-## How the human drives it
-- After each slice PR: **"merge it then start `<next #>`"** (same tight cadence as the whole epic so far).
-- **#114 is HITL** — live-smoke (`bun run dev`) and iterate on the conversation aesthetic; get the security sign-off.
-- Net-new features (Search/Scheduled/Plugins nav, terminal, view modes, multi-tool dock, git Environment/Sources)
-  stay **static placeholders** — do NOT build their functionality (ADR-0010 scope boundary).
-
-## Guardrails (also in HANDOFF/CLAUDE.md)
-- Branch first, never commit to `main`; **targeted `git add <paths>`, never `-A`**; **the user merges**.
-- Worktrees use a **real `bun install`**, NOT a `node_modules` symlink (it broke the build once, #64).
-- `docs/design-tokens.md` **supersedes** `docs/design/brand.md` (softer orange + rounded, reversing `#fa500f` +
-  zero-radius). Use the tokens doc for anything visual.
-- Reference repos are **copy-adapt-and-own** — never add t3code/shadcn/AI-Elements as npm deps. New deps this epic:
-  `class-variance-authority` (shipped, #111); `streamdown` + `@streamdown/code` (add in #114 per the spike).
-- Gates before any slice is done: `bun run lint && bun run typecheck && bun run build && bun run test`.
+## Where the epic's decisions live (for reference / if you touch conversation/composer)
+- **ADR-0010** (design-system decisions) · **ADR-0011** (draft threads / lazy binding) · **ADR-0012** (eager
+  primary session at connect, reused by first prompt — the fix for empty agent-control pickers on a fresh draft).
+- `docs/design-tokens.md` (exact values) · `docs/design-system-components.md` (what was lifted from
+  shadcn/t3code) · `docs/streamdown-spike.md` (the Response/markdown wiring + the security posture).


### PR DESCRIPTION
Refreshes the handoff for the next session now that the **design-system epic (PRD #109) is fully shipped** (all #110–#119 + sidebar cluster; every UI area on tokens + primitives; baseline **675 tests**).

- `HANDOFF.md` header: epic COMPLETE, `main` @ `3485094`+, 675 tests, no active epic.
- `docs/NEXT-SESSION.md`: rewritten as a copy-paste kickoff that (1) confirms the baseline, (2) offers the **follow-up backlog** (#159/#162/#164/#168 + verification debt) and the **next-epic roadmap** (file tree / terminal dock / settings-packaging), and (3) surfaces the two gotchas that bit us — **no lockfile → `bun install` after every pull**, and **judge scope via `git diff <commit>^..<commit>`** since `main` moves fast in parallel.

Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)