### PR TITLE
fix(files): give the Files tree height so its virtualized rows render

### DIFF
--- a/src/renderer/src/side-panel/FilesSurface.tsx
+++ b/src/renderer/src/side-panel/FilesSurface.tsx
@@ -119,7 +119,12 @@ export function FilesSurface({
   return (
     <aside
       aria-label="Files"
-      className="flex w-80 shrink-0 flex-col self-stretch border-l border-border bg-panel text-text"
+      // `flex-1 min-h-0` (not `self-stretch`): the parent Surface slot is a flex COLUMN, where
+      // `align-self:stretch` only stretches the WIDTH — it gives no height. `@pierre/trees` is
+      // virtualized and measures its scroll container, so a content-height (≈0) container renders
+      // ZERO rows (the header/search still show). `flex-1` fills the column's height; `min-h-0`
+      // lets it shrink below content so the inner tree can scroll. (Matches t3code's FileBrowserPanel.)
+      className="flex min-h-0 w-80 flex-1 flex-col border-l border-border bg-panel text-text"
     >
       <div className="flex items-center gap-2 border-b border-border-muted px-3 py-2.5">
         <button


### PR DESCRIPTION
The Files Surface rendered its header ("962 files") and search box but **no tree rows** (reported with a screenshot). 

**Root cause:** `FilesSurface`'s `<aside>` used `self-stretch` where it needed `flex-1`. Its parent Surface slot is a flex **column**, so `align-self:stretch` only stretches width — the aside collapsed to content height. `@pierre/trees` is virtualized (measures its scroll container via ResizeObserver), so a ~0-height container renders zero rows while the fixed-height header/search still show. The data was never the problem (962 files loaded).

**Fix:** one line — `self-stretch` → `flex-1 min-h-0`, matching t3code's `FileBrowserPanel` root. CSS-only; `FilePreview` (#189) already had the correct `flex-1 min-h-0` so it's unaffected. The pure path-mapping unit tests never exercised the rendered widget, which is why this slipped through.

Gates: lint ✓ typecheck ✓ build ✓ test **861/861** ✓ (unchanged — CSS-only).

Live check: open Files (⌘P) → the tree rows now render and scroll. (Also worth eyeballing whether the search field's dark styling clears once the container has real height.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)