### PR TITLE
#168: render file-path chips by guarding harden, not dropping it

### DIFF
--- a/src/renderer/src/conversation/Response.test.ts
+++ b/src/renderer/src/conversation/Response.test.ts
@@ -1,0 +1,88 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { Response } from './Response'
+
+/**
+ * End-to-end tests for the #168 fix, driven through the REAL streamdown render pipeline.
+ * `renderToStaticMarkup(<Response/>)` runs the full markdown → remark → rehype (raw → sanitize →
+ * guarded-harden) → React chain in the vitest node env, so these assert on the actual emitted HTML —
+ * not on isolated parse logic. This is the true adversarial surface: what a user's DOM would receive.
+ *
+ * (No `openFile` context is provided here, so `FileChip` renders its non-navigating `<span>` variant;
+ * the `data-file-chip` marker is present either way.)
+ */
+function render(text: string): string {
+  return renderToStaticMarkup(createElement(Response, { text }))
+}
+
+describe('Response — file-path links render as chips (#168)', () => {
+  const fileLinkCases: ReadonlyArray<[string, string]> = [
+    ['bare filename', '[label](test.txt)'],
+    ['dot-relative path', '[label](./src/x.ts)'],
+    ['absolute path', '[label](/Users/me/project/x.ts)'],
+    ['relative path with line ref', '[label](src/x.ts:42)'],
+  ]
+
+  for (const [name, input] of fileLinkCases) {
+    it(`renders a FileChip for a ${name}, not [blocked]`, () => {
+      const html = render(input)
+      expect(html).toContain('data-file-chip')
+      expect(html).not.toContain('[blocked]')
+      expect(html).not.toContain('Blocked URL')
+    })
+  }
+
+  it('renders the chip with the parsed line ref (L42) for a positioned path', () => {
+    const html = render('[label](src/x.ts:42)')
+    expect(html).toContain('data-file-chip')
+    expect(html).toContain('L42')
+  })
+})
+
+describe('Response — external links stay real, safe anchors', () => {
+  it('keeps an https link as an anchor with href, target=_blank and rel', () => {
+    const html = render('[ext](https://example.com/page)')
+    expect(html).toContain('href="https://example.com/page"')
+    expect(html).toContain('target="_blank"')
+    expect(html).toContain('rel="noreferrer noopener"')
+    expect(html).not.toContain('data-file-chip')
+    expect(html).not.toContain('[blocked]')
+  })
+})
+
+describe('Response — dangerous link schemes are neutralized end-to-end', () => {
+  const dangerous: ReadonlyArray<[string, string, string]> = [
+    ['javascript:', '[x](javascript:alert(1))', 'javascript:'],
+    ['data:text/html', '[x](data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)', 'data:text/html'],
+    ['vbscript:', '[x](vbscript:msgbox(1))', 'vbscript:'],
+  ]
+
+  for (const [name, input, needle] of dangerous) {
+    it(`strips a ${name} link entirely (no scheme, no clickable anchor)`, () => {
+      const html = render(input)
+      // The dangerous scheme string must not survive anywhere in the output (not in an href,
+      // not in a title attribute) — sanitize removes the href before it can render.
+      expect(html).not.toContain(needle)
+      expect(html).not.toContain('href="javascript:')
+      expect(html).not.toContain('href="data:')
+      expect(html).not.toContain('href="vbscript:')
+      // Never rendered as a file chip either.
+      expect(html).not.toContain('data-file-chip')
+    })
+  }
+})
+
+describe('Response — raw HTML stays dropped (skipHtml + sanitize)', () => {
+  it('drops a raw <script> tag', () => {
+    const html = render('Hello <script>alert(1)</script> world')
+    expect(html).not.toContain('<script')
+    expect(html).not.toContain('alert(1)')
+  })
+
+  it('drops an onerror handler and the blocked <img>', () => {
+    const html = render('<img src=x onerror="alert(1)">')
+    expect(html).not.toContain('onerror')
+    expect(html).not.toContain('alert(1)')
+  })
+})

--- a/src/renderer/src/conversation/Response.test.ts
+++ b/src/renderer/src/conversation/Response.test.ts
@@ -73,7 +73,23 @@ describe('Response — dangerous link schemes are neutralized end-to-end', () =>
   }
 })
 
