### PR TITLE
feat(persistence): image attachments persist + replay cache (t3code cheap wins)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,6 +10,8 @@ import {
   type ListMetadataResult,
   type OpenThreadArgs,
   type ReadTranscriptResult,
+  type ReadThreadAttachmentsResult,
+  type TranscriptImageRef,
   type RemoveWorkspaceResult,
   type RespondPermissionArgs,
   type SendPromptArgs,
@@ -47,6 +49,7 @@ import {
   userPromptEntry,
 } from './persistence/transcript'
 import { TranscriptBridge } from './persistence/transcript-bridge'
+import { AttachmentStore } from './persistence/attachment-store'
 import { WorkspaceAgent, WorkspaceAgentError } from './workspace-agent'
 import { AgentPool } from './agent-pool'
 import { AgentActivity } from './agent-activity'
@@ -213,6 +216,8 @@ interface MainDeps {
   store: MetadataStore
   transcript: TranscriptStore | null
   bridge: TranscriptBridge
+  /** Null when the attachments dir `mkdir` failed — image persistence no-ops (logged). */
+  attachments: AttachmentStore | null
 }
 
 /**
@@ -511,10 +516,19 @@ async function runPromptTurn(
   // sending it, so it precedes the streamed events it triggers. We hold the
   // Thread id, so no bridge lookup — a draft's first prompt can't misroute to
   // another Thread. Main has no renderer item id, so mint an opaque replay key.
-  // v1 does NOT persist image base64 — the transcript tees text only (#100). Image
-  // attachments live only in the in-memory echo for this session's live view; a
-  // reopen replays the text-only prompt. Intentional for this slice.
-  deps.bridge.tee(args.threadId, userPromptEntry(randomUUID(), args.text))
+  //
+  // Image attachments persist FIRST (awaited: the refs must exist when the entry
+  // is appended, and the entry must precede the turn's `acp-event` tees — the
+  // TranscriptStore chain serializes in CALL order). `saveAll` never rejects; a
+  // failed/oversized image drops out of the refs and the prompt replays
+  // text-only. Skipped for a tombstoned Thread so a removeWorkspace racing this
+  // in-flight prompt can't re-create the attachments dir after its delete.
+  let imageRefs: TranscriptImageRef[] | undefined
+  if (deps.attachments && args.images?.length && !deps.bridge.isTombstoned(args.threadId)) {
+    imageRefs = await deps.attachments.saveAll(args.threadId, args.images)
+    if (imageRefs.length === 0) imageRefs = undefined
+  }
+  deps.bridge.tee(args.threadId, userPromptEntry(randomUUID(), args.text, imageRefs))
   // On a re-bind (TB4 #33), persist the "context reset" notice right AFTER the
   // user's prompt and BEFORE the turn's events — so a later reopen replays it
   // in the same position the live view rendered it (`thread:bound` -> notice).
@@ -848,6 +862,7 @@ function registerIpc(deps: MainDeps): void {
       threadId,
       store: deps.store,
       transcript: deps.transcript ?? { delete: () => Promise.resolve() },
+      attachments: deps.attachments ?? undefined,
       closeSession: bestEffortCloseFor(deps, threadId),
     })
     return { ok: true }
@@ -878,6 +893,7 @@ function registerIpc(deps: MainDeps): void {
         workspaceId,
         store: deps.store,
         transcript: deps.transcript ?? { delete: () => Promise.resolve() },
+        attachments: deps.attachments ?? undefined,
         // When a warm agent hosts this Workspace, stop it via the SAME path the
         // sweep/stop uses: `pool.dispose` (graceful teardown of hosted sessions) plus
         // `notifyAgentsEvicted` (clears the activity + transcript bridge + per-Thread
@@ -1001,6 +1017,18 @@ function registerIpc(deps: MainDeps): void {
     if (!deps.transcript) return Promise.resolve([])
     return deps.transcript.read(threadId)
   })
+
+  ipcMain.handle(
+    IPC.readThreadAttachments,
+    (_event, threadId: string): Promise<ReadThreadAttachmentsResult> => {
+      // The replay's batched image read: every persisted attachment of the Thread
+      // as `file -> data URL`, resolved against the `user-prompt` entries' refs.
+      // Called by the hydrate effect only when the transcript references images.
+      // A null store (dir mkdir failed) or an image-less Thread reads back {}.
+      if (!deps.attachments) return Promise.resolve({})
+      return deps.attachments.readAll(threadId)
+    },
+  )
 }
 
 app.whenReady().then(async () => {
@@ -1024,13 +1052,25 @@ app.whenReady().then(async () => {
     transcript = null
   }
 
+  // The per-Thread prompt-image attachments dir (sibling of the transcripts —
+  // the store mkdirs each Thread's subdir itself, but probe the root once here
+  // so a broken `userData` degrades to null exactly like the transcript store).
+  const attachmentsDir = join(app.getPath('userData'), 'attachments')
+  let attachments: AttachmentStore | null
+  try {
+    await mkdir(attachmentsDir, { recursive: true })
+    attachments = new AttachmentStore({ dir: attachmentsDir })
+  } catch {
+    attachments = null
+  }
+
   // The ACP-event -> Thread-JSONL router (see `TranscriptBridge`): primary route by
   // the event's own sessionId (via the store), fallback by the agent's active Thread.
   const bridge = new TranscriptBridge({
     sink: transcript,
     resolveBySession: (sessionId) => store.findThreadIdBySessionId(sessionId),
   })
-  const deps: MainDeps = { store, transcript, bridge }
+  const deps: MainDeps = { store, transcript, bridge, attachments }
 
   registerIpc(deps)
   createWindow()

--- a/src/main/persistence/attachment-store.test.ts
+++ b/src/main/persistence/attachment-store.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, afterAll, vi } from 'vitest'
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync, mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { AttachmentStore, MAX_ATTACHMENT_BYTES } from './attachment-store'
+
+/**
+ * The per-Thread prompt-image attachment files (ADR-0005 sibling of the JSONL
+ * transcript). Exercised over a REAL temp dir via the injectable fs seam,
+ * mirroring transcript.test.ts — no `userData`, no Electron.
+ */
+
+const dir = mkdtempSync(join(tmpdir(), 'vibe-attachments-'))
+afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+/** A 1x1 PNG's bytes, as the bare base64 our IPC carries. */
+const PNG_B64 = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).toString('base64')
+
+function storeAt(): AttachmentStore {
+  return new AttachmentStore({ dir })
+}
+
+describe('AttachmentStore saveAll', () => {
+  it('writes <threadId>/<uuid>.<ext> and roundtrips through readAll as a data URL', async () => {
+    const store = storeAt()
+    const refs = await store.saveAll('thread-rt', [
+      { data: PNG_B64, mimeType: 'image/png' },
+      { data: PNG_B64, mimeType: 'image/jpeg' },
+    ])
+
+    expect(refs).toHaveLength(2)
+    expect(refs[0].file).toMatch(/^[0-9a-f-]{36}\.png$/)
+    expect(refs[0].mimeType).toBe('image/png')
+    expect(refs[1].file).toMatch(/^[0-9a-f-]{36}\.jpg$/) // image/jpeg maps to .jpg
+    expect(readdirSync(join(dir, 'thread-rt')).sort()).toEqual([refs[0].file, refs[1].file].sort())
+
+    const all = await store.readAll('thread-rt')
+    expect(all[refs[0].file]).toBe(`data:image/png;base64,${PNG_B64}`)
+    expect(all[refs[1].file]).toBe(`data:image/jpeg;base64,${PNG_B64}`)
+  })
+
+  it('skips an unknown mime type and still persists the rest', async () => {
+    const store = storeAt()
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const refs = await store.saveAll('thread-mime', [
+      { data: PNG_B64, mimeType: 'image/tiff' },
+      { data: PNG_B64, mimeType: 'image/png' },
+    ])
+    errSpy.mockRestore()
+
+    expect(refs).toHaveLength(1)
+    expect(refs[0].mimeType).toBe('image/png')
+  })
+
+  it('skips an image over the per-image cap and still persists the rest', async () => {
+    const store = storeAt()
+    const oversized = Buffer.alloc(MAX_ATTACHMENT_BYTES + 1).toString('base64')
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const refs = await store.saveAll('thread-cap', [
+      { data: oversized, mimeType: 'image/png' },
+      { data: PNG_B64, mimeType: 'image/png' },
+    ])
+    errSpy.mockRestore()
+
+    expect(refs).toHaveLength(1)
+    expect(readdirSync(join(dir, 'thread-cap'))).toEqual([refs[0].file])
+  })
+
+  it('a failing write skips ONLY that image and never rejects', async () => {
+    let calls = 0
+    const store = new AttachmentStore({
+      dir,
+      writeFile: async (path, data) => {
+        calls += 1
+        if (calls === 1) throw new Error('disk full')
+        writeFileSync(path, data)
+      },
+    })
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const refs = await store.saveAll('thread-fail', [
+      { data: PNG_B64, mimeType: 'image/png' },
+      { data: PNG_B64, mimeType: 'image/webp' },
+    ])
+    errSpy.mockRestore()
+
+    expect(refs).toHaveLength(1)
+    expect(refs[0].mimeType).toBe('image/webp')
+  })
+
+  it('refuses a malformed threadId with no fs writes', async () => {
+    const writeFn = vi.fn()
+    const store = new AttachmentStore({ dir, writeFile: writeFn, mkdir: vi.fn() })
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const refs = await store.saveAll('../escape', [{ data: PNG_B64, mimeType: 'image/png' }])
+    errSpy.mockRestore()
+
+    expect(refs).toEqual([])
+    expect(writeFn).not.toHaveBeenCalled()
+  })
+})
+
+describe('AttachmentStore readAll', () => {
+  it('a Thread with no attachments dir reads back {}', async () => {
+    expect(await storeAt().readAll('thread-none')).toEqual({})
+  })
+
+  it('ignores foreign file names in the Thread dir', async () => {
+    const store = storeAt()
+    const refs = await store.saveAll('thread-foreign', [{ data: PNG_B64, mimeType: 'image/png' }])
+    writeFileSync(join(dir, 'thread-foreign', 'evil.sh'), '#!/bin/sh')
+    writeFileSync(join(dir, 'thread-foreign', 'notes.txt'), 'hi')
+
+    const all = await store.readAll('thread-foreign')
+    expect(Object.keys(all)).toEqual([refs[0].file])
+  })
+
+  it('omits an unreadable file but serves the rest', async () => {
+    mkdirSync(join(dir, 'thread-torn'), { recursive: true })
+    writeFileSync(join(dir, 'thread-torn', 'aaaa.png'), Buffer.from(PNG_B64, 'base64'))
+    writeFileSync(join(dir, 'thread-torn', 'bbbb.png'), Buffer.from(PNG_B64, 'base64'))
+    const store = new AttachmentStore({
+      dir,
+      readFile: async (path) => {
+        if (path.endsWith('aaaa.png')) throw new Error('EIO')
+        return Buffer.from(PNG_B64, 'base64')
+      },
+    })
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const all = await store.readAll('thread-torn')
+    errSpy.mockRestore()
+
+    expect(Object.keys(all)).toEqual(['bbbb.png'])
+  })
+
+  it('refuses a malformed threadId', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(await storeAt().readAll('../../etc')).toEqual({})
+    errSpy.mockRestore()
+  })
+})
+
+describe('AttachmentStore delete', () => {
+  it('removes the whole Thread dir; a missing dir is a no-op', async () => {
+    const store = storeAt()
+    await store.saveAll('thread-del', [{ data: PNG_B64, mimeType: 'image/png' }])
+    expect(existsSync(join(dir, 'thread-del'))).toBe(true)
+
+    await store.delete('thread-del')
+    expect(existsSync(join(dir, 'thread-del'))).toBe(false)
+
+    await expect(store.delete('thread-del')).resolves.toBeUndefined() // idempotent
+  })
+
+  it('a failing rm is swallowed (teardown never throws)', async () => {
+    const store = new AttachmentStore({
+      dir,
+      rm: async () => {
+        throw new Error('EPERM')
+      },
+    })
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    await expect(store.delete('thread-eperm')).resolves.toBeUndefined()
+    errSpy.mockRestore()
+  })
+})

