### PR TITLE
fix(composer): clear the input on send, not at turn end — restore on failure

### DIFF
--- a/src/renderer/src/conversation/Composer.tsx
+++ b/src/renderer/src/conversation/Composer.tsx
@@ -231,15 +231,24 @@ export function Composer({
       setPendingImages([])
       return
     }
-    // Idle: send now. `submitPrompt` echoes text/images by value up front, so we can
-    // clear the composer AFTER, but only on a successful outcome — preserving #100's
-    // clear-on-success / keep-on-failure (a failed send keeps text + staged images
-    // for retry, e.g. switching to a vision model).
+    // Idle: send now, clearing the composer OPTIMISTICALLY — `submitPrompt` resolves
+    // only when the whole turn ENDS (the IPC returns at the turn's stopReason), so a
+    // clear-after-await would hold the sent text in the input for the entire streamed
+    // response. The echo is already in the transcript; on a FAILED outcome we RESTORE
+    // the payload for retry (#100's keep-on-failure, e.g. switching to a vision model
+    // after -31008) — unless the user started composing something new meanwhile.
+    const staged = pendingImages
+    setPendingImages([])
+    setDraft('')
+    clearDraft(window.localStorage, threadId)
     const ok = await submitPrompt(text, images)
-    if (ok) {
-      setPendingImages([])
-      setDraft('')
-      clearDraft(window.localStorage, threadId)
+    if (!ok) {
+      setDraft((current) => {
+        if (current.length > 0) return current
+        persistDraft(window.localStorage, threadId, text)
+        return text
+      })
+      setPendingImages((current) => (current.length > 0 ? current : staged))
     }
   }
 


### PR DESCRIPTION
## What

Sending a message left the text in the composer until the agent's response finished streaming.

## Why

The composer cleared only after `await submitPrompt(...)`, which resolves at the turn's **stopReason** (main's `sendPrompt` IPC returns when the whole turn ends) — the clear-on-success/keep-on-failure guarantee from #100 accidentally held the input hostage for the turn's duration.

## How

Clear optimistically at send (the message is already echoed into the transcript). On a failed outcome, restore the text + staged images for retry — preserving the #100 keep-on-failure UX (e.g. switching to a vision model after `-31008`) — unless the user already started composing a new draft mid-turn, in which case the restore backs off. The queued-follow-up path already cleared immediately and is unchanged.

## Gates

`bun run lint && bun run typecheck && bun run build && bun run test` — all green (916 tests). Verified in-app: input empties on send while the response streams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)