-describe('Response — raw HTML stays dropped (skipHtml + sanitize)', () => {
+describe('Response — the wrapped harden still runs (#168 guard liveness)', () => {
+  // A bare extension-less relative href survives sanitize (relative hrefs are allowed) and is
+  // NOT a file path (`parseFileLink('foo')` → null, so the guard doesn't hide it) — the ONLY
+  // thing that blocks it is rehype-harden (unresolvable URL with `defaultOrigin: undefined`).
+  // If `guardFilePathAnchors` ever silently disabled harden, every other test in this file
+  // would still pass (their dangerous hrefs die in sanitize) but this one would fail with a
+  // live `<a href="foo">`. Do not delete it on a streamdown upgrade without a replacement.
+  it('still hard-blocks a relative non-file href (a harden-only block)', () => {
+    const html = render('[click](foo)')
+    expect(html).toContain('[blocked]')
+    expect(html).toContain('Blocked URL')
+    expect(html).not.toContain('href="foo"')
+    expect(html).not.toContain('data-file-chip')
+  })
+})
+
+describe('Response — raw HTML is sanitized, not skipped', () => {
   it('drops a raw <script> tag', () => {
     const html = render('Hello <script>alert(1)</script> world')
     expect(html).not.toContain('<script')

--- a/src/renderer/src/conversation/Response.tsx
+++ b/src/renderer/src/conversation/Response.tsx
@@ -4,6 +4,7 @@ import { code } from '@streamdown/code'
 import { cn } from '../lib/utils'
 import { extractLinkHrefs, fileLinkLabels, isSafeExternalHref, parseFileLink } from './file-link'
 import { FileChip } from './FileChip'
+import { responseRehypePlugins } from './response-rehype'
 
 /**
  * Renders agent-authored text as streaming-safe Markdown (#114, spike #112). Wraps
@@ -12,16 +13,21 @@ import { FileChip } from './FileChip'
  * shiki syntax highlighting + a copy control via the `@streamdown/code` plugin.
  * Themed to our tokens through the `@source` + `@theme inline` map in styles.css.
  *
- * SECURITY: agent output is UNTRUSTED. Two layers defend it:
- *  - `skipHtml` drops raw HTML tags the model emits (`<script>`, `<img onerror=…>`) —
- *    keeping the conservative escape-everything posture our old react-markdown wrapper
- *    had (we accept losing benign inline HTML for it). Do not remove `skipHtml`.
- *  - Dangerous LINK hrefs (`javascript:`/`data:`/`vbscript:`) are neutralized by
- *    streamdown's DEFAULT `rehypePlugins` (rehype-sanitize + harden), which render a
- *    `[blocked]` span instead of ever calling our `a` override. **Do NOT pass a custom
- *    `rehypePlugins` prop without re-adding that harden/sanitize chain** — doing so would
- *    silently reintroduce `javascript:`-href XSS. As defence-in-depth (so the `a` override
- *    is safe even if that chain changes) we also allow-list the scheme in `a` below.
+ * SECURITY: agent output is UNTRUSTED. The `rehypePlugins` below is streamdown's own default
+ * `[raw, sanitize, harden]` chain, minimally reconfigured for #168 — see `response-rehype.ts` for
+ * the full rationale. Each layer:
+ *  - `sanitize` (`rehype-sanitize`) is the XSS wall: it drops raw HTML tags the model emits
+ *    (`<script>`, `<img onerror=…>`) and STRIPS the href off `javascript:`/`data:`/`vbscript:`
+ *    links before render. `skipHtml` (still set below) is belt-and-suspenders on top of it.
+ *  - `harden` (`rehype-harden`) origin-checks external link/image URLs. #168 wraps it so ONLY
+ *    file-path anchors bypass it (reaching the `a` override unrewritten so `FileChip` can render);
+ *    every dangerous or external href still goes through harden exactly as before.
+ *  - the `a` override below is the final layer: it renders a file path as a `FileChip` and only
+ *    emits a real anchor for an `isSafeExternalHref` scheme, so it can't become a `javascript:` sink
+ *    even if the chain upstream ever changes.
+ * We pass `responseRehypePlugins` because the `rehypePlugins` prop REPLACES streamdown's defaults;
+ * **do NOT drop `raw`/`sanitize` from that list** — either would reintroduce raw-HTML/href XSS.
+ * Do not remove `skipHtml` either.
  *
  * Three `components` overrides:
  *  - `inlineCode` — resolves the spike's `muted` token collision: streamdown's default
@@ -71,7 +77,7 @@ export function Response({ text, className }: { text: string; className?: string
       a: ({ href, className: linkClassName, children }) => {
         const link = href ? parseFileLink(href) : null
         if (link) return <FileChip link={link} label={labels.get(link.path) ?? link.basename} />
-        // Defence-in-depth: streamdown's harden chain already blocks dangerous hrefs
+        // Defence-in-depth: the sanitize/harden chain already strips dangerous hrefs
         // before we get here, but only render a real anchor for an allow-listed scheme
         // so a future config change can't turn this override into a `javascript:` sink.
         // A rejected scheme renders as inert text (no href), never a clickable link.
@@ -95,6 +101,7 @@ export function Response({ text, className }: { text: string; className?: string
       className={cn('min-w-0 [&>:first-child]:mt-0 [&>:last-child]:mb-0', className)}
       plugins={{ code }}
       controls={{ code: { copy: true } }}
+      rehypePlugins={responseRehypePlugins}
       parseIncompleteMarkdown
       skipHtml
       components={components}

--- a/src/renderer/src/conversation/Response.tsx
+++ b/src/renderer/src/conversation/Response.tsx
@@ -16,9 +16,13 @@ import { responseRehypePlugins } from './response-rehype'
  * SECURITY: agent output is UNTRUSTED. The `rehypePlugins` below is streamdown's own default
  * `[raw, sanitize, harden]` chain, minimally reconfigured for #168 — see `response-rehype.ts` for
  * the full rationale. Each layer:
- *  - `sanitize` (`rehype-sanitize`) is the XSS wall: it drops raw HTML tags the model emits
- *    (`<script>`, `<img onerror=…>`) and STRIPS the href off `javascript:`/`data:`/`vbscript:`
- *    links before render. `skipHtml` (still set below) is belt-and-suspenders on top of it.
+ *  - `sanitize` (`rehype-sanitize`) is THE XSS wall — the only one: it drops disallowed raw
+ *    HTML elements/attributes the model emits (`<script>`, `<img onerror=…>`, `<svg onload>`)
+ *    and STRIPS the href off `javascript:`/`data:`/`vbscript:` links before render. NB raw
+ *    HTML is NOT "skipped": `raw` parses it into real element nodes first, which makes
+ *    `skipHtml` (below) inert in this chain — it only removes raw-type nodes, which no longer
+ *    exist after `raw` runs. It's kept as a dead-man's guard (it matters again if `raw` is
+ *    ever dropped), NOT as a live protection — do not credit it in a security analysis.
  *  - `harden` (`rehype-harden`) origin-checks external link/image URLs. #168 wraps it so ONLY
  *    file-path anchors bypass it (reaching the `a` override unrewritten so `FileChip` can render);
  *    every dangerous or external href still goes through harden exactly as before.

--- a/src/renderer/src/conversation/response-rehype.test.ts
+++ b/src/renderer/src/conversation/response-rehype.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { defaultRehypePlugins } from 'streamdown'
+import { responseRehypePlugins } from './response-rehype'
+
+/**
+ * Structural pins for the #168 chain. The end-to-end behaviour (file chips render, XSS stays
+ * blocked) is exercised through the real SSR pipeline in `Response.test.ts`; these tests guard the
+ * one property that review hinges on: that we reproduce streamdown's default `[raw, sanitize, harden]`
+ * chain with `raw` and `sanitize` UNCHANGED, wrapping only `harden`.
+ */
+describe('responseRehypePlugins', () => {
+  it('is the [raw, sanitize, harden] chain in order', () => {
+    expect(responseRehypePlugins).toHaveLength(3)
+  })
+
+  it('re-uses streamdown\'s raw and sanitize entries by reference (unchanged)', () => {
+    const defaults = defaultRehypePlugins as Record<'raw' | 'sanitize' | 'harden', unknown>
+    expect(responseRehypePlugins[0]).toBe(defaults.raw)
+    expect(responseRehypePlugins[1]).toBe(defaults.sanitize)
+  })
+
+  it('replaces only the harden entry with our wrapper (a fresh plugin function)', () => {
+    const defaults = defaultRehypePlugins as Record<'raw' | 'sanitize' | 'harden', unknown>
+    expect(responseRehypePlugins[2]).not.toBe(defaults.harden)
+    expect(typeof responseRehypePlugins[2]).toBe('function')
+  })
+})

--- a/src/renderer/src/conversation/response-rehype.ts
+++ b/src/renderer/src/conversation/response-rehype.ts
@@ -1,0 +1,111 @@
+import { defaultRehypePlugins } from 'streamdown'
+import type { Pluggable, PluggableList } from 'unified'
+import { parseFileLink } from './file-link'
+
+/**
+ * The rehype (HTML-AST) plugin chain for {@link Response} (#168).
+ *
+ * Streamdown's DEFAULT chain is `[raw, sanitize, harden]` (in that order — see
+ * `defaultRehypePlugins`, a `Record<'raw'|'sanitize'|'harden', Pluggable>`):
+ *  - `raw`      — `rehype-raw`: parses any raw HTML the model emitted into real hast nodes.
+ *  - `sanitize` — `rehype-sanitize` with streamdown's GitHub-derived schema. THIS is the XSS
+ *                 wall: its tag/attribute allow-list drops `<script>`/`<iframe>`/`on*` handlers,
+ *                 and its `protocols.href` allow-list (http/https/irc/ircs/mailto/xmpp/tel) STRIPS
+ *                 the href off `javascript:`/`data:`/`vbscript:` links before anything renders.
+ *  - `harden`   — `rehype-harden`: origin-validates external link/image URLs (streamdown wildcards
+ *                 to all http(s)), forces `target=_blank rel=noopener`, and permits `data:` images.
+ *
+ * THE PROBLEM (#168): `harden` is configured `defaultOrigin: undefined`, so a file-path href
+ * (`test.txt`, `src/x.ts:42`, `./x`, `/abs/x.ts`) either fails URL parsing outright (bare names)
+ * or is rewritten to a bare pathname (dot-relative/absolute). Bare names are replaced with a
+ * `[blocked]` span BEFORE our `a` override runs, so the `FileChip` override never fires. There is
+ * no `harden` option that passes a file path through unrewritten.
+ *
+ * THE FIX — {@link guardFilePathAnchors}: we reproduce the exact default chain but wrap the real
+ * streamdown `harden` transformer so anchors whose href our own `parseFileLink` recognises as a
+ * file path are hidden from harden (retagged `<a>`→`<span>`, which harden ignores) and restored to
+ * `<a href=…>` — byte-for-byte unrewritten — immediately after. Everything harden used to do to
+ * external links and images is untouched; only inert file-path hrefs bypass it, reaching the `a`
+ * override with their original string so `parseFileLink` (its 26-test contract) matches as before.
+ *
+ * Why the bypass is safe (defence in depth, three layers):
+ *  1. `sanitize` runs FIRST and unconditionally, so by the time our guard runs any dangerous-scheme
+ *     href is already stripped (verified end-to-end: a `javascript:` link reaches harden as
+ *     `href: undefined`). `parseFileLink` only ever returns non-null for a *scheme-less* path
+ *     (it rejects anything matching an external scheme), so a dangerous href can neither reach the
+ *     guard with its scheme intact nor be classified as a file link to bypass harden.
+ *  2. Anything the guard lets through is still an inert, scheme-less path — not an executable URL.
+ *  3. The `a` override in {@link Response} re-checks every surviving href against `isSafeExternalHref`
+ *     and renders a `FileChip` (a non-navigating reveal) or an allow-listed anchor only.
+ *
+ * Consumed via `<Streamdown rehypePlugins={responseRehypePlugins}>`. NOTE: the `rehypePlugins` prop
+ * REPLACES streamdown's defaults (it does not append), which is why this list re-supplies `raw` and
+ * `sanitize` UNCHANGED — dropping either would reintroduce raw-HTML / `javascript:`-href XSS.
+ */
+
+/** The minimal slice of the hast node shape this guard reads or mutates. */
+interface HastNode {
+  type: string
+  tagName?: string
+  properties?: Record<string, unknown>
+  children?: HastNode[]
+}
+
+type HastTransformer = (tree: HastNode) => void
+
+/** Private property key we stash a file-path href under while harden runs. Double-underscored so it
+ *  can never collide with a real hast property name produced from markdown. */
+const STASHED_HREF = '__vibeFileLinkHref'
+
+function hrefString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+/** Depth-first visit of every `element` node, parents before children. */
+function visitElements(node: HastNode, visit: (element: HastNode) => void): void {
+  if (node.type === 'element') visit(node)
+  if (node.children) for (const child of node.children) visitElements(child, visit)
+}
+
+/**
+ * Wrap streamdown's `harden` plugin so file-path anchors bypass it. `hardenEntry` is streamdown's
+ * `defaultRehypePlugins.harden` — a `[attacher, options]` tuple; we reuse BOTH so harden keeps its
+ * exact configured behaviour for every non-file-path link and image.
+ */
+function guardFilePathAnchors(hardenEntry: Pluggable): Pluggable {
+  if (!Array.isArray(hardenEntry)) {
+    // Fail loud if streamdown's shape changes, rather than silently shipping without harden.
+    throw new Error('streamdown defaultRehypePlugins.harden is not the expected [plugin, options] tuple')
+  }
+  const [hardenAttacher, hardenOptions] = hardenEntry as [(options: unknown) => HastTransformer, unknown]
+
+  return function guardedHarden(this: unknown): HastTransformer {
+    const runHarden = hardenAttacher(hardenOptions)
+    return (tree) => {
+      const hidden: HastNode[] = []
+      visitElements(tree, (element) => {
+        if (element.tagName !== 'a') return
+        const properties = (element.properties ??= {})
+        if (!parseFileLink(hrefString(properties.href))) return
+        properties[STASHED_HREF] = properties.href
+        element.tagName = 'span' // harden only rewrites <a>/<img>; a <span> passes through untouched.
+        hidden.push(element)
+      })
+
+      runHarden(tree)
+
+      for (const element of hidden) {
+        element.tagName = 'a'
+        const properties = element.properties ?? {}
+        properties.href = properties[STASHED_HREF]
+        delete properties[STASHED_HREF]
+      }
+    }
+  }
+}
+
+const { raw, sanitize, harden } = defaultRehypePlugins as Record<'raw' | 'sanitize' | 'harden', Pluggable>
+
+/** streamdown's default `[raw, sanitize, harden]` chain, with `harden` wrapped so file-path anchors
+ *  reach the `Response` `a` override unrewritten (#168). `raw` and `sanitize` are UNCHANGED. */
+export const responseRehypePlugins: PluggableList = [raw, sanitize, guardFilePathAnchors(harden)]


### PR DESCRIPTION
Closes #168 (slice 1 of the user-approved two-slice split; slice 2 = bare-path auto-linkify, to be filed).

## Problem
File-path links (`[label](src/x.ts:42)`) NEVER rendered as chips: streamdown's default rehype chain ends in `rehype-harden` with `defaultOrigin: undefined`, so relative/file hrefs fail URL resolution and become `[blocked]` spans BEFORE the `a`/FileChip override runs. The #116 reveal IPC + FileChip were built and secure but unreachable.

## Fix (zero new dependencies)
`response-rehype.ts`: pass a custom `rehypePlugins` — streamdown's exported `raw` + `sanitize` UNCHANGED by reference (the prop REPLACES defaults, so re-supplying them is mandatory), plus streamdown's real `harden` tuple WRAPPED (`guardFilePathAnchors`): anchors whose href `parseFileLink` recognizes as a file path are hidden from harden (retag `a`→`span`, href stashed) and restored byte-for-byte after it runs. File hrefs reach the `a` override unrewritten, so `parseFileLink`'s existing 26-test contract is untouched.

## Security (adversarial security review: APPROVE-WITH-FIXES, both folded)
Three independent layers, all proven END-TO-END via `renderToStaticMarkup` of the real component (15 SSR tests):
1. **sanitize runs first, untouched — it is the XSS wall**: `javascript:`/`data:`/`vbscript:` hrefs (incl. obfuscated), `<script>`/`<iframe>`/`<svg onload>`/`onerror`/`onclick` all die there; a dangerous scheme can never reach the guard nor classify as a file path.
2. **The bypass is inert**: `parseFileLink` matches only scheme-less paths; `FileChip` NEVER emits an href or navigates — click calls the reveal IPC, which realpath-confines to the Workspace (`[p](/etc/passwd)` / `../../../etc/passwd` verified inert + refused).
3. **The `a` override** allowlists schemes for any real anchor (`isSafeExternalHref`).

Attempted attacks that failed: stash-attribute injection (`__vibeFileLinkHref`) — sanitize drops it AND the guard overwrites the stash unconditionally; mid-stream partial links — no transient live href. Review folds: a **harden-liveness test** (`[click](foo)` → `Blocked URL` — producible only by harden; previously a silently-disabled harden kept the suite green) and an accurate security comment (`skipHtml` is INERT in this chain — rehype-raw parses HTML into elements before it acts; kept only as a dead-man's guard). Pre-existing + unchanged: remote images load per streamdown's wildcard image policy (CSP-governed).

## Verification
- Gates: lint ✓ typecheck ✓ build ✓ test **706/706** ✓ (691 baseline + 15; run independently by implementer, lead, and security reviewer).
- Live check at merge: in `bun run dev`, ask the agent for file links → orange chips render, click reveals in Finder; a `javascript:` link in agent output stays dead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)