### PR TITLE
#164: settle non-terminal tool status to a static dot when the turn ends

### DIFF
--- a/src/renderer/src/conversation/Conversation.tsx
+++ b/src/renderer/src/conversation/Conversation.tsx
@@ -22,6 +22,7 @@ import {
   Brain,
   Check,
   ChevronDown,
+  Circle,
   Copy,
   Eye,
   Globe,
@@ -862,7 +863,7 @@ export function Item({
     case 'assistant':
       return <AssistantRow item={item} streaming={streaming} />
     case 'tool':
-      return <ToolRow item={item} />
+      return <ToolRow item={item} streaming={streaming} />
     case 'permission':
       return <PermissionRow item={item} onPermission={onPermission} />
     case 'error':
@@ -1036,7 +1037,8 @@ function ToolKindIcon({ name, className }: { name: ToolIconName; className?: str
 }
 
 /** The right-hand status glyph (pure `tool-status.ts` → lucide): spinner while live,
- *  a muted check when completed, a destructive X on failure. */
+ *  a muted check when completed, a destructive X on failure, a neutral static dot
+ *  when a non-terminal status settled after the turn ended (#164). */
 function ToolStatusGlyph({ glyph }: { glyph: ToolStatusGlyph }): JSX.Element {
   switch (glyph) {
     case 'check':
@@ -1045,6 +1047,8 @@ function ToolStatusGlyph({ glyph }: { glyph: ToolStatusGlyph }): JSX.Element {
       return <X className="size-4 text-bad" aria-hidden />
     case 'spinner':
       return <Loader2 className="size-4 animate-spin text-muted" aria-hidden />
+    case 'dot':
+      return <Circle className="size-2 fill-muted text-muted opacity-60" aria-hidden />
   }
 }
 
@@ -1070,13 +1074,15 @@ function toolPreview(item: ToolItem, heading: string): string | null {
   return raw.trim().toLowerCase() === heading.trim().toLowerCase() ? null : raw
 }
 
-function ToolRow({ item }: { item: ToolItem }): JSX.Element {
+function ToolRow({ item, streaming }: { item: ToolItem; streaming: boolean }): JSX.Element {
   // Tool call (#115, adapted from t3code SimpleWorkEntryRow): a compact row —
   // leading tone-icon (kind→lucide) + heading + dimmed preview + a rotating chevron
   // (only when there's detail) + a right status glyph (ACP status→display). Clicking
   // an expandable row toggles an indented `<pre>` of the raw input/output/content.
+  // `streaming` (#164) settles a non-terminal status to a static dot once this
+  // Thread's turn ends, so a missing terminal `tool_call_update` doesn't spin forever.
   const [expanded, setExpanded] = useState(false)
-  const status = describeToolStatus(item.status)
+  const status = describeToolStatus(item.status, streaming)
   const heading = item.title ?? item.toolKind ?? 'tool'
   const preview = toolPreview(item, heading)
   const detail = toolDetail(item)

--- a/src/renderer/src/conversation/tool-status.test.ts
+++ b/src/renderer/src/conversation/tool-status.test.ts
@@ -31,4 +31,34 @@ describe('describeToolStatus', () => {
     expect(describeToolStatus(undefined)).toEqual({ state: 'pending', glyph: 'spinner' })
     expect(describeToolStatus('')).toEqual({ state: 'pending', glyph: 'spinner' })
   })
+
+  // #164 — a non-terminal status is SETTLED once the turn stops streaming: without
+  // this the row spins forever if ACP omits a terminal `tool_call_update`.
+  describe('settled context (streaming flag)', () => {
+    it('keeps the spinner for non-terminal statuses while streaming', () => {
+      expect(describeToolStatus('pending', true)).toEqual({ state: 'pending', glyph: 'spinner' })
+      expect(describeToolStatus('in_progress', true)).toEqual({ state: 'running', glyph: 'spinner' })
+      expect(describeToolStatus('weird-status', true)).toEqual({ state: 'pending', glyph: 'spinner' })
+      expect(describeToolStatus(null, true)).toEqual({ state: 'pending', glyph: 'spinner' })
+    })
+
+    it('settles non-terminal statuses to a static dot once not streaming', () => {
+      expect(describeToolStatus('pending', false)).toEqual({ state: 'settled', glyph: 'dot' })
+      expect(describeToolStatus('in_progress', false)).toEqual({ state: 'settled', glyph: 'dot' })
+    })
+
+    it('settles unknown/missing statuses to a static dot once not streaming', () => {
+      expect(describeToolStatus('weird-status', false)).toEqual({ state: 'settled', glyph: 'dot' })
+      expect(describeToolStatus(null, false)).toEqual({ state: 'settled', glyph: 'dot' })
+      expect(describeToolStatus(undefined, false)).toEqual({ state: 'settled', glyph: 'dot' })
+      expect(describeToolStatus('', false)).toEqual({ state: 'settled', glyph: 'dot' })
+    })
+
+    it('leaves terminal statuses unaffected by the streaming flag', () => {
+      expect(describeToolStatus('completed', false)).toEqual({ state: 'done', glyph: 'check' })
+      expect(describeToolStatus('completed', true)).toEqual({ state: 'done', glyph: 'check' })
+      expect(describeToolStatus('failed', false)).toEqual({ state: 'failed', glyph: 'x' })
+      expect(describeToolStatus('failed', true)).toEqual({ state: 'failed', glyph: 'x' })
+    })
+  })
 })

--- a/src/renderer/src/conversation/tool-status.ts
+++ b/src/renderer/src/conversation/tool-status.ts
@@ -5,34 +5,49 @@
  * so it's unit-tested as data (`tool-status.test.ts`); the tsx just switches the
  * returned `glyph` to a lucide component.
  *
- * `state` collapses the protocol lifecycle to four display buckets; `glyph`
+ * `state` collapses the protocol lifecycle to five display buckets; `glyph`
  * selects the trailing indicator — a spinner while the call is live (pending or
  * in-progress: "absence of a terminal check"), a `Check` once completed, a
  * destructive `X` on failure. An unknown/missing status defaults to `pending`
  * (spinner) — a freshly-created `tool_call` with no status yet is still "live".
+ *
+ * `streaming` (#164) carries the current-turn liveness so a non-terminal status
+ * doesn't spin forever if ACP omits a terminal `tool_call_update`: once the turn
+ * is no longer streaming, any non-terminal status SETTLES to a neutral static
+ * `dot` — not a spinner (no live work) and not a `check` (don't claim success).
+ * Terminal statuses (`completed`/`failed`) are unaffected by the flag.
  */
-export type ToolDisplayState = 'pending' | 'running' | 'done' | 'failed'
+export type ToolDisplayState = 'pending' | 'running' | 'done' | 'failed' | 'settled'
 
-export type ToolStatusGlyph = 'spinner' | 'check' | 'x'
+export type ToolStatusGlyph = 'spinner' | 'check' | 'x' | 'dot'
 
 export interface ToolStatusDisplay {
   state: ToolDisplayState
   glyph: ToolStatusGlyph
 }
 
-export function describeToolStatus(status: string | null | undefined): ToolStatusDisplay {
+export function describeToolStatus(
+  status: string | null | undefined,
+  streaming = true,
+): ToolStatusDisplay {
   switch (status) {
     case 'completed':
       return { state: 'done', glyph: 'check' }
     case 'failed':
       return { state: 'failed', glyph: 'x' }
     case 'in_progress':
-      return { state: 'running', glyph: 'spinner' }
+      return streaming ? { state: 'running', glyph: 'spinner' } : settled()
     case 'pending':
-      return { state: 'pending', glyph: 'spinner' }
+      return streaming ? { state: 'pending', glyph: 'spinner' } : settled()
     default:
       // Unknown or missing status (e.g. a just-minted `tool_call`) is treated as
-      // still-live: show the spinner, never a false "done".
-      return { state: 'pending', glyph: 'spinner' }
+      // still-live while streaming: show the spinner, never a false "done".
+      return streaming ? { state: 'pending', glyph: 'spinner' } : settled()
   }
+}
+
+/** A non-terminal status once the turn has stopped streaming (#164): neutral,
+ *  static — neither a live spinner nor a success check. */
+function settled(): ToolStatusDisplay {
+  return { state: 'settled', glyph: 'dot' }
 }


### PR DESCRIPTION
Closes #164 (follow-up from #115 adversarial review S2).

## Problem
`describeToolStatus` maps `pending`/`in_progress`/unknown/missing → an animated spinner, and `turn-complete` never reconciles tool statuses — so a tool whose ACP `tool_call_update` never carries a terminal `status` kept spinning after the turn ended, implying live work when there was none.

## Fix
Pure-first, per the repo pattern: `describeToolStatus(status, streaming = true)` — once the turn is no longer streaming, any non-terminal/unknown/missing status settles to `{state:'settled', glyph:'dot'}` (a static muted `Circle`), NOT a spinner (no live work) and NOT a check (don't claim success). Terminal `completed`/`failed` are unaffected. `Item` threads its existing `streaming` prop into `ToolRow`; 4 new test cases cover the matrix.

## Verification
- Adversarial review: **APPROVE**, no MUST/SHOULD findings. Traced with evidence: (1) no stale-spinner revival — `streaming` is already scoped `idx > lastUserIndex` (the #115 mechanism), and the reducer sets `isProcessing` + appends the user item atomically, so an earlier turn's tool stays a dot while a later turn streams; (2) cold reopen (JSONL replay) forces `isProcessing:false` → a replayed non-terminal tool renders the dot — the most common real-world path for this bug; (3) single production call site, default param keeps mid-stream behavior byte-identical; glyph switch is exhaustive with no default.
- Gates: lint ✓ typecheck ✓ build ✓ test **691/691** ✓ (687 baseline + 4 new; run independently by lead + reviewer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)