### PR TITLE
#187: right-panel Surface stack — launcher cards, Review re-homed, ⌘P/⌃⇧G

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,6 +34,21 @@ agent blocks until the user picks a Permission option (allow once / reject once 
 pending queue and answered by request id.
 _Avoid_: approval, confirmation, prompt (reserve "prompt" for the user's message to the agent).
 
+## Side panel
+
+**Surface**:
+One of the expandable areas stacked in the right-hand side panel — Review, Terminal, Browser, Files.
+Collapsed, each Surface shows as a launcher card; at most one is expanded at a time. Review hosts the
+git Changes panel; Files hosts the Files browser; Terminal and Browser are reserved (not yet built).
+_Avoid_: tab, view, pane, dock (reserve "dock" for the future embedded terminal's chrome).
+
+**Files browser**:
+The Files Surface's content — a searchable tree of the Workspace's files, plus read-only previews of
+opened files. With no file open the tree fills the Surface; opening files shows the preview pane beside
+the tree, where each opened file is a tab (many open, one visible) topped by a read-only breadcrumb of
+its path. Browsing and previewing never change files and never involve the agent.
+_Avoid_: file tree (the widget, not the feature), explorer, finder.
+
 ## Agent controls
 
 The three per-Thread knobs the agent runs under, surfaced from `session/new` and changed mid-Thread.

--- a/docs/adr/0013-files-browser-surface-stack-confined-renderer-fs.md
+++ b/docs/adr/0013-files-browser-surface-stack-confined-renderer-fs.md
@@ -1,0 +1,64 @@
+# Files browser: right-panel Surface stack, t3code-style tree+preview, confined renderer-facing fs IPC
+
+**Status: ACCEPTED** (2026-07-02). Builds on **ADR-0002** (thin orchestrator), **ADR-0004** (fs
+confinement — extended here to a NEW, stricter surface), **ADR-0006** (shell/nav), **ADR-0008**
+(active-Workspace-only side panel, `@pierre/*` adoption). Terms: `CONTEXT.md` **Surface**, **Files
+browser**.
+
+## Context
+
+CodexMonitor parity calls for a file browser and the paused `@` file-path autocomplete needs a file
+listing the renderer can consume (the renderer has no `fs`; vibe-acp exposes NO file-search RPC — the
+Vibe CLI indexes client-side, and the agent expands a plain-text `@path` itself via
+`render_path_prompt`). The user's design shows the right panel as a stack of launcher cards — Review
+(⌃⇧G), Terminal, Browser, Files (⌘P) — and t3code (our UI north star) ships the exact feature shape:
+a `@pierre/trees` tree fed by a flat `{path, kind}[]` listing, with a preview pane beside the tree.
+
+## Decision
+
+1. **The right panel becomes a Surface stack.** Collapsed, it renders launcher cards (Review /
+   Terminal / Browser / Files); at most one Surface expands at a time. Review wires the existing git
+   Changes panel (#119) into this model; Terminal and Browser are inert "Soon" cards reserved for
+   their epics; ⌘P opens Files with tree-search focused, ⌃⇧G toggles Review. Active/connected
+   Workspace only (ADR-0008 precedent).
+2. **Files browser = t3code's shape on our stack, plus tabs.** Tree = `@pierre/trees` (new dep;
+   preact/shadow-DOM widget, React 19 peer, NO shiki dependency — cannot reintroduce the #159
+   duplication) fed by `files:list`, with SEARCH first-class (the tree's hide-non-matches filter; ⌘P
+   opens Files with search focused); no file open → tree fills the Surface; opening files shows the
+   READ-ONLY preview pane beside the tree, where each opened file is a TAB (many open, one visible —
+   renderer-only ephemeral state) topped by a read-only BREADCRUMB of its path. Preview highlights via
+   the SAME `@pierre/diffs` shared-shiki path the git panel uses (one highlighter, already
+   regression-gated by #159 tests). Preview actions: Reveal in Finder (reuses the #116 `revealPath`
+   IPC) and Insert `@path` into the composer (renderer-only draft append). We take t3code's layout —
+   diverging where the design says so (t3code has no tab strip; ours does) — but NOT its editability
+   (`EditableFileSurface`): editing means a renderer-facing write IPC, deliberately out of scope.
+3. **Two new renderer-facing fs IPCs, BOTH Workspace-confined and symlink-resolved** (the #116
+   `open-target.ts` posture): `files:list(workspaceId)` → flat `{path, kind}[]` + `truncated`
+   (gitignore-honoring, `.git` skipped, dotfiles included, ~20k-entry cap) and
+   `files:read(workspaceId, relativePath)` → `{content} | {binary} | {tooLarge}` (~1MB cap, null-byte
+   binary sniff). **This is deliberately STRICTER than ADR-0004**, whose unconfined reads are a
+   CLI-parity decision for the *agent's* requests; a renderer-facing surface gets no such parity
+   claim, so it is confined. Do not "unify" the two postures.
+4. **Refresh is manual + piggybacked, no new watcher.** Main caches the listing per Workspace;
+   invalidated by the panel's Refresh button and by the EXISTING git status-stream chokidar watcher
+   (#84) firing. Mirrors the Vibe CLI's own default (its `FileIndexer` watcher ships disabled) and
+   t3code's manual Refresh + "Indexing…" affordance.
+5. **`@` autocomplete matches renderer-side over the shared listing.** Trigger mirrors the CLI
+   `PathCompleter` (fragment after the last `@` before the caret, space-free, ≤10 suggestions,
+   directories included) on the #95 pure-helper + popover skeleton; ranking is
+   substring-then-subsequence over the cached `files:list` result (no per-keystroke IPC). Accepting
+   inserts PLAIN TEXT `@path ` — the wire format is untouched; the agent resolves and inlines the
+   file server-side. A stale suggestion list is acceptable (same invalidation as the panel).
+
+## Considered options
+
+- **Composer-only (no tree)** — rejected: the design explicitly reserves the Files card, and t3code
+  ships both; the tree also gives #185's chips and casual browsing a home.
+- **Prompt library in this epic** — dropped by the user; t3code has none (skills/commands already
+  surface via `/`, #95). May return as its own PRD.
+- **Dedicated index watcher** — rejected for v1: second watcher per Workspace, mass-change storms
+  (`bun install`) need thresholds we'd have to own; the git watcher signal is already paid for.
+- **Main-side per-keystroke `files:search` IPC** — rejected: the capped flat list ranks in-frame in
+  the renderer and stays pure/unit-testable; revisit only if the entry cap proves too small.
+- **Editable preview (t3code parity)** — rejected for v1: requires a confined renderer write IPC and
+  its own security review; the agent is the editor in this product.

--- a/src/renderer/src/connection/ConnectedWorkspace.tsx
+++ b/src/renderer/src/connection/ConnectedWorkspace.tsx
@@ -8,7 +8,7 @@ import type {
 } from '../../../shared/ipc'
 import { ColdThread } from '../conversation/ColdThread'
 import { Conversation } from '../conversation/Conversation'
-import { ChangesPanel } from '../git/ChangesPanel'
+import { SurfacePanel } from '../side-panel/SurfacePanel'
 
 /**
  * A connected Workspace's conversation OUTLET (ADR-0006, TB3 #48). It no longer
@@ -103,9 +103,15 @@ export function ConnectedWorkspace({
           <ColdThread key={activeThread.id} thread={activeThread} onClose={onCloseCold} onContinue={onContinue} />
         )}
       </div>
-      {/* Streamed git status (#84) — observational only; renders nothing for a non-repo
-          Workspace and subscribes only while this is the active Workspace. */}
-      <ChangesPanel workspaceDir={connection.workspaceDir} isActive={isActive} busy={busy} />
+      {/* The right-panel Surface stack (#187, ADR-0013): launcher cards collapsed, one
+          Surface expanded at a time. Review re-homes the streamed git panel (#84,
+          active-Workspace-only); Files is the slice-2 placeholder. */}
+      <SurfacePanel
+        workspaceId={connection.workspaceId}
+        workspaceDir={connection.workspaceDir}
+        isActive={isActive}
+        busy={busy}
+      />
     </div>
   )
 }

--- a/src/renderer/src/git/ChangesPanel.tsx
+++ b/src/renderer/src/git/ChangesPanel.tsx
@@ -13,6 +13,7 @@ import {
 import type { GhPr, GhPrResult, GitBranch as GitBranchInfo, GitStatus } from '../../../shared/ipc'
 import { cn } from '../lib/utils'
 import { Badge, Button, IconButton, Input, Menu, MenuContent, MenuItem, MenuSeparator, MenuTrigger, Textarea } from '../ui'
+import { getCommitDraft, setCommitDraft } from './commit-draft-store'
 import { buildChangesView, reconcileUnchecked, type GitFileView } from './status-view'
 import { DiffWorkerProvider } from './DiffWorkerProvider'
 import { DiffView } from './DiffView'
@@ -73,8 +74,13 @@ export function ChangesPanel({
   // Commit-time file selection (#86), tracked as the paths the user DESELECTED — default
   // empty = all selected, so a new file is selected by default. `message` is the commit
   // message; `committing` blocks a double-submit; `commitError` surfaces git's reason.
-  const [unchecked, setUnchecked] = useState<Set<string>>(() => new Set())
-  const [message, setMessage] = useState('')
+  // Both seed from the module-level draft store: Surface collapse now UNMOUNTS this panel
+  // (#187) where the old collapse merely hid it, so without the store a half-typed commit
+  // message would be one accidental ⌃⇧G away from vanishing.
+  const [unchecked, setUnchecked] = useState<Set<string>>(
+    () => new Set(getCommitDraft(workspaceDir)?.unchecked ?? []),
+  )
+  const [message, setMessage] = useState(() => getCommitDraft(workspaceDir)?.message ?? '')
   const [committing, setCommitting] = useState(false)
   const [commitError, setCommitError] = useState<string | null>(null)
   // Bumped by the header refresh button so the PR section re-fetches `ghCurrentPr` on a
@@ -101,6 +107,12 @@ export function ChangesPanel({
     const paths = status?.isRepo ? status.files.map((f) => f.path) : []
     setUnchecked((prev) => reconcileUnchecked(prev, paths))
   }, [status])
+
+  // Mirror the live draft into the store on every change (#187): a successful commit
+  // clears `message`, which empties (deletes) the entry via setCommitDraft's residue rule.
+  useEffect(() => {
+    setCommitDraft(workspaceDir, { message, unchecked })
+  }, [workspaceDir, message, unchecked])
 
   // Manual refresh: a subscribe/unsubscribe pair re-emits a fresh snapshot without
   // changing the net ref-count (the panel keeps its own hold across this).

--- a/src/renderer/src/git/ChangesPanel.tsx
+++ b/src/renderer/src/git/ChangesPanel.tsx
@@ -3,11 +3,11 @@ import {
   Boxes,
   Check,
   ChevronDown,
-  ChevronRight,
   GitBranch,
   GitCommitHorizontal,
   GitPullRequest,
   Monitor,
+  PanelRightClose,
   RefreshCw,
 } from 'lucide-react'
 import type { GhPr, GhPrResult, GitBranch as GitBranchInfo, GitStatus } from '../../../shared/ipc'
@@ -43,11 +43,17 @@ import { DiffView } from './DiffView'
  * rounded "Environment / Review" aesthetic — Button / Input / Textarea / Badge and the
  * soft `--border-muted` dividers. The git BEHAVIOUR is untouched (ADR-0008): only the
  * chrome changed.
+ *
+ * Re-homed as the Review Surface (#187, ADR-0013): this is now rendered by `SurfacePanel`
+ * only when the Review Surface is expanded. Its former standalone collapse toggle is
+ * FOLDED into the Surface model — the header collapse affordance calls `onCollapse`, which
+ * returns to the launcher-card stack. The git behaviour above is unchanged.
  */
 export function ChangesPanel({
   workspaceDir,
   isActive,
   busy,
+  onCollapse,
 }: {
   workspaceDir: string
   isActive: boolean
@@ -59,9 +65,10 @@ export function ChangesPanel({
    * the panel reflects whatever the agent committed before the user can commit again.
    */
   busy: boolean
-}): JSX.Element | null {
+  /** Collapse the Review Surface back to the card stack (#187) — the header affordance. */
+  onCollapse: () => void
+}): JSX.Element {
   const [status, setStatus] = useState<GitStatus | null>(null)
-  const [collapsed, setCollapsed] = useState(false)
   const [selectedPath, setSelectedPath] = useState<string | null>(null)
   // Commit-time file selection (#86), tracked as the paths the user DESELECTED — default
   // empty = all selected, so a new file is selected by default. `message` is the commit
@@ -105,8 +112,20 @@ export function ChangesPanel({
     setPrRefreshKey((k) => k + 1)
   }
 
-  // No panel before the first snapshot, or for a non-repo Workspace (degrade quietly).
-  if (!status || !status.isRepo) return null
+  // Before the first snapshot, or for a non-repo Workspace: the git surface degrades to a
+  // quiet empty state (#84 "a Workspace need not be a git repo"). As a Surface it still
+  // renders its header so the collapse affordance is always reachable (#187) — a Surface
+  // must never strand the user with no way back to the card stack.
+  if (!status || !status.isRepo) {
+    return (
+      <aside className="flex w-80 shrink-0 flex-col self-stretch border-l border-border bg-panel text-text">
+        <ReviewHeader onCollapse={onCollapse} onRefresh={refresh} />
+        <p className="px-3 py-3 text-[13px] text-muted">
+          {!status ? 'Loading changes…' : 'Not a Git repository.'}
+        </p>
+      </aside>
+    )
+  }
 
   const view = buildChangesView(status)
 
@@ -165,125 +184,131 @@ export function ChangesPanel({
 
   return (
     <aside className="w-80 shrink-0 border-l border-border bg-panel text-text">
-      <div className="flex items-center gap-2 border-b border-border-muted px-3 py-2.5">
-        <button
-          type="button"
-          onClick={() => setCollapsed((c) => !c)}
-          title={collapsed ? 'Expand' : 'Collapse'}
-          aria-expanded={!collapsed}
-          className="flex min-w-0 flex-1 items-center gap-1.5 rounded-md text-left text-sm font-semibold text-text-strong"
-        >
-          {collapsed ? (
-            <ChevronRight size={15} aria-hidden className="shrink-0 text-muted" />
-          ) : (
-            <ChevronDown size={15} aria-hidden className="shrink-0 text-muted" />
-          )}
-          <span>Changes</span>
-          {view.fileCount > 0 && (
-            <Badge variant="outline" className="ml-0.5 rounded-full px-1.5 py-0 text-[11px] tabular-nums text-muted">
-              {view.fileCount}
-            </Badge>
-          )}
-        </button>
-        <IconButton
-          size="icon-sm"
-          onClick={refresh}
-          title="Refresh"
-          aria-label="Refresh git status"
-          className="text-muted"
-        >
-          <RefreshCw className="size-3.5" aria-hidden />
-        </IconButton>
+      <ReviewHeader count={view.fileCount} onCollapse={onCollapse} onRefresh={refresh} />
+
+      {/* Environment (#119) — a STATIC placeholder gesturing at the mockup's fuller
+          "Environment / Local / Sources" side-panel (styled chrome, non-functional,
+          like the sidebar's Search/Scheduled/Plugins "Soon" rows). Not wired to
+          anything; the live git surface begins at the branch header below. */}
+      <div className="border-b border-border-muted px-3 py-2.5">
+        <p className="mb-1 px-1 text-[11px] font-medium text-faint">Environment</p>
+        <div className="flex flex-col gap-0.5">
+          <EnvPlaceholder icon={<Monitor className="size-4" aria-hidden />}>Local</EnvPlaceholder>
+          <EnvPlaceholder icon={<Boxes className="size-4" aria-hidden />}>Sources</EnvPlaceholder>
+        </div>
       </div>
 
-      {!collapsed && (
+      <BranchMenu
+        workspaceDir={workspaceDir}
+        branch={view.branch}
+        ahead={view.ahead}
+        behind={view.behind}
+        busy={busy}
+      />
+
+      <PrSection
+        workspaceDir={workspaceDir}
+        branch={view.branch}
+        detached={view.detached}
+        hasUpstream={status.upstream !== null}
+        busy={busy}
+        refreshKey={prRefreshKey}
+      />
+
+      {view.files.length === 0 ? (
+        <p className="px-3 py-3 text-[13px] text-muted">No changes — working tree clean.</p>
+      ) : (
         <>
-          {/* Environment (#119) — a STATIC placeholder gesturing at the mockup's fuller
-              "Environment / Local / Sources" side-panel (styled chrome, non-functional,
-              like the sidebar's Search/Scheduled/Plugins "Soon" rows). Not wired to
-              anything; the live git surface begins at the branch header below. */}
-          <div className="border-b border-border-muted px-3 py-2.5">
-            <p className="mb-1 px-1 text-[11px] font-medium text-faint">Environment</p>
-            <div className="flex flex-col gap-0.5">
-              <EnvPlaceholder icon={<Monitor className="size-4" aria-hidden />}>Local</EnvPlaceholder>
-              <EnvPlaceholder icon={<Boxes className="size-4" aria-hidden />}>Sources</EnvPlaceholder>
-            </div>
+          <ul className="flex flex-col gap-0.5 py-1.5">
+            {view.files.map((file) => (
+              <FileRow
+                key={file.path}
+                file={file}
+                checked={!unchecked.has(file.path)}
+                onToggle={() =>
+                  setUnchecked((prev) => {
+                    const next = new Set(prev)
+                    if (next.has(file.path)) next.delete(file.path)
+                    else next.add(file.path)
+                    return next
+                  })
+                }
+                onSelect={() => setSelectedPath(file.path)}
+              />
+            ))}
+          </ul>
+
+          {/* Commit area (#86): message + "Commit N". Disabled on an empty message,
+              no selection, or `busy` (the v1 concurrency guard — no concurrent
+              user+agent commit). git's reason surfaces inline + recoverable. */}
+          <div className="flex flex-col gap-2 border-t border-border-muted px-3 py-2.5">
+            <Textarea
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              placeholder="Commit message"
+              rows={2}
+              className="min-h-16 resize-y text-[13px]"
+              // Ctrl/Cmd+Enter commits, matching the prompt composer's submit chord.
+              onKeyDown={(e) => {
+                if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+                  e.preventDefault()
+                  void commit()
+                }
+              }}
+            />
+            {commitError && (
+              <p className="text-[11px] text-bad" role="alert">
+                {commitError}
+              </p>
+            )}
+            {busy && <p className="text-[11px] text-muted">Agent is working…</p>}
+            <Button type="button" size="sm" className="w-full" onClick={() => void commit()} disabled={!canCommit}>
+              <GitCommitHorizontal className="size-4" aria-hidden />
+              {committing ? 'Committing…' : `Commit ${selectedPaths.length}`}
+            </Button>
           </div>
-
-          <BranchMenu
-            workspaceDir={workspaceDir}
-            branch={view.branch}
-            ahead={view.ahead}
-            behind={view.behind}
-            busy={busy}
-          />
-
-          <PrSection
-            workspaceDir={workspaceDir}
-            branch={view.branch}
-            detached={view.detached}
-            hasUpstream={status.upstream !== null}
-            busy={busy}
-            refreshKey={prRefreshKey}
-          />
-
-          {view.files.length === 0 ? (
-            <p className="px-3 py-3 text-[13px] text-muted">No changes — working tree clean.</p>
-          ) : (
-            <>
-              <ul className="flex flex-col gap-0.5 py-1.5">
-                {view.files.map((file) => (
-                  <FileRow
-                    key={file.path}
-                    file={file}
-                    checked={!unchecked.has(file.path)}
-                    onToggle={() =>
-                      setUnchecked((prev) => {
-                        const next = new Set(prev)
-                        if (next.has(file.path)) next.delete(file.path)
-                        else next.add(file.path)
-                        return next
-                      })
-                    }
-                    onSelect={() => setSelectedPath(file.path)}
-                  />
-                ))}
-              </ul>
-
-              {/* Commit area (#86): message + "Commit N". Disabled on an empty message,
-                  no selection, or `busy` (the v1 concurrency guard — no concurrent
-                  user+agent commit). git's reason surfaces inline + recoverable. */}
-              <div className="flex flex-col gap-2 border-t border-border-muted px-3 py-2.5">
-                <Textarea
-                  value={message}
-                  onChange={(e) => setMessage(e.target.value)}
-                  placeholder="Commit message"
-                  rows={2}
-                  className="min-h-16 resize-y text-[13px]"
-                  // Ctrl/Cmd+Enter commits, matching the prompt composer's submit chord.
-                  onKeyDown={(e) => {
-                    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
-                      e.preventDefault()
-                      void commit()
-                    }
-                  }}
-                />
-                {commitError && (
-                  <p className="text-[11px] text-bad" role="alert">
-                    {commitError}
-                  </p>
-                )}
-                {busy && <p className="text-[11px] text-muted">Agent is working…</p>}
-                <Button type="button" size="sm" className="w-full" onClick={() => void commit()} disabled={!canCommit}>
-                  <GitCommitHorizontal className="size-4" aria-hidden />
-                  {committing ? 'Committing…' : `Commit ${selectedPaths.length}`}
-                </Button>
-              </div>
-            </>
-          )}
         </>
       )}
     </aside>
+  )
+}
+
+/**
+ * The Review Surface header (#187): the "Changes" title + optional changed-file count, a
+ * collapse-to-stack affordance (folds the panel's former standalone collapse into the
+ * Surface model, ADR-0013), and the manual git-status Refresh. Shared by the live list
+ * and the non-repo/pre-snapshot empty state so the collapse control is always present.
+ */
+function ReviewHeader({
+  count,
+  onCollapse,
+  onRefresh,
+}: {
+  count?: number
+  onCollapse: () => void
+  onRefresh: () => void
+}): JSX.Element {
+  return (
+    <div className="flex items-center gap-2 border-b border-border-muted px-3 py-2.5">
+      <button
+        type="button"
+        onClick={onCollapse}
+        title="Collapse"
+        aria-label="Collapse Review panel"
+        className="flex min-w-0 flex-1 items-center gap-1.5 rounded-md text-left text-sm font-semibold text-text-strong"
+      >
+        <PanelRightClose size={15} aria-hidden className="shrink-0 text-muted" />
+        <span>Changes</span>
+        {count !== undefined && count > 0 && (
+          <Badge variant="outline" className="ml-0.5 rounded-full px-1.5 py-0 text-[11px] tabular-nums text-muted">
+            {count}
+          </Badge>
+        )}
+      </button>
+      <IconButton size="icon-sm" onClick={onRefresh} title="Refresh" aria-label="Refresh git status" className="text-muted">
+        <RefreshCw className="size-3.5" aria-hidden />
+      </IconButton>
+    </div>
   )
 }
 

--- a/src/renderer/src/git/commit-draft-store.test.ts
+++ b/src/renderer/src/git/commit-draft-store.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { clearCommitDrafts, getCommitDraft, setCommitDraft } from './commit-draft-store'
+
+describe('commit-draft-store', () => {
+  beforeEach(() => {
+    clearCommitDrafts()
+  })
+
+  it('round-trips a draft per Workspace', () => {
+    setCommitDraft('/a', { message: 'fix: thing', unchecked: new Set(['x.ts']) })
+    expect(getCommitDraft('/a')).toEqual({ message: 'fix: thing', unchecked: new Set(['x.ts']) })
+  })
+
+  it('isolates Workspaces', () => {
+    setCommitDraft('/a', { message: 'for a', unchecked: new Set() })
+    setCommitDraft('/b', { message: 'for b', unchecked: new Set() })
+    expect(getCommitDraft('/a')?.message).toBe('for a')
+    expect(getCommitDraft('/b')?.message).toBe('for b')
+  })
+
+  it('returns undefined for a Workspace with no draft', () => {
+    expect(getCommitDraft('/nope')).toBeUndefined()
+  })
+
+  it('deletes the entry when the draft is empty (post-commit leaves no residue)', () => {
+    setCommitDraft('/a', { message: 'wip', unchecked: new Set() })
+    setCommitDraft('/a', { message: '', unchecked: new Set() })
+    expect(getCommitDraft('/a')).toBeUndefined()
+  })
+
+  it('keeps an entry with an empty message but a live deselection set', () => {
+    setCommitDraft('/a', { message: '', unchecked: new Set(['skip.ts']) })
+    expect(getCommitDraft('/a')?.unchecked).toEqual(new Set(['skip.ts']))
+  })
+})

--- a/src/renderer/src/git/commit-draft-store.ts
+++ b/src/renderer/src/git/commit-draft-store.ts
@@ -1,0 +1,34 @@
+/**
+ * Ephemeral per-Workspace commit drafts (#187 review fold). Collapsing the Review Surface
+ * now UNMOUNTS ChangesPanel, whereas its old internal collapse only hid the body — so a
+ * half-typed commit message (and the #86 deselection set) used to survive collapse/expand
+ * and would now be discarded, one accidental ⌃⇧G away. This module-level store restores
+ * that parity across the remount (the follow-up-queue idiom: module state outlives the
+ * component). Renderer-session only — deliberately NOT localStorage: the old behavior
+ * never survived a restart either, and a stale commit message is worse than none.
+ */
+export interface CommitDraft {
+  message: string
+  unchecked: ReadonlySet<string>
+}
+
+const drafts = new Map<string, CommitDraft>()
+
+export function getCommitDraft(workspaceDir: string): CommitDraft | undefined {
+  return drafts.get(workspaceDir)
+}
+
+/**
+ * Store the live draft. An EMPTY draft (no message, nothing deselected) deletes the entry
+ * instead, so the map only holds Workspaces with something worth restoring — and a
+ * successful commit (which clears the message) leaves no residue.
+ */
+export function setCommitDraft(workspaceDir: string, draft: CommitDraft): void {
+  if (draft.message === '' && draft.unchecked.size === 0) drafts.delete(workspaceDir)
+  else drafts.set(workspaceDir, draft)
+}
+
+/** Test seam — the map is module-global. */
+export function clearCommitDrafts(): void {
+  drafts.clear()
+}

--- a/src/renderer/src/side-panel/FilesSurface.tsx
+++ b/src/renderer/src/side-panel/FilesSurface.tsx
@@ -1,0 +1,35 @@
+import { type JSX } from 'react'
+import { FolderTree, PanelRightClose } from 'lucide-react'
+
+/**
+ * The Files Surface (#187, ADR-0013 decision 2; CONTEXT.md "Files browser"). THIS slice
+ * ships the Surface shell only — a header (title + collapse-to-stack affordance) and a
+ * muted empty-state body. Slice 2 swaps the body for the searchable tree WITHOUT touching
+ * the stack model or this header, so the collapse wiring is stable here.
+ */
+export function FilesSurface({ onCollapse }: { onCollapse: () => void }): JSX.Element {
+  return (
+    <aside
+      aria-label="Files"
+      className="flex w-80 shrink-0 flex-col self-stretch border-l border-border bg-panel text-text"
+    >
+      <div className="flex items-center gap-2 border-b border-border-muted px-3 py-2.5">
+        <button
+          type="button"
+          onClick={onCollapse}
+          title="Collapse"
+          aria-label="Collapse Files panel"
+          className="flex min-w-0 flex-1 items-center gap-1.5 rounded-md text-left text-sm font-semibold text-text-strong"
+        >
+          <PanelRightClose size={15} aria-hidden className="shrink-0 text-muted" />
+          <span>Files</span>
+        </button>
+      </div>
+
+      <div className="flex flex-1 flex-col items-center justify-center gap-2 px-6 py-10 text-center">
+        <FolderTree className="size-6 text-faint" aria-hidden />
+        <p className="text-[13px] text-muted">File browsing lands in the next slice.</p>
+      </div>
+    </aside>
+  )
+}

--- a/src/renderer/src/side-panel/SurfacePanel.tsx
+++ b/src/renderer/src/side-panel/SurfacePanel.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useState, type JSX, type ReactNode } from 'react'
+import { FileDiff, Files, Globe, SquareTerminal } from 'lucide-react'
+import { cn } from '../lib/utils'
+import { ChangesPanel } from '../git/ChangesPanel'
+import { FilesSurface } from './FilesSurface'
+import { surfaceForChord } from './surface-keys'
+import { toggleSurface, type ExpandedSurface, type Surface } from './surface-model'
+import { getSurfaceState, setSurfaceState } from './surface-state-store'
+
+/**
+ * The right-hand side panel as a Surface stack (#187, ADR-0013 decision 1; CONTEXT.md
+ * "Surface"). Collapsed, it renders four launcher CARDS — Review (⌃⇧G), Terminal,
+ * Browser (⌘T), Files (⌘P) — top-aligned; at most ONE Surface is expanded at a time and
+ * the cards show only when NONE is. Review re-homes the existing git Changes panel
+ * behavior-identical (#84–#88); Files expands to a slice-2 placeholder; Terminal and
+ * Browser are inert "Soon" cards (the sidebar Search/Scheduled/Plugins precedent).
+ *
+ * The expanded choice persists PER Workspace across restart (localStorage, throw-tolerant
+ * injected-storage store). Because App keys each `ConnectedWorkspace` (hence this panel)
+ * by `agentId`, every Workspace has its own instance seeding from its own stored entry —
+ * so switching Workspace restores that Workspace's Surface with no extra plumbing.
+ *
+ * Rendered by `ConnectedWorkspace` for the active/connected Workspace only. The state
+ * machine is the pure `surface-model`; this component is a thin switch over it plus the
+ * renderer-level keyboard handler.
+ */
+export function SurfacePanel({
+  workspaceId,
+  workspaceDir,
+  isActive,
+  busy,
+}: {
+  workspaceId: string
+  workspaceDir: string
+  /** Whether this is the on-screen Workspace (#84) — gates git streaming AND shortcuts. */
+  isActive: boolean
+  /** Whether a turn is streaming (#86) — threaded to the Review panel's commit guard. */
+  busy: boolean
+}): JSX.Element {
+  const [expanded, setExpanded] = useState<ExpandedSurface>(() =>
+    getSurfaceState(window.localStorage, workspaceId),
+  )
+
+  // Set + persist together so the per-Workspace choice survives restart (ADR-0013).
+  function apply(next: ExpandedSurface): void {
+    setExpanded(next)
+    setSurfaceState(window.localStorage, workspaceId, next)
+  }
+
+  // Renderer-level shortcuts (NO Electron accelerators): ⌘P toggles Files, ⌃⇧G toggles
+  // Review. Gated on `isActive` so a backgrounded (mounted-hidden) Workspace never grabs
+  // keys. Both chords carry a modifier, so plain typing never matches — a focused
+  // textarea is intentionally NOT exempt (⌘P must open Files even while composing); the
+  // composer's own Enter/Esc handling is untouched (those chords aren't ours). We
+  // preventDefault the match to stop the browser's ⌘P print dialog.
+  useEffect(() => {
+    if (!isActive) return
+    function onKeyDown(e: KeyboardEvent): void {
+      const surface = surfaceForChord(e)
+      if (!surface) return
+      e.preventDefault()
+      setExpanded((current) => {
+        const next = toggleSurface(current, surface)
+        setSurfaceState(window.localStorage, workspaceId, next)
+        return next
+      })
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [isActive, workspaceId])
+
+  if (expanded === 'review') {
+    // The Review Surface IS the existing Changes panel, behavior-identical (#84–#88). It
+    // sizes itself (w-80 list / flex-1 diff); its header collapse returns to the stack.
+    return <ChangesPanel workspaceDir={workspaceDir} isActive={isActive} busy={busy} onCollapse={() => apply(null)} />
+  }
+
+  if (expanded === 'files') {
+    return <FilesSurface onCollapse={() => apply(null)} />
+  }
+
+  return <SurfaceStack onOpen={(surface) => apply(surface)} />
+}
+
+/** A launcher card's definition. Live cards open a Surface; inert ones are reserved. */
+interface CardDef {
+  /** The live Surface it opens, or a reserved slot with no expanded state. */
+  target: Surface | 'terminal' | 'browser'
+  label: string
+  icon: ReactNode
+  /** The keyboard-shortcut hint (aspirational chrome for the inert Browser card). */
+  hint?: string
+  live: boolean
+}
+
+const CARDS: readonly CardDef[] = [
+  { target: 'review', label: 'Review', icon: <FileDiff aria-hidden />, hint: '⌃⇧G', live: true },
+  { target: 'terminal', label: 'Terminal', icon: <SquareTerminal aria-hidden />, live: false },
+  { target: 'browser', label: 'Browser', icon: <Globe aria-hidden />, hint: '⌘T', live: false },
+  { target: 'files', label: 'Files', icon: <Files aria-hidden />, hint: '⌘P', live: true },
+]
+
+/**
+ * The collapsed card stack: full-width rounded launcher rows on the panel background,
+ * top-aligned (leading icon + label, trailing shortcut hint). Live cards open their
+ * Surface; the inert Terminal/Browser cards are disabled + `aria-disabled` and tagged
+ * "Soon" (the sidebar PlaceholderNav precedent).
+ */
+function SurfaceStack({ onOpen }: { onOpen: (surface: Surface) => void }): JSX.Element {
+  return (
+    <aside
+      aria-label="Side panel"
+      className="flex w-80 shrink-0 flex-col gap-2 self-stretch border-l border-border bg-panel p-3 text-text"
+    >
+      {CARDS.map((card) => (
+        <LauncherCard
+          key={card.label}
+          card={card}
+          onClick={card.live ? () => onOpen(card.target as Surface) : undefined}
+        />
+      ))}
+    </aside>
+  )
+}
+
+/**
+ * One launcher card. A live card is a real button opening its Surface; an inert card is
+ * disabled + `aria-disabled` with a muted "Soon" tag, so it reads as intentionally
+ * reserved rather than broken. Shortcut hints render as small muted keycaps either way.
+ */
+function LauncherCard({ card, onClick }: { card: CardDef; onClick?: () => void }): JSX.Element {
+  const inert = onClick === undefined
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={inert}
+      aria-disabled={inert || undefined}
+      title={inert ? 'Coming soon' : card.label}
+      className={cn(
+        'flex w-full items-center gap-3 rounded-xl border border-border bg-surface px-3 py-2.5 text-left text-[14px] text-text outline-none transition-colors',
+        '[&_svg]:size-[18px] [&_svg]:shrink-0 [&_svg]:text-muted',
+        inert
+          ? 'cursor-default opacity-60'
+          : 'hover:bg-accent/10 focus-visible:bg-accent/10 [&_svg]:hover:text-text-strong',
+      )}
+    >
+      {card.icon}
+      <span className="min-w-0 flex-1 truncate font-medium">{card.label}</span>
+      {card.hint && (
+        <kbd className="shrink-0 rounded-md px-1 text-[11px] font-medium tabular-nums text-faint">{card.hint}</kbd>
+      )}
+      {inert && <span className="shrink-0 text-[11px] font-medium text-faint">Soon</span>}
+    </button>
+  )
+}

--- a/src/renderer/src/side-panel/surface-keys.test.ts
+++ b/src/renderer/src/side-panel/surface-keys.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { surfaceForChord, type KeyChord } from './surface-keys'
+
+/** A chord with everything up (no modifiers), overridden per case. */
+function chord(over: Partial<KeyChord>): KeyChord {
+  return { key: '', metaKey: false, ctrlKey: false, shiftKey: false, altKey: false, ...over }
+}
+
+describe('surfaceForChord — ⌘P → Files', () => {
+  it('matches meta+p (either case)', () => {
+    expect(surfaceForChord(chord({ key: 'p', metaKey: true }))).toBe('files')
+    expect(surfaceForChord(chord({ key: 'P', metaKey: true }))).toBe('files')
+  })
+
+  it('does not match ⌃P, ⌘⇧P, or ⌘⌥P', () => {
+    expect(surfaceForChord(chord({ key: 'p', ctrlKey: true }))).toBeNull()
+    expect(surfaceForChord(chord({ key: 'p', metaKey: true, shiftKey: true }))).toBeNull()
+    expect(surfaceForChord(chord({ key: 'p', metaKey: true, altKey: true }))).toBeNull()
+  })
+
+  it('does not match bare p (plain typing)', () => {
+    expect(surfaceForChord(chord({ key: 'p' }))).toBeNull()
+  })
+})
+
+describe('surfaceForChord — ⌃⇧G → Review', () => {
+  it('matches ctrl+shift+g (either case)', () => {
+    expect(surfaceForChord(chord({ key: 'g', ctrlKey: true, shiftKey: true }))).toBe('review')
+    expect(surfaceForChord(chord({ key: 'G', ctrlKey: true, shiftKey: true }))).toBe('review')
+  })
+
+  it('does not match ⌃G, ⇧G, or ⌘⇧G', () => {
+    expect(surfaceForChord(chord({ key: 'g', ctrlKey: true }))).toBeNull()
+    expect(surfaceForChord(chord({ key: 'g', shiftKey: true }))).toBeNull()
+    expect(surfaceForChord(chord({ key: 'g', metaKey: true, shiftKey: true }))).toBeNull()
+  })
+})
+
+describe('surfaceForChord — unbound chords', () => {
+  it('leaves ⌘T (Browser hint) unbound — the card is inert', () => {
+    expect(surfaceForChord(chord({ key: 't', metaKey: true }))).toBeNull()
+  })
+
+  it('ignores plain typing and unrelated keys', () => {
+    expect(surfaceForChord(chord({ key: 'a' }))).toBeNull()
+    expect(surfaceForChord(chord({ key: 'Enter' }))).toBeNull()
+    expect(surfaceForChord(chord({ key: 'Escape' }))).toBeNull()
+  })
+})

--- a/src/renderer/src/side-panel/surface-keys.ts
+++ b/src/renderer/src/side-panel/surface-keys.ts
@@ -1,0 +1,34 @@
+import type { Surface } from './surface-model'
+
+/** The subset of a `KeyboardEvent` the shortcut matcher reads (DOM-free for testing). */
+export interface KeyChord {
+  key: string
+  metaKey: boolean
+  ctrlKey: boolean
+  shiftKey: boolean
+  altKey: boolean
+}
+
+/**
+ * Which Surface a keydown toggles, or `null` when the chord is unbound. Renderer-level
+ * shortcuts (NO Electron menu accelerators, ADR-0013 decision 1):
+ *   - ⌘P  → Files   (the tree-search focus part lands in slice 2)
+ *   - ⌃⇧G → Review
+ * Browser's ⌘T hint is aspirational chrome — deliberately UNBOUND (the card is inert).
+ *
+ * Both bound chords carry a modifier, so plain typing never matches: a focused text input
+ * can be left to type normally EXCEPT these two combos (neither is a typing combo), which
+ * stay live even while a textarea has focus.
+ */
+export function surfaceForChord(chord: KeyChord): Surface | null {
+  const key = chord.key.toLowerCase()
+  // ⌘P → Files. Meta only (no ctrl/alt/shift) so ⌘⇧P and ⌃P stay free.
+  if (key === 'p' && chord.metaKey && !chord.ctrlKey && !chord.altKey && !chord.shiftKey) {
+    return 'files'
+  }
+  // ⌃⇧G → Review. Ctrl+Shift only (no meta/alt).
+  if (key === 'g' && chord.ctrlKey && chord.shiftKey && !chord.metaKey && !chord.altKey) {
+    return 'review'
+  }
+  return null
+}

--- a/src/renderer/src/side-panel/surface-model.test.ts
+++ b/src/renderer/src/side-panel/surface-model.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import {
+  coerceExpandedSurface,
+  collapseSurface,
+  EXPANDABLE_SURFACES,
+  toggleSurface,
+} from './surface-model'
+
+describe('toggleSurface', () => {
+  it('expands a Surface from the collapsed stack', () => {
+    expect(toggleSurface(null, 'review')).toBe('review')
+    expect(toggleSurface(null, 'files')).toBe('files')
+  })
+
+  it('collapses back to the stack when re-toggling the expanded Surface', () => {
+    expect(toggleSurface('review', 'review')).toBeNull()
+    expect(toggleSurface('files', 'files')).toBeNull()
+  })
+
+  it('switches to the other Surface (at most one open at a time)', () => {
+    expect(toggleSurface('review', 'files')).toBe('files')
+    expect(toggleSurface('files', 'review')).toBe('review')
+  })
+})
+
+describe('collapseSurface', () => {
+  it('always returns the collapsed (null) stack state', () => {
+    expect(collapseSurface()).toBeNull()
+  })
+})
+
+describe('coerceExpandedSurface', () => {
+  it('accepts the two live Surface ids', () => {
+    expect(coerceExpandedSurface('review')).toBe('review')
+    expect(coerceExpandedSurface('files')).toBe('files')
+  })
+
+  it('collapses any unknown / legacy / inert value to null', () => {
+    expect(coerceExpandedSurface(null)).toBeNull()
+    expect(coerceExpandedSurface(undefined)).toBeNull()
+    expect(coerceExpandedSurface('terminal')).toBeNull()
+    expect(coerceExpandedSurface('browser')).toBeNull()
+    expect(coerceExpandedSurface('')).toBeNull()
+    expect(coerceExpandedSurface(0)).toBeNull()
+    expect(coerceExpandedSurface({})).toBeNull()
+    expect(coerceExpandedSurface(['review'])).toBeNull()
+  })
+})
+
+describe('EXPANDABLE_SURFACES', () => {
+  it('is exactly the two live Surfaces', () => {
+    expect([...EXPANDABLE_SURFACES]).toEqual(['review', 'files'])
+  })
+})

--- a/src/renderer/src/side-panel/surface-model.ts
+++ b/src/renderer/src/side-panel/surface-model.ts
@@ -1,0 +1,41 @@
+/**
+ * The right-hand side panel's Surface model (ADR-0013 decision 1, CONTEXT.md "Surface").
+ * At most ONE Surface is expanded at a time; `null` means the collapsed launcher-card
+ * stack is showing. Pure + DOM-free (the nav-reducer #48 idiom) — the JSX is a thin
+ * switch over this.
+ *
+ * Only Review and Files are LIVE (expandable) Surfaces this slice; Terminal and Browser
+ * are inert "Soon" cards with no expanded state, so they are not part of this set.
+ */
+
+/** A live, expandable Surface. */
+export type Surface = 'review' | 'files'
+
+/** Which Surface is expanded, or `null` for the collapsed card stack. */
+export type ExpandedSurface = Surface | null
+
+/** The live (expandable) Surfaces. */
+export const EXPANDABLE_SURFACES: readonly Surface[] = ['review', 'files']
+
+/**
+ * Toggle a Surface: expand it, or collapse back to the card stack when it is ALREADY the
+ * expanded one. Opening a Surface while a DIFFERENT one is expanded switches to it — at
+ * most one is ever open. Backs both the launcher-card click and the keyboard shortcut.
+ */
+export function toggleSurface(current: ExpandedSurface, surface: Surface): ExpandedSurface {
+  return current === surface ? null : surface
+}
+
+/** Collapse to the card stack (the expanded Surface header's collapse affordance). */
+export function collapseSurface(): ExpandedSurface {
+  return null
+}
+
+/**
+ * Coerce an untrusted stored value into a valid `ExpandedSurface`. Anything that is not a
+ * known live Surface collapses to `null`, so a corrupt / renamed / legacy blob degrades to
+ * the card stack rather than a broken expanded state.
+ */
+export function coerceExpandedSurface(raw: unknown): ExpandedSurface {
+  return raw === 'review' || raw === 'files' ? raw : null
+}

--- a/src/renderer/src/side-panel/surface-state-store.test.ts
+++ b/src/renderer/src/side-panel/surface-state-store.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  getSurfaceState,
+  setSurfaceState,
+  SURFACE_STATE_STORAGE_KEY,
+  type SurfaceStateStorage,
+} from './surface-state-store'
+
+/** A throwaway in-memory Storage seam for the tests. */
+function fakeStorage(seed?: Record<string, string>): SurfaceStateStorage & { map: Map<string, string> } {
+  const map = new Map<string, string>(Object.entries(seed ?? {}))
+  return {
+    map,
+    getItem: (k) => map.get(k) ?? null,
+    setItem: (k, v) => void map.set(k, v),
+  }
+}
+
+describe('getSurfaceState', () => {
+  it('defaults to null (collapsed) when nothing is stored', () => {
+    expect(getSurfaceState(fakeStorage(), 'ws-1')).toBeNull()
+  })
+
+  it('defaults to null for a null/undefined store', () => {
+    expect(getSurfaceState(null, 'ws-1')).toBeNull()
+    expect(getSurfaceState(undefined, 'ws-1')).toBeNull()
+  })
+
+  it('reads a per-Workspace entry, independent of other Workspaces', () => {
+    const storage = fakeStorage({
+      [SURFACE_STATE_STORAGE_KEY]: JSON.stringify({ 'ws-1': 'review', 'ws-2': 'files' }),
+    })
+    expect(getSurfaceState(storage, 'ws-1')).toBe('review')
+    expect(getSurfaceState(storage, 'ws-2')).toBe('files')
+    expect(getSurfaceState(storage, 'ws-3')).toBeNull()
+  })
+
+  it('drops members that are not a live Surface', () => {
+    const storage = fakeStorage({
+      [SURFACE_STATE_STORAGE_KEY]: JSON.stringify({ 'ws-1': 'terminal', 'ws-2': 42, 'ws-3': 'files' }),
+    })
+    expect(getSurfaceState(storage, 'ws-1')).toBeNull()
+    expect(getSurfaceState(storage, 'ws-2')).toBeNull()
+    expect(getSurfaceState(storage, 'ws-3')).toBe('files')
+  })
+
+  it('treats a non-object / corrupt payload as absent → null', () => {
+    expect(getSurfaceState(fakeStorage({ [SURFACE_STATE_STORAGE_KEY]: '{not json' }), 'ws-1')).toBeNull()
+    expect(getSurfaceState(fakeStorage({ [SURFACE_STATE_STORAGE_KEY]: '["review"]' }), 'ws-1')).toBeNull()
+    expect(getSurfaceState(fakeStorage({ [SURFACE_STATE_STORAGE_KEY]: '"review"' }), 'ws-1')).toBeNull()
+  })
+
+  it('never throws when the store throws on read', () => {
+    const storage: SurfaceStateStorage = {
+      getItem: () => {
+        throw new Error('blocked')
+      },
+      setItem: () => {},
+    }
+    expect(getSurfaceState(storage, 'ws-1')).toBeNull()
+  })
+})
+
+describe('setSurfaceState', () => {
+  it('round-trips a per-Workspace choice', () => {
+    const storage = fakeStorage()
+    setSurfaceState(storage, 'ws-1', 'review')
+    expect(getSurfaceState(storage, 'ws-1')).toBe('review')
+    setSurfaceState(storage, 'ws-1', 'files')
+    expect(getSurfaceState(storage, 'ws-1')).toBe('files')
+  })
+
+  it('clears a Workspace entry on null without disturbing others', () => {
+    const storage = fakeStorage()
+    setSurfaceState(storage, 'ws-1', 'review')
+    setSurfaceState(storage, 'ws-2', 'files')
+    setSurfaceState(storage, 'ws-1', null)
+    expect(getSurfaceState(storage, 'ws-1')).toBeNull()
+    expect(getSurfaceState(storage, 'ws-2')).toBe('files')
+  })
+
+  it('no-ops for a null/undefined store', () => {
+    expect(() => setSurfaceState(null, 'ws-1', 'review')).not.toThrow()
+    expect(() => setSurfaceState(undefined, 'ws-1', 'review')).not.toThrow()
+  })
+
+  it('swallows a throwing store (quota/security) without propagating', () => {
+    const setItem = vi.fn(() => {
+      throw new Error('quota exceeded')
+    })
+    const storage: SurfaceStateStorage = { getItem: () => null, setItem }
+    expect(() => setSurfaceState(storage, 'ws-1', 'review')).not.toThrow()
+    expect(setItem).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/side-panel/surface-state-store.ts
+++ b/src/renderer/src/side-panel/surface-state-store.ts
@@ -1,0 +1,76 @@
+import { coerceExpandedSurface, type ExpandedSurface } from './surface-model'
+
+/**
+ * Which Surface is expanded PER Workspace (ADR-0013 decision 1) — a renderer-only,
+ * display-only choice that survives restart. Like the sidebar-collapsed flag (#127) and
+ * the open-projects set (#138), it is pure UI chrome (it never spawns an agent or touches
+ * persistence), so it lives in localStorage alone via the established injected-storage,
+ * throw-tolerant pattern: no IPC, no main.
+ *
+ * Stored as a single JSON object keyed by workspaceId; a collapsed (`null`) Workspace is
+ * OMITTED from the map. Any malformed / absent / throwing store degrades to `null` (the
+ * card stack) so a blocked store never traps a Surface open or shut.
+ */
+
+/** The single localStorage key holding the per-Workspace expanded-Surface map. */
+export const SURFACE_STATE_STORAGE_KEY = 'vibe-mistro:surface-state:v1'
+
+/** The slice of the Web Storage API we depend on — `window.localStorage` satisfies it. */
+export interface SurfaceStateStorage {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+}
+
+/**
+ * The whole persisted map, defensively coerced: a non-object payload, or a member that
+ * isn't a live Surface, is dropped. Throws only if the store's `getItem`/`JSON.parse`
+ * throws — callers wrap in try/catch and fall back to `{}`.
+ */
+function readMap(storage: SurfaceStateStorage): Record<string, Exclude<ExpandedSurface, null>> {
+  const raw = storage.getItem(SURFACE_STATE_STORAGE_KEY)
+  if (!raw) return {}
+  const parsed: unknown = JSON.parse(raw)
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {}
+  const out: Record<string, Exclude<ExpandedSurface, null>> = {}
+  for (const [id, value] of Object.entries(parsed as Record<string, unknown>)) {
+    const surface = coerceExpandedSurface(value)
+    if (surface) out[id] = surface
+  }
+  return out
+}
+
+/**
+ * The expanded Surface for a Workspace, or `null` when absent / unknown / unavailable.
+ * Never throws — a blocked/throwing/corrupt store must not trap the panel shut.
+ */
+export function getSurfaceState(
+  storage: SurfaceStateStorage | null | undefined,
+  workspaceId: string,
+): ExpandedSurface {
+  if (!storage) return null
+  try {
+    return readMap(storage)[workspaceId] ?? null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Persist a Workspace's expanded Surface best-effort; a `null` clears its entry (so a
+ * collapsed Workspace leaves no stale blob). A quota/security exception is swallowed.
+ */
+export function setSurfaceState(
+  storage: SurfaceStateStorage | null | undefined,
+  workspaceId: string,
+  surface: ExpandedSurface,
+): void {
+  if (!storage) return
+  try {
+    const map = readMap(storage)
+    if (surface) map[workspaceId] = surface
+    else delete map[workspaceId]
+    storage.setItem(SURFACE_STATE_STORAGE_KEY, JSON.stringify(map))
+  } catch {
+    // Best-effort: a full/blocked storage must never throw from a Surface toggle.
+  }
+}


### PR DESCRIPTION
Closes #187 (slice 1/4 of the Files browser epic — PRD #186, ADR-0013 decision 1; the ADR + CONTEXT.md terms ride this branch).

## What
The right panel becomes the **Surface stack** from the design mockup: collapsed = four launcher cards — **Review** (⌃⇧G), **Terminal** (Soon), **Browser** (⌘T hint, inert), **Files** (⌘P) — at most one Surface expanded at a time. Review re-homes the existing git Changes panel; Files expands to the slice-2 placeholder. Expanded choice persists per Workspace (localStorage, throw-tolerant store). Active/connected Workspace only.

New `src/renderer/src/side-panel/`: pure TDD'd `surface-model` (toggle/coerce), `surface-keys` (chord matcher: ⌘P→Files, ⌃⇧G→Review, strict modifier exclusions so typing never matches; `preventDefault` kills the print dialog), `surface-state-store` (per-Workspace, mirrors project-open-store), thin `SurfacePanel`/`FilesSurface` JSX.

## Two deliberate behavior changes (call-outs, both intended)
1. **Non-repo/pre-snapshot Workspaces**: the old panel rendered `null`; the Review Surface now shows its header + "Not a Git repository." — a Surface must never strand you without the way back to the cards.
2. **Resting state is the card stack**: the Changes panel is no longer open by default; git status streams only while Review is expanded (reviewer-verified: the ref-counted stream manager handles the churn, watcher no longer runs while collapsed — a resource improvement).

## Verification
- Adversarial review: **APPROVE**. Load-bearing items verified with evidence: exactly ONE live keydown listener (gated on `isActive`; App keeps one active Workspace), cleanup on unmount/eviction, no competing ⌘P/⌃⇧G handler; `git diff -w` proves the 259-line ChangesPanel diff is pure de-indentation + header extraction — git logic/hook order untouched (all 7 hooks above the early return); subscription lifecycle correct under expand/collapse spam.
- Review SHOULD-FIX **folded**: collapse now unmounts the panel, which would have discarded a half-typed commit message (one accidental ⌃⇧G away) — new module-level `commit-draft-store` (follow-up-queue idiom) seeds/mirrors the message + #86 deselection set across the remount; ephemeral by design, deleted on successful commit.
- Gates: lint ✓ typecheck ✓ build ✓ test **740/740** ✓ (711 baseline + 24 + 5 fold; run independently by implementer, lead, reviewer).
- Live check at merge: cards render per the mockup, ⌘P/⌃⇧G toggle, Review looks/behaves exactly as before, collapse→expand keeps a typed commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)