### PR TITLE
#159: dedup shiki grammars via a single 3.x override (~9MB renderer JS saved)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,10 @@
     "tailwindcss": "^4",
     "use-stick-to-bottom": "^1.1.6"
   },
+  "overrides": {
+    "shiki": "3.23.0",
+    "@shikijs/transformers": "3.23.0"
+  },
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@types/node": "^22.10.0",

--- a/src/renderer/src/conversation/code-highlight.test.ts
+++ b/src/renderer/src/conversation/code-highlight.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { code } from '@streamdown/code'
+import type { BundledLanguage } from 'shiki'
+
+/**
+ * Regression guard for #159 (shiki dedup). `Response` renders assistant markdown with
+ * `streamdown` + `@streamdown/code`, whose fenced-code highlighting is backed by shiki
+ * (`@streamdown/code` requires `shiki: "^3.19.0"`). #159 pins ONE shiki 3.x across the app so
+ * this consumer and `@pierre/diffs` share a single grammar bundle. This confirms the highlight
+ * path still tokenizes on the pinned shiki. The plugin's `highlight` is callback-based (returns
+ * null until grammars load), so we wrap it in a promise.
+ */
+
+const SAMPLES: Record<string, string> = {
+  typescript: 'const x: number = 42',
+  python: 'def f(x):\n    return x',
+  css: '.a { color: red }',
+}
+
+interface HighlightLine {
+  content: string
+  htmlStyle?: { color?: string }
+}
+
+function highlight(language: string, source: string): Promise<{ tokens: HighlightLine[][] }> {
+  return new Promise((resolve) => {
+    const sync = code.highlight(
+      { code: source, language: language as BundledLanguage, themes: ['github-light', 'github-dark'] },
+      resolve,
+    )
+    if (sync) resolve(sync)
+  })
+}
+
+describe('@streamdown/code highlighting on the pinned shiki 3.x (#159)', () => {
+  it('reports the shiki-backed plugin', () => {
+    expect(code.name).toBe('shiki')
+    expect(code.supportsLanguage('typescript' as BundledLanguage)).toBe(true)
+  })
+
+  it('tokenizes fenced code with colors for each language', async () => {
+    for (const language of Object.keys(SAMPLES)) {
+      const result = await highlight(language, SAMPLES[language])
+      const tokens = result.tokens.flat()
+      expect(tokens.length).toBeGreaterThan(0)
+      expect(tokens.some((t) => t.htmlStyle?.color)).toBe(true)
+    }
+  })
+})

