### PR TITLE
fix: allow data: image URLs in CSP (composer attachment previews)

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' data:"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:"
     />
     <title>Vibe Mistro</title>
   </head>


### PR DESCRIPTION
The composer's image-attachment thumbnail previews rendered as broken images.

**Cause:** the renderer CSP (`src/renderer/index.html`) had no `img-src` directive, so it inherited `default-src 'self'` — which blocks `data:` URLs. The previews use `src={previewUrl}` where `previewUrl` is a `data:image/...;base64,...` URL (from `FileReader.readAsDataURL`), so they were CSP-blocked. Not a regression from the design-system epic — `img-src` was never set (the scaffold only had `default-src`/`script-src`/`style-src`; #160 added `font-src data:` for Geist).

**Fix:** add `img-src 'self' data: blob:` — `data:` for the base64 attachment previews + echoed user-turn thumbnails, `blob:` for robustness. Remote `https:` images are deliberately left blocked (agent output is untrusted — no tracking pixels).

Live-verified: attaching an image now shows the preview thumbnail. Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)