### PR TITLE
fix(conversation): pin the Composer to the bottom with an internally-scrolling transcript

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -533,7 +533,9 @@ export function App(): JSX.Element {
         const conn = connections[wid]
         if (conn.status !== 'connected') return null
         return (
-          <div key={wid} hidden={inSettings || wid !== selectedWs}>
+          // h-full: complete the height chain from <main> down to `.conv` (100%)
+          // so the transcript scrolls internally and the Composer stays pinned.
+          <div key={wid} className="h-full" hidden={inSettings || wid !== selectedWs}>
             {renderConnected(conn.thread, !inSettings && wid === selectedWs, wsFlags[wid]?.streaming ?? false)}
           </div>
         )

--- a/src/renderer/src/connection/ConnectedWorkspace.tsx
+++ b/src/renderer/src/connection/ConnectedWorkspace.tsx
@@ -80,8 +80,12 @@ export function ConnectedWorkspace({
   onAuthExpired: (authMethods: AuthMethod[]) => void
 }): JSX.Element {
   return (
-    <div className="flex min-h-0 flex-1 items-start gap-4">
-      <div className="flex min-w-0 flex-1 flex-col gap-3">
+    // h-full on the row + chat column completes the height chain from <main> down to
+    // `.conv` (100%): the transcript scrolls internally and the Composer pins to the
+    // bottom. `items-start` stays so the SurfacePanel keeps floating at its content
+    // height — the explicit h-full on the chat column overrides start-alignment sizing.
+    <div className="flex h-full min-h-0 flex-1 items-start gap-4">
+      <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col gap-3">
         {isLive ? (
           <Conversation
             key={activeThread.id}

--- a/src/renderer/src/conversation/MessageScroller.tsx
+++ b/src/renderer/src/conversation/MessageScroller.tsx
@@ -25,7 +25,10 @@ export function MessageScroller({
     resize: 'smooth',
   })
   return (
-    <div className={cn('relative', className)}>
+    // A flex column itself, so `.messages` (flex: 1, min-height: 0) fills it and
+    // scrolls internally; `flex-1 min-h-0` makes THIS wrapper take the height the
+    // `.conv` column leaves over, keeping the Composer sibling pinned below.
+    <div className={cn('relative flex min-h-0 flex-1 flex-col', className)}>
       <div ref={scrollRef} className="messages">
         <div ref={contentRef} className="flex flex-col gap-3">
           {children}

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -437,6 +437,10 @@ body {
   display: flex;
   flex-direction: column;
   gap: 12px;
+  /* Fill the outlet so the transcript scrolls INTERNALLY and the Composer stays
+     pinned at the bottom (the flex-sibling pinning t3code's ChatView uses). */
+  height: 100%;
+  min-height: 0;
 }
 
 .conv__head {
@@ -491,7 +495,11 @@ body {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  max-height: 360px;
+  /* Own the vertical scroll: take all height the column leaves over (flex: 1) and
+     allow shrinking below content size (min-height: 0) so overflow-y engages,
+     instead of the old fixed 360px cap that left the Composer mid-screen. */
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
   padding: 4px 2px;
 }


### PR DESCRIPTION
## What

The composer scrolled away with the conversation instead of staying pinned at the bottom (t3code-style). The chat column had no height chain: `.conv` grew with content, `.messages` was capped at a scaffold-era `max-height: 360px`, and the Shell's `<main>` did the scrolling.

## How

Build the chain top-down (flex-sibling pinning, adapted from t3code's ChatView):

- App outlet wrapper + ConnectedWorkspace row/chat column: `h-full min-h-0`
- `.conv`: `height: 100%`
- MessageScroller wrapper: `flex-1 min-h-0 flex-col`
- `.messages`: `flex: 1` + `min-height: 0` instead of the fixed cap — it owns the vertical scroll now; `use-stick-to-bottom` behavior unchanged

ColdThread reuses `.conv`/`.messages`, so cold replays get the same pinned layout.

## Gates

`bun run lint && bun run typecheck && bun run build && bun run test` — all green (902 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)