--- a/src/renderer/src/git/diff-highlight.test.ts
+++ b/src/renderer/src/git/diff-highlight.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import {
+  codeToHtml,
+  getSharedHighlighter,
+  ShikiStreamTokenizer,
+  processFile,
+  renderDiffWithHighlighter,
+} from '@pierre/diffs'
+
+/**
+ * Regression guard for #159 (shiki dedup). `DiffView` renders the working-tree diff with
+ * `@pierre/diffs`, whose highlighting is backed by shiki. #159 pins ONE shiki 3.x (via a
+ * package.json `overrides`) to collapse the streamdown-3.x / @pierre/diffs-4.x duplication.
+ * `@pierre/diffs` declares `shiki: "^3.0.0 || ^4.0.0"`, so pinning 3.x is only safe if its
+ * highlight path still tokenizes on shiki 3.x. This exercises that path headlessly — the same
+ * library entry points the diff worker uses — so a future dep bump that breaks the pin fails here
+ * instead of silently shipping an unhighlighted diff panel. (unified vs split is a downstream
+ * layout option over these same tokens, not a separate shiki call.)
+ */
+
+const SAMPLES: Record<string, { file: string; code: string }> = {
+  typescript: { file: 'f.ts', code: 'const greet = (name: string): string => `hi ${name}`' },
+  python: { file: 'f.py', code: 'def greet(name: str) -> str:\n    return f"hi {name}"' },
+  css: { file: 'f.css', code: '.foo { color: #ff0000; margin: 0 auto; }' },
+}
+const LANGS = Object.keys(SAMPLES)
+const THEME = 'github-light'
+
+describe('@pierre/diffs highlighting on the pinned shiki 3.x (#159)', () => {
+  it('re-exports shiki codeToHtml and produces styled spans', async () => {
+    for (const lang of LANGS) {
+      const html = await codeToHtml(SAMPLES[lang].code, { lang, theme: THEME })
+      expect(html).toContain('<span')
+      expect(html).toContain('style=')
+    }
+  })
+
+  it('tokenizes via the shared highlighter + stream tokenizer (the worker path)', async () => {
+    const highlighter = await getSharedHighlighter({ themes: [THEME], langs: LANGS })
+    expect(highlighter).toBeTruthy()
+    for (const lang of LANGS) {
+      const tokenizer = new ShikiStreamTokenizer({ highlighter, lang, theme: THEME })
+      await tokenizer.enqueue(SAMPLES[lang].code)
+      const { stable } = tokenizer.close()
+      const colored = stable.filter((t) => t.color && t.content.trim().length > 0)
+      expect(stable.length).toBeGreaterThan(0)
+      expect(colored.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('renders a parsed file diff end-to-end (processFile -> renderDiffWithHighlighter)', async () => {
+    const highlighter = await getSharedHighlighter({ themes: [THEME], langs: LANGS })
+    for (const lang of LANGS) {
+      const { file } = SAMPLES[lang]
+      const patch = [
+        `diff --git a/${file} b/${file}`,
+        'index 000..111 100644',
+        `--- a/${file}`,
+        `+++ b/${file}`,
+        '@@ -1,2 +1,2 @@',
+        '-const x = 1',
+        '+const x = 2',
+        ' const y = x',
+      ].join('\n')
+      const fileDiff = processFile(patch, { isGitDiff: true, throwOnError: true })
+      expect(fileDiff).toBeTruthy()
+      const result = renderDiffWithHighlighter(fileDiff!, highlighter, {
+        theme: THEME,
+        useTokenTransformer: false,
+        tokenizeMaxLineLength: 100_000,
+        lineDiffType: 'word',
+        maxLineDiffLength: 1_000,
+      })
+      expect(result.code).toBeTruthy()
+      expect(result.themeStyles.length).toBeGreaterThan(0)
+    }
+  })
+})


### PR DESCRIPTION
Closes #159 (follow-up from #114/#112).

## ⚠️ AFTER PULLING THIS: CLEAN-REINSTALL, not just `bun install`
```
rm -rf node_modules && bun install
```
The repo tracks no lockfile, and an INCREMENTAL `bun install` does NOT re-hoist — it leaves a stale nested shiki copy and the bundle stays doubled (verified: 692 files, worse than before). Every existing checkout/worktree needs the clean reinstall for the dedup to materialize. Building against stale node_modules keeps the old dup silently (no error).

## Problem
`streamdown`/`@streamdown/code` pin shiki `^3.19.0`; `@pierre/diffs` resolved shiki 4.x — every TextMate grammar bundled twice (~9MB of duplicated lazy chunks, two 780kB emacs-lisp etc.; `docs/streamdown-spike.md` §Bundle impact).

## Fix
Root `package.json` `"overrides": {"shiki": "3.23.0", "@shikijs/transformers": "3.23.0"}` — the two packages @pierre/diffs imports directly; the rest of `@shikijs/*` follows transitively. 3.23.0 is the newest 3.x satisfying both `^3.19.0` and `^3.0.0 || ^4.0.0`.

**Result:** renderer assets 627 → 326 files, ~21.6MB → ~12.5MB JS (~42% less), one grammar chunk per language.

Plus 5 colocated regression tests (`git/diff-highlight.test.ts`, `conversation/code-highlight.test.ts`) driving @pierre/diffs' real highlight entry points (shared highlighter + stream tokenizer + `processFile`→`renderDiffWithHighlighter`) and @streamdown/code's plugin path on the pinned shiki — a future dep bump that breaks the pin fails in CI, with non-vacuous colored-token assertions.

## Verification
- Adversarial review: **APPROVE**. Empirically confirmed: the entire `@shikijs/*` family resolves to exactly one 3.23.0 (no 4.x stragglers, no nested copies); every shiki symbol @pierre/diffs@1.2.12 and @streamdown/code import at runtime exists in 3.23.0's exports; the built diff-worker bundle resolves the same deduped shiki and keeps the CSP-safe JS-regex engine default (no WASM path triggered — `script-src 'self'` posture from #112 preserved).
- Gates: lint ✓ typecheck ✓ build ✓ test **696/696** ✓ (691 baseline + 5; run independently by implementer, lead, and reviewer).

## 👀 Live check at merge (the one path unit tests don't drive: the worker *wiring*)
Open git Changes → DiffView on a diff touching a `.ts`/`.py`/`.css` file → syntax colors render; devtools console shows no CSP violation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)