--- a/src/main/persistence/attachment-store.ts
+++ b/src/main/persistence/attachment-store.ts
@@ -1,0 +1,216 @@
+import { mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import type { PromptImage, TranscriptImageRef } from '../../shared/ipc'
+
+/**
+ * The per-Thread prompt-image attachments we OWN (ADR-0005 sibling of the JSONL
+ * transcript). `runPromptTurn` persists a prompt's images here BEFORE teeing the
+ * `user-prompt` entry, so the entry's `images` refs point at files that already
+ * exist; on reopen the renderer resolves the refs back to data URLs via ONE
+ * batched `readThreadAttachments` and replays the prompt with its images. The
+ * LIVE send is untouched — the agent receives the base64 directly; these files
+ * exist only for our replay.
+ *
+ * SEAM CONTRACT (mirrors TranscriptStore): this class is the ONLY reader/writer
+ * of the attachment files. No other module may build an `attachments/<threadId>`
+ * path — the `userData` attachments dir is single-sourced in `src/main/index.ts`
+ * and injected here. Keep it that way so a future storage swap stays a drop-in.
+ *
+ * Every operation is best-effort and NEVER throws (ADR-0005): a failed image
+ * write degrades that image out of the returned refs (the prompt replays
+ * text-only), a failed read omits that image, and delete failures are swallowed
+ * — always logged, never gating the live turn or teardown.
+ */
+
+/**
+ * Per-image persistence cap (decoded bytes). Per-image, not per-thread: images
+ * arrive and fail per-image (vibe's own -31008 is per-image), and a per-thread
+ * budget would need cumulative bookkeeping for no real win — thread deletion
+ * already reclaims. An oversized image is simply not persisted (replays
+ * text-only); the live send is not our limit to enforce.
+ */
+export const MAX_ATTACHMENT_BYTES = 5 * 1024 * 1024
+
+/**
+ * Total-bytes cap on a `readAll` reply, so one pathological thread of
+ * screenshots can't blow the IPC payload. Files beyond it are omitted (logged).
+ */
+export const MAX_READ_ALL_BYTES = 64 * 1024 * 1024
+
+/**
+ * The persistable mime set — mirrors the renderer's `ACCEPTED_IMAGE_TYPES`
+ * (src/renderer/src/conversation/image-attach.ts). An unknown mime is skipped at
+ * save (nothing upstream should produce one; log if it happens).
+ */
+const EXT_BY_MIME: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/webp': 'webp',
+  'image/gif': 'gif',
+}
+const MIME_BY_EXT: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  webp: 'image/webp',
+  gif: 'image/gif',
+}
+
+/**
+ * Belt-and-suspenders vs path traversal: we mint every filename (uuid + mapped
+ * extension) and key dirs by our minted Thread ids, but validate BOTH on every
+ * entry point anyway — this store creates directories, so it hardens harder
+ * than `readTranscript` (which only ever reads `<threadId>.jsonl`).
+ */
+const THREAD_ID_RE = /^[A-Za-z0-9_-]+$/
+const FILE_NAME_RE = /^[A-Za-z0-9-]+\.(png|jpg|webp|gif)$/
+
+/**
+ * The injectable seam: where the attachment dirs live and how to touch the fs.
+ * Production wires `node:fs/promises` + a `userData` attachments dir; tests pass
+ * a temp dir (and may stub `writeFile` to simulate a failing disk), mirroring
+ * TranscriptStore.
+ */
+export interface AttachmentStoreDeps {
+  /** Directory holding the per-Thread subdirs (`<dir>/<threadId>/<file>`). */
+  dir: string
+  /** Create a Thread's subdir (recursive). Defaults to `fs.mkdir`. */
+  mkdir?: (path: string) => Promise<unknown>
+  /** Write one image file. Defaults to `fs.writeFile`. */
+  writeFile?: (path: string, data: Uint8Array) => Promise<void>
+  /** Read one image file. Defaults to `fs.readFile`. */
+  readFile?: (path: string) => Promise<Buffer>
+  /** List a Thread's subdir. Defaults to `fs.readdir`. */
+  readdir?: (path: string) => Promise<string[]>
+  /** Remove a Thread's whole subdir. Defaults to `fs.rm` (recursive + force). */
+  rm?: (path: string) => Promise<void>
+}
+
+export class AttachmentStore {
+  private readonly dir: string
+  private readonly mkdirFn: (path: string) => Promise<unknown>
+  private readonly writeFileFn: (path: string, data: Uint8Array) => Promise<void>
+  private readonly readFileFn: (path: string) => Promise<Buffer>
+  private readonly readdirFn: (path: string) => Promise<string[]>
+  private readonly rmFn: (path: string) => Promise<void>
+
+  constructor(deps: AttachmentStoreDeps) {
+    this.dir = deps.dir
+    this.mkdirFn = deps.mkdir ?? ((path) => mkdir(path, { recursive: true }))
+    this.writeFileFn = deps.writeFile ?? ((path, data) => writeFile(path, data))
+    this.readFileFn = deps.readFile ?? ((path) => readFile(path))
+    this.readdirFn = deps.readdir ?? ((path) => readdir(path))
+    this.rmFn = deps.rm ?? ((path) => rm(path, { recursive: true, force: true }))
+  }
+
+  /** Absolute path of a Thread's attachments subdir. */
+  private dirFor(threadId: string): string {
+    return join(this.dir, threadId)
+  }
+
+  /**
+   * Persist a prompt's images; returns the refs for the transcript's
+   * `user-prompt` entry. Best-effort PER IMAGE: an oversized, unknown-mime, or
+   * write-failed image is skipped (logged) and the rest still persist — the
+   * caller tees whatever survived. Always resolves; never throws (a persistence
+   * failure must never gate the live turn).
+   */
+  async saveAll(threadId: string, images: PromptImage[]): Promise<TranscriptImageRef[]> {
+    if (!THREAD_ID_RE.test(threadId)) {
+      console.error(`[vibe-mistro:attachments] saveAll refused malformed threadId: ${threadId}`)
+      return []
+    }
+    const refs: TranscriptImageRef[] = []
+    let dirReady = false
+    for (const image of images) {
+      try {
+        const ext = EXT_BY_MIME[image.mimeType]
+        if (!ext) {
+          console.error(`[vibe-mistro:attachments] skipped unknown mime ${image.mimeType} (${threadId})`)
+          continue
+        }
+        const bytes = Buffer.from(image.data, 'base64')
+        if (bytes.byteLength > MAX_ATTACHMENT_BYTES) {
+          console.error(
+            `[vibe-mistro:attachments] skipped oversized image (${bytes.byteLength} bytes) (${threadId})`,
+          )
+          continue
+        }
+        if (!dirReady) {
+          await this.mkdirFn(this.dirFor(threadId))
+          dirReady = true
+        }
+        const file = `${randomUUID()}.${ext}`
+        await this.writeFileFn(join(this.dirFor(threadId), file), bytes)
+        refs.push({ file, mimeType: image.mimeType })
+      } catch (err) {
+        console.error(
+          `[vibe-mistro:attachments] image write failed (${threadId}): ` +
+            `${err instanceof Error ? err.message : String(err)}`,
+        )
+      }
+    }
+    return refs
+  }
+
+  /**
+   * All of a Thread's attachments as `file name -> data URL` — the batched
+   * replay read. A missing subdir (image-less Thread) reads back `{}`; a foreign
+   * or unreadable file is omitted; past `MAX_READ_ALL_BYTES` total, the rest are
+   * omitted (logged) so the reply stays bounded. Never throws.
+   */
+  async readAll(threadId: string): Promise<Record<string, string>> {
+    if (!THREAD_ID_RE.test(threadId)) {
+      console.error(`[vibe-mistro:attachments] readAll refused malformed threadId: ${threadId}`)
+      return {}
+    }
+    let names: string[]
+    try {
+      names = await this.readdirFn(this.dirFor(threadId))
+    } catch {
+      return {} // ENOENT — the Thread has no attachments
+    }
+    const result: Record<string, string> = {}
+    let total = 0
+    for (const name of names) {
+      if (!FILE_NAME_RE.test(name)) continue // foreign file — not ours to serve
+      try {
+        const bytes = await this.readFileFn(join(this.dirFor(threadId), name))
+        total += bytes.byteLength
+        if (total > MAX_READ_ALL_BYTES) {
+          console.error(`[vibe-mistro:attachments] readAll capped at ${MAX_READ_ALL_BYTES} bytes (${threadId})`)
+          break
+        }
+        const mime = MIME_BY_EXT[name.slice(name.lastIndexOf('.') + 1)]
+        result[name] = `data:${mime};base64,${bytes.toString('base64')}`
+      } catch (err) {
+        console.error(
+          `[vibe-mistro:attachments] read failed (${threadId}/${name}): ` +
+            `${err instanceof Error ? err.message : String(err)}`,
+        )
+      }
+    }
+    return result
+  }
+
+  /**
+   * Drop the Thread's whole attachments subdir (thread delete / remove-Workspace
+   * teardown, alongside the transcript drop). Best-effort: a missing dir is a
+   * no-op (`force`), any failure is logged and swallowed — tearing down our
+   * records must never throw (ADR-0005).
+   */
+  async delete(threadId: string): Promise<void> {
+    if (!THREAD_ID_RE.test(threadId)) {
+      console.error(`[vibe-mistro:attachments] delete refused malformed threadId: ${threadId}`)
+      return
+    }
+    try {
+      await this.rmFn(this.dirFor(threadId))
+    } catch (err) {
+      console.error(
+        `[vibe-mistro:attachments] delete failed (${threadId}): ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+      )
+    }
+  }
+}

--- a/src/main/persistence/delete-thread.test.ts
+++ b/src/main/persistence/delete-thread.test.ts
@@ -71,6 +71,30 @@ describe('deleteThread (TB6 #35)', () => {
     expect(store.deleteThread).toHaveBeenCalledWith('t5')
   })
 
+  it('drops the attachments alongside the records when the seam is provided', async () => {
+    const { store, transcript } = fakes()
+    const attachments = { delete: vi.fn<AsyncId>(async () => {}) }
+
+    await deleteThread({ threadId: 't6', store, transcript, attachments })
+
+    expect(attachments.delete).toHaveBeenCalledWith('t6')
+  })
+
+  it('RESOLVES even when the attachments removal rejects (best-effort)', async () => {
+    const { store, transcript } = fakes()
+    const attachments = {
+      delete: vi.fn<AsyncId>(async () => {
+        throw new Error('EPERM')
+      }),
+    }
+
+    await expect(
+      deleteThread({ threadId: 't7', store, transcript, attachments }),
+    ).resolves.toBeUndefined()
+    expect(store.deleteThread).toHaveBeenCalledWith('t7')
+    expect(transcript.delete).toHaveBeenCalledWith('t7')
+  })
+
   it('still completes the deletion when the best-effort close REJECTS (no error surfaced)', async () => {
     const { store, transcript } = fakes()
     const closeSession = vi.fn(async () => {

--- a/src/main/persistence/delete-thread.ts
+++ b/src/main/persistence/delete-thread.ts
@@ -27,10 +27,17 @@ export interface DeleteThreadTranscript {
   delete(threadId: string): Promise<void>
 }
 
+/** The attachments surface needed to drop a Thread's image files (missing = no-op). */
+export interface DeleteThreadAttachments {
+  delete(threadId: string): Promise<void>
+}
+
 export interface DeleteThreadArgs {
   threadId: string
   store: DeleteThreadStore
   transcript: DeleteThreadTranscript
+  /** Omitted when the attachments dir failed to create at startup (null store). */
+  attachments?: DeleteThreadAttachments
   /**
    * Best-effort close of the Thread's live ACP session, when one is hosted on an
    * active agent. Omitted for a cold Thread / unbound draft (nothing to close).
@@ -62,5 +69,12 @@ export async function deleteThread(args: DeleteThreadArgs): Promise<void> {
   } catch {
     // A transcript unlink failure is non-fatal (the store already swallows ENOENT;
     // this guards the injected/no-op seam and any unexpected reject too).
+  }
+  if (args.attachments) {
+    try {
+      await args.attachments.delete(args.threadId)
+    } catch {
+      // An attachments removal failure is non-fatal — same guard as the transcript.
+    }
   }
 }

--- a/src/main/persistence/remove-workspace.test.ts
+++ b/src/main/persistence/remove-workspace.test.ts
@@ -35,6 +35,32 @@ describe('removeWorkspace ("Remove project")', () => {
     expect(transcript.delete).toHaveBeenCalledTimes(2)
   })
 
+  it('drops each removed Thread\'s attachments when the seam is provided', async () => {
+    const { store, transcript } = fakes(['t1', 't2'])
+    const attachments = { delete: vi.fn<DeleteFn>(async () => {}) }
+
+    await removeWorkspace({ workspaceId: 'w1', store, transcript, attachments })
+
+    expect(attachments.delete).toHaveBeenCalledWith('t1')
+    expect(attachments.delete).toHaveBeenCalledWith('t2')
+    expect(attachments.delete).toHaveBeenCalledTimes(2)
+  })
+
+  it('a rejecting attachments removal never rejects the orchestration nor skips the rest', async () => {
+    const { store, transcript } = fakes(['t1', 't2'])
+    const attachments = {
+      delete: vi.fn<DeleteFn>(async (threadId) => {
+        if (threadId === 't1') throw new Error('EPERM')
+      }),
+    }
+
+    await expect(
+      removeWorkspace({ workspaceId: 'w1', store, transcript, attachments }),
+    ).resolves.toBeUndefined()
+    expect(attachments.delete).toHaveBeenCalledWith('t2')
+    expect(transcript.delete).toHaveBeenCalledTimes(2)
+  })
+
   it('stops the agent BEFORE touching the store when a warm agent is present', async () => {
     const { store, transcript } = fakes(['t1'])
     const order: string[] = []

--- a/src/main/persistence/remove-workspace.ts
+++ b/src/main/persistence/remove-workspace.ts
@@ -27,10 +27,17 @@ export interface RemoveWorkspaceTranscript {
   delete(threadId: string): Promise<void>
 }
 
+/** The attachments surface needed to drop one Thread's image files (missing = no-op). */
+export interface RemoveWorkspaceAttachments {
+  delete(threadId: string): Promise<void>
+}
+
 export interface RemoveWorkspaceArgs {
   workspaceId: string
   store: RemoveWorkspaceStore
   transcript: RemoveWorkspaceTranscript
+  /** Omitted when the attachments dir failed to create at startup (null store). */
+  attachments?: RemoveWorkspaceAttachments
   /**
    * Best-effort clean stop of the Workspace's LIVE warm agent, when one is warm.
    * Omitted for a cold Workspace (nothing to stop). Any rejection is swallowed — a
@@ -66,6 +73,13 @@ export async function removeWorkspace(args: RemoveWorkspaceArgs): Promise<void> 
       await args.transcript.delete(threadId)
     } catch {
       // A transcript unlink failure is non-fatal — continue with the rest.
+    }
+    if (args.attachments) {
+      try {
+        await args.attachments.delete(threadId)
+      } catch {
+        // An attachments removal failure is non-fatal — continue with the rest.
+      }
     }
   }
 }

--- a/src/main/persistence/transcript-bridge.test.ts
+++ b/src/main/persistence/transcript-bridge.test.ts
@@ -89,4 +89,12 @@ describe('TranscriptBridge.tee', () => {
     b.tee('t2', ENTRY) // other Threads unaffected
     expect(appended).toEqual([{ threadId: 't2' }])
   })
+
+  it('exposes the tombstone via isTombstoned so sibling persistence can skip alongside', () => {
+    const b = bridge()
+    expect(b.isTombstoned('t1')).toBe(false)
+    b.tombstone('t1')
+    expect(b.isTombstoned('t1')).toBe(true)
+    expect(b.isTombstoned('t2')).toBe(false)
+  })
 })

--- a/src/main/persistence/transcript-bridge.ts
+++ b/src/main/persistence/transcript-bridge.ts
@@ -73,6 +73,16 @@ export class TranscriptBridge {
     this.tombstoned.add(threadId)
   }
 
+  /**
+   * Whether a Thread is tombstoned — lets sibling persistence (the attachment
+   * save in `runPromptTurn`) skip alongside the suppressed tee, so a
+   * removeWorkspace racing an in-flight prompt can't re-create the Thread's
+   * attachments dir after its delete (same hazard class the tee guard closes).
+   */
+  isTombstoned(threadId: string): boolean {
+    return this.tombstoned.has(threadId)
+  }
+
   /** Resolve the Thread id for a chokepoint, or null to skip the tee (best-effort). */
   threadIdFor(agentId: string, sessionId?: string | null): string | null {
     return this.deps.resolveBySession(sessionId ?? null) ?? this.threads.get(agentId) ?? null

--- a/src/main/persistence/transcript.test.ts
+++ b/src/main/persistence/transcript.test.ts
@@ -123,6 +123,29 @@ describe('TranscriptStore read / parseTranscript', () => {
     const read = await store.read(id)
     expect(read).toEqual([{ t: 'user-prompt', id: 'u1', text: 'hi' }])
   })
+
+  it('parses a user-prompt WITH image refs and a legacy one WITHOUT, side by side', () => {
+    // The additive optional `images` needs no schema-version bump: the guard
+    // discriminates on `t` alone, so legacy lines and new lines coexist in one log.
+    const raw =
+      '{"t":"user-prompt","id":"u1","text":"old"}\n' +
+      '{"t":"user-prompt","id":"u2","text":"new","images":[{"file":"a.png","mimeType":"image/png"}]}\n'
+
+    expect(parseTranscript(raw)).toEqual([
+      { t: 'user-prompt', id: 'u1', text: 'old' },
+      { t: 'user-prompt', id: 'u2', text: 'new', images: [{ file: 'a.png', mimeType: 'image/png' }] },
+    ])
+  })
+})
+
+describe('userPromptEntry images', () => {
+  it('carries the refs when given, and omits the field entirely when absent or empty', () => {
+    const refs = [{ file: 'a.png', mimeType: 'image/png' }]
+    expect(userPromptEntry('u1', 'hi', refs)).toEqual({ t: 'user-prompt', id: 'u1', text: 'hi', images: refs })
+    // Legacy byte-identical shape — no `images` key, not even undefined.
+    expect(userPromptEntry('u2', 'hi')).toEqual({ t: 'user-prompt', id: 'u2', text: 'hi' })
+    expect('images' in userPromptEntry('u3', 'hi', [])).toBe(false)
+  })
 })
 
 describe('TranscriptStore schema versioning (ADR-0005 hardening)', () => {

--- a/src/main/persistence/transcript.ts
+++ b/src/main/persistence/transcript.ts
@@ -1,6 +1,6 @@
 import { appendFile, readFile, unlink } from 'node:fs/promises'
 import { join } from 'node:path'
-import type { TranscriptEntry } from '../../shared/ipc'
+import type { TranscriptEntry, TranscriptImageRef } from '../../shared/ipc'
 
 /**
  * The per-Thread visible-conversation transcript we OWN (ADR-0005). The main
@@ -60,9 +60,18 @@ export function transcriptVersionOf(raw: string): number {
   return TRANSCRIPT_SCHEMA_VERSION
 }
 
-/** The user's prompt, teed at `sendPrompt` — mirrors the `send-prompt` action. */
-export function userPromptEntry(id: string, text: string): TranscriptEntry {
-  return { t: 'user-prompt', id, text }
+/**
+ * The user's prompt, teed at `sendPrompt` — mirrors the `send-prompt` action.
+ * `images` are the refs of the prompt's attachments already persisted by the
+ * `AttachmentStore` (omitted entirely when none survived — an image-less entry
+ * stays byte-identical to the legacy shape).
+ */
+export function userPromptEntry(
+  id: string,
+  text: string,
+  images?: TranscriptImageRef[],
+): TranscriptEntry {
+  return images && images.length > 0 ? { t: 'user-prompt', id, text, images } : { t: 'user-prompt', id, text }
 }
 
 /** A streamed payload, teed at the `acp:event` forward — mirrors `acp-event`. */

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -26,6 +26,7 @@ import {
   type GitStatusSubscriptionArgs,
   type ListMetadataResult,
   type ReadTranscriptResult,
+  type ReadThreadAttachmentsResult,
   type RemoveWorkspaceResult,
   type RespondPermissionArgs,
   type OpenThreadArgs,
@@ -98,6 +99,8 @@ const api = {
     ipcRenderer.invoke(IPC.setThreadTitle, args),
   readTranscript: (threadId: string): Promise<ReadTranscriptResult> =>
     ipcRenderer.invoke(IPC.readTranscript, threadId),
+  readThreadAttachments: (threadId: string): Promise<ReadThreadAttachmentsResult> =>
+    ipcRenderer.invoke(IPC.readThreadAttachments, threadId),
   gitSubscribeStatus: (args: GitStatusSubscriptionArgs): Promise<void> =>
     ipcRenderer.invoke(IPC.gitSubscribeStatus, args),
   gitUnsubscribeStatus: (args: GitStatusSubscriptionArgs): Promise<void> =>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -28,6 +28,7 @@ import { useThreadControls } from './connection/use-thread-controls'
 import { useWorkspaceActions } from './connection/use-workspace-actions'
 import { resolveActiveControls } from './connection/resolve-controls'
 import { setThreadStatus, type ThreadStatusMap } from './conversation/thread-status'
+import { replayCache, wireReplayCacheInvalidation } from './conversation/replay-cache'
 import { setWorkspaceControls, workspaceControlsKey } from './connection/workspace-controls-store'
 import { ArrowLeft, ArrowRight, Maximize2, PanelLeft, PanelRight, Terminal } from 'lucide-react'
 import { IconButton } from './ui/icon-button'
@@ -314,6 +315,12 @@ export function App(): JSX.Element {
       void refreshRecents()
     })
   }, [])
+
+  // Wire the replay-cache invalidation ONCE: any acp:event session-tagged to a
+  // cached (unmounted) Thread means main teed to its transcript behind our back,
+  // and a thread:title push covers the cold store-only rename — both dirty the
+  // entry so the next mount replays fresh instead of hydrating stale.
+  useEffect(() => wireReplayCacheInvalidation(replayCache, window.api), [])
 
   /**
    * Select a Workspace from the sidebar: pin it in the nav reducer and

--- a/src/renderer/src/connection/use-workspace-actions.ts
+++ b/src/renderer/src/connection/use-workspace-actions.ts
@@ -3,6 +3,7 @@ import type { ListMetadataResult, ThreadMeta } from '../../../shared/ipc'
 import type { NavAction, NavState } from '../shell/nav-reducer'
 import { clearThreadStatus, type ThreadStatusMap } from '../conversation/thread-status'
 import { clearDraft } from '../conversation/composer-draft-store'
+import { replayCache } from '../conversation/replay-cache'
 import { removeWorkspacePanel } from '../side-panel/side-panel-store'
 import { agentIdOf, type ConnectionAction, type ConnectionMap } from './connections'
 import {
@@ -74,6 +75,8 @@ export function useWorkspaceActions(deps: WorkspaceActionsDeps): WorkspaceAction
       deps.setStatuses((prev) => clearThreadStatus(prev, thread.id))
       // Drop the deleted Thread's persisted composer draft (#60) — no orphaned text.
       clearDraft(deps.storage, thread.id)
+      // And its cached replay view — a re-created Thread id must never see it.
+      replayCache.invalidate(thread.id)
       await deps.refreshRecents()
     },
 
@@ -108,6 +111,8 @@ export function useWorkspaceActions(deps: WorkspaceActionsDeps): WorkspaceAction
       // Drop the side-panel entry too (#193): workspaceIds are fresh UUIDs, so a removed
       // Workspace's open-tabs blob would otherwise sit unreachable in localStorage forever.
       removeWorkspacePanel(workspaceId)
+      // And every removed Thread's cached replay view.
+      replayCache.invalidateByWorkspace(workspaceId)
       await deps.refreshRecents()
     },
 
@@ -142,6 +147,11 @@ export function useWorkspaceActions(deps: WorkspaceActionsDeps): WorkspaceAction
         sessionId: thread.sessionId,
       })
       if (!result.ok) return
+      // A cached replay view carries the OLD title in `state.title`, which would
+      // beat the fresh metadata title on the next mount — drop it. (The
+      // `thread:title` wire also covers pushes main initiates; this covers the
+      // rename WE initiated without depending on an echo.)
+      replayCache.invalidate(thread.id)
       await deps.refreshRecents()
     },
   }

--- a/src/renderer/src/conversation/ColdThread.tsx
+++ b/src/renderer/src/conversation/ColdThread.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState, type JSX } from 'react'
+import { useEffect, useRef, useState, type JSX } from 'react'
 import type { ThreadMeta } from '../../../shared/ipc'
 import { Item } from './items/Item'
 import { UsageBar } from './items/UsageBar'
 import { initialConversationState, type ConversationState } from './reducer'
-import { replayTranscript } from './replay'
+import { replayTranscript, transcriptHasImages } from './replay'
+import { replayCache } from './replay-cache'
 
 /**
  * A reopened Thread rendered READ-ONLY from its persisted JSONL (ADR-0005, TB3
@@ -28,17 +29,52 @@ export function ColdThread({
 }): JSX.Element {
   // null = still loading; a ConversationState once the transcript has replayed.
   const [state, setState] = useState<ConversationState | null>(null)
+  // Mirror for the unmount snapshot (a cleanup closes over the first render's
+  // `state` otherwise). `null` (read never resolved) is never cached.
+  const stateRef = useRef(state)
+  stateRef.current = state
 
-  // Fetch + replay once per Thread. Reads only — no agent is started here.
+  // Fetch + replay once per Thread — cache first (take = consume), so a
+  // switch-back within the LRU window skips the IPC + re-fold entirely.
+  // Reads only — no agent is started here.
   useEffect(() => {
+    const cached = replayCache.take(thread.id)
+    if (cached) {
+      // Sync the snapshot mirror NOW, not at the re-render: an unmount landing
+      // before the render (StrictMode's dev double-mount) would otherwise see
+      // `null` and drop the consumed entry instead of putting it back.
+      stateRef.current = cached.state
+      setState(cached.state)
+      return
+    }
     let active = true
-    void window.api.readTranscript(thread.id).then((entries) => {
-      if (active) setState(replayTranscript(entries))
+    void window.api.readTranscript(thread.id).then(async (entries) => {
+      // Resolve persisted image attachments (one batched IPC) ONLY when the
+      // transcript references any — an image-less reopen costs nothing extra.
+      const attachments = transcriptHasImages(entries)
+        ? await window.api.readThreadAttachments(thread.id)
+        : undefined
+      if (active) setState(replayTranscript(entries, attachments))
     })
     return () => {
       active = false
     }
   }, [thread.id])
+
+  // Unmount snapshot: a replayed cold view is settled by construction (no live
+  // turn here — `isProcessing` is forced false by replay), so cache it for the
+  // next open. A still-loading view (`null`) is never cached.
+  useEffect(() => {
+    return () => {
+      if (stateRef.current !== null) {
+        replayCache.put(thread.id, {
+          state: stateRef.current,
+          sessionId: thread.sessionId,
+          workspaceId: thread.workspaceId,
+        })
+      }
+    }
+  }, [thread.id, thread.sessionId, thread.workspaceId])
 
   const view = state ?? initialConversationState
   const title = view.title ?? thread.title ?? 'Untitled thread'

--- a/src/renderer/src/conversation/Conversation.tsx
+++ b/src/renderer/src/conversation/Conversation.tsx
@@ -17,7 +17,8 @@ import {
   type PermissionOption,
 } from './reducer'
 import { eventBelongsToThread } from './event-routing'
-import { replayTranscript } from './replay'
+import { replayTranscript, transcriptHasImages } from './replay'
+import { replayCache } from './replay-cache'
 import { MessageScroller } from './MessageScroller'
 import { Item } from './items/Item'
 import { UsageBar } from './items/UsageBar'
@@ -104,6 +105,15 @@ export function Conversation({
   // True once any live event has been folded in: guards the async hydrate from
   // clobbering events that streamed in before the JSONL read resolved.
   const liveSeen = useRef(false)
+  // True once this view holds real history (a cache hit, a resolved transcript
+  // read — even an empty one — or a live event): the unmount snapshot below may
+  // only cache a HYDRATED view, else an instant switch-away before the read
+  // resolved would cache an empty state and replay a non-empty Thread as empty.
+  const hydratedRef = useRef(false)
+  // Mirror of the reducer state for the unmount snapshot (an unmount cleanup
+  // closes over the FIRST render's `state` otherwise). Fresh per key-remount.
+  const stateRef = useRef(state)
+  stateRef.current = state
 
   // The follow-up queue for THIS Thread (#105, ADR-0009): submitting while a turn
   // streams enqueues here (the queue lives in a module store ABOVE this remount, so
@@ -119,16 +129,56 @@ export function Conversation({
   // `liveSeen` guard keeps a late hydrate from clobbering resumed live events, but
   // the brief early-history gap on such a reopen is accepted for this slice.
   useEffect(() => {
+    // Cache first (take = consume — the mounted view owns the state from here):
+    // a switch-back within the LRU window hydrates instantly, no IPC, no re-fold.
+    const cached = replayCache.take(thread.threadId)
+    if (cached) {
+      hydratedRef.current = true
+      // Sync the snapshot mirror NOW, not at the re-render: an unmount landing
+      // between this dispatch and its render (StrictMode's dev double-mount
+      // does exactly that) would otherwise snapshot the still-initial state and
+      // poison the cache with an empty view for this Thread.
+      stateRef.current = cached.state
+      dispatch({ type: 'hydrate', state: cached.state })
+      return
+    }
     let active = true
-    void window.api.readTranscript(thread.threadId).then((entries) => {
+    void window.api.readTranscript(thread.threadId).then(async (entries) => {
+      // Resolve persisted image attachments (one batched IPC) ONLY when the
+      // transcript references any — an image-less reopen costs nothing extra.
+      const attachments = transcriptHasImages(entries)
+        ? await window.api.readThreadAttachments(thread.threadId)
+        : undefined
       if (!active || liveSeen.current) return
-      const replayed = replayTranscript(entries)
-      if (replayed.items.length > 0) dispatch({ type: 'hydrate', state: replayed })
+      // Hydrated even when the transcript is EMPTY — a legitimately empty
+      // Thread may cache as empty; only an unresolved read must not.
+      hydratedRef.current = true
+      const replayed = replayTranscript(entries, attachments)
+      if (replayed.items.length > 0) {
+        stateRef.current = replayed // pre-render sync, same poison guard as above
+        dispatch({ type: 'hydrate', state: replayed })
+      }
     })
     return () => {
       active = false
     }
   }, [thread.threadId])
+
+  // Unmount snapshot: give the folded view back to the cache so the next mount
+  // of THIS Thread skips the JSONL re-read + re-fold. `put` refuses a mid-turn
+  // (`isProcessing`) state — a turn outliving the unmount keeps teeing to the
+  // transcript, so that snapshot would go stale (the next mount replays fully).
+  useEffect(() => {
+    return () => {
+      if (hydratedRef.current || liveSeen.current) {
+        replayCache.put(thread.threadId, {
+          state: stateRef.current,
+          sessionId: boundRef.current,
+          workspaceId: thread.workspaceId,
+        })
+      }
+    }
+  }, [thread.threadId, thread.workspaceId])
 
   // Bind a draft to its OWN session the instant main signals `thread:bound` —
   // BEFORE that session's first event arrives (main emits it ahead of the prompt

--- a/src/renderer/src/conversation/replay-cache.test.ts
+++ b/src/renderer/src/conversation/replay-cache.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi } from 'vitest'
+import { initialConversationState, type ConversationState } from './reducer'
+import {
+  createReplayCache,
+  wireReplayCacheInvalidation,
+  MAX_CACHED_THREADS,
+  type CachedThreadView,
+  type ReplayCacheSignals,
+} from './replay-cache'
+
+/**
+ * The renderer-side folded-view cache: take-on-mount / put-on-unmount so a
+ * Thread switch skips the full JSONL re-read + re-fold, invalidated over the
+ * EXISTING channels when main tees to an unmounted Thread's transcript. Pure
+ * module — no React, no preload; signals are driven by stubs.
+ */
+
+function view(overrides?: Partial<CachedThreadView>): CachedThreadView {
+  return {
+    state: initialConversationState,
+    sessionId: 's1',
+    workspaceId: 'w1',
+    ...overrides,
+  }
+}
+
+describe('createReplayCache take/put', () => {
+  it('roundtrips a settled view, and take CONSUMES the entry (mount takes ownership)', () => {
+    const cache = createReplayCache()
+    const v = view()
+    cache.put('t1', v)
+
+    expect(cache.take('t1')).toBe(v)
+    // Consumed: the mounted view owns the state now; a second mount must re-replay.
+    expect(cache.take('t1')).toBeNull()
+  })
+
+  it('refuses a mid-turn (isProcessing) snapshot — stale by construction', () => {
+    const cache = createReplayCache()
+    const midTurn: ConversationState = { ...initialConversationState, isProcessing: true }
+    cache.put('t1', view({ state: midTurn }))
+
+    expect(cache.take('t1')).toBeNull()
+  })
+
+  it('LRU-evicts the least-recently-put past the cap; a re-put refreshes recency', () => {
+    const cache = createReplayCache(2)
+    cache.put('t1', view())
+    cache.put('t2', view())
+    cache.put('t1', view()) // refresh t1 — t2 is now the oldest
+    cache.put('t3', view()) // over cap: evicts t2, not t1
+
+    expect(cache.take('t2')).toBeNull()
+    expect(cache.take('t1')).not.toBeNull()
+    expect(cache.take('t3')).not.toBeNull()
+  })
+
+  it('defaults to MAX_CACHED_THREADS entries', () => {
+    const cache = createReplayCache()
+    for (let i = 0; i <= MAX_CACHED_THREADS; i++) cache.put(`t${i}`, view())
+
+    expect(cache.take('t0')).toBeNull() // the one over the cap evicted the oldest
+    expect(cache.take(`t${MAX_CACHED_THREADS}`)).not.toBeNull()
+  })
+})
+
+describe('createReplayCache invalidation', () => {
+  it('invalidate drops one Thread; clear drops everything', () => {
+    const cache = createReplayCache()
+    cache.put('t1', view())
+    cache.put('t2', view())
+
+    cache.invalidate('t1')
+    expect(cache.take('t1')).toBeNull()
+    expect(cache.take('t2')).not.toBeNull()
+
+    cache.put('t3', view())
+    cache.clear()
+    expect(cache.take('t3')).toBeNull()
+  })
+
+  it('invalidateBySession drops only entries folded up to that session — null never matches', () => {
+    const cache = createReplayCache()
+    cache.put('t1', view({ sessionId: 's1' }))
+    cache.put('t2', view({ sessionId: 's2' }))
+    cache.put('t3', view({ sessionId: null })) // unbound draft / cold Thread
+
+    cache.invalidateBySession('s1')
+    expect(cache.take('t1')).toBeNull()
+    expect(cache.take('t2')).not.toBeNull()
+    expect(cache.take('t3')).not.toBeNull()
+  })
+
+  it('invalidateByWorkspace drops every entry under the removed Workspace', () => {
+    const cache = createReplayCache()
+    cache.put('t1', view({ workspaceId: 'w1' }))
+    cache.put('t2', view({ workspaceId: 'w1' }))
+    cache.put('t3', view({ workspaceId: 'w2' }))
+
+    cache.invalidateByWorkspace('w1')
+    expect(cache.take('t1')).toBeNull()
+    expect(cache.take('t2')).toBeNull()
+    expect(cache.take('t3')).not.toBeNull()
+  })
+})
+
+describe('wireReplayCacheInvalidation', () => {
+  /** Stub signals capturing the listeners so tests can fire events by hand. */
+  function stubSignals(): {
+    signals: ReplayCacheSignals
+    fireEvent: (payload: unknown) => void
+    fireTitle: (threadId: string) => void
+    offEvent: ReturnType<typeof vi.fn>
+    offTitle: ReturnType<typeof vi.fn>
+  } {
+    let eventListener: ((e: { agentId: string; payload: unknown }) => void) | null = null
+    let titleListener: ((e: { threadId: string; title: string }) => void) | null = null
+    const offEvent = vi.fn()
+    const offTitle = vi.fn()
+    return {
+      signals: {
+        onAcpEvent: (l) => {
+          eventListener = l
+          return offEvent
+        },
+        onThreadTitle: (l) => {
+          titleListener = l
+          return offTitle
+        },
+      },
+      fireEvent: (payload) => eventListener?.({ agentId: 'a1', payload }),
+      fireTitle: (threadId) => titleListener?.({ threadId, title: 'renamed' }),
+      offEvent,
+      offTitle,
+    }
+  }
+
+  it('a session-tagged acp:event dirties the matching cached entry (background tee)', () => {
+    const cache = createReplayCache()
+    const { signals, fireEvent } = stubSignals()
+    wireReplayCacheInvalidation(cache, signals)
+    cache.put('t1', view({ sessionId: 's1' }))
+    cache.put('t2', view({ sessionId: 's2' }))
+
+    fireEvent({ method: 'session/update', params: { sessionId: 's1', update: {} } })
+
+    expect(cache.take('t1')).toBeNull()
+    expect(cache.take('t2')).not.toBeNull()
+  })
+
+  it('a session-less lifecycle payload touches nothing (cache ≡ replay for those)', () => {
+    const cache = createReplayCache()
+    const { signals, fireEvent } = stubSignals()
+    wireReplayCacheInvalidation(cache, signals)
+    cache.put('t1', view({ sessionId: 's1' }))
+
+    fireEvent({ type: 'exit', code: 0 })
+
+    expect(cache.take('t1')).not.toBeNull()
+  })
+
+  it('a thread:title push dirties the renamed Thread (cold store-only rename)', () => {
+    const cache = createReplayCache()
+    const { signals, fireTitle } = stubSignals()
+    wireReplayCacheInvalidation(cache, signals)
+    cache.put('t1', view())
+
+    fireTitle('t1')
+
+    expect(cache.take('t1')).toBeNull()
+  })
+
+  it('the returned disposer unsubscribes both signals', () => {
+    const cache = createReplayCache()
+    const { signals, offEvent, offTitle } = stubSignals()
+    const dispose = wireReplayCacheInvalidation(cache, signals)
+
+    dispose()
+
+    expect(offEvent).toHaveBeenCalledOnce()
+    expect(offTitle).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/conversation/replay-cache.ts
+++ b/src/renderer/src/conversation/replay-cache.ts
@@ -1,0 +1,136 @@
+import type { ConversationState } from './reducer'
+import { sessionIdOfEvent } from './event-routing'
+
+/**
+ * A renderer-side cache of folded conversation views, so switching Threads
+ * doesn't re-read + re-fold the whole JSONL on every remount (the transcript
+ * grows with the conversation; the fold is O(entries) and Conversation/ColdThread
+ * are remount-keyed by Thread id).
+ *
+ * TAKE-ON-MOUNT / PUT-ON-UNMOUNT: the mounting view CONSUMES its entry
+ * (`take` = get + delete), so the live fold owns the state while on screen and
+ * no invalidation can race the mounted Thread. On unmount the settled state is
+ * `put` back. `put` REFUSES a mid-turn (`isProcessing`) snapshot: a turn spans
+ * the unmount (the in-flight `sendPrompt` keeps teeing to the transcript in the
+ * background), so that snapshot is stale by construction — the next mount does
+ * the full replay instead. Turns only START from a mounted Conversation today
+ * (submit + follow-up drain are per-mounted-instance), so every cached entry is
+ * a turn-quiet view; if a future slice adds background turn-starting, the
+ * `acp:event` invalidation below still dirties the entry within one event of the
+ * turn's first stream.
+ *
+ * INVALIDATION rides existing channels only (no new main-process bookkeeping):
+ *  - `acp:event`: any payload session-tagged to a cached entry's `sessionId`
+ *    means main teed something to that Thread's transcript behind our back
+ *    (e.g. the lazy `session_info_update` title echo) — drop the entry.
+ *    Session-less lifecycle payloads (exit/error) fold into state only while
+ *    `isProcessing` — never true for a cached entry — and their teed replay is
+ *    equally a no-op, so ignoring them keeps cache ≡ replay.
+ *  - `thread:title`: covers the COLD store-only rename (no ACP echo), where a
+ *    stale cached `state.title` would beat the fresh `ThreadMeta.title`.
+ *  - Thread delete / Workspace remove: the caller invalidates explicitly
+ *    (`use-workspace-actions`). Agent EVICTION is deliberately NOT a signal —
+ *    it changes no transcript (re-warm transparency, ADR-0006).
+ *
+ * Data URLs from replayed image attachments are cached as-is: they're GC'd with
+ * the entry (object URLs would need a revoke lifecycle threaded through
+ * reducer-owned state), and the per-image persistence cap bounds the worst case
+ * across `MAX_CACHED_THREADS` entries.
+ */
+
+/** LRU capacity — ConversationState holds full item arrays, so keep this small. */
+export const MAX_CACHED_THREADS = 8
+
+/** A settled (never mid-turn) folded view, cached across the per-Thread remount. */
+export interface CachedThreadView {
+  state: ConversationState
+  /**
+   * The ACP session the view was folded up to — the `acp:event` invalidation
+   * key (`null` for an unbound draft / a cold Thread with no session).
+   */
+  sessionId: string | null
+  /** Owning Workspace — the remove-Workspace invalidation key. */
+  workspaceId: string
+}
+
+export interface ReplayCache {
+  /** Consume the Thread's cached view (get + delete) — the mount takes ownership. */
+  take(threadId: string): CachedThreadView | null
+  /** Cache a settled view; refuses `isProcessing` states; LRU-evicts past the cap. */
+  put(threadId: string, view: CachedThreadView): void
+  invalidate(threadId: string): void
+  invalidateBySession(sessionId: string): void
+  invalidateByWorkspace(workspaceId: string): void
+  clear(): void
+}
+
+/** Pure Map-based LRU factory — the app uses the {@link replayCache} singleton. */
+export function createReplayCache(max: number = MAX_CACHED_THREADS): ReplayCache {
+  // Map iteration order is insertion order; re-putting deletes first, so the
+  // FIRST key is always the least-recently-put — the LRU eviction victim.
+  const entries = new Map<string, CachedThreadView>()
+  return {
+    take(threadId) {
+      const view = entries.get(threadId) ?? null
+      entries.delete(threadId)
+      return view
+    },
+    put(threadId, view) {
+      if (view.state.isProcessing) return // mid-turn snapshot — stale by construction
+      entries.delete(threadId)
+      entries.set(threadId, view)
+      if (entries.size > max) {
+        const oldest = entries.keys().next().value
+        if (oldest !== undefined) entries.delete(oldest)
+      }
+    },
+    invalidate(threadId) {
+      entries.delete(threadId)
+    },
+    invalidateBySession(sessionId) {
+      for (const [threadId, view] of entries) {
+        if (view.sessionId === sessionId) entries.delete(threadId)
+      }
+    },
+    invalidateByWorkspace(workspaceId) {
+      for (const [threadId, view] of entries) {
+        if (view.workspaceId === workspaceId) entries.delete(threadId)
+      }
+    },
+    clear() {
+      entries.clear()
+    },
+  }
+}
+
+/** The app singleton (module state resets with the window — single-window app). */
+export const replayCache = createReplayCache()
+
+/**
+ * The structural slice of the preload api the invalidation wiring needs — keeps
+ * this module preload-import-free and lets tests drive it with stub listeners.
+ */
+export interface ReplayCacheSignals {
+  onAcpEvent(listener: (e: { agentId: string; payload: unknown }) => void): () => void
+  onThreadTitle(listener: (e: { threadId: string; title: string }) => void): () => void
+}
+
+/**
+ * Subscribe ONCE (App mount) to the signals that dirty cached entries behind an
+ * unmounted Thread's back. A non-matching event is one cheap Map scan; the
+ * mounted Thread's own stream can't evict anything because its entry was taken.
+ * Returns a disposer that unsubscribes both.
+ */
+export function wireReplayCacheInvalidation(cache: ReplayCache, api: ReplayCacheSignals): () => void {
+  const offEvent = api.onAcpEvent((e) => {
+    const sessionId = sessionIdOfEvent(e.payload)
+    if (sessionId) cache.invalidateBySession(sessionId)
+  })
+  const offTitle = api.onThreadTitle((e) => {
+    cache.invalidate(e.threadId)
+  })
+  return () => {
+    offEvent()
+    offTitle()
+  }
+}

--- a/src/renderer/src/conversation/replay.test.ts
+++ b/src/renderer/src/conversation/replay.test.ts
@@ -11,7 +11,7 @@ import {
   type ReasoningItem,
   type ToolItem,
 } from './reducer'
-import { replayTranscript } from './replay'
+import { replayTranscript, transcriptHasImages } from './replay'
 
 /**
  * TB3 (#32): a reopened Thread renders FROM its JSONL, no `vibe-acp` spawned.
@@ -138,5 +138,59 @@ describe('replayTranscript (TB3 #32)', () => {
     expect(replayed).toEqual(initialConversationState)
     expect(replayed.items).toHaveLength(0)
     expect(replayed.isProcessing).toBe(false)
+  })
+})
+
+describe('replayTranscript image attachments', () => {
+  const PROMPT_WITH_IMAGES: TranscriptEntry[] = [
+    {
+      t: 'user-prompt',
+      id: 'user:0',
+      text: 'what is in this screenshot?',
+      images: [
+        { file: 'aaaa.png', mimeType: 'image/png' },
+        { file: 'bbbb.jpg', mimeType: 'image/jpeg' },
+      ],
+    },
+    { t: 'turn-complete' },
+  ]
+
+  it('resolves image refs through the attachment map into previewUrls on the user item', () => {
+    const replayed = replayTranscript(PROMPT_WITH_IMAGES, {
+      'aaaa.png': 'data:image/png;base64,AAAA',
+      'bbbb.jpg': 'data:image/jpeg;base64,BBBB',
+    })
+
+    const user = replayed.items[0]
+    expect(user.kind).toBe('user')
+    expect(user.kind === 'user' && user.images).toEqual([
+      { previewUrl: 'data:image/png;base64,AAAA' },
+      { previewUrl: 'data:image/jpeg;base64,BBBB' },
+    ])
+  })
+
+  it('a ref missing from the map (deleted/corrupt file) degrades that image, keeping the rest', () => {
+    const replayed = replayTranscript(PROMPT_WITH_IMAGES, {
+      'bbbb.jpg': 'data:image/jpeg;base64,BBBB',
+    })
+
+    const user = replayed.items[0]
+    expect(user.kind === 'user' && user.images).toEqual([{ previewUrl: 'data:image/jpeg;base64,BBBB' }])
+  })
+
+  it('no attachment map at all (store failed / legacy caller) replays text-only, never throwing', () => {
+    const replayed = replayTranscript(PROMPT_WITH_IMAGES)
+
+    const user = replayed.items[0]
+    expect(user.kind).toBe('user')
+    expect(user.kind === 'user' && user.images).toBeUndefined()
+    expect(user.kind === 'user' && user.text).toBe('what is in this screenshot?')
+  })
+
+  it('transcriptHasImages gates the attachments IPC: true only when a prompt carries refs', () => {
+    expect(transcriptHasImages(PROMPT_WITH_IMAGES)).toBe(true)
+    expect(transcriptHasImages(READ_TRANSCRIPT)).toBe(false)
+    expect(transcriptHasImages([{ t: 'user-prompt', id: 'u1', text: 'hi', images: [] }])).toBe(false)
+    expect(transcriptHasImages([])).toBe(false)
   })
 })

--- a/src/renderer/src/conversation/replay.ts
+++ b/src/renderer/src/conversation/replay.ts
@@ -22,19 +22,50 @@ import {
  *    and a log whose final turn was cut off (app closed before its terminal entry)
  *    would otherwise leave a phantom in-flight spinner.
  */
-export function replayTranscript(entries: TranscriptEntry[]): ConversationState {
+/**
+ * A Thread's persisted attachments (`file name -> data URL`), the reply of the
+ * batched `readThreadAttachments` IPC. Resolved against each `user-prompt`
+ * entry's image refs so a replayed prompt renders its images; a ref whose file
+ * is missing from the map (deleted/corrupt on disk) is silently omitted — the
+ * prompt degrades to text-only, replay never breaks.
+ */
+export type AttachmentMap = Readonly<Record<string, string>>
+
+/** Whether any entry references persisted images — gates the attachments IPC. */
+export function transcriptHasImages(entries: TranscriptEntry[]): boolean {
+  return entries.some((e) => e.t === 'user-prompt' && (e.images?.length ?? 0) > 0)
+}
+
+export function replayTranscript(
+  entries: TranscriptEntry[],
+  attachments?: AttachmentMap,
+): ConversationState {
   let state = initialConversationState
   for (const entry of entries) {
-    state = conversationReducer(state, toAction(entry, state))
+    state = conversationReducer(state, toAction(entry, state, attachments))
   }
   return state.isProcessing ? { ...state, isProcessing: false } : state
 }
 
 /** Map one logged entry to its reducer action (using `state` to recover names). */
-function toAction(entry: TranscriptEntry, state: ConversationState): ConversationAction {
+function toAction(
+  entry: TranscriptEntry,
+  state: ConversationState,
+  attachments?: AttachmentMap,
+): ConversationAction {
   switch (entry.t) {
-    case 'user-prompt':
-      return { type: 'send-prompt', id: entry.id, text: entry.text }
+    case 'user-prompt': {
+      const images = entry.images
+        ?.map((ref) => attachments?.[ref.file])
+        .filter((url): url is string => typeof url === 'string')
+        .map((previewUrl) => ({ previewUrl }))
+      return {
+        type: 'send-prompt',
+        id: entry.id,
+        text: entry.text,
+        images: images && images.length > 0 ? images : undefined,
+      }
+    }
     case 'acp-event':
       return { type: 'acp-event', payload: entry.payload }
     case 'turn-complete':

--- a/src/shared/ipc/thread.ts
+++ b/src/shared/ipc/thread.ts
@@ -25,6 +25,12 @@ export const threadChannels = {
   listMetadata: 'metadata:list',
   /** Read a Thread's persisted JSONL transcript for a process-free reopen (TB3). */
   readTranscript: 'transcript:read',
+  /**
+   * Read a Thread's persisted image attachments for replay — ONE batched read per
+   * reopen (file name -> data URL), called only when the transcript references
+   * images, so image-less reopens cost no extra IPC.
+   */
+  readThreadAttachments: 'transcript:attachments',
   /** Delete a Thread (TB6) — see {@link DeleteThreadResult}. */
   deleteThread: 'thread:delete',
   /** Remove a Workspace ("Remove project") — see {@link RemoveWorkspaceResult}. */
@@ -352,7 +358,7 @@ export type ListMetadataResult = WorkspaceThreads[]
  * — the renderer cannot import the main process. `transcript.ts` re-exports it.
  */
 export type TranscriptEntry =
-  | { t: 'user-prompt'; id: string; text: string }
+  | { t: 'user-prompt'; id: string; text: string; images?: TranscriptImageRef[] }
   | { t: 'acp-event'; payload: unknown }
   | { t: 'turn-complete' }
   | { t: 'turn-error'; message: string }
@@ -365,3 +371,22 @@ export type TranscriptEntry =
 
 /** The `readTranscript` reply: a Thread's transcript entries (empty when none). */
 export type ReadTranscriptResult = TranscriptEntry[]
+
+/**
+ * A persisted image attachment referenced by a `user-prompt` transcript entry.
+ * Additive/optional on the v1 entry — NO schema-version bump: `isTranscriptEntry`
+ * discriminates on `t` alone, so legacy lines (no `images`) parse unchanged and
+ * older readers ignore the field (same precedent as `ThreadMeta.pinned`).
+ */
+export interface TranscriptImageRef {
+  /** File name under the Thread's attachments dir (e.g. `3f2a….png`). Never a path. */
+  file: string
+  /** e.g. 'image/png' — recorded for forward use; reads derive mime from the extension. */
+  mimeType: string
+}
+
+/**
+ * The `readThreadAttachments` reply: attachment file name -> full data URL for
+ * every image persisted under the Thread. Missing dir (image-less Thread) → `{}`.
+ */
+export type ReadThreadAttachmentsResult = Record<string, string>


### PR DESCRIPTION
## Summary

Two persistence "cheap wins" from the t3code comparison, planned and scoped in-session (sidebar-summary slice deferred by choice):

- **Persist prompt-image attachments** — new `AttachmentStore` writes each prompt's images to `userData/attachments/<threadId>/<uuid>.<ext>` (5MB/image cap, best-effort per image, never gating the turn) before the `user-prompt` tee; the transcript entry carries optional `images` refs (additive on schema v1, no bump). Reopen resolves refs via ONE batched `readThreadAttachments` IPC, only when the transcript references images; a missing file degrades that image to text-only. Teardown drops the dir alongside the JSONL; tombstoned Threads skip the save.
- **Replay cache** — renderer-side LRU (8) of folded `ConversationState`, take-on-mount / put-on-unmount in `Conversation`/`ColdThread`; `put` refuses mid-turn snapshots. Invalidation rides existing channels (`acp:event` by sessionId, `thread:title`, delete/removeWorkspace/rename). Includes the StrictMode fix found in verification: sync the `stateRef` snapshot mirror at hydrate-dispatch time, else the dev double-mount caches an empty view that self-perpetuates.

## Verification

- Gates green: lint + typecheck + build + **949 tests / 77 files**.
- Driven end-to-end over CDP against the running app: real Composer paste → PNG on disk + JSONL refs; cold-boot reopen renders the image from disk; cache roundtrips lossless (instrumented take/put); deleted-file probe replays text-only without breaking; 470-entry legacy transcript unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)