### PR TITLE
#189: confined files:read IPC + tabbed read-only file preview

### DIFF
--- a/src/main/files/read-file.test.ts
+++ b/src/main/files/read-file.test.ts
@@ -62,6 +62,23 @@ describe('readWorkspaceFile — classify (cap, binary sniff, text)', () => {
     expect(result).toEqual({ kind: 'text', content: 'y'.repeat(16) })
   })
 
+  // #189 security review (size-cap TOCTOU): the BOUNDED read is authoritative, not stat. A file
+  // that lies about its size (grew after stat, or a stat that under-reports) still can't exceed the
+  // cap — the read stops at maxBytes+1 and reports tooLarge. Injected fs proves the read path alone
+  // enforces it, independent of stat.size.
+  it('caps by the bounded read even when stat under-reports the size (TOCTOU)', async () => {
+    const realRoot = '/ws'
+    const fs = {
+      realpath: async (p: string) => p,
+      // stat lies: reports 4 bytes (under the cap) though the file is really larger.
+      stat: async () => ({ isFile: () => true, size: 4 }),
+      // the actual file is 2048 bytes; a bounded read of limit returns exactly `limit` bytes.
+      readBounded: async (_p: string, limit: number) => Buffer.alloc(Math.min(2_048, limit), 0x78),
+    }
+    const result = await readWorkspaceFile(realRoot, 'grew.txt', { maxBytes: 16, fs })
+    expect(result).toEqual({ kind: 'tooLarge' })
+  })
+
   it('reads an empty file as empty text', async () => {
     const root = tmp('vibe-read-')
     write(root, 'empty.txt', '')

--- a/src/main/files/read-file.test.ts
+++ b/src/main/files/read-file.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { readWorkspaceFile } from './read-file'
+
+/**
+ * The reader runs against REAL tmpdir fixtures (prior art: `list-files.test.ts`, the fs-write
+ * suites) so the CONFINEMENT behavior — real symlinks, real out-of-tree targets — is exercised
+ * against the actual `realpath` + `isWithinDir` machinery, not mocked. Every fixture dir is
+ * tracked and removed after each test.
+ */
+const created: string[] = []
+function tmp(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  created.push(dir)
+  return dir
+}
+afterEach(() => {
+  for (const dir of created.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+function write(root: string, rel: string, content: string | Buffer = ''): void {
+  const abs = join(root, rel)
+  mkdirSync(join(abs, '..'), { recursive: true })
+  writeFileSync(abs, content)
+}
+
+describe('readWorkspaceFile — classify (cap, binary sniff, text)', () => {
+  it('reads a utf8 text file as { kind: text }', async () => {
+    const root = tmp('vibe-read-')
+    write(root, 'src/app.ts', 'const x: number = 1\n')
+    const result = await readWorkspaceFile(root, 'src/app.ts')
+    expect(result).toEqual({ kind: 'text', content: 'const x: number = 1\n' })
+  })
+
+  it('preserves multibyte utf8 content exactly', async () => {
+    const root = tmp('vibe-read-')
+    write(root, 'note.md', '# héllo — café 🚀\n')
+    const result = await readWorkspaceFile(root, 'note.md')
+    expect(result).toEqual({ kind: 'text', content: '# héllo — café 🚀\n' })
+  })
+
+  it('classifies a file with a NUL byte in the first chunk as { kind: binary }', async () => {
+    const root = tmp('vibe-read-')
+    write(root, 'blob.bin', Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x1a, 0x0a]))
+    const result = await readWorkspaceFile(root, 'blob.bin')
+    expect(result).toEqual({ kind: 'binary' })
+  })
+
+  it('flags a file larger than the cap as { kind: tooLarge } (via stat, not by reading it)', async () => {
+    const root = tmp('vibe-read-')
+    write(root, 'big.txt', 'x'.repeat(2_048))
+    const result = await readWorkspaceFile(root, 'big.txt', { maxBytes: 1_024 })
+    expect(result).toEqual({ kind: 'tooLarge' })
+  })
+
+  it('reads a file exactly at the cap', async () => {
+    const root = tmp('vibe-read-')
+    write(root, 'edge.txt', 'y'.repeat(16))
+    const result = await readWorkspaceFile(root, 'edge.txt', { maxBytes: 16 })
+    expect(result).toEqual({ kind: 'text', content: 'y'.repeat(16) })
+  })
+
+  it('reads an empty file as empty text', async () => {
+    const root = tmp('vibe-read-')
+    write(root, 'empty.txt', '')
+    const result = await readWorkspaceFile(root, 'empty.txt')
+    expect(result).toEqual({ kind: 'text', content: '' })
+  })
+
+  it('errors for a missing file', async () => {
+    const root = tmp('vibe-read-')
+    expect(await readWorkspaceFile(root, 'nope.txt')).toEqual({ kind: 'error' })
+  })
+
+  it('errors for a directory (must be a regular file)', async () => {
+    const root = tmp('vibe-read-')
+    write(root, 'dir/child.ts', '')
+    expect(await readWorkspaceFile(root, 'dir')).toEqual({ kind: 'error' })
+  })
+
+  it('errors for an unreadable / missing Workspace root', async () => {
+    expect(await readWorkspaceFile(join(tmpdir(), 'vibe-no-such-root-xyz'), 'a.txt')).toEqual({
+      kind: 'error',
+    })
+  })
+})
+
+describe('readWorkspaceFile — confinement (out-of-tree refused, read-only)', () => {
+  it('refuses a `..` traversal that escapes the Workspace root', async () => {
+    const root = tmp('vibe-ws-')
+    const outside = tmp('vibe-outside-')
+    write(outside, 'secret.txt', 'do not read')
+    // The tree-relative path can never legitimately contain `..`, but a crafted one must be refused.
+    expect(await readWorkspaceFile(root, '../' + join(outside).split('/').pop() + '/secret.txt')).toEqual({
+      kind: 'error',
+    })
+  })
+
+  it('refuses an absolute path pointing outside the Workspace', async () => {
+    const root = tmp('vibe-ws-')
+    const outside = tmp('vibe-outside-')
+    write(outside, 'secret.txt', 'do not read')
+    expect(await readWorkspaceFile(root, join(outside, 'secret.txt'))).toEqual({ kind: 'error' })
+  })
+
+  it('refuses a symlink that escapes the Workspace root (never reads the outside target)', async () => {
+    const root = tmp('vibe-ws-')
+    const outside = tmp('vibe-outside-')
+    write(outside, 'secret.txt', 'TOP SECRET')
+    symlinkSync(join(outside, 'secret.txt'), join(root, 'escape.txt')) // in-tree link pointing OUT
+    const result = await readWorkspaceFile(root, 'escape.txt')
+    expect(result).toEqual({ kind: 'error' })
+    // Belt-and-suspenders: the outside content must never surface, whatever the kind.
+    expect(JSON.stringify(result)).not.toContain('TOP SECRET')
+  })
+
+  it('reads a file reached through an IN-tree symlink (resolves within the root)', async () => {
+    const root = tmp('vibe-ws-')
+    write(root, 'real/data.txt', 'inside')
+    symlinkSync(join(root, 'real', 'data.txt'), join(root, 'link.txt')) // link stays inside
+    expect(await readWorkspaceFile(root, 'link.txt')).toEqual({ kind: 'text', content: 'inside' })
+  })
+})

--- a/src/main/files/read-file.ts
+++ b/src/main/files/read-file.ts
@@ -1,4 +1,4 @@
-import { readFile, realpath, stat } from 'node:fs/promises'
+import { open, realpath, stat } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import type { FilesReadResult } from '../../shared/ipc'
 import { resolveWorkspacePath } from '../resolve-workspace-path'
@@ -20,8 +20,11 @@ import { isWithinDir } from '../open-target'
  *      a `..`/absolute escape or a symlink pointing OUT of the tree → `error` (logged). We only ever
  *      `readFile` the realpath'd, in-tree target, so an out-of-tree file's bytes are never read.
  *
- * CLASSIFY: the size cap is checked from `stat.size` BEFORE reading (a huge file never loads) →
- * `tooLarge`. Otherwise the bytes are read once as a Buffer; a NUL byte within the first
+ * CLASSIFY: a huge file is rejected `tooLarge` WITHOUT loading it fully. `stat.size` is a cheap
+ * fast-path (skip opening an obviously-huge file), but the AUTHORITATIVE cap is a BOUNDED read:
+ * we only ever read `maxBytes + 1` bytes, and if that many come back the file exceeds the cap →
+ * `tooLarge`. This closes the stat→read TOCTOU (a file growing between the two can't sneak past the
+ * cap), so at most `maxBytes + 1` bytes are ever buffered. Within the cap: a NUL byte in the first
  * {@link BINARY_SNIFF_BYTES} → `binary` (the standard "looks binary" heuristic); else utf8 → `text`.
  *
  * Best-effort: EVERY throw (bad root, stat/realpath/read failure) is caught and degrades to
@@ -40,13 +43,23 @@ export const BINARY_SNIFF_BYTES = 8_000
 export interface ReadFileFs {
   realpath(path: string): Promise<string>
   stat(path: string): Promise<{ isFile(): boolean; size: number }>
-  readFile(path: string): Promise<Buffer>
+  /** Read AT MOST `limit` bytes from the start of `path` (bounded — never loads a huge file). */
+  readBounded(path: string, limit: number): Promise<Buffer>
 }
 
 const nodeFs: ReadFileFs = {
   realpath: (p) => realpath(p),
   stat: (p) => stat(p),
-  readFile: (p) => readFile(p),
+  readBounded: async (p, limit) => {
+    const fh = await open(p, 'r')
+    try {
+      const buf = Buffer.alloc(limit)
+      const { bytesRead } = await fh.read(buf, 0, limit, 0)
+      return buf.subarray(0, bytesRead)
+    } finally {
+      await fh.close()
+    }
+  },
 }
 
 export interface ReadFileOptions {
@@ -88,9 +101,12 @@ export async function readWorkspaceFile(
       return { kind: 'error' }
     }
 
-    if (stats.size > maxBytes) return { kind: 'tooLarge' } // never read a file over the cap
+    if (stats.size > maxBytes) return { kind: 'tooLarge' } // cheap fast-path: skip an obviously-huge file
 
-    const buf = await fs.readFile(realTarget) // realpath'd + confirmed in-tree — safe to read
+    // Authoritative cap (closes the stat→read TOCTOU): read at most maxBytes+1 bytes from the
+    // realpath'd, in-tree target. If maxBytes+1 come back, the file grew past the cap → tooLarge.
+    const buf = await fs.readBounded(realTarget, maxBytes + 1)
+    if (buf.length > maxBytes) return { kind: 'tooLarge' }
     if (looksBinary(buf)) return { kind: 'binary' }
     return { kind: 'text', content: buf.toString('utf8') }
   } catch (err) {

--- a/src/main/files/read-file.ts
+++ b/src/main/files/read-file.ts
@@ -1,0 +1,101 @@
+import { readFile, realpath, stat } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import type { FilesReadResult } from '../../shared/ipc'
+import { resolveWorkspacePath } from '../resolve-workspace-path'
+import { isWithinDir } from '../open-target'
+
+/**
+ * The Workspace file reader for the read-only preview (#189, ADR-0013 decisions 2-3). Given a
+ * Workspace root and a tree-relative path, it confines the target, enforces a size cap, sniffs
+ * for binary content, and returns a discriminated {@link FilesReadResult} the preview renders
+ * without ever showing garbage. STRICTLY read-only — there is no write path anywhere in here.
+ *
+ * CONFINEMENT (the security core; the SAME posture + machinery as the `revealPath` handler, so
+ * the two are easy to compare):
+ *   1. `realpath` the Workspace root once.
+ *   2. Resolve the (relative) target against the root via `resolveWorkspacePath` — an absolute or
+ *      `~` input resolves too, but step 4 rejects it if it lands outside.
+ *   3. `stat` it; a non-regular-file (directory, socket, missing) → `error`.
+ *   4. `realpath` the target (collapsing any symlink) and require `isWithinDir(realRoot, realTarget)`;
+ *      a `..`/absolute escape or a symlink pointing OUT of the tree → `error` (logged). We only ever
+ *      `readFile` the realpath'd, in-tree target, so an out-of-tree file's bytes are never read.
+ *
+ * CLASSIFY: the size cap is checked from `stat.size` BEFORE reading (a huge file never loads) →
+ * `tooLarge`. Otherwise the bytes are read once as a Buffer; a NUL byte within the first
+ * {@link BINARY_SNIFF_BYTES} → `binary` (the standard "looks binary" heuristic); else utf8 → `text`.
+ *
+ * Best-effort: EVERY throw (bad root, stat/realpath/read failure) is caught and degrades to
+ * `error`; the function never rejects and never leaks an absolute path or stack to the caller.
+ * Pure over an injectable fs boundary (default: `node:fs/promises`); the colocated tests exercise
+ * the DEFAULT boundary against real tmpdir fixtures (symlink escapes, caps, binary, text).
+ */
+
+/** ~1MB read cap. A file larger than this is reported `tooLarge` (checked via `stat`, not read). */
+export const FILES_READ_MAX_BYTES = 1_000_000
+
+/** Bytes scanned for a NUL when deciding binary-vs-text (git uses the same first-8000-bytes rule). */
+export const BINARY_SNIFF_BYTES = 8_000
+
+/** Injectable fs boundary (Seam). The default wires `node:fs/promises`. */
+export interface ReadFileFs {
+  realpath(path: string): Promise<string>
+  stat(path: string): Promise<{ isFile(): boolean; size: number }>
+  readFile(path: string): Promise<Buffer>
+}
+
+const nodeFs: ReadFileFs = {
+  realpath: (p) => realpath(p),
+  stat: (p) => stat(p),
+  readFile: (p) => readFile(p),
+}
+
+export interface ReadFileOptions {
+  fs?: ReadFileFs
+  maxBytes?: number
+  /** Injected for `resolveWorkspacePath`'s `~` expansion; defaults to the real home dir. */
+  homeDir?: string
+}
+
+/** True when any of the first {@link BINARY_SNIFF_BYTES} bytes of `buf` is a NUL. */
+function looksBinary(buf: Buffer): boolean {
+  const end = Math.min(buf.length, BINARY_SNIFF_BYTES)
+  for (let i = 0; i < end; i++) {
+    if (buf[i] === 0) return true
+  }
+  return false
+}
+
+export async function readWorkspaceFile(
+  workspaceDir: string,
+  relativePath: string,
+  opts: ReadFileOptions = {},
+): Promise<FilesReadResult> {
+  const fs = opts.fs ?? nodeFs
+  const maxBytes = opts.maxBytes ?? FILES_READ_MAX_BYTES
+  const homeDir = opts.homeDir ?? homedir()
+
+  try {
+    const realRoot = await fs.realpath(workspaceDir)
+    const requested = resolveWorkspacePath(workspaceDir, relativePath, homeDir)
+    const stats = await fs.stat(requested)
+    if (!stats.isFile()) return { kind: 'error' } // a dir / socket / missing target — refuse
+
+    const realTarget = await fs.realpath(requested)
+    if (!isWithinDir(realRoot, realTarget)) {
+      // An out-of-tree target (a `..`/absolute path, or a symlink escaping the root). Log the
+      // realpath for main's console only — the renderer gets a bare `error`, never the path.
+      console.error(`[vibe-mistro:files-read] refused (outside Workspace): ${realTarget}`)
+      return { kind: 'error' }
+    }
+
+    if (stats.size > maxBytes) return { kind: 'tooLarge' } // never read a file over the cap
+
+    const buf = await fs.readFile(realTarget) // realpath'd + confirmed in-tree — safe to read
+    if (looksBinary(buf)) return { kind: 'binary' }
+    return { kind: 'text', content: buf.toString('utf8') }
+  } catch (err) {
+    // Bad root / stat / realpath / read failure — best-effort, never rejects, never leaks a stack.
+    console.error(`[vibe-mistro:files-read] ${relativePath}: ${String(err)}`)
+    return { kind: 'error' }
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -23,6 +23,8 @@ import {
   type GitStatusSubscriptionArgs,
   type FilesListArgs,
   type FilesListResult,
+  type FilesReadArgs,
+  type FilesReadResult,
   type ListMetadataResult,
   type RevealPathArgs,
   type OpenThreadArgs,
@@ -82,6 +84,7 @@ import { ghCreatePr, ghCurrentPr } from './git/github'
 import { GitStatusManager } from './git/status-stream'
 import { chokidarWatchFactory, realClock } from './git/runtime'
 import { listFiles } from './files/list-files'
+import { readWorkspaceFile } from './files/read-file'
 import { FilesListCache, shouldInvalidateFilesCacheOnGitStatus } from './files/cache'
 
 /**
@@ -1261,6 +1264,20 @@ function registerIpc(): void {
     const result = await listFiles(workspaceDir)
     filesListCache.set(workspaceDir, result)
     return result
+  })
+
+  ipcMain.handle(IPC.filesRead, async (_event, args: FilesReadArgs): Promise<FilesReadResult> => {
+    // READ one Workspace file for the read-only preview (#189, ADR-0013). The read root is the
+    // warm agent's OWN workspaceDir — resolved via `pool.get`, NOT a renderer-supplied path
+    // (review F3, matching `filesList` / `revealPath`) — so the renderer can only read a
+    // CONNECTED Workspace's files. `readWorkspaceFile` does the SAME confinement as `revealPath`
+    // (resolveWorkspacePath + realpath + isWithinDir): a `..`/absolute target or a symlink escaping
+    // the root → `error`, never reading out of tree. It caps at ~1MB (via stat, before reading),
+    // sniffs a NUL byte for binary, and is STRICTLY read-only. NOT agent activity, so — like
+    // `files:list` / `git:diff` — it does NOT `pool.touch`. Unknown agent / any throw → `error`.
+    const agent = pool.get(args.agentId)
+    if (!agent) return { kind: 'error' }
+    return readWorkspaceFile(agent.workspaceDir, args.relativePath)
   })
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -20,6 +20,8 @@ import {
   type RevealPathArgs,
   type FilesListArgs,
   type FilesListResult,
+  type FilesReadArgs,
+  type FilesReadResult,
   type GitStatusEvent,
   type GitStatusSubscriptionArgs,
   type ListMetadataResult,
@@ -100,6 +102,7 @@ const api = {
     ipcRenderer.invoke(IPC.ghCreatePr, args),
   revealPath: (args: RevealPathArgs): Promise<void> => ipcRenderer.invoke(IPC.revealPath, args),
   filesList: (args: FilesListArgs): Promise<FilesListResult> => ipcRenderer.invoke(IPC.filesList, args),
+  filesRead: (args: FilesReadArgs): Promise<FilesReadResult> => ipcRenderer.invoke(IPC.filesRead, args),
   onAcpEvent: (listener: (event: AcpEvent) => void): (() => void) => {
     const handler = (_e: unknown, payload: AcpEvent): void => listener(payload)
     ipcRenderer.on(IPC.acpEvent, handler)

--- a/src/renderer/src/connection/ConnectedWorkspace.tsx
+++ b/src/renderer/src/connection/ConnectedWorkspace.tsx
@@ -112,6 +112,7 @@ export function ConnectedWorkspace({
         workspaceId={connection.workspaceId}
         workspaceDir={connection.workspaceDir}
         agentId={connection.agentId}
+        activeThreadId={activeThread.id}
         isActive={isActive}
         busy={busy}
       />

--- a/src/renderer/src/conversation/Conversation.tsx
+++ b/src/renderer/src/conversation/Conversation.tsx
@@ -75,6 +75,7 @@ import { replayTranscript } from './replay'
 import { Response } from './Response'
 import { MessageScroller } from './MessageScroller'
 import { getDraft, setDraft as persistDraft, clearDraft } from './composer-draft-store'
+import { appendMention, subscribeComposerInsert } from './composer-insert'
 import {
   applyCommand,
   filterCommands,
@@ -250,6 +251,20 @@ export function Conversation({
       // NOW — main emits `thread:bound` before the prompt streams, so it lands
       // after the user's prompt and before the agent's response (matching replay).
       if (e.rebound) dispatch({ type: 'agent-rebound' })
+    })
+  }, [thread.threadId])
+
+  // Insert `@path` from the Files preview's action (#189): the side panel is a sibling of this
+  // view, so it reaches the composer through the module-level `composer-insert` channel keyed by
+  // threadId. We append to the CURRENT persisted draft (kept in lockstep with `draft` state on
+  // every keystroke below), then write state + persisted draft together — the same write-through
+  // the textarea's onChange uses. Plain text only: the agent expands `@path` itself (ADR-0002).
+  useEffect(() => {
+    return subscribeComposerInsert(thread.threadId, (relativePath) => {
+      const next = appendMention(getDraft(window.localStorage, thread.threadId), relativePath)
+      setDraft(next)
+      persistDraft(window.localStorage, thread.threadId, next)
+      inputRef.current?.focus()
     })
   }, [thread.threadId])
 

--- a/src/renderer/src/conversation/composer-insert.test.ts
+++ b/src/renderer/src/conversation/composer-insert.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest'
+import { appendMention, emitComposerInsert, subscribeComposerInsert } from './composer-insert'
+
+describe('appendMention', () => {
+  it('inserts into an empty draft with a trailing space', () => {
+    expect(appendMention('', 'src/app.ts')).toBe('@src/app.ts ')
+  })
+
+  it('adds a separating space when the draft does not end in whitespace', () => {
+    expect(appendMention('see', 'src/app.ts')).toBe('see @src/app.ts ')
+  })
+
+  it('does not double the space when the draft already ends in whitespace', () => {
+    expect(appendMention('see ', 'src/app.ts')).toBe('see @src/app.ts ')
+    expect(appendMention('see\n', 'src/app.ts')).toBe('see\n@src/app.ts ')
+  })
+})
+
+describe('composer-insert channel', () => {
+  it('delivers an emit to the subscriber for that Thread only', () => {
+    const a = vi.fn()
+    const b = vi.fn()
+    const offA = subscribeComposerInsert('thread-a', a)
+    const offB = subscribeComposerInsert('thread-b', b)
+    emitComposerInsert('thread-a', 'src/app.ts')
+    expect(a).toHaveBeenCalledWith('src/app.ts')
+    expect(b).not.toHaveBeenCalled()
+    offA()
+    offB()
+  })
+
+  it('is a no-op when no composer is subscribed for the Thread', () => {
+    expect(() => emitComposerInsert('nobody', 'x.ts')).not.toThrow()
+  })
+
+  it('stops delivering after unsubscribe', () => {
+    const listener = vi.fn()
+    const off = subscribeComposerInsert('thread-a', listener)
+    off()
+    emitComposerInsert('thread-a', 'x.ts')
+    expect(listener).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/conversation/composer-insert.ts
+++ b/src/renderer/src/conversation/composer-insert.ts
@@ -1,0 +1,54 @@
+/**
+ * A tiny module-level channel for the Files preview's "Insert @path into composer" action (#189,
+ * ADR-0013 decision 2). The preview lives in the side panel — a SIBLING of the conversation, not
+ * a parent — so it can't reach the composer through props/context. Instead it EMITS an insert for
+ * a Thread id here; the mounted `Conversation` for that Thread SUBSCRIBES (keyed by its own
+ * `threadId`) and appends the plain-text `@path` to its draft (which stays in lockstep with the
+ * #60 composer-draft store). Renderer-only, no IPC: the wire format is untouched — the agent
+ * expands the plain-text `@path` itself server-side (ADR-0002; we add no client-side expansion).
+ *
+ * If no composer is mounted for the target Thread (e.g. the active Thread is a cold replay), the
+ * emit is a harmless no-op — there is no subscriber to receive it. Reveal-in-Finder does not go
+ * through here and works regardless.
+ */
+
+/** A subscriber receiving the plain-text fragment to append to its Thread's composer draft. */
+type InsertListener = (mention: string) => void
+
+const listenersByThread = new Map<string, Set<InsertListener>>()
+
+/**
+ * Append a plain-text `@path` reference to `draft`, keeping it space-separated: a trailing space
+ * is added after the mention (so the next token starts clean), and a separating space is inserted
+ * before it unless the draft is empty or already ends in whitespace. Pure — the composer computes
+ * the next value with this, then writes state + persisted draft together.
+ */
+export function appendMention(draft: string, relativePath: string): string {
+  const mention = `@${relativePath}`
+  if (draft.length === 0) return `${mention} `
+  const separator = /\s$/.test(draft) ? '' : ' '
+  return `${draft}${separator}${mention} `
+}
+
+/** Subscribe a Thread's composer to insert requests; returns an unsubscribe. */
+export function subscribeComposerInsert(threadId: string, listener: InsertListener): () => void {
+  let set = listenersByThread.get(threadId)
+  if (!set) {
+    set = new Set()
+    listenersByThread.set(threadId, set)
+  }
+  set.add(listener)
+  return () => {
+    const current = listenersByThread.get(threadId)
+    if (!current) return
+    current.delete(listener)
+    if (current.size === 0) listenersByThread.delete(threadId)
+  }
+}
+
+/** Request the given Thread's composer append `@<relativePath>`; a no-op if none is mounted. */
+export function emitComposerInsert(threadId: string, relativePath: string): void {
+  const set = listenersByThread.get(threadId)
+  if (!set) return
+  for (const listener of set) listener(relativePath)
+}

--- a/src/renderer/src/side-panel/FilePreview.tsx
+++ b/src/renderer/src/side-panel/FilePreview.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useState, type JSX } from 'react'
+import { getFiletypeFromFileName, getSharedHighlighter } from '@pierre/diffs'
+import { AtSign, FolderOpen } from 'lucide-react'
+import type { FilesReadResult } from '../../../shared/ipc'
+import { cn } from '../lib/utils'
+import { emitComposerInsert } from '../conversation/composer-insert'
+import { breadcrumbSegments } from './breadcrumb-segments'
+
+/**
+ * The read-only file preview for a `file:` Surface (#189, ADR-0013 decision 2; CONTEXT.md "Files
+ * browser"). Given the warm agent handle + a tree-relative path, it fetches the confined
+ * `files:read` IPC and renders the outcome: TEXT is syntax-highlighted read-only; BINARY /
+ * TOO-LARGE / ERROR each render a clear muted notice (never garbage). Topped by a read-only,
+ * non-interactive BREADCRUMB of the path and two header actions — Reveal in Finder (the confined
+ * #116 `revealPath` IPC) and Insert `@path` into the composer (renderer-only, #189).
+ *
+ * Highlighting reuses the EXACT `@pierre/diffs` shared-shiki path the git diff panel uses (#159's
+ * single pinned shiki) — `getSharedHighlighter` + `codeToHtml` with the diff panel's `pierre-light`
+ * theme — so NO new highlighting dependency is added and the preview matches the diff panel's theme.
+ * The language is derived from the filename via the lib's `getFiletypeFromFileName`. This is strictly
+ * READ-ONLY: it only ever calls `files:read` / `revealPath`, never any write path.
+ */
+
+/** The diff panel's theme (`DiffWorkerProvider`'s `DIFF_THEME`) — reused so the preview matches it. */
+const PREVIEW_THEME = 'pierre-light'
+
+/** Highlight `content` to a `<pre>` HTML string via the shared shiki, or `null` to fall back to plain. */
+async function highlightToHtml(content: string, fileName: string): Promise<string | null> {
+  try {
+    const lang = getFiletypeFromFileName(fileName)
+    const highlighter = await getSharedHighlighter({ themes: [PREVIEW_THEME], langs: [lang] })
+    return highlighter.codeToHtml(content, { lang, theme: PREVIEW_THEME })
+  } catch {
+    return null // unknown/unloadable grammar — the caller renders the raw text instead
+  }
+}
+
+export function FilePreview({
+  agentId,
+  relativePath,
+  activeThreadId,
+}: {
+  /** The warm agent handle — `files:read` / `revealPath` resolve the Workspace root from it (F3). */
+  agentId: string
+  /** The tree-relative path of the file to preview (from a `filesList` entry). */
+  relativePath: string
+  /** The live Thread whose composer receives an Insert-@path (null when none is mounted). */
+  activeThreadId: string | null
+}): JSX.Element {
+  const [result, setResult] = useState<FilesReadResult | null>(null)
+  const [html, setHtml] = useState<string | null>(null)
+
+  // Fetch the file on mount / path change. Cancellation-guarded so a fast tab switch never lands a
+  // stale result. Any rejection degrades to `error` (the handler itself never rejects, but the IPC
+  // round-trip could) — the preview then shows the read-error notice rather than hanging on "Loading".
+  useEffect(() => {
+    let cancelled = false
+    setResult(null)
+    setHtml(null)
+    window.api
+      .filesRead({ agentId, relativePath })
+      .then((r) => {
+        if (!cancelled) setResult(r)
+      })
+      .catch(() => {
+        if (!cancelled) setResult({ kind: 'error' })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [agentId, relativePath])
+
+  // Highlight text results off the render path; a failure leaves `html` null → the raw-text fallback.
+  useEffect(() => {
+    if (result?.kind !== 'text') return
+    let cancelled = false
+    const fileName = relativePath.slice(relativePath.lastIndexOf('/') + 1)
+    void highlightToHtml(result.content, fileName).then((h) => {
+      if (!cancelled) setHtml(h)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [result, relativePath])
+
+  const crumbs = breadcrumbSegments(relativePath)
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col self-stretch border-l border-border bg-panel text-text">
+      <div className="flex items-center gap-2 border-b border-border-muted px-3 py-2">
+        {/* Read-only, non-interactive breadcrumb of the file's path. */}
+        <nav aria-label="File path" className="flex min-w-0 flex-1 items-center gap-1 text-[11px] text-muted">
+          {crumbs.map((crumb, index) => (
+            <span key={index} className="flex min-w-0 items-center gap-1">
+              {index > 0 && <span className="text-faint">/</span>}
+              <span
+                className={cn(
+                  'truncate',
+                  index === crumbs.length - 1 && !crumb.ellipsis && 'text-text-strong',
+                )}
+              >
+                {crumb.label}
+              </span>
+            </span>
+          ))}
+        </nav>
+        <button
+          type="button"
+          onClick={() => void window.api.revealPath({ agentId, path: relativePath })}
+          title="Reveal in Finder"
+          aria-label="Reveal in Finder"
+          className="shrink-0 rounded-md p-1 text-muted outline-none transition-colors hover:bg-accent/10 hover:text-text-strong focus-visible:bg-accent/10"
+        >
+          <FolderOpen size={14} aria-hidden />
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            if (activeThreadId) emitComposerInsert(activeThreadId, relativePath)
+          }}
+          disabled={!activeThreadId}
+          title="Insert @path into composer"
+          aria-label="Insert @path into composer"
+          className="shrink-0 rounded-md p-1 text-muted outline-none transition-colors hover:bg-accent/10 hover:text-text-strong focus-visible:bg-accent/10 disabled:opacity-40"
+        >
+          <AtSign size={14} aria-hidden />
+        </button>
+      </div>
+
+      <PreviewBody result={result} html={html} />
+    </div>
+  )
+}
+
+/** The body: highlighted text, the raw-text fallback, or a muted notice per non-text outcome. */
+function PreviewBody({
+  result,
+  html,
+}: {
+  result: FilesReadResult | null
+  html: string | null
+}): JSX.Element {
+  if (result === null) return <Notice>Loading…</Notice>
+  switch (result.kind) {
+    case 'binary':
+      return <Notice>Binary file — can’t preview.</Notice>
+    case 'tooLarge':
+      return <Notice>File too large to preview.</Notice>
+    case 'error':
+      return <Notice>Could not read file.</Notice>
+    case 'text':
+      return (
+        <div className="min-h-0 flex-1 overflow-auto text-[12.5px] leading-relaxed [&_pre]:min-h-full [&_pre]:p-3">
+          {html !== null ? (
+            // Highlighted HTML from the shared shiki (the diff panel's exact path). The `<pre>`
+            // carries its own theme background; we only add padding/scroll around it.
+            <div dangerouslySetInnerHTML={{ __html: html }} />
+          ) : (
+            // Fallback before highlighting resolves / for an unhighlightable grammar: raw text,
+            // React-escaped by construction.
+            <pre className="whitespace-pre p-3 font-mono">{result.content}</pre>
+          )}
+        </div>
+      )
+  }
+}
+
+/** A centered muted message for the non-text (and loading) states. */
+function Notice({ children }: { children: React.ReactNode }): JSX.Element {
+  return (
+    <div className="flex flex-1 items-center justify-center px-6 py-10 text-center text-[13px] text-muted">
+      {children}
+    </div>
+  )
+}

--- a/src/renderer/src/side-panel/SurfacePanel.tsx
+++ b/src/renderer/src/side-panel/SurfacePanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, type JSX, type ReactNode } from 'react'
-import { FileDiff, Files, Globe, SquareTerminal, X } from 'lucide-react'
+import { FileDiff, FileText, Files, Globe, SquareTerminal, X } from 'lucide-react'
 import { cn } from '../lib/utils'
 import { useMediaQuery } from '../lib/use-media-query'
 import {
@@ -12,6 +12,8 @@ import {
 } from '../ui'
 import { ChangesPanel } from '../git/ChangesPanel'
 import { FilesSurface } from './FilesSurface'
+import { FilePreview } from './FilePreview'
+import { fileBasename } from './breadcrumb-segments'
 import { surfaceForChord } from './surface-keys'
 import {
   activateWorkspaceSurface,
@@ -20,6 +22,7 @@ import {
   closeWorkspacePanel,
   closeWorkspaceSurface,
   closeWorkspaceSurfacesToRight,
+  openWorkspaceFileSurface,
   openWorkspaceSurface,
   toggleWorkspaceSurface,
   useWorkspacePanel,
@@ -48,13 +51,16 @@ export function SurfacePanel({
   workspaceId,
   workspaceDir,
   agentId,
+  activeThreadId,
   isActive,
   busy,
 }: {
   workspaceId: string
   workspaceDir: string
-  /** The warm agent handle — Files addresses `files:list` by this (confinement, #188 F3). */
+  /** The warm agent handle — Files addresses `files:list`/`files:read` by this (confinement, #188 F3). */
   agentId: string
+  /** The live Thread whose composer a file preview's Insert-@path targets (#189); null when none. */
+  activeThreadId: string | null
   /** Whether this is the on-screen Workspace (#84) — gates git streaming AND shortcuts. */
   isActive: boolean
   /** Whether a turn is streaming (#86) — threaded to the Review panel's commit guard. */
@@ -99,6 +105,7 @@ export function SurfacePanel({
       workspaceId={workspaceId}
       workspaceDir={workspaceDir}
       agentId={agentId}
+      activeThreadId={activeThreadId}
       isActive={isActive}
       busy={busy}
       panel={panel}
@@ -132,6 +139,7 @@ function PanelBody({
   workspaceId,
   workspaceDir,
   agentId,
+  activeThreadId,
   isActive,
   busy,
   panel,
@@ -139,6 +147,7 @@ function PanelBody({
   workspaceId: string
   workspaceDir: string
   agentId: string
+  activeThreadId: string | null
   isActive: boolean
   busy: boolean
   panel: ReturnType<typeof useWorkspacePanel>
@@ -174,23 +183,29 @@ function PanelBody({
           // tab and the panel is open — and focuses its own search on mount, so ⌘P (which
           // opens/activates Files via the store) and a Files card/tab click both land in a
           // search-focused tree (ADR-0013 decision 1), with no per-trigger plumbing.
-          // Selecting a file emits an open-file intent that slice 3 (#189) will route to a
-          // `file:` Surface via the store; a no-op until then.
+          // Selecting a file opens a panel-level `file:` Surface (a preview tab) via the
+          // store — dedupes on the path, so re-selecting an open file just re-activates it.
           <FilesSurface
             onCollapse={() => closeWorkspaceSurface(workspaceId, 'files')}
             agentId={agentId}
-            onOpenFile={NO_OPEN_FILE}
+            onOpenFile={(relativePath) => openWorkspaceFileSurface(workspaceId, relativePath)}
+          />
+        )}
+        {active?.kind === 'file' && (
+          // A read-only file preview tab (#189): fetches the confined `files:read` and renders
+          // the highlighted content (or a binary/too-large/error notice), keyed by the path so a
+          // tab switch remounts a fresh fetch.
+          <FilePreview
+            key={active.id}
+            agentId={agentId}
+            relativePath={active.relativePath}
+            activeThreadId={activeThreadId}
           />
         )}
       </div>
     </div>
   )
 }
-
-// Selecting a file emits an open-file intent; slice 3 (#189) swaps this for opening a
-// `file:` Surface (a panel-level file tab) via the store. A no-op until then (a zero-arg
-// fn satisfies the callback type).
-const NO_OPEN_FILE = (): void => undefined
 
 /** A Surface's tab-strip presentation: its kind icon + a short human label. */
 function surfaceMeta(surface: Surface): { icon: ReactNode; label: string } {
@@ -200,7 +215,7 @@ function surfaceMeta(surface: Surface): { icon: ReactNode; label: string } {
     case 'files':
       return { icon: <Files aria-hidden />, label: 'Files' }
     case 'file':
-      return { icon: <Files aria-hidden />, label: surface.relativePath.slice(surface.relativePath.lastIndexOf('/') + 1) }
+      return { icon: <FileText aria-hidden />, label: fileBasename(surface.relativePath) }
     case 'terminal':
       return { icon: <SquareTerminal aria-hidden />, label: 'Terminal' }
     case 'browser':

--- a/src/renderer/src/side-panel/breadcrumb-segments.test.ts
+++ b/src/renderer/src/side-panel/breadcrumb-segments.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { breadcrumbSegments, fileBasename } from './breadcrumb-segments'
+
+describe('fileBasename', () => {
+  it('returns the last segment', () => {
+    expect(fileBasename('src/app.ts')).toBe('app.ts')
+    expect(fileBasename('README.md')).toBe('README.md')
+  })
+
+  it('tolerates trailing/leading/duplicate slashes and empty input', () => {
+    expect(fileBasename('src/dir/')).toBe('dir')
+    expect(fileBasename('/a/b')).toBe('b')
+    expect(fileBasename('a//b')).toBe('b')
+    expect(fileBasename('')).toBe('')
+  })
+})
+
+describe('breadcrumbSegments', () => {
+  it('returns every segment as a label within the budget', () => {
+    expect(breadcrumbSegments('src/app.ts')).toEqual([{ label: 'src' }, { label: 'app.ts' }])
+    expect(breadcrumbSegments('a/b/c/d', 4)).toEqual([
+      { label: 'a' },
+      { label: 'b' },
+      { label: 'c' },
+      { label: 'd' },
+    ])
+  })
+
+  it('truncates a deep path to first + ellipsis + last segments', () => {
+    // 6 segments, budget 4 → [a, …, e, f.ts]: head + ellipsis + last 2.
+    expect(breadcrumbSegments('a/b/c/d/e/f.ts', 4)).toEqual([
+      { label: 'a' },
+      { label: '…', ellipsis: true },
+      { label: 'e' },
+      { label: 'f.ts' },
+    ])
+  })
+
+  it('always keeps the file name (last segment) when truncating', () => {
+    const crumbs = breadcrumbSegments('one/two/three/four/five/six/seven.ts', 4)
+    expect(crumbs.at(-1)).toEqual({ label: 'seven.ts' })
+    expect(crumbs[0]).toEqual({ label: 'one' })
+    expect(crumbs.filter((c) => c.ellipsis)).toHaveLength(1)
+  })
+
+  it('drops empty segments and handles a single segment', () => {
+    expect(breadcrumbSegments('/src//app.ts')).toEqual([{ label: 'src' }, { label: 'app.ts' }])
+    expect(breadcrumbSegments('app.ts')).toEqual([{ label: 'app.ts' }])
+    expect(breadcrumbSegments('')).toEqual([])
+  })
+})

--- a/src/renderer/src/side-panel/breadcrumb-segments.ts
+++ b/src/renderer/src/side-panel/breadcrumb-segments.ts
@@ -1,0 +1,35 @@
+/**
+ * Pure view-model helpers for the file-preview breadcrumb + tab label (#189, ADR-0013 decision 2).
+ * A `file:` Surface's breadcrumb is a read-only, non-interactive trail of its relative path; the
+ * tab shows the basename. Kept DOM-free so the load-bearing splitting/truncation is unit-tested
+ * and the `FilePreview` JSX stays a thin map over these.
+ */
+
+/** One breadcrumb crumb: a path segment `label`, or an `ellipsis` placeholder for elided middles. */
+export interface BreadcrumbSegment {
+  label: string
+  /** True for the single "…" crumb inserted when a deep path is truncated (no label then). */
+  ellipsis?: boolean
+}
+
+/** The file name (last segment) of a relative path — the tab label. Empty string for empty input. */
+export function fileBasename(relativePath: string): string {
+  const parts = relativePath.split('/').filter((s) => s.length > 0)
+  return parts.at(-1) ?? ''
+}
+
+/**
+ * Split a forward-slash relative path into breadcrumb crumbs, truncating a DEEP path gracefully:
+ * when it has more than `maxSegments` segments, keep the FIRST segment (orientation) + a single
+ * "…" ellipsis crumb + the LAST `maxSegments - 2` segments (the file and its nearest parents, the
+ * most specific context). A path within the budget returns all its segments as labels. Empty
+ * segments (leading/duplicate slashes) are dropped; empty input yields `[]`.
+ */
+export function breadcrumbSegments(relativePath: string, maxSegments = 4): BreadcrumbSegment[] {
+  const parts = relativePath.split('/').filter((s) => s.length > 0)
+  if (parts.length <= maxSegments) return parts.map((label) => ({ label }))
+  const tailCount = Math.max(1, maxSegments - 2)
+  const head: BreadcrumbSegment = { label: parts[0] }
+  const tail = parts.slice(parts.length - tailCount).map((label) => ({ label }))
+  return [head, { label: '…', ellipsis: true }, ...tail]
+}

--- a/src/renderer/src/side-panel/side-panel-store.test.ts
+++ b/src/renderer/src/side-panel/side-panel-store.test.ts
@@ -11,7 +11,9 @@ import {
   coerceSurface,
   EMPTY_PANEL_STATE,
   getWorkspacePanel,
+  openFileSurface,
   openSurface,
+  openWorkspaceFileSurface,
   openWorkspaceSurface,
   readPanelMap,
   removeWorkspacePanel,
@@ -69,6 +71,42 @@ describe('openSurface', () => {
       activeSurfaceId: 'files',
       surfaces: [FILES],
     })
+  })
+})
+
+describe('openFileSurface', () => {
+  const APP: Surface = { id: 'file:src/app.ts', kind: 'file', relativePath: 'src/app.ts' }
+  const UTIL: Surface = { id: 'file:src/util.ts', kind: 'file', relativePath: 'src/util.ts' }
+
+  it('opens a file tab (id keyed by path) and activates it, opening the panel', () => {
+    expect(openFileSurface(empty(), 'src/app.ts')).toEqual({
+      isOpen: true,
+      activeSurfaceId: 'file:src/app.ts',
+      surfaces: [APP],
+    })
+  })
+
+  it('appends a second distinct file tab, activating the new one', () => {
+    const one = openFileSurface(empty(), 'src/app.ts')
+    expect(openFileSurface(one, 'src/util.ts')).toEqual({
+      isOpen: true,
+      activeSurfaceId: 'file:src/util.ts',
+      surfaces: [APP, UTIL],
+    })
+  })
+
+  it('re-activates an already-open file (dedupe by path) instead of duplicating it', () => {
+    const both = openFileSurface(openFileSurface(empty(), 'src/app.ts'), 'src/util.ts')
+    const again = openFileSurface(both, 'src/app.ts')
+    expect(again.surfaces).toEqual([APP, UTIL]) // no duplicate appended
+    expect(again.activeSurfaceId).toBe('file:src/app.ts') // just re-activated
+  })
+
+  it('coexists with singleton surfaces (opened beside Review/Files)', () => {
+    const withReview = openSurface(empty(), 'review')
+    const withFile = openFileSurface(withReview, 'src/app.ts')
+    expect(withFile.surfaces).toEqual([REVIEW, APP])
+    expect(withFile.activeSurfaceId).toBe('file:src/app.ts')
   })
 })
 
@@ -308,8 +346,22 @@ describe('coerceSurface', () => {
     expect(coerceSurface({ id: 'files', kind: 'files' })).toEqual(FILES)
   })
 
+  it('accepts a well-formed persisted file tab (id matches file:<relativePath>)', () => {
+    expect(coerceSurface({ id: 'file:src/app.ts', kind: 'file', relativePath: 'src/app.ts' })).toEqual({
+      id: 'file:src/app.ts',
+      kind: 'file',
+      relativePath: 'src/app.ts',
+    })
+  })
+
+  it('drops a malformed file tab (missing/mismatched id, empty or non-string path)', () => {
+    expect(coerceSurface({ kind: 'file', relativePath: 'x' })).toBeNull() // no id
+    expect(coerceSurface({ id: 'file:wrong', kind: 'file', relativePath: 'x' })).toBeNull() // id≠file:x
+    expect(coerceSurface({ id: 'file:', kind: 'file', relativePath: '' })).toBeNull() // empty path
+    expect(coerceSurface({ id: 'file:5', kind: 'file', relativePath: 5 })).toBeNull() // non-string
+  })
+
   it('drops not-yet-implemented / unknown / malformed descriptors', () => {
-    expect(coerceSurface({ kind: 'file', relativePath: 'x' })).toBeNull()
     expect(coerceSurface({ kind: 'terminal' })).toBeNull()
     expect(coerceSurface({ kind: 'nope' })).toBeNull()
     expect(coerceSurface(null)).toBeNull()
@@ -420,6 +472,22 @@ describe('module singleton', () => {
       activeSurfaceId: 'files',
       surfaces: [FILES],
     })
+  })
+
+  it('opens + persists a file tab through the workspace-scoped wrapper', () => {
+    const storage = fakeStorage()
+    _resetSidePanelStore(storage)
+    openWorkspaceFileSurface('ws-a', 'src/app.ts')
+    const stored = readPanelMap(storage)['ws-a']
+    expect(stored).toEqual({
+      isOpen: true,
+      activeSurfaceId: 'file:src/app.ts',
+      surfaces: [{ id: 'file:src/app.ts', kind: 'file', relativePath: 'src/app.ts' }],
+    })
+    // Re-opening the same path just re-activates (no duplicate) and survives a reload round-trip.
+    openWorkspaceFileSurface('ws-a', 'src/app.ts')
+    _resetSidePanelStore(storage)
+    expect(getWorkspacePanel('ws-a').surfaces).toHaveLength(1)
   })
 
   it('notifies subscribers on a real change only', () => {

--- a/src/renderer/src/side-panel/side-panel-store.ts
+++ b/src/renderer/src/side-panel/side-panel-store.ts
@@ -100,6 +100,21 @@ export function openSurface(state: WorkspacePanelState, kind: SingletonKind): Wo
   return upsertSurface(state, singletonSurface(kind))
 }
 
+/** A per-file Surface descriptor, its id keyed by the relative path so it dedupes (#189). */
+function fileSurface(relativePath: string): Surface {
+  return { id: `file:${relativePath}`, kind: 'file', relativePath }
+}
+
+/**
+ * Open a `file:<relativePath>` preview Surface and activate it (#189). Keyed by the path, so
+ * opening an already-open file just RE-ACTIVATES its tab rather than duplicating it — the same
+ * `upsertSurface` dedupe the singletons use. The content re-reads on activate (`FilePreview`),
+ * so this holds only the path, never the file's bytes.
+ */
+export function openFileSurface(state: WorkspacePanelState, relativePath: string): WorkspacePanelState {
+  return upsertSurface(state, fileSurface(relativePath))
+}
+
 /**
  * The ⌘P / ⌃⇧G semantics (t3code `toggle`): if the panel is open AND this kind is the
  * ACTIVE tab, hide the panel (keep the tabs + active id). Otherwise open/activate the
@@ -213,6 +228,17 @@ export function coerceSurface(raw: unknown): Surface | null {
   const kind = (raw as { kind?: unknown }).kind
   if (kind === 'review') return { id: 'review', kind: 'review' }
   if (kind === 'files') return { id: 'files', kind: 'files' }
+  if (kind === 'file') {
+    // A persisted file tab names a path — harmless to restore (the content re-reads on activate;
+    // a since-deleted file just shows the preview's error). Validate the shape defensively: a
+    // non-empty `relativePath` string whose `id` matches the `file:<path>` convention, else drop.
+    const relativePath = (raw as { relativePath?: unknown }).relativePath
+    const id = (raw as { id?: unknown }).id
+    if (typeof relativePath === 'string' && relativePath.length > 0 && id === `file:${relativePath}`) {
+      return { id: `file:${relativePath}`, kind: 'file', relativePath }
+    }
+    return null
+  }
   return null
 }
 
@@ -329,6 +355,9 @@ function apply(workspaceId: string, updater: (current: WorkspacePanelState) => W
 
 export function openWorkspaceSurface(workspaceId: string, kind: SingletonKind): void {
   apply(workspaceId, (state) => openSurface(state, kind))
+}
+export function openWorkspaceFileSurface(workspaceId: string, relativePath: string): void {
+  apply(workspaceId, (state) => openFileSurface(state, relativePath))
 }
 export function toggleWorkspaceSurface(workspaceId: string, kind: SingletonKind): void {
   apply(workspaceId, (state) => toggleSurface(state, kind))

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -231,6 +231,21 @@ export const IPC = {
    * walk failure degrades to the empty result (never throws).
    */
   filesList: 'files:list',
+  /**
+   * Renderer -> main: READ one Workspace file for the read-only preview (#189, ADR-0013
+   * decisions 2-3). Invoke, `{ agentId, relativePath }` -> `FilesReadResult` — a discriminated
+   * union `{ kind:'text', content } | { kind:'binary' } | { kind:'tooLarge' } | { kind:'error' }`.
+   * `relativePath` is a tree-relative path from `filesList` (forward-slash, never absolute/`..`).
+   * The read root is the warm agent's OWN `workspaceDir` (`pool.get(agentId)`, NOT a
+   * renderer-supplied path — review F3, matching `filesList`/`revealPath`); an unknown agent →
+   * `{kind:'error'}`. The target is confined with the SAME machinery as `revealPath`
+   * (`resolveWorkspacePath` + `realpath` + `isWithinDir`), so a `..`/absolute target or a symlink
+   * escaping the root → `{kind:'error'}` (logged, never leaking the absolute path/stack). Must be
+   * a regular file; a ~1MB size cap is checked via `stat` BEFORE reading → `{kind:'tooLarge'}`; a
+   * NUL byte in the first chunk → `{kind:'binary'}`; else utf8 → `{kind:'text'}`. STRICTLY
+   * read-only (no write path). Best-effort: any throw degrades to `{kind:'error'}`, never rejects.
+   */
+  filesRead: 'files:read',
 } as const
 
 /**
@@ -983,3 +998,29 @@ export interface FilesListResult {
   entries: FileEntry[]
   truncated: boolean
 }
+
+/**
+ * Args for `filesRead` (#189): read one Workspace file for the read-only preview. Addressed by
+ * `agentId` — main resolves the read root from the warm agent's OWN `workspaceDir`
+ * (`pool.get(agentId)`), NOT a renderer-supplied path (review F3, matching `filesList`). `relativePath`
+ * is a tree-relative path from a `filesList` entry (forward-slash separated, never absolute or `..`);
+ * main confines the resolved target to the Workspace root (realpath + `isWithinDir`) before reading.
+ */
+export interface FilesReadArgs {
+  agentId: string
+  relativePath: string
+}
+
+/**
+ * The `filesRead` reply (#189), a discriminated union so the preview renders each outcome cleanly
+ * and never shows garbage. `text` carries the utf8-decoded `content`; `binary` (a NUL byte was found
+ * in the first chunk) and `tooLarge` (the file exceeds the ~1MB cap, checked via `stat` before any
+ * read) render muted notices; `error` covers EVERY failure — an unknown agent, a confinement refusal
+ * (out-of-tree/absolute/`..`/symlink escape), a non-regular-file target, or any fs throw — and never
+ * leaks an absolute path or stack to the renderer.
+ */
+export type FilesReadResult =
+  | { kind: 'text'; content: string }
+  | { kind: 'binary' }
+  | { kind: 'tooLarge' }
+  | { kind: 'error' }


### PR DESCRIPTION
Closes #189 (Files browser epic, PRD #186; ADR-0013 decisions 2-3). Second HITL/security slice.

## What
Opening a file from the tree opens a panel-level `file:` Surface tab whose content is a **read-only preview**: shared-shiki highlighting (reuses the `@pierre/diffs` highlighter the git panel uses — no new dep, #159 pin verified intact), a read-only breadcrumb of the path, and header actions Reveal-in-Finder (`revealPath`) + Insert-`@path`-into-composer.
- **`files:read` IPC** — `{agentId, relativePath}` → `{kind:'text',content} | {kind:'binary'} | {kind:'tooLarge'} | {kind:'error'}`. Root resolves from `pool.get(agentId).workspaceDir` (the #188 F3 model — never a renderer path). Pure `read-file.ts` mirrors `revealPath`'s confinement exactly (realpath root → resolveWorkspacePath → stat isFile → realpath target → `isWithinDir`), reads only the realpath'd in-tree target, ~1MB cap, NUL-byte binary sniff, strictly read-only.
- **Store `file:` Surface ops** — `openFileSurface` (dedupe by path) + defensive coercion so file tabs survive reload.
- **Insert-@path** — renderer-only module channel (preview → the active Thread's composer draft, keyed by threadId); plain-text `@path`, agent expands server-side (ADR-0002).

## Security (adversarial review: APPROVE — HITL-signed-off)
Reviewer refused every vector against the REAL module with probes + a delete-the-guard experiment (removing `isWithinDir` / reading the pre-realpath path leaks `/etc/passwd` → the committed confinement tests catch it):
- `../`-traversal, absolute path, `~` expansion, symlink escape → all `error`, out-of-tree content never read (reads the realpath'd target).
- FIFO/`/dev/zero` → `isFile()` false → refused before any read; no OOM.
- Content-as-text XSS: shiki `codeToHtml` escapes arbitrary bytes (`</span><script>` payload → every `<`→`&#x3C;`); breadcrumb + notices React-escaped.
- No cross-Thread composer injection (channel keyed by exact threadId); no error-path leak (union has no path/stack field; `console.error` stays main-side).
- **Folded (the one low SHOULD-FIX, user-chosen):** size-cap **TOCTOU** — the read was bounded only by `stat.size`. Now a BOUNDED read (`fs.open` + read of `maxBytes+1`) is authoritative: a file growing between stat and read still can't exceed the cap (→ `tooLarge`), so at most maxBytes+1 bytes are ever buffered. Injected-fs test proves the read path alone enforces it.
- Gates: lint ✓ typecheck ✓ build ✓ test **835/835** ✓ (802 + 33).

## Live check at merge
Open a file from the tree → highlighted read-only preview + breadcrumb; a binary/huge file shows a notice not garbage; Reveal-in-Finder works; Insert-@path drops `@path` into the composer.

## Blocked by
None. (Independent of #190 — disjoint files; either merges first.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)