### PR TITLE
feat(side-panel): t3code-parity panel shell — flush full-height column, resizable width, launcher grid, tab-strip + menu

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -526,6 +526,9 @@ export function App(): JSX.Element {
   // sidebar gear used to toggle. It swaps the conversation/cold/empty outlet WITHOUT
   // unmounting the connected Workspaces — they stay mounted-but-hidden so a background
   // turn keeps streaming, and closing Settings returns to exactly the same view.
+  // <main> is full-bleed now (the side panel reaches the window edges, t3code-style),
+  // so each NON-connected view re-adds the old p-6 breathing room via a wrapper here;
+  // the connected view spends it inside its chat column (ConnectedWorkspace) instead.
   const inSettings = nav.view === 'settings'
   const outlet = (
     <>
@@ -541,7 +544,8 @@ export function App(): JSX.Element {
         )
       })}
       {inSettings ? (
-        <SettingsView
+        <div className="p-6">
+          <SettingsView
           detect={detect}
           loading={loading}
           onRecheck={() => void runDetect()}
@@ -571,32 +575,36 @@ export function App(): JSX.Element {
             navDispatch({ type: 'close-settings' })
           }}
         />
+        </div>
       ) : selected.status === 'connected' ? null : ( // connected: rendered (visible) in the keep-mounted map above
-        selected.status !== 'idle' ? (
-          <TransientOutlet
-            connect={selected}
-            onContinueToThread={(agentId) => void continueToThread(selectedWs ?? '', agentId)}
-            onRetry={() => selectedWs && void connectWorkspace(selectedWs)}
-          />
-        ) : (
-          <ColdOutlet
-            recents={recents}
-            nav={nav}
-            onClose={() => navDispatch({ type: 'clear' })}
-            onContinue={(thread) => void continueColdThread(thread)}
-            empty={
-              <EmptyState
-                state={firstRunState(detect, recents)}
-                detect={detect}
-                loading={loading}
-                opening={opening}
-                workspaceName={selectedWorkspaceName}
-                onRecheck={() => void runDetect()}
-                onOpenProject={() => void openProject()}
-              />
-            }
-          />
-        )
+        // h-full so a cold Thread's `.conv` (height: 100%) keeps its internal scroll.
+        <div className="h-full p-6">
+          {selected.status !== 'idle' ? (
+            <TransientOutlet
+              connect={selected}
+              onContinueToThread={(agentId) => void continueToThread(selectedWs ?? '', agentId)}
+              onRetry={() => selectedWs && void connectWorkspace(selectedWs)}
+            />
+          ) : (
+            <ColdOutlet
+              recents={recents}
+              nav={nav}
+              onClose={() => navDispatch({ type: 'clear' })}
+              onContinue={(thread) => void continueColdThread(thread)}
+              empty={
+                <EmptyState
+                  state={firstRunState(detect, recents)}
+                  detect={detect}
+                  loading={loading}
+                  opening={opening}
+                  workspaceName={selectedWorkspaceName}
+                  onRecheck={() => void runDetect()}
+                  onOpenProject={() => void openProject()}
+                />
+              }
+            />
+          )}
+        </div>
       )}
     </>
   )

