### PR TITLE
#187 follow-up: side panel is header-toggled, closed by default

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -38,8 +38,10 @@ _Avoid_: approval, confirmation, prompt (reserve "prompt" for the user's message
 
 **Surface**:
 One of the expandable areas stacked in the right-hand side panel — Review, Terminal, Browser, Files.
-Collapsed, each Surface shows as a launcher card; at most one is expanded at a time. Review hosts the
-git Changes panel; Files hosts the Files browser; Terminal and Browser are reserved (not yet built).
+The side panel itself is closed by default and toggled from the window header (or a Surface's
+shortcut); open, each Surface shows as a launcher card and at most one is expanded at a time. Review
+hosts the git Changes panel; Files hosts the Files browser; Terminal and Browser are reserved (not
+yet built).
 _Avoid_: tab, view, pane, dock (reserve "dock" for the future embedded terminal's chrome).
 
 **Files browser**:

--- a/docs/adr/0013-files-browser-surface-stack-confined-renderer-fs.md
+++ b/docs/adr/0013-files-browser-surface-stack-confined-renderer-fs.md
@@ -16,11 +16,14 @@ a `@pierre/trees` tree fed by a flat `{path, kind}[]` listing, with a preview pa
 
 ## Decision
 
-1. **The right panel becomes a Surface stack.** Collapsed, it renders launcher cards (Review /
-   Terminal / Browser / Files); at most one Surface expands at a time. Review wires the existing git
-   Changes panel (#119) into this model; Terminal and Browser are inert "Soon" cards reserved for
-   their epics; ⌘P opens Files with tree-search focused, ⌃⇧G toggles Review. Active/connected
-   Workspace only (ADR-0008 precedent).
+1. **The right panel becomes a header-toggled Surface stack.** The side panel is CLOSED by default
+   and opens from the window header's PanelRight icon (the left sidebar toggle's mirror; app-global,
+   persisted) — it is NOT an always-visible dock. Open with no Surface expanded, it renders launcher
+   cards (Review / Terminal / Browser / Files); at most one Surface expands at a time (per-Workspace,
+   persisted). Review wires the existing git Changes panel (#119) into this model; Terminal and
+   Browser are inert "Soon" cards reserved for their epics. Shortcuts resolve across the closed
+   state: ⌘P from anywhere = open the panel with Files expanded (tree-search focused), pressed again
+   = close it; ⌃⇧G the same for Review. Active/connected Workspace only (ADR-0008 precedent).
 2. **Files browser = t3code's shape on our stack, plus tabs.** Tree = `@pierre/trees` (new dep;
    preact/shadow-DOM widget, React 19 peer, NO shiki dependency — cannot reintroduce the #159
    duplication) fed by `files:list`, with SEARCH first-class (the tree's hide-non-matches filter; ⌘P

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -64,6 +64,10 @@ import {
   getSidebarCollapsed,
   setSidebarCollapsed as setSidebarCollapsedStore,
 } from './shell/sidebar-collapsed-store'
+import {
+  getSidePanelOpen,
+  setSidePanelOpen as setSidePanelOpenStore,
+} from './side-panel/side-panel-open-store'
 import { deriveUnifiedThreads, workspaceFlags, type UnifiedThreadRow } from './shell/unified-threads'
 
 /** A stable empty live-set for Workspaces with no live-state yet (no re-alloc). */
@@ -103,6 +107,15 @@ export function App(): JSX.Element {
       setSidebarCollapsedStore(window.localStorage, next)
       return next
     })
+  }
+  // Whether the right SIDE PANEL is open (#187 follow-up): the header's PanelRight icon
+  // toggles it (the sidebar toggle's mirror), CLOSED by default. App-global chrome —
+  // WHICH Surface shows inside stays per-Workspace (surface-state-store). A Surface
+  // shortcut (⌘P/⌃⇧G) can also open/close it via `setSidePanelOpenState`.
+  const [sidePanelOpen, setSidePanelOpen] = useState(() => getSidePanelOpen(window.localStorage))
+  function setSidePanelOpenState(open: boolean): void {
+    setSidePanelOpen(open)
+    setSidePanelOpenStore(window.localStorage, open)
   }
   // Navigation (decision 2): WHICH Workspace/Thread the user is looking at —
   // lifted here so the connect flow (Open project, Continue, sign-in) can drive it.
@@ -656,6 +669,8 @@ export function App(): JSX.Element {
           isLive={isLive}
           isActive={isActive}
           busy={busy}
+          sidePanelOpen={sidePanelOpen}
+          onSidePanelOpenChange={setSidePanelOpenState}
           seedSessionId={seed}
           controls={
             // A bound Thread sources its OWN live config (#70); a draft (no config
@@ -837,9 +852,15 @@ export function App(): JSX.Element {
           </IconButton>
         </div>
         <div className="flex-1" />
-        {/* placeholder — layout / view modes (#future) */}
+        {/* Right-region layout controls: the side-panel toggle is LIVE (#187 follow-up,
+            the design's header affordance); Terminal/Expand stay placeholders (#future). */}
         <div className="flex items-center gap-0.5 [-webkit-app-region:no-drag]">
-          <IconButton size="icon-sm" aria-label="Toggle side panel" title="Toggle side panel">
+          <IconButton
+            size="icon-sm"
+            aria-label={sidePanelOpen ? 'Close side panel' : 'Open side panel'}
+            title={sidePanelOpen ? 'Close side panel' : 'Open side panel'}
+            onClick={() => setSidePanelOpenState(!sidePanelOpen)}
+          >
             <PanelRight className="size-4" aria-hidden />
           </IconButton>
           <IconButton size="icon-sm" aria-label="Toggle terminal" title="Toggle terminal">

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useReducer, useRef, useState, type JSX, type ReactNode } from 'react'
+import { useCallback, useEffect, useReducer, useRef, useState, type JSX, type ReactNode } from 'react'
 import type {
   AuthMethod,
   ListMetadataResult,
@@ -113,10 +113,12 @@ export function App(): JSX.Element {
   // WHICH Surface shows inside stays per-Workspace (surface-state-store). A Surface
   // shortcut (⌘P/⌃⇧G) can also open/close it via `setSidePanelOpenState`.
   const [sidePanelOpen, setSidePanelOpen] = useState(() => getSidePanelOpen(window.localStorage))
-  function setSidePanelOpenState(open: boolean): void {
+  // Stable identity (review fold): this reaches SurfacePanel's keydown-effect deps, and a
+  // fresh function every App render would re-bind the window listener on every ACP tick.
+  const setSidePanelOpenState = useCallback((open: boolean): void => {
     setSidePanelOpen(open)
     setSidePanelOpenStore(window.localStorage, open)
-  }
+  }, [])
   // Navigation (decision 2): WHICH Workspace/Thread the user is looking at —
   // lifted here so the connect flow (Open project, Continue, sign-in) can drive it.
   const [nav, navDispatch] = useReducer(navReducer, initialNavState)

--- a/src/renderer/src/connection/ConnectedWorkspace.tsx
+++ b/src/renderer/src/connection/ConnectedWorkspace.tsx
@@ -39,6 +39,8 @@ export function ConnectedWorkspace({
   busy,
   seedSessionId,
   controls,
+  sidePanelOpen,
+  onSidePanelOpenChange,
   onSetConfig,
   onBound,
   onContinue,
@@ -67,6 +69,10 @@ export function ConnectedWorkspace({
   seedSessionId: string | null
   /** The active Thread's OWN agent-controls (#70), or null when none are seeded yet. */
   controls: ThreadAgentControls | null
+  /** Whether the right side panel is open (#187 follow-up) — App owns it (header icon). */
+  sidePanelOpen: boolean
+  /** Open/close the side panel (a Surface shortcut resolving across the closed state). */
+  onSidePanelOpenChange: (open: boolean) => void
   /** Change an agent control on the active Thread (#66/#70, ADR-0007): a bound session
    *  fires the IPC; a null session is a draft pre-pick App caches to apply on bind (#75). */
   onSetConfig: (axis: ThreadConfigAxis, value: string, sessionId: string | null) => void
@@ -103,14 +109,17 @@ export function ConnectedWorkspace({
           <ColdThread key={activeThread.id} thread={activeThread} onClose={onCloseCold} onContinue={onContinue} />
         )}
       </div>
-      {/* The right-panel Surface stack (#187, ADR-0013): launcher cards collapsed, one
-          Surface expanded at a time. Review re-homes the streamed git panel (#84,
-          active-Workspace-only); Files is the slice-2 placeholder. */}
+      {/* The right side panel (#187, ADR-0013): header-toggled, closed by default; open,
+          it shows the Surface stack (launcher cards / one expanded Surface). Review
+          re-homes the streamed git panel (#84, active-Workspace-only); Files is the
+          slice-2 placeholder. Stays mounted while closed so ⌘P/⌃⇧G can open it. */}
       <SurfacePanel
         workspaceId={connection.workspaceId}
         workspaceDir={connection.workspaceDir}
         isActive={isActive}
         busy={busy}
+        open={sidePanelOpen}
+        onOpenChange={onSidePanelOpenChange}
       />
     </div>
   )

--- a/src/renderer/src/side-panel/SurfacePanel.tsx
+++ b/src/renderer/src/side-panel/SurfacePanel.tsx
@@ -4,31 +4,38 @@ import { cn } from '../lib/utils'
 import { ChangesPanel } from '../git/ChangesPanel'
 import { FilesSurface } from './FilesSurface'
 import { surfaceForChord } from './surface-keys'
-import { toggleSurface, type ExpandedSurface, type Surface } from './surface-model'
+import { resolveSurfaceChord, type ExpandedSurface, type Surface } from './surface-model'
 import { getSurfaceState, setSurfaceState } from './surface-state-store'
 
 /**
  * The right-hand side panel as a Surface stack (#187, ADR-0013 decision 1; CONTEXT.md
- * "Surface"). Collapsed, it renders four launcher CARDS — Review (⌃⇧G), Terminal,
- * Browser (⌘T), Files (⌘P) — top-aligned; at most ONE Surface is expanded at a time and
- * the cards show only when NONE is. Review re-homes the existing git Changes panel
- * behavior-identical (#84–#88); Files expands to a slice-2 placeholder; Terminal and
- * Browser are inert "Soon" cards (the sidebar Search/Scheduled/Plugins precedent).
+ * "Surface"). The PANEL ITSELF is toggled from the window header's PanelRight icon and
+ * is CLOSED by default (#187 follow-up — `open`/`onOpenChange` are owned by App next to
+ * the sidebar toggle, persisted app-globally). Open, it renders four launcher CARDS —
+ * Review (⌃⇧G), Terminal, Browser (⌘T), Files (⌘P) — top-aligned; at most ONE Surface is
+ * expanded at a time and the cards show only when NONE is. Review re-homes the existing
+ * git Changes panel behavior-identical (#84–#88); Files expands to a slice-2 placeholder;
+ * Terminal and Browser are inert "Soon" cards (the sidebar Search/Scheduled/Plugins
+ * precedent).
  *
  * The expanded choice persists PER Workspace across restart (localStorage, throw-tolerant
  * injected-storage store). Because App keys each `ConnectedWorkspace` (hence this panel)
  * by `agentId`, every Workspace has its own instance seeding from its own stored entry —
  * so switching Workspace restores that Workspace's Surface with no extra plumbing.
  *
- * Rendered by `ConnectedWorkspace` for the active/connected Workspace only. The state
- * machine is the pure `surface-model`; this component is a thin switch over it plus the
- * renderer-level keyboard handler.
+ * Rendered by `ConnectedWorkspace` for the active/connected Workspace only. When the
+ * panel is closed it renders NOTHING but stays mounted, so the shortcut listener stays
+ * live — ⌘P/⌃⇧G resolve through the pure `resolveSurfaceChord` (closed → open with that
+ * Surface; same Surface → close; other → switch). The state machine is the pure
+ * `surface-model`; this component is a thin switch over it plus the keyboard handler.
  */
 export function SurfacePanel({
   workspaceId,
   workspaceDir,
   isActive,
   busy,
+  open,
+  onOpenChange,
 }: {
   workspaceId: string
   workspaceDir: string
@@ -36,7 +43,11 @@ export function SurfacePanel({
   isActive: boolean
   /** Whether a turn is streaming (#86) — threaded to the Review panel's commit guard. */
   busy: boolean
-}): JSX.Element {
+  /** Whether the side panel is showing at all — App owns it (header PanelRight icon). */
+  open: boolean
+  /** Ask App to open/close the panel (a shortcut resolving across the closed state). */
+  onOpenChange: (open: boolean) => void
+}): JSX.Element | null {
   const [expanded, setExpanded] = useState<ExpandedSurface>(() =>
     getSurfaceState(window.localStorage, workspaceId),
   )
@@ -47,27 +58,33 @@ export function SurfacePanel({
     setSurfaceState(window.localStorage, workspaceId, next)
   }
 
-  // Renderer-level shortcuts (NO Electron accelerators): ⌘P toggles Files, ⌃⇧G toggles
-  // Review. Gated on `isActive` so a backgrounded (mounted-hidden) Workspace never grabs
-  // keys. Both chords carry a modifier, so plain typing never matches — a focused
-  // textarea is intentionally NOT exempt (⌘P must open Files even while composing); the
-  // composer's own Enter/Esc handling is untouched (those chords aren't ours). We
-  // preventDefault the match to stop the browser's ⌘P print dialog.
+  // Renderer-level shortcuts (NO Electron accelerators): ⌘P for Files, ⌃⇧G for Review,
+  // resolved against the WHOLE panel state (closed → open+Surface; same → close panel;
+  // other → switch). Gated on `isActive` so a backgrounded (mounted-hidden) Workspace
+  // never grabs keys; live even while the panel is CLOSED (this component stays mounted
+  // rendering null). Both chords carry a modifier, so plain typing never matches — a
+  // focused textarea is intentionally NOT exempt (⌘P must open Files even while
+  // composing); the composer's own Enter/Esc handling is untouched (those chords aren't
+  // ours). We preventDefault the match to stop the browser's ⌘P print dialog.
   useEffect(() => {
     if (!isActive) return
     function onKeyDown(e: KeyboardEvent): void {
       const surface = surfaceForChord(e)
       if (!surface) return
       e.preventDefault()
-      setExpanded((current) => {
-        const next = toggleSurface(current, surface)
-        setSurfaceState(window.localStorage, workspaceId, next)
-        return next
-      })
+      const next = resolveSurfaceChord({ open, expanded }, surface)
+      setExpanded(next.expanded)
+      setSurfaceState(window.localStorage, workspaceId, next.expanded)
+      if (next.open !== open) onOpenChange(next.open)
     }
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [isActive, workspaceId])
+    // `expanded` in deps: the listener re-binds on each change (cheap) so the chord
+    // always resolves against fresh state without side effects inside an updater.
+  }, [isActive, workspaceId, open, expanded, onOpenChange])
+
+  // Closed panel: render nothing, keep the listener (the effect above) alive.
+  if (!open) return null
 
   if (expanded === 'review') {
     // The Review Surface IS the existing Changes panel, behavior-identical (#84–#88). It

--- a/src/renderer/src/side-panel/side-panel-open-store.test.ts
+++ b/src/renderer/src/side-panel/side-panel-open-store.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import {
+  SIDE_PANEL_OPEN_STORAGE_KEY,
+  getSidePanelOpen,
+  setSidePanelOpen,
+  type SidePanelOpenStorage,
+} from './side-panel-open-store'
+
+function fakeStorage(initial: Record<string, string> = {}): SidePanelOpenStorage & {
+  data: Record<string, string>
+} {
+  const data = { ...initial }
+  return {
+    data,
+    getItem: (key) => (key in data ? data[key] : null),
+    setItem: (key, value) => {
+      data[key] = value
+    },
+  }
+}
+
+describe('side-panel-open-store', () => {
+  it('defaults to CLOSED when nothing is stored', () => {
+    expect(getSidePanelOpen(fakeStorage())).toBe(false)
+  })
+
+  it('round-trips open and closed', () => {
+    const storage = fakeStorage()
+    setSidePanelOpen(storage, true)
+    expect(getSidePanelOpen(storage)).toBe(true)
+    setSidePanelOpen(storage, false)
+    expect(getSidePanelOpen(storage)).toBe(false)
+  })
+
+  it('treats an unknown stored value as closed', () => {
+    expect(getSidePanelOpen(fakeStorage({ [SIDE_PANEL_OPEN_STORAGE_KEY]: 'maybe' }))).toBe(false)
+  })
+
+  it('tolerates an absent storage', () => {
+    expect(getSidePanelOpen(null)).toBe(false)
+    expect(() => setSidePanelOpen(undefined, true)).not.toThrow()
+  })
+
+  it('tolerates a throwing storage', () => {
+    const throwing: SidePanelOpenStorage = {
+      getItem: () => {
+        throw new Error('blocked')
+      },
+      setItem: () => {
+        throw new Error('quota')
+      },
+    }
+    expect(getSidePanelOpen(throwing)).toBe(false)
+    expect(() => setSidePanelOpen(throwing, true)).not.toThrow()
+  })
+})

--- a/src/renderer/src/side-panel/side-panel-open-store.ts
+++ b/src/renderer/src/side-panel/side-panel-open-store.ts
@@ -1,0 +1,44 @@
+/**
+ * Whether the right SIDE PANEL is OPEN (#187 follow-up): a renderer-only, display-only,
+ * app-global boolean — the mirror of the left sidebar's collapsed flag (#127). The
+ * user's design opens the panel from the window header's PanelRight icon (or a Surface
+ * shortcut); it is CLOSED by default, so the conversation gets the full width until
+ * asked. Which Surface is expanded INSIDE the panel stays per-Workspace in
+ * `surface-state-store` — this flag only says whether the panel is showing at all.
+ *
+ * Storage seam injected (tests pass a fake, render code passes `window.localStorage`);
+ * every path tolerates an unavailable/throwing/corrupt store and falls back to the
+ * default (CLOSED = `false`) so a blocked store never wedges the panel open.
+ */
+
+/** The single localStorage key holding the side-panel-open flag. */
+export const SIDE_PANEL_OPEN_STORAGE_KEY = 'vibe-mistro:side-panel-open:v1'
+
+/** The slice of the Web Storage API we depend on — `window.localStorage` satisfies it. */
+export interface SidePanelOpenStorage {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+}
+
+/** The persisted open flag, or `false` (closed) when absent/unknown/unavailable. */
+export function getSidePanelOpen(storage: SidePanelOpenStorage | null | undefined): boolean {
+  if (!storage) return false
+  try {
+    return storage.getItem(SIDE_PANEL_OPEN_STORAGE_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+/** Persist the open flag best-effort; a quota/security exception is swallowed. */
+export function setSidePanelOpen(
+  storage: SidePanelOpenStorage | null | undefined,
+  open: boolean,
+): void {
+  if (!storage) return
+  try {
+    storage.setItem(SIDE_PANEL_OPEN_STORAGE_KEY, open ? 'true' : 'false')
+  } catch {
+    // Best-effort: a full/blocked storage must never throw from a panel toggle.
+  }
+}

--- a/src/renderer/src/side-panel/surface-model.test.ts
+++ b/src/renderer/src/side-panel/surface-model.test.ts
@@ -3,6 +3,7 @@ import {
   coerceExpandedSurface,
   collapseSurface,
   EXPANDABLE_SURFACES,
+  resolveSurfaceChord,
   toggleSurface,
 } from './surface-model'
 
@@ -50,5 +51,42 @@ describe('coerceExpandedSurface', () => {
 describe('EXPANDABLE_SURFACES', () => {
   it('is exactly the two live Surfaces', () => {
     expect([...EXPANDABLE_SURFACES]).toEqual(['review', 'files'])
+  })
+})
+
+// #187 follow-up: the panel itself is header-toggled and defaults closed, so a shortcut
+// resolves against the WHOLE panel state (open + expanded), not just the Surface.
+describe('resolveSurfaceChord', () => {
+  it('opens a closed panel with that Surface expanded', () => {
+    expect(resolveSurfaceChord({ open: false, expanded: null }, 'files')).toEqual({
+      open: true,
+      expanded: 'files',
+    })
+    expect(resolveSurfaceChord({ open: false, expanded: 'review' }, 'files')).toEqual({
+      open: true,
+      expanded: 'files',
+    })
+  })
+
+  it('closes the panel when its Surface is already expanded, keeping the choice', () => {
+    expect(resolveSurfaceChord({ open: true, expanded: 'files' }, 'files')).toEqual({
+      open: false,
+      expanded: 'files',
+    })
+    expect(resolveSurfaceChord({ open: true, expanded: 'review' }, 'review')).toEqual({
+      open: false,
+      expanded: 'review',
+    })
+  })
+
+  it('switches Surface when the panel is open on another (or none)', () => {
+    expect(resolveSurfaceChord({ open: true, expanded: 'review' }, 'files')).toEqual({
+      open: true,
+      expanded: 'files',
+    })
+    expect(resolveSurfaceChord({ open: true, expanded: null }, 'review')).toEqual({
+      open: true,
+      expanded: 'review',
+    })
   })
 })

--- a/src/renderer/src/side-panel/surface-model.ts
+++ b/src/renderer/src/side-panel/surface-model.ts
@@ -39,3 +39,24 @@ export function collapseSurface(): ExpandedSurface {
 export function coerceExpandedSurface(raw: unknown): ExpandedSurface {
   return raw === 'review' || raw === 'files' ? raw : null
 }
+
+/** The side panel's full keyboard-visible state: open at all + which Surface, if any. */
+export interface SidePanelState {
+  open: boolean
+  expanded: ExpandedSurface
+}
+
+/**
+ * Resolve a Surface shortcut (⌘P / ⌃⇧G) against the WHOLE panel state (#187 follow-up:
+ * the panel itself is toggled from the window header's PanelRight icon and defaults
+ * CLOSED, so a shortcut must be able to open it):
+ *  - panel closed              → open it with that Surface expanded (one keystroke in);
+ *  - open, SAME Surface        → close the panel (one keystroke back out) — the expanded
+ *    choice is kept, so the header icon reopens where you left off;
+ *  - open, other/none expanded → switch to (expand) that Surface, panel stays open.
+ */
+export function resolveSurfaceChord(state: SidePanelState, surface: Surface): SidePanelState {
+  if (!state.open) return { open: true, expanded: surface }
+  if (state.expanded === surface) return { open: false, expanded: surface }
+  return { open: true, expanded: surface }
+}


### PR DESCRIPTION
Design correction for #187 (Files browser epic, PRD #186 / ADR-0013): the right side panel is NOT an always-visible dock — the window header's **PanelRight icon** (previously a static #113 placeholder) toggles it, and it starts **closed** so the conversation gets full width. #187's Surface stack (cards, one-expanded, Review re-home) is unchanged as the panel's *content*.

## What
- `side-panel-open-store` — app-global open flag (mirror of the #127 sidebar toggle; default closed; throw-tolerant; 5 tests).
- Pure `resolveSurfaceChord` — shortcuts resolve across the whole panel state: **closed → open with that Surface** (⌘P/⌃⇧G work one-keystroke from anywhere), **same Surface → close the panel** (choice kept, icon reopens where you left off), **other → switch** (3 tests).
- `SurfacePanel` stays mounted rendering null while closed so its keydown listener stays live; App owns the flag next to the sidebar toggle and wires the header icon; ConnectedWorkspace passes it through.
- ADR-0013 decision 1 + CONTEXT.md "Surface" corrected to match the real design.

## Verification
- Adversarial review: **APPROVE** — verified no stale closures (deps carry open/expanded), the two writers (icon vs chord) can't fight and background Workspaces can't fire the chord (listener gated on the single active instance), hooks all precede the null return, and the commit draft survives close→open via the #187 draft store. One perf NIT folded (`useCallback` so the window listener stops re-binding on every ACP tick).
- Gates: lint ✓ typecheck ✓ build ✓ test **748/748** ✓ (740 + 8).
- Live check at merge: panel starts closed; header icon toggles; ⌘P opens it straight to Files, ⌘P again closes; ⌃⇧G same for Review; a half-typed commit message survives close→reopen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)