### PR TITLE
#190: @ file-path autocomplete in the composer over the shared listing

### DIFF
--- a/src/renderer/src/conversation/Conversation.tsx
+++ b/src/renderer/src/conversation/Conversation.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react'
 import type {
   AuthMethod,
+  FileEntry,
   ThreadAgentControls,
   ThreadConfigAxis,
   ThreadModes,
@@ -25,6 +26,8 @@ import {
   Circle,
   Copy,
   Eye,
+  File,
+  Folder,
   Globe,
   Loader2,
   Mic,
@@ -81,6 +84,7 @@ import {
   getCommandQuery,
   moveSelection,
 } from './command-autocomplete'
+import { applyPath, filterPaths, getPathQuery } from './path-autocomplete'
 import { ACCEPTED_IMAGE_TYPES, isAcceptedImageType, parseDataUrl } from './image-attach'
 import { isSending, nextQueueId, useFollowUpQueue } from './follow-up-queue'
 
@@ -205,6 +209,22 @@ export function Conversation({
   // you keep typing (the escape hatch for sending literal `/text`). Cleared once the
   // token closes/deletes or a different `/` opens, so a fresh trigger reopens.
   const dismissedStartRef = useRef<number | null>(null)
+  // Ephemeral `@` file-path autocomplete state (#190), the mid-sentence sibling of the
+  // `/` popover: the open trigger (the `@`'s index + the fragment after it), the
+  // highlighted row, its scroll ref, and the Esc-dismiss latch (per-token, same shape as
+  // `/`'s so a user can type a literal `@foo`). Renderer-local; a Thread switch remounts
+  // this view (keyed by threadId), so it always starts closed. `null` = closed.
+  const [pathTrigger, setPathTrigger] = useState<{ start: number; query: string } | null>(null)
+  const [pathIndex, setPathIndex] = useState(0)
+  const activePathRowRef = useRef<HTMLLIElement>(null)
+  const pathDismissedStartRef = useRef<number | null>(null)
+  // The shared `files:list` listing (ADR-0013 decision 5), fetched ONCE per composer
+  // mount on the first `@` (lazy) and cached here — ranking runs in the renderer, so no
+  // per-keystroke IPC. `requestedRef` guards the single fetch; a failed/empty listing is
+  // tolerated (the popup just shows nothing — a typed `@path` still sends fine, the agent
+  // resolves it). Addressed by the connection's `agentId`, like the Files Surface.
+  const [pathEntries, setPathEntries] = useState<FileEntry[]>([])
+  const pathEntriesRequestedRef = useRef(false)
   // True once any live event has been folded in: guards the async hydrate from
   // clobbering events that streamed in before the JSONL read resolved.
   const liveSeen = useRef(false)
@@ -501,11 +521,25 @@ export function Conversation({
   const showCommands = commandTrigger !== null && commandRows.length > 0
   const activeIndex = Math.min(commandIndex, commandRows.length - 1)
 
+  // The `@` popover's live matches (#190): the cached listing ranked substring-then-
+  // subsequence by the open fragment. MUTUAL EXCLUSION with `/`: the two triggers CAN
+  // both match (e.g. `/foo@bar` at a line start), so the start-anchored `/` popover wins
+  // — `showPaths` is gated on `!showCommands`, and the keyboard handler runs the `/`
+  // block first (which returns), so at most one popover is ever open. `activePathIndex`
+  // clamps the stored highlight in case the match count shrank as the fragment grew.
+  const pathRows: FileEntry[] = pathTrigger ? filterPaths(pathEntries, pathTrigger.query) : []
+  const showPaths = !showCommands && pathTrigger !== null && pathRows.length > 0
+  const activePathIndex = Math.min(pathIndex, pathRows.length - 1)
+
   // Keep the highlighted row visible when ↑/↓ walk past the popover's max-height
   // (#95). `block: 'nearest'` scrolls only the overflow list, not the whole page.
   useEffect(() => {
     if (showCommands) activeRowRef.current?.scrollIntoView({ block: 'nearest' })
   }, [showCommands, activeIndex])
+
+  useEffect(() => {
+    if (showPaths) activePathRowRef.current?.scrollIntoView({ block: 'nearest' })
+  }, [showPaths, activePathIndex])
 
   // Re-derive the trigger from the composer's value + caret after any edit or caret
   // move. Reads the live caret so `hello /re` (mid-line) never triggers while `/re`
@@ -551,6 +585,71 @@ export function Conversation({
     })
   }
 
+  // Fetch the shared `files:list` listing ONCE per composer mount, lazily on the first
+  // `@` (ADR-0013 decision 5). Serves main's per-Workspace cache (no `refresh`), so it is
+  // cheap; a failure is swallowed — the popup just stays empty and a typed `@path` still
+  // sends. The resolved entries land in state, which re-renders the open popover with them.
+  function ensurePathEntries(): void {
+    if (pathEntriesRequestedRef.current) return
+    pathEntriesRequestedRef.current = true
+    void window.api.filesList({ agentId: thread.agentId }).then(
+      (result) => setPathEntries(result.entries),
+      () => {
+        /* tolerate a failed listing — typed paths still send; the agent resolves them */
+      },
+    )
+  }
+
+  // Re-derive the `@` trigger from the composer's value + caret after any edit or caret
+  // move (mid-sentence, unlike `/`). Mirrors `refreshCommandTrigger`: an active trigger
+  // kicks the lazy listing fetch and clears/holds the Esc latch the same way.
+  function refreshPathTrigger(value: string, caret: number | null): void {
+    const trigger = caret === null ? null : getPathQuery(value, caret)
+    if (!trigger || !trigger.active) {
+      pathDismissedStartRef.current = null
+      setPathTrigger(null)
+      setPathIndex(0)
+      return
+    }
+    if (pathDismissedStartRef.current === trigger.start) {
+      // Still the Esc-dismissed token — stay closed as the fragment grows (lets a user
+      // type a literal `@foo`).
+      setPathTrigger(null)
+      return
+    }
+    pathDismissedStartRef.current = null
+    ensurePathEntries()
+    setPathTrigger({ start: trigger.start, query: trigger.query })
+    setPathIndex(0)
+  }
+
+  // Accept a path completion: splice the plain-text `@<path>` over the `@fragment` token
+  // (a FILE gets a trailing space and closes the token; a DIRECTORY gets a trailing slash
+  // and REOPENS the popover on the new fragment so completion drills into the dir), keep
+  // the draft + persisted draft (#60) in lockstep, then restore focus + caret via rAF.
+  function acceptPath(entry: FileEntry): void {
+    if (!pathTrigger) return
+    const node = inputRef.current
+    const caret = node ? node.selectionStart : draft.length
+    const next = applyPath(draft, pathTrigger.start, caret, entry)
+    setDraft(next.value)
+    persistDraft(window.localStorage, thread.threadId, next.value)
+    setPathIndex(0)
+    if (entry.kind === 'directory') {
+      // `@dir/` — re-derive immediately so the popup continues into the directory.
+      refreshPathTrigger(next.value, next.caret)
+    } else {
+      pathDismissedStartRef.current = null
+      setPathTrigger(null)
+    }
+    requestAnimationFrame(() => {
+      const el = inputRef.current
+      if (!el) return
+      el.focus()
+      el.setSelectionRange(next.caret, next.caret)
+    })
+  }
+
   function onKeyDown(e: KeyboardEvent<HTMLTextAreaElement>): void {
     // Popover-open key interception (#95): navigation + accept must win over Enter's
     // send and Tab's focus move. When closed, every key falls through unchanged.
@@ -575,6 +674,33 @@ export function Conversation({
         // Latch this token as dismissed so typing more doesn't reopen it (#95).
         dismissedStartRef.current = commandTrigger?.start ?? null
         setCommandTrigger(null)
+        return
+      }
+    }
+    // The `@` popover's key interception (#190) — same contract as `/`, and reachable
+    // only when the `/` popover is closed (`showPaths` is gated on `!showCommands`, and
+    // the block above returns), so the two never fight over a key.
+    if (showPaths) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setPathIndex(moveSelection(activePathIndex, pathRows.length, 1))
+        return
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setPathIndex(moveSelection(activePathIndex, pathRows.length, -1))
+        return
+      }
+      if (e.key === 'Enter' || e.key === 'Tab') {
+        e.preventDefault()
+        acceptPath(pathRows[activePathIndex])
+        return
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        // Latch this token as dismissed so typing more doesn't reopen it (#190).
+        pathDismissedStartRef.current = pathTrigger?.start ?? null
+        setPathTrigger(null)
         return
       }
     }
@@ -722,6 +848,41 @@ export function Conversation({
                   ))}
                 </ul>
               )}
+              {showPaths && (
+                <ul
+                  className="absolute right-0 bottom-full left-0 z-10 mb-2 max-h-56 list-none overflow-y-auto rounded-xl border border-border bg-panel p-1 shadow-lg"
+                  role="listbox"
+                  aria-label="File paths"
+                >
+                  {pathRows.map((entry, i) => (
+                    <li
+                      key={entry.path}
+                      ref={i === activePathIndex ? activePathRowRef : null}
+                      role="option"
+                      aria-selected={i === activePathIndex}
+                      className={cn(
+                        'flex cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5',
+                        i === activePathIndex && 'bg-[var(--accent-tint)]',
+                      )}
+                      // mousedown (not click) so we accept BEFORE the textarea blurs.
+                      onMouseDown={(e) => {
+                        e.preventDefault()
+                        acceptPath(entry)
+                      }}
+                    >
+                      {entry.kind === 'directory' ? (
+                        <Folder className="size-3.5 shrink-0 text-muted" aria-hidden />
+                      ) : (
+                        <File className="size-3.5 shrink-0 text-muted" aria-hidden />
+                      )}
+                      <span className="truncate text-[13px] text-text-body">
+                        {entry.path}
+                        {entry.kind === 'directory' && '/'}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
               <Textarea
                 ref={inputRef}
                 className="min-h-0 resize-none border-0 bg-transparent p-0 text-[17px] leading-normal focus-visible:border-0"
@@ -733,13 +894,15 @@ export function Conversation({
                   // Write-through: keep React state and the persisted draft (#60) in lockstep.
                   setDraft(e.target.value)
                   persistDraft(window.localStorage, thread.threadId, e.target.value)
-                  // Re-derive the `/` autocomplete trigger from the new value + caret (#95).
+                  // Re-derive the `/` (#95) and `@` (#190) triggers from the new value + caret.
                   refreshCommandTrigger(e.target.value, e.target.selectionStart)
+                  refreshPathTrigger(e.target.value, e.target.selectionStart)
                 }}
-                // Caret moves (arrows/click) with no edit also open/close the trigger (#95).
-                onSelect={(e) =>
+                // Caret moves (arrows/click) with no edit also open/close the triggers.
+                onSelect={(e) => {
                   refreshCommandTrigger(e.currentTarget.value, e.currentTarget.selectionStart)
-                }
+                  refreshPathTrigger(e.currentTarget.value, e.currentTarget.selectionStart)
+                }}
                 onKeyDown={onKeyDown}
                 onPaste={onPaste}
                 rows={2}

--- a/src/renderer/src/conversation/path-autocomplete.test.ts
+++ b/src/renderer/src/conversation/path-autocomplete.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest'
+import {
+  applyPath,
+  filterPaths,
+  getPathQuery,
+  moveSelection,
+  MAX_PATH_RESULTS,
+} from './path-autocomplete'
+import type { FileEntry } from '../../../shared/ipc'
+
+/**
+ * `@` file-path autocomplete (#190, ADR-0013 decision 5): the pure derivation behind the
+ * composer's path popover — mid-sentence trigger detection, substring-then-subsequence
+ * ranking, the plain-text insertion transform (file space vs directory slash), and the
+ * shared wrapping selection. All DOM-free, so these exercise the logic as plain data with
+ * no renderer. Mirrors the `/` command-autocomplete suite.
+ */
+
+const ENTRIES: FileEntry[] = [
+  { path: 'src', kind: 'directory' },
+  { path: 'src/index.ts', kind: 'file' },
+  { path: 'src/reducer.ts', kind: 'file' },
+  { path: 'README.md', kind: 'file' },
+  { path: 'docs', kind: 'directory' },
+]
+
+describe('getPathQuery — mid-sentence trigger detection', () => {
+  it('activates on an `@`-token at input start with the caret after the `@`', () => {
+    expect(getPathQuery('@src', 4)).toEqual({ active: true, query: 'src', start: 0 })
+  })
+
+  it('reports an empty query right after a bare `@`', () => {
+    expect(getPathQuery('@', 1)).toEqual({ active: true, query: '', start: 0 })
+  })
+
+  it('activates MID-SENTENCE (the key difference from `/`)', () => {
+    // "see @src" — the `@` opens at index 4 even though it is not at the line start.
+    expect(getPathQuery('see @src', 8)).toEqual({ active: true, query: 'src', start: 4 })
+  })
+
+  it('takes the LAST `@` before the caret when several are present', () => {
+    expect(getPathQuery('@a @b', 5)).toEqual({ active: true, query: 'b', start: 3 })
+  })
+
+  it('does NOT activate once the token is closed by a space', () => {
+    expect(getPathQuery('@src ', 5).active).toBe(false)
+  })
+
+  it('does NOT activate when whitespace sits between the `@` and the caret', () => {
+    // "@src foo" with the caret inside `foo` — the token closed at the space.
+    expect(getPathQuery('@src foo', 8).active).toBe(false)
+  })
+
+  it('does NOT activate when there is no `@` before the caret', () => {
+    expect(getPathQuery('hello world', 5).active).toBe(false)
+  })
+
+  it('does NOT activate when the caret rests on the `@` itself', () => {
+    expect(getPathQuery('@src', 0).active).toBe(false)
+  })
+
+  it('uses the caret, not the end of value, for the query', () => {
+    // Caret sits after `sr`, before the trailing `c`.
+    expect(getPathQuery('@src', 3)).toEqual({ active: true, query: 'sr', start: 0 })
+  })
+
+  it('stays active for a directory fragment ending in a slash (dir continuation)', () => {
+    expect(getPathQuery('@src/', 5)).toEqual({ active: true, query: 'src/', start: 0 })
+  })
+
+  it('clamps an out-of-range caret rather than throwing', () => {
+    expect(getPathQuery('@src', 99)).toEqual({ active: true, query: 'src', start: 0 })
+    expect(getPathQuery('@src', -5).active).toBe(false)
+  })
+})
+
+describe('filterPaths — substring then subsequence, case-insensitive, ≤10, dirs included', () => {
+  it('keeps the listing head for an empty query', () => {
+    expect(filterPaths(ENTRIES, '')).toEqual(ENTRIES)
+  })
+
+  it('orders substring matches before subsequence (fuzzy) matches', () => {
+    // `reducer` substring-matches `src/reducer.ts`; `README.md` matches only as a
+    // subsequence (r-e-…-d-…), so it ranks after.
+    expect(filterPaths(ENTRIES, 'red').map((e) => e.path)).toEqual([
+      'src/reducer.ts',
+      'README.md',
+    ])
+  })
+
+  it('is case-insensitive on both sides', () => {
+    expect(filterPaths(ENTRIES, 'SRC').map((e) => e.path)).toEqual([
+      'src',
+      'src/index.ts',
+      'src/reducer.ts',
+    ])
+  })
+
+  it('includes directories alongside files', () => {
+    const kinds = filterPaths(ENTRIES, 'src').map((e) => e.kind)
+    expect(kinds).toContain('directory')
+    expect(kinds).toContain('file')
+  })
+
+  it('drops non-matches', () => {
+    expect(filterPaths(ENTRIES, 'zzz')).toEqual([])
+  })
+
+  it(`caps the result at ${MAX_PATH_RESULTS}`, () => {
+    const many: FileEntry[] = Array.from({ length: 25 }, (_, i) => ({
+      path: `file-${i}.ts`,
+      kind: 'file',
+    }))
+    expect(filterPaths(many, 'file')).toHaveLength(MAX_PATH_RESULTS)
+  })
+
+  it('preserves listing order within each rank group', () => {
+    const entries: FileEntry[] = [
+      { path: 'ab.ts', kind: 'file' },
+      { path: 'xa_b.ts', kind: 'file' },
+      { path: 'a-b.ts', kind: 'file' },
+    ]
+    // Query `ab`: substring group is ab.ts, a-b?no. `ab` substring: ab.ts only; `a-b.ts`
+    // and `xa_b.ts` match only as subsequences (a…b), kept in listing order.
+    expect(filterPaths(entries, 'ab').map((e) => e.path)).toEqual([
+      'ab.ts',
+      'xa_b.ts',
+      'a-b.ts',
+    ])
+  })
+})
+
+describe('applyPath — plain-text insertion transform', () => {
+  it('inserts a FILE with a trailing space and places the caret after it', () => {
+    expect(applyPath('@re', 0, 3, { path: 'src/reducer.ts', kind: 'file' })).toEqual({
+      value: '@src/reducer.ts ',
+      caret: 16,
+    })
+  })
+
+  it('inserts a DIRECTORY with a trailing slash and no space (continuation)', () => {
+    expect(applyPath('@sr', 0, 3, { path: 'src', kind: 'directory' })).toEqual({
+      value: '@src/',
+      caret: 5,
+    })
+  })
+
+  it('keeps text after the caret intact', () => {
+    const out = applyPath('@re rest', 0, 3, { path: 'README.md', kind: 'file' })
+    expect(out.value).toBe('@README.md  rest')
+    expect(out.caret).toBe(11)
+  })
+
+  it('applies to a token that starts mid-sentence', () => {
+    const out = applyPath('see @sr done', 4, 7, { path: 'src', kind: 'directory' })
+    expect(out.value).toBe('see @src/ done')
+    expect(out.caret).toBe(9)
+  })
+})
+
+describe('moveSelection — wrapping (shared with the `/` core)', () => {
+  it('advances within range', () => {
+    expect(moveSelection(0, 3, 1)).toBe(1)
+  })
+
+  it('wraps past the end', () => {
+    expect(moveSelection(2, 3, 1)).toBe(0)
+  })
+
+  it('wraps past the start', () => {
+    expect(moveSelection(0, 3, -1)).toBe(2)
+  })
+
+  it('clamps to 0 for an empty list', () => {
+    expect(moveSelection(0, 0, 1)).toBe(0)
+  })
+})

--- a/src/renderer/src/conversation/path-autocomplete.ts
+++ b/src/renderer/src/conversation/path-autocomplete.ts
@@ -1,0 +1,124 @@
+/**
+ * `@` file-path autocomplete logic (#190, ADR-0013 decision 5): the pure core of the
+ * composer's path popover. It mirrors the `/` slash-command core (command-autocomplete.ts)
+ * — trigger detection, filtering, the insertion transform, and selection wrapping — but
+ * over the shared `files:list` listing (FileEntry[]) rather than the Vibe-streamed
+ * commands, and with the Vibe CLI PathCompleter's semantics.
+ *
+ * The KEY difference from `/`: this trigger is NOT start-anchored. `@` fires MID-SENTENCE
+ * — the active fragment is whatever follows the LAST `@` before the caret, as long as it
+ * is space-free (whitespace after the `@` closes the token, matching the CLI). This lets a
+ * user drop a `@path` reference anywhere in a prompt.
+ *
+ * Accepting inserts PLAIN TEXT `@<path>` with NO client-side expansion (ADR-0002): a FILE
+ * gets a trailing space (`@path `, token closed, caret past it); a DIRECTORY gets a
+ * trailing slash (`@dir/`, no space) so re-deriving the fragment naturally continues into
+ * the directory's children. The agent resolves the literal `@path` itself server-side
+ * (render_path_prompt).
+ *
+ * Deliberately DOM-free and side-effect-free so it unit-tests as plain data
+ * (path-autocomplete.test.ts) while `Conversation.tsx` keeps the thin JSX + keyboard
+ * wiring. `moveSelection` is shared with the `/` core (identical wrapping), re-exported here.
+ */
+
+import type { FileEntry } from '../../../shared/ipc'
+
+export { moveSelection } from './command-autocomplete'
+
+/**
+ * The result of probing the composer value + caret for an active `@` trigger. `active`
+ * gates the popover; `query` is the fragment after the `@` up to the caret (lower-cased
+ * matching happens in `filterPaths`); `start` is the index of the `@` so `applyPath` knows
+ * where the token begins.
+ */
+export interface PathTrigger {
+  active: boolean
+  query: string
+  start: number
+}
+
+/** An inactive probe result — the single shape returned when no trigger qualifies. */
+const NO_TRIGGER: PathTrigger = { active: false, query: '', start: -1 }
+
+/** Whitespace closes an `@`-token: a caret past one of these is no longer inside it. */
+const TOKEN_WHITESPACE = /\s/
+
+/** The popup is capped so it stays fast + scannable over a ~20k-entry listing. */
+export const MAX_PATH_RESULTS = 10
+
+/**
+ * Detect an `@`-path trigger at the caret. Unlike the `/` core this is NOT start-anchored:
+ * the token opens at the LAST `@` before the caret (`@` allowed mid-sentence), and is
+ * active only while the fragment from that `@` up to the caret contains no whitespace (the
+ * token is still open). Returns the query (text after the `@`, up to the caret) and the
+ * `@`'s index on a hit.
+ *
+ * `caret` is clamped defensively — a caller may hand us a DOM `selectionStart` that a
+ * controlled re-render has momentarily desynced from `value`.
+ */
+export function getPathQuery(value: string, caret: number): PathTrigger {
+  const pos = Math.max(0, Math.min(caret, value.length))
+  // The last `@` strictly before the caret opens the token; a caret resting ON the `@`
+  // (pos <= at) isn't inside it yet, so no trigger.
+  const at = value.lastIndexOf('@', pos - 1)
+  if (at < 0 || pos <= at) return NO_TRIGGER
+  const query = value.slice(at + 1, pos)
+  // Whitespace anywhere between the `@` and the caret closes the token (e.g. `@src foo`
+  // with the caret past the space), so the popover must not show.
+  if (TOKEN_WHITESPACE.test(query)) return NO_TRIGGER
+  return { active: true, query, start: at }
+}
+
+/** True when every char of `needle` appears in `hay` in order (fuzzy subsequence match). */
+function isSubsequence(needle: string, hay: string): boolean {
+  let i = 0
+  for (let j = 0; j < hay.length && i < needle.length; j++) {
+    if (hay[j] === needle[i]) i++
+  }
+  return i === needle.length
+}
+
+/**
+ * Rank listing entries against a query over their relative paths, case-insensitively:
+ * substring matches first (in listing order), then the remaining subsequence (fuzzy)
+ * matches (also in listing order), capped at {@link MAX_PATH_RESULTS}. Directories are
+ * included (the caller shows a dir/file icon and `applyPath` slash-vs-space keys off
+ * `kind`). An empty query keeps the listing head (every path contains ''), so the popover
+ * opens showing the first entries right after a bare `@`.
+ */
+export function filterPaths(entries: readonly FileEntry[], query: string): FileEntry[] {
+  const needle = query.toLowerCase()
+  const substring: FileEntry[] = []
+  const subsequence: FileEntry[] = []
+  for (const entry of entries) {
+    const hay = entry.path.toLowerCase()
+    if (hay.includes(needle)) substring.push(entry)
+    else if (isSubsequence(needle, hay)) subsequence.push(entry)
+  }
+  return [...substring, ...subsequence].slice(0, MAX_PATH_RESULTS)
+}
+
+/** The value + caret produced by accepting a completion, applied to the composer. */
+export interface PathInsertion {
+  value: string
+  caret: number
+}
+
+/**
+ * Replace the `@query` token (from `start` up to `caret`) with the plain-text `@<path>`
+ * plus a trailing separator: a SPACE for a file (`@path `, token closed, caret past it) or
+ * a SLASH for a directory (`@dir/`, no space, so re-deriving continues into the dir). Text
+ * after the caret is kept, so accepting mid-sentence splices the reference in without
+ * eating what follows.
+ */
+export function applyPath(
+  value: string,
+  start: number,
+  caret: number,
+  entry: FileEntry,
+): PathInsertion {
+  const suffix = entry.kind === 'directory' ? '/' : ' '
+  const insert = `@${entry.path}${suffix}`
+  const nextValue = value.slice(0, start) + insert + value.slice(caret)
+  return { value: nextValue, caret: start + insert.length }
+}

--- a/src/renderer/src/conversation/path-autocomplete.ts
+++ b/src/renderer/src/conversation/path-autocomplete.ts
@@ -110,6 +110,12 @@ export interface PathInsertion {
  * a SLASH for a directory (`@dir/`, no space, so re-deriving continues into the dir). Text
  * after the caret is kept, so accepting mid-sentence splices the reference in without
  * eating what follows.
+ *
+ * KNOWN LIMITATION (matches the Vibe CLI PathCompleter; plain-text design, ADR-0002): a
+ * path containing a SPACE inserts as `@my file.ts ` — a token the space-free trigger can't
+ * re-derive, and which the agent likely reads only up to the space. We neither quote nor
+ * drop such paths (quoting is unverified against the agent's `render_path_prompt`; dropping
+ * would silently hide real files) — spaced paths are simply not usefully referenceable here.
  */
 export function applyPath(
   value: string,


### PR DESCRIPTION
Closes #190 (Files browser epic, PRD #186; ADR-0013 decision 5 — the final slice).

## What
Typing `@` in the composer pops file-path suggestions, mirroring the proven `/` slash-command popover. New pure `path-autocomplete.ts` (26 tests): `getPathQuery` (trigger = fragment after the LAST `@` before the caret, space-free, **mid-sentence** — the key difference from `/`'s start-anchored trigger), `filterPaths` (substring-then-subsequence, ≤10, directories included), `applyPath` (plain text: file → `@path `, directory → `@dir/` to drill in). `Conversation.tsx` adds a sibling popover: lazy `files:list({agentId})` fetch once per mount (the same #188 listing; no per-keystroke IPC), full `/`-contract parity (Enter/Tab accept only-while-open, ↑/↓ wrap + scrollIntoView, per-token Esc latch, mousedown-beats-blur, rAF caret restore, draft + #60 sync), mutually exclusive with `/` (start-anchored `/` wins). Accept inserts LITERAL text — no chip, no expansion, no metadata; the agent resolves `@path` server-side (ADR-0002). Works while streaming (queued follow-ups). No new dependency.

## Verification
- Adversarial review: **APPROVE**, no MUST-FIX. Verified: trigger edges (caret-on-@, multiple-@, tab/newline close, clamp), the splice + both accept variants, `/`-priority mutual exclusion with no popover/handler desync, the fetch guarded against per-keystroke IPC + refetch loops (swallows failure → typed paths still send), and Enter-to-accept correctly winning over Enter-to-queue while open. Send path sends `draft.trim()` verbatim.
- One documented limitation (folded as a code note, matches the Vibe CLI, ADR-0002): a path containing a SPACE inserts as `@my file.ts ` — the space-free trigger can't re-derive it and the agent likely truncates at the space; we neither quote (unverified vs `render_path_prompt`) nor drop (hides real files). Two NITs left as-is (email-like `foo@bar` opens the popover — matches CLI, Esc-latches; a double-space on mid-sentence file accept — identical to `applyCommand`).
- Gates: lint ✓ typecheck ✓ build ✓ test **828/828** ✓ (802 + 26).

## Live check at merge
Type `@` in the composer → suggestions from the repo; ↑/↓/Enter/Tab/Esc behave like the `/` popup; accept a dir → `@dir/` re-opens into it; accept a file → `@path `; the sent prompt contains the literal `@path`.

## Blocked by
None. (Independent of #189 — disjoint files.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)