### PR TITLE
fix(files): pin light color-scheme so the tree search box isn't dark

### DIFF
--- a/src/renderer/src/side-panel/FilesSurface.tsx
+++ b/src/renderer/src/side-panel/FilesSurface.tsx
@@ -20,6 +20,13 @@ import { indexEntryKinds, selectedFilePath, toTreePaths } from './tree-paths'
 /** Map the tree's shadow-DOM theme onto our tokens (styles.css). */
 const TREE_UNSAFE_CSS = `
   :host {
+    /* The widget's defaults use CSS light-dark() (e.g. --trees-input-bg =
+       light-dark(#f8f8f8, #070707)); with no color-scheme pinned it followed the OS, so on a
+       dark-mode Mac the search field rendered near-black. vibe-mistro is a light-only app, so
+       pin the light branch here (scoped to the widget's shadow root) and paint the search
+       input on our warm inset surface to match the panel. */
+    color-scheme: light;
+    --trees-input-bg-override: var(--sidebar);
     --trees-bg-override: transparent;
     --trees-selected-bg-override: var(--accent-tint);
     --trees-hover-bg-override: color-mix(in srgb, var(--accent) 8%, transparent);


### PR DESCRIPTION
Follow-up to #198 (the tree now renders). The Files tree's **search input rendered near-black** on a dark-mode Mac.

**Cause:** `@pierre/trees` styles its search input with `--trees-input-bg = light-dark(#f8f8f8, #070707)`, which resolves against the element's `color-scheme`. The app pins no `color-scheme`, so inside the widget's shadow root `light-dark()` followed the OS → the dark branch `#070707`. (The tree body was fine because we override its bg to transparent; the input has its own token we never set.)

**Fix:** pin `color-scheme: light` on the widget `:host` (scoped to its shadow root — resolves all the widget's `light-dark()` defaults to the light branch, which is correct for our light-only app) and set `--trees-input-bg-override` to our warm `--sidebar` surface so the field matches the panel. CSS-only; 861 tests unchanged.

Note: pinning `color-scheme: light` app-wide (on `:root`) would preempt this whole class of OS-dark bleed-through for a light-only app — a reasonable follow-up, left out here to keep the fix scoped and side-effect-free.

Live check: open Files (⌘P) → the search field is now light/warm, not black.

🤖 Generated with [Claude Code](https://claude.com/claude-code)