### PR TITLE
#162: repaint markdown table header off the bg-muted collision

### DIFF
--- a/src/renderer/src/conversation/Response.tsx
+++ b/src/renderer/src/conversation/Response.tsx
@@ -23,10 +23,16 @@ import { FileChip } from './FileChip'
  *    silently reintroduce `javascript:`-href XSS. As defence-in-depth (so the `a` override
  *    is safe even if that chain changes) we also allow-list the scheme in `a` below.
  *
- * Two `components` overrides:
+ * Three `components` overrides:
  *  - `inlineCode` — resolves the spike's `muted` token collision: streamdown's default
  *    inline code is `bg-muted`, but our `--color-muted` is a text-grey, so we repaint
  *    inline code on `--accent-tint` instead (code BLOCKS use `bg-sidebar`, no collision).
+ *  - `thead` — same collision (#162): streamdown fills the table header row with
+ *    `bg-muted/80`, which our text-grey `--color-muted` renders as ~80% dark warm-grey.
+ *    Repaint the one colliding class onto `bg-sidebar` (the same warm-light container
+ *    surface code BLOCKS use); the `th` cells keep streamdown's default border/padding/
+ *    font-weight untouched. Fixed here, NOT in the token map — `--color-muted` must stay
+ *    a text-grey everywhere else it's used.
  *  - `a` — turns file-path destinations into an orange `FileChip`; other links stay
  *    plain accent-underlined anchors (opened in the system browser).
  */
@@ -54,6 +60,13 @@ export function Response({ text, className }: { text: string; className?: string
         >
           {children}
         </code>
+      ),
+      // Repaint only streamdown's colliding `bg-muted/80` (see header comment, #162);
+      // `data-streamdown="table-header"` kept for parity with streamdown's default markup.
+      thead: ({ className: theadClassName, children }) => (
+        <thead data-streamdown="table-header" className={cn('bg-sidebar', theadClassName)}>
+          {children}
+        </thead>
       ),
       a: ({ href, className: linkClassName, children }) => {
         const link = href ? parseFileLink(href) : null


### PR DESCRIPTION
Closes #162 (follow-up from #114).

## Problem
Streamdown styles a markdown table's `<thead>` with `bg-muted/80`, but our `--color-muted` is bound to a FOREGROUND text-grey (`#6b645d`) — so table header rows filled with ~80% dark warm-grey. Same token-collision family #114 fixed for inline code via the `inlineCode` override.

## Fix
One `thead` entry added to `Response.tsx`'s streamdown `components` map: repaints the background onto `bg-sidebar` (the warm-light surface code blocks already use — and fully opaque, so streamdown's sticky fullscreen-table header doesn't bleed scrolled rows through). The `th` cells are a separate streamdown component and keep their default border/padding/font-weight. Fixed at the component, NOT the token map — `--color-muted` keeps its text-grey meaning everywhere else.

## Verification
- Adversarial review: **APPROVE**, no MUST/SHOULD findings. Verified against the actual streamdown 2.5.0 dist: user components spread OVER the default map, so the override fully replaces the default renderer (`bg-muted/80` never renders, no tailwind-merge ordering hazard); `data-streamdown="table-header"` matches byte-for-byte; `thead` override is fully typed (`JSX.IntrinsicElements['thead'] & ExtraProps`). One comment-accuracy NIT folded.
- Gates: lint ✓ typecheck ✓ build ✓ test **687/687** ✓ (run independently by lead + reviewer).
- Visual check of a rendered table in `bun run dev` recommended at merge time (change is tables-only, cosmetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)