### PR TITLE
Composer narrow-column adaptivity + open old chats ready to resume

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -133,13 +133,31 @@ export function App(): JSX.Element {
 
   /**
    * Select a Thread from the sidebar (TB3 #48): pin it in nav (the single source of
-   * truth) and, for a connected Workspace, remember it as the active (kept-mounted)
-   * Thread so backgrounding the Workspace keeps it streaming.
+   * truth) and open it READY TO RESUME — no Continue step (#resume-on-first-prompt):
+   *
+   * - Connected Workspace: host the Thread live immediately (`open`). Conversation
+   *   hydrates its JSONL history for instant reading, the composer is ENABLED, and
+   *   its FIRST prompt resumes the stored session via main's `ensureBoundSession`
+   *   (`session/load`, re-binding fresh + "context reset" notice on failure) — the
+   *   exact lazy binding a draft uses, so reading stays free until you actually send.
+   * - No connection yet (cold app start / evicted agent): auto-continue — spawn-or-
+   *   reuse the Workspace agent seeded with THIS Thread (`continueColdThread`), the
+   *   same call the old Continue button made, just without the button.
+   * - Connecting / sign-in / error: nav-select only; the transient outlet resolves.
    */
   function selectThreadInWorkspace(workspaceId: string, threadId: string): void {
     navDispatch({ type: 'select-thread', workspaceId, threadId })
+    const status = connections[workspaceId]?.status
+    if (status === 'connected') {
+      wtDispatch({ type: 'open', workspaceId, threadId })
+      return
+    }
     if (workspaceThreadStateFor(workspaceThreads, workspaceId)) {
       wtDispatch({ type: 'select', workspaceId, threadId })
+    }
+    if (status === undefined) {
+      const meta = threadsForWorkspace(recents, workspaceId).find((t) => t.id === threadId)
+      if (meta) void continueColdThread(meta)
     }
   }
 

--- a/src/renderer/src/conversation/AgentControls.tsx
+++ b/src/renderer/src/conversation/AgentControls.tsx
@@ -38,7 +38,9 @@ export function AgentControls({
 }): JSX.Element | null {
   if (!modes && !models && !reasoningEffort) return null
   return (
-    <div className="flex flex-wrap items-center gap-1">
+    // min-w-0 + no wrap: in a narrow composer the chips SHRINK (labels truncate, see
+    // AgentControl) instead of wrapping into a stack that overflows the control row.
+    <div className="flex min-w-0 items-center gap-1">
       {modes && (
         <AgentControl
           label="Mode"
@@ -107,14 +109,19 @@ function AgentControl({
         aria-label={label}
         title={label}
         className={cn(
-          'inline-flex items-center gap-1.5 rounded-lg px-1.5 py-1 text-sm text-text-body outline-none transition-colors',
+          'inline-flex min-w-0 items-center gap-1.5 rounded-lg px-1.5 py-1 text-sm text-text-body outline-none transition-colors @max-[480px]:gap-1',
           'hover:text-accent-text',
           'disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:text-text-body',
           '[&_svg]:pointer-events-none [&_svg]:shrink-0',
         )}
       >
         {Icon && <Icon className="size-4 text-muted" aria-hidden />}
-        <span className="font-medium">{currentLabel}</span>
+        {/* truncate (not wrap): a long model id like "devstral-small" must never
+            line-break inside the chip; in a tight column it ellipsizes instead. Below
+            480px of composer width the label HIDES entirely — an empty truncated span
+            would still cost two flex gaps between icon and chevron — leaving a clean
+            icon+chevron chip (the trigger's title/aria-label still name it). */}
+        <span className="min-w-0 truncate font-medium @max-[480px]:hidden">{currentLabel}</span>
         <ChevronDown className="size-3.5 text-faint" aria-hidden />
       </MenuTrigger>
       <MenuContent align="start">

--- a/src/renderer/src/conversation/Composer.tsx
+++ b/src/renderer/src/conversation/Composer.tsx
@@ -254,9 +254,14 @@ export function Composer({
   }
 
   return (
-    <div className="mx-auto w-full max-w-[830px]">
-      <Card className="gap-0 p-0">
-        <div className="flex flex-col px-6 pt-[22px] pb-[14px]">
+    // @container: the composer adapts to ITS OWN width (container queries), not the
+    // viewport's — with the sidebar + side panel open the chat column narrows while
+    // the window stays wide, so viewport breakpoints would never fire.
+    <div className="mx-auto w-full max-w-[830px] @container">
+      {/* shadow-xs: a lighter lift than the Card default — the composer sits over the
+          transcript, so the full shadow-sm read as a heavy smudge under it. */}
+      <Card className="gap-0 p-0 shadow-xs">
+        <div className="flex flex-col px-6 pt-[22px] pb-[14px] @max-[480px]:px-4">
           {followUps.queued.length > 0 && (
             // Queued follow-ups (#105, ADR-0009): messages submitted while a turn
             // streams, auto-flushed one per turn end. Each row shows its text (or a
@@ -351,7 +356,9 @@ export function Composer({
 
           {/* Control row (prototype: 44px gap below the input). Attach + agent
               controls left; mic + interrupt + gradient send right. */}
-          <div className="mt-[44px] flex items-center gap-3.5">
+          {/* min-w-0 lets the AgentControls chips absorb the squeeze (they shrink +
+              truncate) so the send button NEVER leaves the card in a narrow column. */}
+          <div className="mt-[44px] flex min-w-0 items-center gap-3.5 @max-[560px]:gap-2">
             <IconButton
               size="icon-sm"
               aria-label="Attach images"
@@ -376,8 +383,9 @@ export function Composer({
 
             <div className="flex-1" />
 
-            {/* Decorative voice-input affordance from the prototype; not yet wired. */}
-            <Mic className="size-[19px] shrink-0 text-muted" aria-hidden />
+            {/* Decorative voice-input affordance from the prototype; not yet wired.
+                First thing to yield in a tight column (it does nothing yet). */}
+            <Mic className="size-[19px] shrink-0 text-muted @max-[400px]:hidden" aria-hidden />
 
             {isProcessing && boundSessionId && (
               // Interrupt the active turn (#103, ADR-0009): fire `session/cancel`. The
@@ -405,9 +413,9 @@ export function Composer({
               disabled={draft.trim().length === 0 && pendingImages.length === 0}
               aria-label={followUps.sending ? 'Queue message' : 'Send message'}
               title={followUps.sending ? 'Queue' : 'Send'}
-              className="inline-flex size-9 shrink-0 items-center justify-center rounded-full text-white shadow-[0_1px_2px_var(--accent-shadow)] outline-none transition-opacity [background:var(--accent-grad-action)] hover:opacity-90 disabled:cursor-default disabled:opacity-40"
+              className="inline-flex size-9 shrink-0 items-center justify-center rounded-full text-white shadow-[0_1px_2px_var(--accent-shadow)] outline-none transition-opacity [background:var(--accent-grad-action)] hover:opacity-90 disabled:cursor-default disabled:opacity-40 @max-[560px]:size-8"
             >
-              <ArrowUp className="size-5" aria-hidden />
+              <ArrowUp className="size-5 @max-[560px]:size-4" aria-hidden />
             </button>
           </div>
         </div>


### PR DESCRIPTION
Two follow-ups to #201/#202, verified in-app:

## fix(composer): adapt to a narrow column (container queries) + lighter shadow

With the sidebar and side panel both open, the chat column narrows while the window stays wide — viewport breakpoints never fire. The composer is now a `@container` adapting to its own width:

- Controls row gets a real shrink path (`min-w-0`): the send button never leaves the card.
- Mode/Model/Effort chips shrink + truncate instead of wrapping into a stack; below 480px they go icon-only (an empty truncated label still cost two flex gaps between icon and chevron — the reported spacing glitch).
- Send button steps 36→32px under 560px, matching the 32px stop/+ buttons in the mid-turn row; decorative mic hides under 400px.
- Composer card: `shadow-xs` instance override (other Cards keep `shadow-sm`).

## feat(threads): open old chats ready to resume — no Continue step

Clicking an old Thread no longer lands on the read-only history view with a Continue button:

- **Connected Workspace**: the Thread is hosted live immediately — instant JSONL history, composer enabled, and the first prompt resumes the stored session via `ensureBoundSession` (`session/load`; re-bind + "context reset" notice on failure). Reading stays free — no session touched until you send.
- **No agent yet**: auto-continue (the same `startThread({continueThreadId})` the button made).
- Connecting/sign-in/error states unchanged; ColdThread/ColdOutlet remain as edge-state fallbacks.

Accepted nuance (documented in `resolve-controls.ts`): a reopened Thread shows default Mode/Model until its first prompt's bind self-corrects.

## Gates

`bun run lint && bun run typecheck && bun run build && bun run test` — all green (916 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)