--- a/src/renderer/src/connection/ConnectedWorkspace.tsx
+++ b/src/renderer/src/connection/ConnectedWorkspace.tsx
@@ -82,10 +82,11 @@ export function ConnectedWorkspace({
   return (
     // h-full on the row + chat column completes the height chain from <main> down to
     // `.conv` (100%): the transcript scrolls internally and the Composer pins to the
-    // bottom. `items-start` stays so the SurfacePanel keeps floating at its content
-    // height — the explicit h-full on the chat column overrides start-alignment sizing.
-    <div className="flex h-full min-h-0 flex-1 items-start gap-4">
-      <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col gap-3">
+    // bottom. The row is FULL-BLEED (t3code): the chat column carries the p-6 that
+    // <main> used to, and the panel sits flush against it — its border-l is the only
+    // separator — stretching the full height to the window edges.
+    <div className="flex h-full min-h-0 flex-1">
+      <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col gap-3 p-6">
         {isLive ? (
           <Conversation
             key={activeThread.id}

--- a/src/renderer/src/git/ChangesPanel.tsx
+++ b/src/renderer/src/git/ChangesPanel.tsx
@@ -15,7 +15,7 @@ import { DiffView } from './DiffView'
  * the Workspace's STREAMED git status while it is the ACTIVE one (`isActive`), holds the
  * latest snapshot, and renders the branch header + changed-files list. Clicking a file
  * opens its working-tree diff (#85): the panel has two modes —
- *  - LIST: the narrow (`w-80`) file list + branch header (the #84 view).
+ *  - LIST: the file list + branch header (the #84 view), filling the SurfacePanel shell.
  *  - DIFF: a WIDER (`flex-1`) view of the selected file's diff (`DiffView`), with a
  *    "← Changes" back button. A diff needs width, so the panel widens rather than
  *    cramming a side-by-side into 80px.
@@ -122,7 +122,7 @@ export function ChangesPanel({
   // must never strand the user with no way back to the card stack.
   if (!status || !status.isRepo) {
     return (
-      <aside className="flex w-80 shrink-0 flex-col self-stretch border-l border-border bg-panel text-text">
+      <aside className="flex min-h-0 flex-1 flex-col text-text">
         <ReviewHeader onCollapse={onCollapse} onRefresh={refresh} />
         <p className="px-3 py-3 text-[13px] text-muted">
           {!status ? 'Loading changes…' : 'Not a Git repository.'}
@@ -169,7 +169,7 @@ export function ChangesPanel({
   const selected = isActive && selectedPath ? view.files.find((f) => f.path === selectedPath) : undefined
   if (selected) {
     return (
-      <aside className="flex min-h-0 flex-1 shrink-0 flex-col self-stretch border-l border-border bg-panel text-text">
+      <aside className="flex min-h-0 flex-1 flex-col text-text">
         <DiffWorkerProvider>
           <DiffView
             workspaceDir={workspaceDir}
@@ -187,7 +187,9 @@ export function ChangesPanel({
   }
 
   return (
-    <aside className="w-80 shrink-0 border-l border-border bg-panel text-text">
+    // The SHELL (SurfacePanel) owns the panel's width + border-l chrome now; this fills
+    // it and scrolls internally — the shell column is viewport-height, not <main>-scrolled.
+    <aside className="flex min-h-0 flex-1 flex-col overflow-y-auto text-text">
       <ReviewHeader count={view.fileCount} onCollapse={onCollapse} onRefresh={refresh} />
 
       {/* Environment (#119) — a STATIC placeholder gesturing at the mockup's fuller

--- a/src/renderer/src/shell/Shell.tsx
+++ b/src/renderer/src/shell/Shell.tsx
@@ -189,7 +189,10 @@ export function Shell({
         </div>
       )}
 
-      <main className="min-w-0 flex-1 overflow-y-auto p-6">{outlet}</main>
+      {/* Full-bleed (t3code): the side panel must reach the window edges, so the
+          padding lives in each outlet view (the chat column / the p-6 wrappers in
+          App's outlet), not here. */}
+      <main className="min-w-0 flex-1 overflow-y-auto">{outlet}</main>
     </div>
   )
 }

--- a/src/renderer/src/side-panel/FilePreview.tsx
+++ b/src/renderer/src/side-panel/FilePreview.tsx
@@ -87,7 +87,7 @@ export function FilePreview({
   const crumbs = breadcrumbSegments(relativePath)
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col self-stretch border-l border-border bg-panel text-text">
+    <div className="flex min-h-0 flex-1 flex-col text-text">
       <div className="flex items-center gap-2 border-b border-border-muted px-3 py-2">
         {/* Read-only, non-interactive breadcrumb of the file's path. */}
         <nav aria-label="File path" className="flex min-w-0 flex-1 items-center gap-1 text-[11px] text-muted">

--- a/src/renderer/src/side-panel/FilesSurface.tsx
+++ b/src/renderer/src/side-panel/FilesSurface.tsx
@@ -131,7 +131,7 @@ export function FilesSurface({
       // virtualized and measures its scroll container, so a content-height (≈0) container renders
       // ZERO rows (the header/search still show). `flex-1` fills the column's height; `min-h-0`
       // lets it shrink below content so the inner tree can scroll. (Matches t3code's FileBrowserPanel.)
-      className="flex min-h-0 w-80 flex-1 flex-col border-l border-border bg-panel text-text"
+      className="flex min-h-0 flex-1 flex-col text-text"
     >
       <div className="flex items-center gap-2 border-b border-border-muted px-3 py-2.5">
         <button

--- a/src/renderer/src/side-panel/SurfacePanel.tsx
+++ b/src/renderer/src/side-panel/SurfacePanel.tsx
@@ -1,5 +1,5 @@
-import { useEffect, type JSX, type ReactNode } from 'react'
-import { FileDiff, FileText, Files, Globe, SquareTerminal, X } from 'lucide-react'
+import { useEffect, useRef, useState, type JSX, type PointerEvent, type ReactNode } from 'react'
+import { FileDiff, FileText, Files, Globe, Plus, SquareTerminal, X } from 'lucide-react'
 import { cn } from '../lib/utils'
 import { useMediaQuery } from '../lib/use-media-query'
 import {
@@ -7,6 +7,10 @@ import {
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuTrigger,
+  Menu,
+  MenuContent,
+  MenuItem,
+  MenuTrigger,
   Sheet,
   SheetPopup,
 } from '../ui'
@@ -29,6 +33,12 @@ import {
   type SingletonKind,
   type Surface,
 } from './side-panel-store'
+import {
+  clampPanelWidth,
+  DEFAULT_PANEL_WIDTH,
+  getPanelWidth,
+  setPanelWidth,
+} from './panel-width-store'
 
 /** Windows this narrow present the panel as a slide-over Sheet (t3code's 980px break). */
 const NARROW_QUERY = '(max-width: 980px)'
@@ -41,11 +51,14 @@ const NARROW_QUERY = '(max-width: 980px)'
  * CARDS (its empty state). Review re-homes the git Changes panel behavior-identical
  * (#84–#88, ADR-0008); Files is the searchable tree (#188); Terminal/Browser are inert.
  *
- * Presentation is DUAL: inline beside the conversation on wide windows, and inside a Sheet
- * (right-edge slide-over, dimmed/blurred backdrop, Esc/outside-click closes) on narrow ones
- * — the SAME `PanelBody` feeds both. Rendered by `ConnectedWorkspace` for the active/
- * connected Workspace only. Stays MOUNTED even while closed so the ⌘P/⌃⇧G listener stays
- * live (a matched chord toggles the Surface, opening a closed panel).
+ * Presentation is DUAL: inline beside the conversation on wide windows — a full-height,
+ * flush, `border-l`-separated column (t3code's editor-panel chrome) whose width is
+ * DRAG-RESIZABLE on its left edge (`panel-width-store`: default 540, min 360, max 70% of
+ * the viewport, persisted per-window) — and inside a Sheet (right-edge slide-over, dimmed/
+ * blurred backdrop, Esc/outside-click closes) on narrow ones; the SAME `PanelBody` feeds
+ * both. Rendered by `ConnectedWorkspace` for the active/connected Workspace only. Stays
+ * MOUNTED even while closed so the ⌘P/⌃⇧G listener stays live (a matched chord toggles
+ * the Surface, opening a closed panel).
  */
 export function SurfacePanel({
   workspaceId,
@@ -102,6 +115,7 @@ export function SurfacePanel({
   // closed narrow Sheet renders its empty shell.
   const body = panel.isOpen ? (
     <PanelBody
+      mode={narrow ? 'sheet' : 'inline'}
       workspaceId={workspaceId}
       workspaceDir={workspaceDir}
       agentId={agentId}
@@ -131,11 +145,16 @@ export function SurfacePanel({
 }
 
 /**
- * The panel's content, shared across both presentations: the tab strip + active Surface
- * when ≥1 Surface is open, or the launcher cards (empty state) when none is. A fixed-width
- * (`w-80`) column; the active Surface brings its own header + border/bg (frozen chrome).
+ * The panel's content, shared across both presentations: the full-height SHELL (t3code's
+ * `PreviewPanelShell`) holding either the tab strip + active Surface (≥1 Surface open) or
+ * the centered launcher grid (zero open). Inline, the shell is a flush `border-l` column
+ * at the drag-resizable width (left-edge handle: pointer-captured drag, clamp to the
+ * viewport-relative range, persist on release, double-click resets — the sidebar's
+ * #drag-to-resize pattern mirrored). In a Sheet the popup owns width + chrome, so the
+ * shell just fills it (no handle, no border).
  */
 function PanelBody({
+  mode,
   workspaceId,
   workspaceDir,
   agentId,
@@ -144,6 +163,7 @@ function PanelBody({
   busy,
   panel,
 }: {
+  mode: 'inline' | 'sheet'
   workspaceId: string
   workspaceDir: string
   agentId: string
@@ -152,58 +172,123 @@ function PanelBody({
   busy: boolean
   panel: ReturnType<typeof useWorkspacePanel>
 }): JSX.Element {
-  if (panel.surfaces.length === 0) {
-    return <LauncherCards onOpen={(kind) => openWorkspaceSurface(workspaceId, kind)} />
+  const inline = mode === 'inline'
+  const [width, setWidth] = useState(() => getPanelWidth(window.localStorage, window.innerWidth))
+  const [dragging, setDragging] = useState(false)
+  const dragOrigin = useRef<{ x: number; width: number } | null>(null)
+
+  function onHandlePointerDown(e: PointerEvent<HTMLDivElement>): void {
+    dragOrigin.current = { x: e.clientX, width }
+    setDragging(true)
+    e.currentTarget.setPointerCapture(e.pointerId)
+  }
+  function onHandlePointerMove(e: PointerEvent<HTMLDivElement>): void {
+    const origin = dragOrigin.current
+    if (!origin) return
+    // The handle rides the panel's LEFT edge: dragging left (negative clientX delta)
+    // grows the panel. Clamped live so the drag can never overshoot the range.
+    setWidth(clampPanelWidth(origin.width + (origin.x - e.clientX), window.innerWidth))
+  }
+  function endDrag(e: PointerEvent<HTMLDivElement>): void {
+    if (!dragOrigin.current) return
+    dragOrigin.current = null
+    setDragging(false)
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId)
+    }
+    // Persist the settled width (best-effort). Read from state via the setter to avoid
+    // a stale closure — setWidth's identity update returns the current value.
+    setWidth((current) => {
+      setPanelWidth(window.localStorage, current, window.innerWidth)
+      return current
+    })
+  }
+  function resetWidth(): void {
+    const fallback = clampPanelWidth(DEFAULT_PANEL_WIDTH, window.innerWidth)
+    setWidth(fallback)
+    setPanelWidth(window.localStorage, fallback, window.innerWidth)
   }
 
   const active = panel.surfaces.find((s) => s.id === panel.activeSurfaceId) ?? null
 
   return (
-    <div className="flex min-h-0 w-80 shrink-0 flex-col self-stretch">
-      <SurfaceTabStrip
-        surfaces={panel.surfaces}
-        activeSurfaceId={panel.activeSurfaceId}
-        onActivate={(id) => activateWorkspaceSurface(workspaceId, id)}
-        onClose={(id) => closeWorkspaceSurface(workspaceId, id)}
-        onCloseOthers={(id) => closeOtherWorkspaceSurfaces(workspaceId, id)}
-        onCloseToRight={(id) => closeWorkspaceSurfacesToRight(workspaceId, id)}
-        onCloseAll={() => closeAllWorkspaceSurfaces(workspaceId)}
-      />
-      <div className="flex min-h-0 flex-1 flex-col">
-        {active?.kind === 'review' && (
-          <ChangesPanel
-            workspaceDir={workspaceDir}
-            isActive={isActive}
-            busy={busy}
-            onCollapse={() => closeWorkspaceSurface(workspaceId, 'review')}
+    <aside
+      aria-label="Side panel"
+      style={inline ? { width } : undefined}
+      className={cn(
+        'relative flex h-full min-h-0 flex-col bg-panel text-text',
+        inline ? 'shrink-0 self-stretch border-l border-border' : 'w-full',
+        dragging && 'select-none',
+      )}
+    >
+      {/* Resize handle (inline only): an 8px invisible hit strip straddling the left
+          border, its visible affordance a 1px seam that lights on hover/drag. */}
+      {inline && (
+        <div
+          aria-hidden
+          onPointerDown={onHandlePointerDown}
+          onPointerMove={onHandlePointerMove}
+          onPointerUp={endDrag}
+          onPointerCancel={endDrag}
+          onDoubleClick={resetWidth}
+          className={cn(
+            'absolute inset-y-0 -left-1 z-20 w-2 cursor-col-resize select-none [-webkit-app-region:no-drag]',
+            'after:absolute after:inset-y-0 after:left-1 after:w-px after:bg-transparent after:transition-colors after:content-[""] hover:after:bg-accent/40',
+            dragging && 'after:bg-accent/60',
+          )}
+        />
+      )}
+      {panel.surfaces.length === 0 ? (
+        <LauncherGrid onOpen={(kind) => openWorkspaceSurface(workspaceId, kind)} />
+      ) : (
+        <>
+          <SurfaceTabStrip
+            surfaces={panel.surfaces}
+            activeSurfaceId={panel.activeSurfaceId}
+            onActivate={(id) => activateWorkspaceSurface(workspaceId, id)}
+            onClose={(id) => closeWorkspaceSurface(workspaceId, id)}
+            onCloseOthers={(id) => closeOtherWorkspaceSurfaces(workspaceId, id)}
+            onCloseToRight={(id) => closeWorkspaceSurfacesToRight(workspaceId, id)}
+            onCloseAll={() => closeAllWorkspaceSurfaces(workspaceId)}
+            onOpen={(kind) => openWorkspaceSurface(workspaceId, kind)}
           />
-        )}
-        {active?.kind === 'files' && (
-          // The Files Surface tree (#188). It only mounts here — when `files` is the ACTIVE
-          // tab and the panel is open — and focuses its own search on mount, so ⌘P (which
-          // opens/activates Files via the store) and a Files card/tab click both land in a
-          // search-focused tree (ADR-0013 decision 1), with no per-trigger plumbing.
-          // Selecting a file opens a panel-level `file:` Surface (a preview tab) via the
-          // store — dedupes on the path, so re-selecting an open file just re-activates it.
-          <FilesSurface
-            onCollapse={() => closeWorkspaceSurface(workspaceId, 'files')}
-            agentId={agentId}
-            onOpenFile={(relativePath) => openWorkspaceFileSurface(workspaceId, relativePath)}
-          />
-        )}
-        {active?.kind === 'file' && (
-          // A read-only file preview tab (#189): fetches the confined `files:read` and renders
-          // the highlighted content (or a binary/too-large/error notice), keyed by the path so a
-          // tab switch remounts a fresh fetch.
-          <FilePreview
-            key={active.id}
-            agentId={agentId}
-            relativePath={active.relativePath}
-            activeThreadId={activeThreadId}
-          />
-        )}
-      </div>
-    </div>
+          <div className="flex min-h-0 flex-1 flex-col">
+            {active?.kind === 'review' && (
+              <ChangesPanel
+                workspaceDir={workspaceDir}
+                isActive={isActive}
+                busy={busy}
+                onCollapse={() => closeWorkspaceSurface(workspaceId, 'review')}
+              />
+            )}
+            {active?.kind === 'files' && (
+              // The Files Surface tree (#188). It only mounts here — when `files` is the ACTIVE
+              // tab and the panel is open — and focuses its own search on mount, so ⌘P (which
+              // opens/activates Files via the store) and a Files card/tab click both land in a
+              // search-focused tree (ADR-0013 decision 1), with no per-trigger plumbing.
+              // Selecting a file opens a panel-level `file:` Surface (a preview tab) via the
+              // store — dedupes on the path, so re-selecting an open file just re-activates it.
+              <FilesSurface
+                onCollapse={() => closeWorkspaceSurface(workspaceId, 'files')}
+                agentId={agentId}
+                onOpenFile={(relativePath) => openWorkspaceFileSurface(workspaceId, relativePath)}
+              />
+            )}
+            {active?.kind === 'file' && (
+              // A read-only file preview tab (#189): fetches the confined `files:read` and renders
+              // the highlighted content (or a binary/too-large/error notice), keyed by the path so a
+              // tab switch remounts a fresh fetch.
+              <FilePreview
+                key={active.id}
+                agentId={agentId}
+                relativePath={active.relativePath}
+                activeThreadId={activeThreadId}
+              />
+            )}
+          </div>
+        </>
+      )}
+    </aside>
   )
 }
 
@@ -226,8 +311,10 @@ function surfaceMeta(surface: Surface): { icon: ReactNode; label: string } {
 /**
  * The tab strip across the panel top (t3code `RightPanelTabs`): one tab per open Surface —
  * kind icon + label + a close ×, the active tab visually distinct. Clicking a tab activates
- * it; right-click opens a context menu (Close / Close others / Close to the right). A
- * `tablist` / `tab` a11y contract with `aria-selected` on the active tab.
+ * it; MIDDLE-click closes it (t3code's aux-click); right-click opens a context menu (Close /
+ * Close others / Close to the right / Close all). A trailing "+" menu (t3code's add-surface
+ * button) opens another Surface without going back through the launcher. A `tablist` /
+ * `tab` a11y contract with `aria-selected` on the active tab.
  */
 function SurfaceTabStrip({
   surfaces,
@@ -237,6 +324,7 @@ function SurfaceTabStrip({
   onCloseOthers,
   onCloseToRight,
   onCloseAll,
+  onOpen,
 }: {
   surfaces: Surface[]
   activeSurfaceId: string | null
@@ -245,12 +333,13 @@ function SurfaceTabStrip({
   onCloseOthers: (id: string) => void
   onCloseToRight: (id: string) => void
   onCloseAll: () => void
+  onOpen: (kind: SingletonKind) => void
 }): JSX.Element {
   return (
     <div
       role="tablist"
       aria-label="Open surfaces"
-      className="flex w-80 shrink-0 items-center gap-1 overflow-x-auto border-b border-l border-border bg-panel px-2 py-1.5"
+      className="flex w-full shrink-0 items-center gap-1 overflow-x-auto border-b border-border bg-panel px-2 py-1.5"
     >
       {surfaces.map((surface, index) => {
         const active = surface.id === activeSurfaceId
@@ -258,6 +347,10 @@ function SurfaceTabStrip({
         return (
           <ContextMenu key={surface.id}>
             <ContextMenuTrigger
+              onAuxClick={(e) => {
+                // Middle-click closes the tab (t3code parity); right-click is the menu's.
+                if (e.button === 1) onClose(surface.id)
+              }}
               className={cn(
                 'group flex h-7 min-w-0 max-w-40 shrink-0 items-center gap-1.5 rounded-md pl-2 pr-1 text-[13px] transition-colors',
                 '[&_svg]:size-3.5 [&_svg]:shrink-0',
@@ -305,6 +398,31 @@ function SurfaceTabStrip({
           </ContextMenu>
         )
       })}
+      {/* Add-surface "+" (t3code): opens/activates a Surface directly from the strip.
+          The store dedupes singletons, so picking an already-open kind just activates it. */}
+      <Menu>
+        <MenuTrigger
+          aria-label="Open a surface"
+          className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted outline-none transition-colors hover:bg-accent/10 hover:text-text-strong focus-visible:bg-accent/10"
+        >
+          <Plus className="size-4" aria-hidden />
+        </MenuTrigger>
+        <MenuContent align="start">
+          {CARDS.map((card) => (
+            <MenuItem
+              key={card.label}
+              disabled={!card.live}
+              onClick={card.live ? () => onOpen(card.target as SingletonKind) : undefined}
+            >
+              <span className="flex items-center gap-2 [&_svg]:size-4 [&_svg]:shrink-0 [&_svg]:text-muted">
+                {card.icon}
+                {card.label}
+                {!card.live && <span className="text-[11px] font-medium text-faint">Soon</span>}
+              </span>
+            </MenuItem>
+          ))}
+        </MenuContent>
+      </Menu>
     </div>
   )
 }
@@ -314,6 +432,7 @@ interface CardDef {
   /** The live Surface it opens, or a reserved slot with no Surface kind yet. */
   target: SingletonKind | 'terminal' | 'browser'
   label: string
+  description: string
   icon: ReactNode
   /** The keyboard-shortcut hint (aspirational chrome for the inert Browser card). */
   hint?: string
@@ -321,33 +440,65 @@ interface CardDef {
 }
 
 const CARDS: readonly CardDef[] = [
-  { target: 'review', label: 'Review', icon: <FileDiff aria-hidden />, hint: '⌃⇧G', live: true },
-  { target: 'terminal', label: 'Terminal', icon: <SquareTerminal aria-hidden />, live: false },
-  { target: 'browser', label: 'Browser', icon: <Globe aria-hidden />, hint: '⌘T', live: false },
-  { target: 'files', label: 'Files', icon: <Files aria-hidden />, hint: '⌘P', live: true },
+  {
+    target: 'review',
+    label: 'Review',
+    description: 'Inspect and commit working-tree changes.',
+    icon: <FileDiff aria-hidden />,
+    hint: '⌃⇧G',
+    live: true,
+  },
+  {
+    target: 'terminal',
+    label: 'Terminal',
+    description: 'Run commands in the Workspace.',
+    icon: <SquareTerminal aria-hidden />,
+    live: false,
+  },
+  {
+    target: 'browser',
+    label: 'Browser',
+    description: 'Preview a local dev server.',
+    icon: <Globe aria-hidden />,
+    hint: '⌘T',
+    live: false,
+  },
+  {
+    target: 'files',
+    label: 'Files',
+    description: 'Browse and preview Workspace files.',
+    icon: <Files aria-hidden />,
+    hint: '⌘P',
+    live: true,
+  },
 ]
 
 /**
- * The launcher-card EMPTY STATE (panel open, zero Surfaces): full-width rounded launcher
- * rows on the panel background, top-aligned (leading icon + label, trailing shortcut hint).
- * Live cards open their Surface; the inert Terminal/Browser cards are disabled + tagged
- * "Soon" (the sidebar PlaceholderNav precedent). Opening one replaces the cards with the
- * tab strip; closing the last tab returns here.
+ * The launcher EMPTY STATE (panel open, zero Surfaces) — t3code's `RightPanelEmptyState`:
+ * a centered "Open a surface" heading over a 2-column grid of cards (leading icon, label +
+ * shortcut hint, a short description). Live cards open their Surface; the inert Terminal/
+ * Browser cards are disabled + tagged "Soon" (the sidebar PlaceholderNav precedent).
+ * Opening one replaces the grid with the tab strip; closing the last tab returns here.
  */
-function LauncherCards({ onOpen }: { onOpen: (kind: SingletonKind) => void }): JSX.Element {
+function LauncherGrid({ onOpen }: { onOpen: (kind: SingletonKind) => void }): JSX.Element {
   return (
-    <aside
-      aria-label="Side panel"
-      className="flex w-80 shrink-0 flex-col gap-2 self-stretch border-l border-border bg-panel p-3 text-text"
-    >
-      {CARDS.map((card) => (
-        <LauncherCard
-          key={card.label}
-          card={card}
-          onClick={card.live ? () => onOpen(card.target as SingletonKind) : undefined}
-        />
-      ))}
-    </aside>
+    <div className="flex min-h-0 flex-1 items-center justify-center overflow-y-auto p-6">
+      <div className="w-full max-w-xl">
+        <div className="mb-5 text-center">
+          <h3 className="text-sm font-medium text-text-strong">Open a surface</h3>
+          <p className="mt-1 text-xs text-muted">Choose what to show in the side panel.</p>
+        </div>
+        <div className="grid grid-cols-2 gap-2">
+          {CARDS.map((card) => (
+            <LauncherCard
+              key={card.label}
+              card={card}
+              onClick={card.live ? () => onOpen(card.target as SingletonKind) : undefined}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
   )
 }
 
@@ -366,19 +517,22 @@ function LauncherCard({ card, onClick }: { card: CardDef; onClick?: () => void }
       aria-disabled={inert || undefined}
       title={inert ? 'Coming soon' : card.label}
       className={cn(
-        'flex w-full items-center gap-3 rounded-xl border border-border bg-surface px-3 py-2.5 text-left text-[14px] text-text outline-none transition-colors',
-        '[&_svg]:size-[18px] [&_svg]:shrink-0 [&_svg]:text-muted',
+        'flex min-h-28 w-full flex-col items-start rounded-lg border border-border bg-surface p-4 text-left outline-none transition-colors',
+        '[&_svg]:size-5 [&_svg]:shrink-0 [&_svg]:text-muted',
         inert
-          ? 'cursor-default opacity-60'
+          ? 'cursor-default opacity-50'
           : 'hover:bg-accent/10 focus-visible:bg-accent/10 [&_svg]:hover:text-text-strong',
       )}
     >
-      {card.icon}
-      <span className="min-w-0 flex-1 truncate font-medium">{card.label}</span>
-      {card.hint && (
-        <kbd className="shrink-0 rounded-md px-1 text-[11px] font-medium tabular-nums text-faint">{card.hint}</kbd>
-      )}
-      {inert && <span className="shrink-0 text-[11px] font-medium text-faint">Soon</span>}
+      <span className="mb-3">{card.icon}</span>
+      <span className="flex w-full items-center gap-2">
+        <span className="min-w-0 flex-1 truncate text-sm font-medium text-text">{card.label}</span>
+        {card.hint && (
+          <kbd className="shrink-0 rounded-md text-[11px] font-medium tabular-nums text-faint">{card.hint}</kbd>
+        )}
+        {inert && <span className="shrink-0 text-[11px] font-medium text-faint">Soon</span>}
+      </span>
+      <span className="mt-1 text-xs leading-relaxed text-muted">{card.description}</span>
     </button>
   )
 }

--- a/src/renderer/src/side-panel/panel-width-store.test.ts
+++ b/src/renderer/src/side-panel/panel-width-store.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  clampPanelWidth,
+  DEFAULT_PANEL_WIDTH,
+  getPanelWidth,
+  MAX_PANEL_WIDTH_PX,
+  maxPanelWidth,
+  MIN_PANEL_WIDTH,
+  PANEL_WIDTH_STORAGE_KEY,
+  setPanelWidth,
+  type PanelWidthStorage,
+} from './panel-width-store'
+
+/** A wide-desktop viewport where the 0.7 fraction (1344) is the binding ceiling. */
+const VIEWPORT = 1920
+
+/** A throwaway in-memory Storage seam for the tests. */
+function fakeStorage(
+  seed?: Record<string, string>,
+): PanelWidthStorage & { map: Map<string, string> } {
+  const map = new Map<string, string>(Object.entries(seed ?? {}))
+  return {
+    map,
+    getItem: (k) => map.get(k) ?? null,
+    setItem: (k, v) => void map.set(k, v),
+  }
+}
+
+describe('maxPanelWidth', () => {
+  it('takes 70% of the viewport when below the hard ceiling', () => {
+    expect(maxPanelWidth(1000)).toBe(700)
+    expect(maxPanelWidth(VIEWPORT)).toBe(Math.floor(VIEWPORT * 0.7))
+  })
+
+  it('hard-caps at MAX_PANEL_WIDTH_PX on very wide viewports', () => {
+    expect(maxPanelWidth(4000)).toBe(MAX_PANEL_WIDTH_PX)
+  })
+
+  it('never dips below MIN on a degenerate viewport (clamp range must not invert)', () => {
+    expect(maxPanelWidth(100)).toBe(MIN_PANEL_WIDTH)
+    expect(maxPanelWidth(0)).toBe(MIN_PANEL_WIDTH)
+  })
+
+  it('falls back to the hard ceiling on a non-finite viewport', () => {
+    expect(maxPanelWidth(Number.NaN)).toBe(MAX_PANEL_WIDTH_PX)
+    expect(maxPanelWidth(Number.POSITIVE_INFINITY)).toBe(MAX_PANEL_WIDTH_PX)
+  })
+})
+
+describe('clampPanelWidth', () => {
+  it('passes an in-range width through unchanged', () => {
+    expect(clampPanelWidth(DEFAULT_PANEL_WIDTH, VIEWPORT)).toBe(DEFAULT_PANEL_WIDTH)
+    expect(clampPanelWidth(800, VIEWPORT)).toBe(800)
+  })
+
+  it('clamps below the minimum up to MIN', () => {
+    expect(clampPanelWidth(MIN_PANEL_WIDTH - 100, VIEWPORT)).toBe(MIN_PANEL_WIDTH)
+    expect(clampPanelWidth(0, VIEWPORT)).toBe(MIN_PANEL_WIDTH)
+    expect(clampPanelWidth(-50, VIEWPORT)).toBe(MIN_PANEL_WIDTH)
+  })
+
+  it('clamps above the viewport-relative maximum', () => {
+    expect(clampPanelWidth(10_000, VIEWPORT)).toBe(maxPanelWidth(VIEWPORT))
+    expect(clampPanelWidth(900, 1000)).toBe(700)
+  })
+
+  it('falls back to the default (itself clamped) on a non-finite width', () => {
+    expect(clampPanelWidth(Number.NaN, VIEWPORT)).toBe(DEFAULT_PANEL_WIDTH)
+    // Viewport whose ceiling (~489) is under the default 540: fallback fits it.
+    expect(clampPanelWidth(Number.NaN, 700)).toBe(maxPanelWidth(700))
+  })
+})
+
+describe('getPanelWidth', () => {
+  it('returns the default when storage is missing or empty', () => {
+    expect(getPanelWidth(null, VIEWPORT)).toBe(DEFAULT_PANEL_WIDTH)
+    expect(getPanelWidth(undefined, VIEWPORT)).toBe(DEFAULT_PANEL_WIDTH)
+    expect(getPanelWidth(fakeStorage(), VIEWPORT)).toBe(DEFAULT_PANEL_WIDTH)
+  })
+
+  it('returns the stored width clamped to the current viewport', () => {
+    expect(getPanelWidth(fakeStorage({ [PANEL_WIDTH_STORAGE_KEY]: '640' }), VIEWPORT)).toBe(640)
+    // Persisted on a wide monitor, read back in a 1000px window: 0.7 ceiling binds.
+    expect(getPanelWidth(fakeStorage({ [PANEL_WIDTH_STORAGE_KEY]: '1300' }), 1000)).toBe(700)
+  })
+
+  it('falls back to the default on a corrupt value', () => {
+    expect(getPanelWidth(fakeStorage({ [PANEL_WIDTH_STORAGE_KEY]: 'garbage' }), VIEWPORT)).toBe(
+      DEFAULT_PANEL_WIDTH,
+    )
+  })
+
+  it('falls back to the default when the store throws', () => {
+    const storage: PanelWidthStorage = {
+      getItem: vi.fn(() => {
+        throw new Error('blocked')
+      }),
+      setItem: vi.fn(),
+    }
+    expect(getPanelWidth(storage, VIEWPORT)).toBe(DEFAULT_PANEL_WIDTH)
+  })
+})
+
+describe('setPanelWidth', () => {
+  it('persists the clamped width under the single key', () => {
+    const storage = fakeStorage()
+    setPanelWidth(storage, 10_000, VIEWPORT)
+    expect(storage.map.get(PANEL_WIDTH_STORAGE_KEY)).toBe(String(maxPanelWidth(VIEWPORT)))
+  })
+
+  it('tolerates a missing or throwing store', () => {
+    expect(() => setPanelWidth(null, 500, VIEWPORT)).not.toThrow()
+    const storage: PanelWidthStorage = {
+      getItem: vi.fn(),
+      setItem: vi.fn(() => {
+        throw new Error('quota')
+      }),
+    }
+    expect(() => setPanelWidth(storage, 500, VIEWPORT)).not.toThrow()
+  })
+})

--- a/src/renderer/src/side-panel/panel-width-store.ts
+++ b/src/renderer/src/side-panel/panel-width-store.ts
@@ -1,0 +1,95 @@
+/**
+ * The side panel's INLINE width in pixels (#drag-to-resize, t3code parity): a
+ * renderer-only, display-only number, exactly like the sidebar's width
+ * (`shell/sidebar-width-store.ts`) — pure UI chrome, so it lives in localStorage
+ * alone: no IPC, no main, no persistence store. Per-window, not per-Workspace
+ * (t3code persists its panel width the same way).
+ *
+ * Unlike the sidebar, the MAX is viewport-relative (t3code's rule): the panel may
+ * take at most 70% of the window, hard-capped at 1400px, so a huge stored width
+ * (or a drag on a wide monitor persisted before a window shrink) can never bury
+ * the conversation. The clamp therefore takes the CURRENT viewport width; when the
+ * viewport is so narrow the ceiling would dip under the floor, the floor wins
+ * (below ~980px the panel presents as a Sheet anyway).
+ *
+ * The storage seam is INJECTED so tests pass a fake and render code passes
+ * `window.localStorage`; every path tolerates an unavailable/throwing/corrupt
+ * store and falls back to the default.
+ */
+
+/** Narrowest the panel may be dragged (px) — t3code's 360. */
+export const MIN_PANEL_WIDTH = 360
+/** Hard ceiling regardless of viewport (px) — t3code's 1400. */
+export const MAX_PANEL_WIDTH_PX = 1400
+/** The panel may take at most this fraction of the viewport — t3code's 0.7. */
+export const MAX_PANEL_WIDTH_FRACTION = 0.7
+/** The default (and double-click reset) panel width (px) — t3code's 540. */
+export const DEFAULT_PANEL_WIDTH = 540
+
+/** The single localStorage key holding the side panel's inline width. */
+export const PANEL_WIDTH_STORAGE_KEY = 'vibe-mistro:side-panel-width:v1'
+
+/** The slice of the Web Storage API we depend on — `window.localStorage` satisfies it. */
+export interface PanelWidthStorage {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+}
+
+/**
+ * The effective maximum for a given viewport: `min(1400, floor(viewport * 0.7))`,
+ * but never below {@link MIN_PANEL_WIDTH} (a degenerate viewport must not invert
+ * the clamp range). A NaN/non-finite viewport falls back to the hard ceiling.
+ */
+export function maxPanelWidth(viewportWidth: number): number {
+  if (!Number.isFinite(viewportWidth)) return MAX_PANEL_WIDTH_PX
+  const fromViewport = Math.floor(viewportWidth * MAX_PANEL_WIDTH_FRACTION)
+  return Math.max(MIN_PANEL_WIDTH, Math.min(MAX_PANEL_WIDTH_PX, fromViewport))
+}
+
+/**
+ * Clamp a width to [MIN, maxPanelWidth(viewport)]. A NaN/non-finite width (e.g. a
+ * corrupt parse) falls back to {@link DEFAULT_PANEL_WIDTH} (itself clamped, so a
+ * narrow viewport still yields a fitting width). Pure — the single source of truth
+ * for "a valid panel width".
+ */
+export function clampPanelWidth(px: number, viewportWidth: number): number {
+  const max = maxPanelWidth(viewportWidth)
+  if (!Number.isFinite(px)) return Math.min(DEFAULT_PANEL_WIDTH, max)
+  if (px < MIN_PANEL_WIDTH) return MIN_PANEL_WIDTH
+  if (px > max) return max
+  return px
+}
+
+/**
+ * The persisted (clamped) panel width, or {@link DEFAULT_PANEL_WIDTH} when
+ * absent/unknown/unavailable. Never throws — a blocked/throwing/corrupt store must
+ * not trap the panel at a bad width.
+ */
+export function getPanelWidth(
+  storage: PanelWidthStorage | null | undefined,
+  viewportWidth: number,
+): number {
+  const fallback = clampPanelWidth(DEFAULT_PANEL_WIDTH, viewportWidth)
+  if (!storage) return fallback
+  try {
+    const raw = storage.getItem(PANEL_WIDTH_STORAGE_KEY)
+    if (!raw) return fallback
+    return clampPanelWidth(Number(raw), viewportWidth)
+  } catch {
+    return fallback
+  }
+}
+
+/** Persist the panel width (clamped) best-effort; a quota/security exception is swallowed. */
+export function setPanelWidth(
+  storage: PanelWidthStorage | null | undefined,
+  px: number,
+  viewportWidth: number,
+): void {
+  if (!storage) return
+  try {
+    storage.setItem(PANEL_WIDTH_STORAGE_KEY, String(clampPanelWidth(px, viewportWidth)))
+  } catch {
+    // Best-effort: a full/blocked storage must never throw from a resize drag.
+  }
+}


### PR DESCRIPTION
## What

Match the side panel to t3code's `PreviewPanelShell`/`RightPanelTabs` (#193 follow-up, ADR-0013 chrome):

- **Full-bleed shell**: `<main>` drops its `p-6` (moved into the chat column and wrappers around the Settings/transient/cold outlet views) so the panel is a full-height flush column to the window edges — `border-l` as the only separator.
- **Drag-resizable width**: new pure `side-panel/panel-width-store` (+14 tests) — default 540 / min 360 / max `min(1400px, 70% viewport)`, left-edge pointer-captured handle (the sidebar's #drag-to-resize pattern), persisted per-window on release, double-click resets.
- **Empty state**: centered "Open a surface" heading over a 2-col launcher card grid (icon, label, shortcut keycap, description); Terminal/Browser stay inert "Soon" cards.
- **Tab strip**: full panel width, plus t3code's add-surface "+" menu and middle-click-to-close; context menu + hover × unchanged.
- **Surfaces fill the shell**: ChangesPanel/FilesSurface/FilePreview drop their own `w-80`/`border-l` chrome; the Review list scrolls internally now that the column is viewport-height.

Sheet (narrow ≤980px) presentation unchanged. Not included (follow-ups): maximize control, tab auto-scroll-into-view.

## Gates

`bun run lint && bun run typecheck && bun run build && bun run test` — all green (916 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)