### PR TITLE
feat(terminal): Terminal Surface slice 1 — main-owned PTY, unconfined Workspace shell (ADR-0014)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -38,10 +38,10 @@ _Avoid_: approval, confirmation, prompt (reserve "prompt" for the user's message
 
 **Surface**:
 One open area in the side panel, shown as a tab in its tab strip. Review (the git Changes panel) and
-Files (the Files browser) are singletons; each previewed file is its own Surface; Terminal and Browser
-are reserved (not yet built). Many Surfaces can be open at once; one is active (visible). Open-Surface
-state is per-Workspace.
-_Avoid_: view, pane, dock (reserve "dock" for the future embedded terminal's chrome).
+Files (the Files browser) are singletons; each previewed file is its own Surface; Terminal is the
+Workspace shell (one session this slice); Browser is reserved (not yet built). Many Surfaces can be
+open at once; one is active (visible). Open-Surface state is per-Workspace.
+_Avoid_: view, pane, dock.
 
 **Side panel**:
 The right-hand panel hosting Surfaces. Closed by default; toggled from the window header or a
@@ -55,6 +55,14 @@ The Files Surface's content — a searchable tree of the Workspace's files. Open
 that file's own Surface: a read-only preview topped by a read-only breadcrumb of its path. Browsing
 and previewing never change files and never involve the agent.
 _Avoid_: file tree (the widget, not the feature), explorer, finder.
+
+**Terminal session**:
+The real user shell (PTY) a Workspace's Terminal Surface drives, hosted in the main process
+(ADR-0014). Deliberately UNCONFINED — full CLI parity, unlike the confined Files reads — and
+independent of the warm agent: it outlives tab switches and panel closes (the view reattaches and
+replays its scrollback), and dies only on its tab's explicit close, Workspace removal, or app quit.
+One session per Workspace this slice (`term-1`).
+_Avoid_: console; "terminal dock" (the epic's working name, not a UI term).
 
 ## Agent controls
 

--- a/docs/adr/0014-terminal-unconfined-user-shell-main-owned-pty.md
+++ b/docs/adr/0014-terminal-unconfined-user-shell-main-owned-pty.md
@@ -1,0 +1,64 @@
+# Terminal: an unconfined user shell on a main-owned PTY, per Workspace
+
+**Status: ACCEPTED** (2026-07-02). Builds on **ADR-0002** (thin orchestrator), **ADR-0004** (the
+CLI-parity posture this extends to a shell), **ADR-0006** (warm-agent pool — whose lifetime this is
+explicitly INDEPENDENT of), **ADR-0013** (the Surface/tab model the Terminal Surface slots into).
+Terms: `CONTEXT.md` **Terminal session**. Reference implementation: t3code's `TerminalManager` +
+`ThreadTerminalDrawer` (server-owned PTY behind an attach-stream; the UI a disposable view).
+
+## Context
+
+CodexMonitor parity reserves a Terminal card in the side panel (#187/#193 shipped it inert). t3code —
+our UI north star — ships the target shape: xterm.js as a thin, reconnectable view; the PTY process,
+its scrollback, and its lifetime owned by their backend server; plain UTF-8 strings over the wire;
+client-chosen session ids. We have no server process — the Electron main process IS our backend — and
+our side panel is per-Workspace (t3code's is per-Thread; our Threads share the working tree).
+
+## Decision
+
+1. **Main owns the PTY.** A `TerminalManager` in `src/main/terminal/` spawns and supervises shell
+   sessions via **node-pty** (`^1.1.0`); the renderer's xterm.js view is DISPOSABLE and drives the
+   session over four invokes (`terminal:open/write/resize/close`) plus one streamed `terminal:event`
+   channel tagged `{workspaceId, terminalId}` — the `acp:event` pattern. Output is UTF-8 strings
+   (no base64), writes capped at 64 KiB, cols/rows clamped.
+
+2. **A FULL, UNCONFINED user shell — deliberately.** CLI parity: the same shell, env, and reach the
+   user has in their own terminal (they could run anything there anyway; t3code ships the same
+   posture). This is the OPPOSITE of the confined `files:*` reads (ADR-0013) and that contrast is
+   intentional: Files is an agent-adjacent read surface consumed programmatically; the Terminal is
+   the USER acting as themselves. The safety boundary is ADDRESSING, not confinement:
+   `terminal:open` is `agentId`-addressed (#188 F3 model) — the cwd resolves main-side from
+   `pool.get(agentId).workspaceDir`, never from a renderer-supplied path — so the renderer can only
+   open a shell in a CONNECTED Workspace. Env = the login-shell probe (`shell-env.ts`) minus a small
+   BLOCKLIST (Electron/dev plumbing; deliberately not an allowlist so PATH/toolchains survive).
+   Shell = `$SHELL` with zsh/bash/sh fallbacks, not `-l` (the env already came from a login probe).
+
+3. **Per-Workspace sessions, independent of the warm agent.** One session per Workspace this slice
+   (id `term-1`, client-chosen — t3code's convention; the event shape already carries `terminalId`
+   so multi-terminal tabs are additive). Pool eviction must NEVER kill a shell — the user's
+   long-running process outlives our LRU policy. A session dies only on: its tab's explicit close
+   (the × — SIGTERM, then SIGKILL after 1s), Workspace removal, window-all-closed, or app quit.
+
+4. **The view reattaches; the session buffers.** Tab switches and panel closes unmount xterm; the
+   manager retains a capped in-memory scrollback (~2 MB, line-boundary trimmed) and `terminal:open`
+   is open-OR-REATTACH — a live session replies with its snapshot for replay. No disk persistence
+   (a shell is ephemeral; t3code's history files are deferred with the rest of slice-2+ polish).
+   An exited session keeps its buffer + banner until the tab closes or reopens (fresh spawn).
+
+5. **Packaging: no rebuild.** node-pty 1.x is N-API/ABI-stable — no `electron-rebuild`, no
+   postinstall (verified in t3code's own manifest and comments). node-pty is imported ONLY in the
+   registrar (`register-ipc.ts`); the manager takes it through an injected `spawnPty` seam, keeping
+   the native module out of the unit-test import graph.
+
+## Consequences
+
+- The renderer never touches a process API; the preload stays a typed pass-through (ADR-0002 intact:
+  the shell is OUR feature, not an agent capability — vibe-acp is uninvolved).
+- A terminal open does NOT count as agent activity (`pool.touch` is not called): an open shell never
+  pins a warm agent, and an evicted agent leaves the shell running. Only `terminal:open` needs the
+  agent (for the cwd); a session whose agent was later evicted keeps working — write/resize/close
+  address the session, not the agent.
+- Deferred to later slices, recorded here so they're choices not gaps: sequence-numbered attach
+  protocol + output coalescing (slice 2), multiple terminals per Workspace (slice 3), link provider /
+  selection-to-composer / live re-theme (slice 4), splits, disk-persisted history, subprocess-name
+  tab labels, Windows/conpty + WSL.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:update": "playwright test --update-snapshots",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "postinstall": "node scripts/fix-node-pty-perms.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
@@ -27,10 +28,13 @@
     "@pierre/trees": "1.0.0-beta.5",
     "@streamdown/code": "1.1.1",
     "@tailwindcss/vite": "^4",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "chokidar": "^5.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.564",
+    "node-pty": "^1.1.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "streamdown": "2.5.0",

--- a/scripts/fix-node-pty-perms.mjs
+++ b/scripts/fix-node-pty-perms.mjs
@@ -1,0 +1,16 @@
+// Restore the execute bit on node-pty's darwin `spawn-helper` prebuilds (ADR-0014).
+// npm preserves the tarball's file modes; BUN does not — a bun install leaves
+// spawn-helper 0644, and every PTY spawn then dies with `posix_spawnp failed`.
+// Runs as OUR postinstall (bun runs the project's own lifecycle scripts even
+// while blocking dependencies'). Best-effort + silent on absence: non-darwin
+// platforms and a not-yet-installed node-pty are no-ops, never a failed install.
+import { chmodSync, existsSync } from 'node:fs'
+
+for (const arch of ['darwin-arm64', 'darwin-x64']) {
+  const helper = new URL(`../node_modules/node-pty/prebuilds/${arch}/spawn-helper`, import.meta.url)
+  try {
+    if (existsSync(helper)) chmodSync(helper, 0o755)
+  } catch {
+    // Best-effort — a read-only store is the packager's problem, not install's.
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -62,6 +62,8 @@ import { GitStatusManager } from './git/status-stream'
 import { chokidarWatchFactory, realClock } from './git/runtime'
 import { registerGitIpc } from './git/register-ipc'
 import { registerFilesIpc } from './files/register-ipc'
+import { createTerminalManager, registerTerminalIpc } from './terminal/register-ipc'
+import type { TerminalManager } from './terminal/terminal-manager'
 import { FilesListCache, shouldInvalidateFilesCacheOnGitStatus } from './files/cache'
 
 // Test seam (e2e smoke): point the whole persisted profile (metadata.json +
@@ -203,6 +205,13 @@ const gitStatus = new GitStatusManager({
 
 /** The periodic idle-evict sweep timer (cleared on quit). */
 let sweepTimer: ReturnType<typeof setInterval> | null = null
+
+/**
+ * The Workspace terminal sessions (ADR-0014), created at app-ready (its env comes
+ * from the login-shell probe). Module-level like the pool so the quit hooks and
+ * the remove-Workspace teardown reach it.
+ */
+let terminalManager: TerminalManager | null = null
 
 /**
  * The stores + transcript bridge every conversation-flow handler needs, created at
@@ -598,6 +607,8 @@ function registerIpc(deps: MainDeps): void {
   // next to them.
   registerGitIpc({ gitStatus })
   registerFilesIpc({ pool, cache: filesListCache })
+  terminalManager = createTerminalManager()
+  registerTerminalIpc({ pool, manager: terminalManager })
 
   ipcMain.handle(IPC.detectVibe, () => detectVibe())
 
@@ -889,6 +900,9 @@ function registerIpc(deps: MainDeps): void {
       for (const t of snapshot.threads) {
         if (t.workspaceId === workspaceId) deps.bridge.tombstone(t.id)
       }
+      // Kill the Workspace's shell session too (ADR-0014) — a removed project must
+      // not leave a live PTY behind. Best-effort like every other step here.
+      terminalManager?.close(workspaceId)
       await removeWorkspace({
         workspaceId,
         store: deps.store,
@@ -1099,6 +1113,10 @@ app.on('window-all-closed', () => {
   // The pool is process-global, which is fine for single-window TB1/TB2.
   // A future multi-window slice should scope the pool per window.
   pool.disposeAll()
+  // Shell sessions die with the windows too (ADR-0014): with no window to ever
+  // reattach from, a surviving PTY would just be an orphaned process — mirror
+  // the pool's teardown rather than the warm-across-reopen behaviour.
+  terminalManager?.disposeAll()
   if (process.platform !== 'darwin') app.quit()
 })
 
@@ -1112,4 +1130,7 @@ app.on('will-quit', () => {
   // Tear down every git-status subscription (#84) so no fs watcher or fetch timer
   // outlives the app — mirrors the sweep-timer cleanup above.
   gitStatus.disposeAll()
+  // And every shell session (idempotent after window-all-closed; this also covers
+  // the darwin quit-from-dock path where no window-all-closed fired).
+  terminalManager?.disposeAll()
 })

--- a/src/main/terminal/register-ipc.ts
+++ b/src/main/terminal/register-ipc.ts
@@ -1,0 +1,78 @@
+import { BrowserWindow, ipcMain } from 'electron'
+import { spawn } from 'node-pty'
+import {
+  IPC,
+  type TerminalCloseArgs,
+  type TerminalEvent,
+  type TerminalOpenArgs,
+  type TerminalOpenResult,
+  type TerminalResizeArgs,
+  type TerminalWriteArgs,
+} from '../../shared/ipc'
+import type { AgentPool } from '../agent-pool'
+import { getShellEnv } from '../shell-env'
+import { TerminalManager } from './terminal-manager'
+
+/**
+ * The Workspace-terminal IPC handlers (ADR-0014), registered next to the manager
+ * they pass through to. The shell's cwd is the warm agent's OWN `workspaceDir` —
+ * resolved via `pool.get`, NOT a renderer-supplied path (the #188 F3 addressing
+ * model) — so the renderer can only open a shell in a CONNECTED Workspace. The
+ * shell itself is deliberately UNCONFINED (a full user shell, ADR-0014). Not
+ * agent activity: no `pool.touch` — an open terminal never keeps a warm agent
+ * alive (the SESSION's lifetime is already independent of the agent's).
+ *
+ * node-pty lives HERE (and only here): the manager takes it through the
+ * `spawnPty` seam, keeping the native module out of the unit-test import graph.
+ */
+
+/**
+ * The production manager: node-pty spawns (`xterm-256color`), env from the
+ * login-shell probe (`getShellEnv` — PATH survives Finder/Dock launches), and
+ * events broadcast to every window (single-window app; the renderer filters by
+ * `workspaceId`, the `acp:event` pattern).
+ */
+export function createTerminalManager(): TerminalManager {
+  return new TerminalManager({
+    spawnPty: ({ file, args, cwd, env, cols, rows }) =>
+      spawn(file, args, { name: 'xterm-256color', cwd, env, cols, rows }),
+    env: getShellEnv(),
+    emit: (event: TerminalEvent) => {
+      for (const win of BrowserWindow.getAllWindows()) {
+        if (!win.webContents.isDestroyed()) win.webContents.send(IPC.terminalEvent, event)
+      }
+    },
+  })
+}
+
+export function registerTerminalIpc(deps: { pool: AgentPool; manager: TerminalManager }): void {
+  ipcMain.handle(IPC.terminalOpen, (_event, args: TerminalOpenArgs): TerminalOpenResult => {
+    // OPEN-or-REATTACH the Workspace's shell (ADR-0014). A live session replies
+    // with its scrollback snapshot (the Surface remounted after a tab switch /
+    // panel close); an exited or absent one spawns fresh. The cwd comes from the
+    // pool — an unknown/cold agent refuses, so a stale renderer handle can't
+    // spawn a shell with no Workspace behind it.
+    const agent = deps.pool.get(args.agentId)
+    if (!agent) return { ok: false, error: 'Workspace agent is not connected.' }
+    return deps.manager.openOrAttach(args.workspaceId, {
+      cwd: agent.workspaceDir,
+      cols: args.cols,
+      rows: args.rows,
+    })
+  })
+
+  // Input/resize/close address the SESSION (workspaceId): they can only reach a
+  // session a prior agent-addressed `open` created. Each is a bounded no-op on an
+  // unknown session — never a throw into the renderer's fire-and-forget calls.
+  ipcMain.handle(IPC.terminalWrite, (_event, args: TerminalWriteArgs): void => {
+    deps.manager.write(args.workspaceId, args.data)
+  })
+
+  ipcMain.handle(IPC.terminalResize, (_event, args: TerminalResizeArgs): void => {
+    deps.manager.resize(args.workspaceId, args.cols, args.rows)
+  })
+
+  ipcMain.handle(IPC.terminalClose, (_event, args: TerminalCloseArgs): void => {
+    deps.manager.close(args.workspaceId)
+  })
+}

--- a/src/main/terminal/terminal-manager.test.ts
+++ b/src/main/terminal/terminal-manager.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  capScrollback,
+  MAX_SCROLLBACK_CHARS,
+  shellCandidates,
+  terminalEnv,
+  TerminalManager,
+  type PtyLike,
+  type SpawnPtyOptions,
+} from './terminal-manager'
+import { MAX_TERMINAL_WRITE_CHARS, type TerminalEvent } from '../../shared/ipc'
+
+/**
+ * The main-side Workspace terminal sessions (ADR-0014). Exercised entirely
+ * through the injected `spawnPty` seam with a scripted fake PTY — no node-pty,
+ * no real shell. The seam mirrors the node-pty surface the registrar wires.
+ */
+
+class FakePty implements PtyLike {
+  pid = 4242
+  written: string[] = []
+  resized: Array<[number, number]> = []
+  killed: string[] = []
+  private dataListener: ((data: string) => void) | null = null
+  private exitListener: ((e: { exitCode: number; signal?: number }) => void) | null = null
+
+  onData(listener: (data: string) => void): void {
+    this.dataListener = listener
+  }
+  onExit(listener: (e: { exitCode: number; signal?: number }) => void): void {
+    this.exitListener = listener
+  }
+  write(data: string): void {
+    this.written.push(data)
+  }
+  resize(cols: number, rows: number): void {
+    this.resized.push([cols, rows])
+  }
+  kill(signal?: string): void {
+    this.killed.push(signal ?? 'SIGTERM')
+  }
+
+  emitData(data: string): void {
+    this.dataListener?.(data)
+  }
+  emitExit(exitCode: number): void {
+    this.exitListener?.({ exitCode })
+  }
+}
+
+function harness(overrides?: {
+  spawn?: (opts: SpawnPtyOptions) => PtyLike
+  env?: NodeJS.ProcessEnv
+}): {
+  manager: TerminalManager
+  events: TerminalEvent[]
+  ptys: FakePty[]
+  spawns: SpawnPtyOptions[]
+  timers: Array<{ fn: () => void }>
+} {
+  const events: TerminalEvent[] = []
+  const ptys: FakePty[] = []
+  const spawns: SpawnPtyOptions[] = []
+  const timers: Array<{ fn: () => void }> = []
+  const manager = new TerminalManager({
+    spawnPty:
+      overrides?.spawn ??
+      ((opts) => {
+        spawns.push(opts)
+        const pty = new FakePty()
+        ptys.push(pty)
+        return pty
+      }),
+    env: overrides?.env ?? { SHELL: '/bin/zsh', PATH: '/usr/bin' },
+    emit: (event) => events.push(event),
+    setTimeoutFn: ((fn: () => void) => {
+      const timer = { fn }
+      timers.push(timer)
+      return timer as unknown as ReturnType<typeof setTimeout>
+    }) as typeof setTimeout,
+    clearTimeoutFn: (() => {}) as typeof clearTimeout,
+  })
+  return { manager, events, ptys, spawns, timers }
+}
+
+describe('shellCandidates / terminalEnv', () => {
+  it('orders $SHELL first, dedupes, and always ends at /bin/sh', () => {
+    expect(shellCandidates({ SHELL: '/bin/zsh' })).toEqual(['/bin/zsh', '/bin/bash', '/bin/sh'])
+    expect(shellCandidates({})).toEqual(['/bin/zsh', '/bin/bash', '/bin/sh'])
+    expect(shellCandidates({ SHELL: '/opt/fish' })[0]).toBe('/opt/fish')
+  })
+
+  it('strips the Electron/dev blocklist but keeps PATH and toolchain vars (denylist, not allowlist)', () => {
+    const env = terminalEnv({
+      PATH: '/usr/bin:/opt/homebrew/bin',
+      HOME: '/Users/u',
+      ELECTRON_RUN_AS_NODE: '1',
+      ELECTRON_RENDERER_PORT: '5173',
+      PORT: '3000',
+      NODE_OPTIONS: '--inspect',
+      VIBE_MISTRO_INTERNAL: 'x',
+      CARGO_HOME: '/Users/u/.cargo',
+      GONE: undefined,
+    })
+    expect(env.PATH).toBe('/usr/bin:/opt/homebrew/bin')
+    expect(env.CARGO_HOME).toBe('/Users/u/.cargo')
+    expect(env).not.toHaveProperty('ELECTRON_RUN_AS_NODE')
+    expect(env).not.toHaveProperty('ELECTRON_RENDERER_PORT')
+    expect(env).not.toHaveProperty('PORT')
+    expect(env).not.toHaveProperty('NODE_OPTIONS')
+    expect(env).not.toHaveProperty('VIBE_MISTRO_INTERNAL')
+    expect(env).not.toHaveProperty('GONE')
+  })
+})
+
+describe('TerminalManager openOrAttach', () => {
+  it('spawns the shell in the given cwd and streams output events tagged by workspace + terminal', () => {
+    const { manager, events, ptys, spawns } = harness()
+    const result = manager.openOrAttach('w1', { cwd: '/proj', cols: 120, rows: 30 })
+
+    expect(result).toEqual({ ok: true, terminalId: 'term-1', snapshot: '', exited: false })
+    expect(spawns[0]).toMatchObject({ file: '/bin/zsh', cwd: '/proj', cols: 120, rows: 30 })
+
+    ptys[0].emitData('hello\r\n')
+    expect(events).toEqual([
+      { workspaceId: 'w1', terminalId: 'term-1', event: { type: 'output', data: 'hello\r\n' } },
+    ])
+  })
+
+  it('REATTACHES to a running session: no respawn, snapshot carries the buffered scrollback', () => {
+    const { manager, ptys, spawns } = harness()
+    manager.openOrAttach('w1', { cwd: '/proj', cols: 120, rows: 30 })
+    ptys[0].emitData('$ ls\r\nsrc\r\n')
+
+    const again = manager.openOrAttach('w1', { cwd: '/proj', cols: 80, rows: 24 })
+    expect(again).toEqual({ ok: true, terminalId: 'term-1', snapshot: '$ ls\r\nsrc\r\n', exited: false })
+    expect(spawns).toHaveLength(1) // no second spawn
+  })
+
+  it('walks the shell fallback chain when a candidate throws (missing shell)', () => {
+    const spawns: SpawnPtyOptions[] = []
+    const pty = new FakePty()
+    const { manager } = harness({
+      spawn: (opts) => {
+        spawns.push(opts)
+        if (opts.file !== '/bin/sh') throw new Error(`ENOENT: ${opts.file}`)
+        return pty
+      },
+      env: { SHELL: '/opt/gone-fish' },
+    })
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const result = manager.openOrAttach('w1', { cwd: '/proj', cols: 80, rows: 24 })
+    errSpy.mockRestore()
+
+    expect(result.ok).toBe(true)
+    expect(spawns.map((s) => s.file)).toEqual(['/opt/gone-fish', '/bin/zsh', '/bin/bash', '/bin/sh'])
+  })
+
+  it('resolves {ok:false} when EVERY candidate fails — never throws', () => {
+    const { manager } = harness({
+      spawn: () => {
+        throw new Error('ENOENT')
+      },
+    })
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const result = manager.openOrAttach('w1', { cwd: '/proj', cols: 80, rows: 24 })
+    errSpy.mockRestore()
+
+    expect(result).toEqual({ ok: false, error: 'Could not start a shell: ENOENT' })
+    expect(manager.has('w1')).toBe(false)
+  })
+
+  it('an EXITED session is respawned fresh on reopen (banner was seen; new shell)', () => {
+    const { manager, ptys, spawns, events } = harness()
+    manager.openOrAttach('w1', { cwd: '/proj', cols: 80, rows: 24 })
+    ptys[0].emitExit(0)
+    expect(events.at(-1)).toEqual({
+      workspaceId: 'w1',
+      terminalId: 'term-1',
+      event: { type: 'exited', exitCode: 0 },
+    })
+
+    const reopened = manager.openOrAttach('w1', { cwd: '/proj', cols: 80, rows: 24 })
+    expect(reopened).toEqual({ ok: true, terminalId: 'term-1', snapshot: '', exited: false })
+    expect(spawns).toHaveLength(2)
+  })
+})
+
+describe('TerminalManager write / resize', () => {
+  it('forwards writes and clamps resize to the shared bounds', () => {
+    const { manager, ptys } = harness()
+    manager.openOrAttach('w1', { cwd: '/proj', cols: 80, rows: 24 })
+
+    manager.write('w1', 'ls\r')
+    expect(ptys[0].written).toEqual(['ls\r'])
+
+    manager.resize('w1', 5000, 0)
+    expect(ptys[0].resized).toEqual([[1000, 1]])
+  })
+
+  it('refuses an oversized write whole and ignores unknown/exited sessions', () => {
+    const { manager, ptys } = harness()
+    manager.openOrAttach('w1', { cwd: '/proj', cols: 80, rows: 24 })
+
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    manager.write('w1', 'x'.repeat(MAX_TERMINAL_WRITE_CHARS + 1))
+    errSpy.mockRestore()
+    expect(ptys[0].written).toEqual([])
+
+    manager.write('missing', 'ls\r') // unknown workspace — no throw
+    ptys[0].emitExit(0)
+    manager.write('w1', 'ls\r') // exited — dropped
+    expect(ptys[0].written).toEqual([])
+  })
+})
+
+describe('TerminalManager close / disposeAll', () => {
+  it('closes with SIGTERM, then SIGKILL after the grace when the process lingers', () => {
+    const { manager, ptys, timers } = harness()
+    manager.openOrAttach('w1', { cwd: '/proj', cols: 80, rows: 24 })
+
+    manager.close('w1')
+    expect(ptys[0].killed).toEqual(['SIGTERM'])
+    expect(manager.has('w1')).toBe(false)
+
+    timers[0].fn() // the grace elapses without an exit
+    expect(ptys[0].killed).toEqual(['SIGTERM', 'SIGKILL'])
+  })
+
+  it('skips the SIGKILL when the process exits within the grace', () => {
+    const { manager, ptys, timers } = harness()
+    manager.openOrAttach('w1', { cwd: '/proj', cols: 80, rows: 24 })
+
+    manager.close('w1')
+    ptys[0].emitExit(143)
+    timers[0].fn()
+    expect(ptys[0].killed).toEqual(['SIGTERM'])
+  })
+
+  it('a dying shell\'s late output/exit never bleeds into a reopened session', () => {
+    const { manager, ptys, events } = harness()
+    manager.openOrAttach('w1', { cwd: '/proj', cols: 80, rows: 24 })
+    manager.close('w1')
+    manager.openOrAttach('w1', { cwd: '/proj', cols: 80, rows: 24 })
+    events.length = 0
+
+    ptys[0].emitData('late gasp') // the OLD pty
+    ptys[0].emitExit(137)
+    expect(events).toEqual([]) // nothing emitted for the stale session
+
+    ptys[1].emitData('fresh')
+    expect(events).toEqual([
+      { workspaceId: 'w1', terminalId: 'term-1', event: { type: 'output', data: 'fresh' } },
+    ])
+  })
+
+  it('disposeAll closes every session (app quit)', () => {
+    const { manager, ptys } = harness()
+    manager.openOrAttach('w1', { cwd: '/a', cols: 80, rows: 24 })
+    manager.openOrAttach('w2', { cwd: '/b', cols: 80, rows: 24 })
+
+    manager.disposeAll()
+    expect(ptys[0].killed).toEqual(['SIGTERM'])
+    expect(ptys[1].killed).toEqual(['SIGTERM'])
+    expect(manager.has('w1')).toBe(false)
+    expect(manager.has('w2')).toBe(false)
+  })
+})
+
+describe('capScrollback', () => {
+  it('keeps a under-cap buffer untouched and trims an over-cap one at a line boundary', () => {
+    expect(capScrollback('short')).toBe('short')
+
+    const lines = `${'x'.repeat(100)}\n`.repeat(Math.ceil(MAX_SCROLLBACK_CHARS / 101) + 50)
+    const capped = capScrollback(lines)
+    expect(capped.length).toBeLessThanOrEqual(MAX_SCROLLBACK_CHARS)
+    expect(capped.startsWith('x'.repeat(100))).toBe(true) // opens on a whole line
+
+    const oneLine = 'y'.repeat(MAX_SCROLLBACK_CHARS + 500)
+    expect(capScrollback(oneLine)).toHaveLength(MAX_SCROLLBACK_CHARS) // no newline — hard cut
+  })
+})

--- a/src/main/terminal/terminal-manager.ts
+++ b/src/main/terminal/terminal-manager.ts
@@ -1,0 +1,271 @@
+import {
+  DEFAULT_TERMINAL_ID,
+  MAX_TERMINAL_COLS,
+  MAX_TERMINAL_ROWS,
+  MAX_TERMINAL_WRITE_CHARS,
+  MIN_TERMINAL_COLS,
+  MIN_TERMINAL_ROWS,
+  type TerminalEvent,
+} from '../../shared/ipc'
+
+/**
+ * The Workspace terminal sessions we host in MAIN (ADR-0014; t3code's server-side
+ * `TerminalManager` mapped onto our no-server architecture). One PTY per Workspace
+ * this slice (id `term-1`); the session OUTLIVES the renderer's Surface — a tab
+ * switch or panel close unmounts the xterm view, and the next `openOrAttach`
+ * replays the in-memory scrollback buffer instead of respawning. The PTY dies only
+ * on explicit `close` (tab ×), Workspace removal, or app quit (`disposeAll`).
+ *
+ * Deliberately a FULL user shell (ADR-0014): no confinement, no approval gating —
+ * the same posture as the user's own terminal, CLI parity with running `vibe` by
+ * hand. The addressing boundary lives in the registrar (agentId -> pool -> cwd).
+ *
+ * The pty layer is an injected seam (`spawnPty`) so this core is unit-testable
+ * with a fake PTY — node-pty is wired in `register-ipc.ts` only, keeping the
+ * native module out of the test import graph.
+ */
+
+/** The slice of a node-pty `IPty` we depend on (injected; faked in tests). */
+export interface PtyLike {
+  pid: number
+  onData(listener: (data: string) => void): void
+  onExit(listener: (e: { exitCode: number; signal?: number }) => void): void
+  write(data: string): void
+  resize(cols: number, rows: number): void
+  kill(signal?: string): void
+}
+
+export interface SpawnPtyOptions {
+  /** The shell executable to launch. */
+  file: string
+  args: string[]
+  cwd: string
+  env: Record<string, string>
+  cols: number
+  rows: number
+}
+
+/** Spawn one PTY. MAY THROW synchronously (missing shell) — callers walk the fallback chain. */
+export type SpawnPtyFn = (options: SpawnPtyOptions) => PtyLike
+
+/**
+ * Scrollback retention cap, in characters (~a few thousand dense lines — the
+ * renderer's xterm keeps its own 5k-line scrollback; this buffer only has to
+ * cover the REATTACH replay). Trimmed at a line boundary so a replay never
+ * starts mid-escape-sequence of a torn first line.
+ */
+export const MAX_SCROLLBACK_CHARS = 2_000_000
+
+/** SIGTERM -> SIGKILL escalation grace (t3code's 1s). */
+export const KILL_GRACE_MS = 1_000
+
+/**
+ * Env vars stripped from the shell's environment (t3code's blocklist model — a
+ * small denylist, deliberately NOT an allowlist, so PATH/toolchain vars survive):
+ * Electron/dev-server plumbing a user shell must not inherit.
+ */
+const ENV_BLOCKLIST = ['ELECTRON_RUN_AS_NODE', 'ELECTRON_RENDERER_PORT', 'PORT', 'NODE_OPTIONS']
+const ENV_BLOCKLIST_PREFIX = 'VIBE_MISTRO_'
+
+/**
+ * The ordered shell candidates (t3code `resolveShellCandidates`, POSIX): the
+ * user's `$SHELL`, then common absolute fallbacks. NOT a login shell — the env
+ * already comes from the login-shell probe (`shell-env.ts`), and `-l` would
+ * re-source rc files into a second login context.
+ */
+export function shellCandidates(env: NodeJS.ProcessEnv): string[] {
+  const candidates = [env.SHELL, '/bin/zsh', '/bin/bash', '/bin/sh']
+  return [...new Set(candidates.filter((c): c is string => typeof c === 'string' && c.length > 0))]
+}
+
+/** The PTY env: the resolved shell env minus the blocklist, holes dropped for node-pty. */
+export function terminalEnv(base: NodeJS.ProcessEnv): Record<string, string> {
+  const env: Record<string, string> = {}
+  for (const [key, value] of Object.entries(base)) {
+    if (value === undefined) continue
+    if (ENV_BLOCKLIST.includes(key) || key.startsWith(ENV_BLOCKLIST_PREFIX)) continue
+    env[key] = value
+  }
+  return env
+}
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, Math.floor(value)))
+
+interface Session {
+  terminalId: string
+  pty: PtyLike
+  /** Retained scrollback for the reattach replay, capped at {@link MAX_SCROLLBACK_CHARS}. */
+  scrollback: string
+  exited: boolean
+  /** The pending SIGKILL escalation timer, when a close is in flight. */
+  killTimer: ReturnType<typeof setTimeout> | null
+}
+
+export interface TerminalManagerDeps {
+  spawnPty: SpawnPtyFn
+  /** The base environment (production: `getShellEnv()`). */
+  env: NodeJS.ProcessEnv
+  /** Publish one stream event to the renderer(s). */
+  emit: (event: TerminalEvent) => void
+  /** Injectable clock for the kill escalation (tests use fake timers). */
+  setTimeoutFn?: typeof setTimeout
+  clearTimeoutFn?: typeof clearTimeout
+}
+
+export class TerminalManager {
+  private readonly sessions = new Map<string, Session>()
+  private readonly deps: TerminalManagerDeps
+
+  constructor(deps: TerminalManagerDeps) {
+    this.deps = deps
+  }
+
+  /**
+   * Open the Workspace's shell session, or REATTACH to the live one. A running
+   * session just replies with its scrollback snapshot (the Surface remounted); an
+   * exited session is respawned fresh (its banner was seen — reopening the tab
+   * means "give me a shell"); no session spawns one. Never throws: a spawn failure
+   * (no usable shell / bad cwd) resolves `{ok:false}` for the Surface to render.
+   */
+  openOrAttach(
+    workspaceId: string,
+    options: { cwd: string; cols: number; rows: number },
+  ): { ok: true; terminalId: string; snapshot: string; exited: boolean } | { ok: false; error: string } {
+    const existing = this.sessions.get(workspaceId)
+    if (existing && !existing.exited) {
+      return { ok: true, terminalId: existing.terminalId, snapshot: existing.scrollback, exited: false }
+    }
+    if (existing) this.drop(workspaceId) // exited residue — respawn below
+
+    const cols = clamp(options.cols, MIN_TERMINAL_COLS, MAX_TERMINAL_COLS)
+    const rows = clamp(options.rows, MIN_TERMINAL_ROWS, MAX_TERMINAL_ROWS)
+    const env = terminalEnv(this.deps.env)
+    let pty: PtyLike | null = null
+    let lastError: unknown = null
+    for (const shell of shellCandidates(this.deps.env)) {
+      try {
+        pty = this.deps.spawnPty({ file: shell, args: [], cwd: options.cwd, env, cols, rows })
+        break
+      } catch (err) {
+        lastError = err // missing/broken shell — walk the fallback chain
+      }
+    }
+    if (!pty) {
+      const message = lastError instanceof Error ? lastError.message : String(lastError)
+      console.error(`[vibe-mistro:terminal] spawn failed (${workspaceId}): ${message}`)
+      return { ok: false, error: `Could not start a shell: ${message}` }
+    }
+
+    const session: Session = {
+      terminalId: DEFAULT_TERMINAL_ID,
+      pty,
+      scrollback: '',
+      exited: false,
+      killTimer: null,
+    }
+    this.sessions.set(workspaceId, session)
+    // Both callbacks guard on the session still being the CURRENT record for the
+    // key: after a `close` (record dropped) a dying shell's final output — or its
+    // exit — must not bleed into a freshly reopened session under the same id.
+    pty.onData((data) => {
+      if (this.sessions.get(workspaceId) !== session) return
+      session.scrollback = capScrollback(session.scrollback + data)
+      this.deps.emit({ workspaceId, terminalId: session.terminalId, event: { type: 'output', data } })
+    })
+    pty.onExit(({ exitCode }) => {
+      session.exited = true
+      this.cancelKillTimer(session)
+      if (this.sessions.get(workspaceId) !== session) return
+      this.deps.emit({ workspaceId, terminalId: session.terminalId, event: { type: 'exited', exitCode } })
+    })
+    return { ok: true, terminalId: session.terminalId, snapshot: '', exited: false }
+  }
+
+  /** Forward input to the session's PTY. Oversized writes are refused whole (logged). */
+  write(workspaceId: string, data: string): void {
+    const session = this.sessions.get(workspaceId)
+    if (!session || session.exited) return
+    if (data.length > MAX_TERMINAL_WRITE_CHARS) {
+      console.error(`[vibe-mistro:terminal] write refused: ${data.length} chars (${workspaceId})`)
+      return
+    }
+    session.pty.write(data)
+  }
+
+  /** Resize the session's PTY, clamped to the shared bounds. */
+  resize(workspaceId: string, cols: number, rows: number): void {
+    const session = this.sessions.get(workspaceId)
+    if (!session || session.exited) return
+    session.pty.resize(
+      clamp(cols, MIN_TERMINAL_COLS, MAX_TERMINAL_COLS),
+      clamp(rows, MIN_TERMINAL_ROWS, MAX_TERMINAL_ROWS),
+    )
+  }
+
+  /**
+   * Kill the session (explicit tab close / Workspace removal): SIGTERM, then
+   * SIGKILL after {@link KILL_GRACE_MS} if the process hasn't exited (t3code's
+   * escalation). The session record drops immediately — a close is final, so
+   * late output from the dying process is not re-buffered or re-emitted.
+   */
+  close(workspaceId: string): void {
+    const session = this.sessions.get(workspaceId)
+    if (!session) return
+    this.sessions.delete(workspaceId)
+    if (session.exited) return
+    try {
+      session.pty.kill('SIGTERM')
+    } catch {
+      return // already-dead process — nothing to escalate
+    }
+    const setTimeoutFn = this.deps.setTimeoutFn ?? setTimeout
+    session.killTimer = setTimeoutFn(() => {
+      if (session.exited) return
+      try {
+        session.pty.kill('SIGKILL')
+      } catch {
+        // Exited between the check and the kill — the escalation is moot.
+      }
+    }, KILL_GRACE_MS)
+    // Don't hold the process open for a grace timer alone (Electron quit path).
+    ;(session.killTimer as { unref?: () => void }).unref?.()
+  }
+
+  /** Whether the Workspace currently has a session (running or exited residue). */
+  has(workspaceId: string): boolean {
+    return this.sessions.has(workspaceId)
+  }
+
+  /** Kill every session (app quit). */
+  disposeAll(): void {
+    for (const workspaceId of [...this.sessions.keys()]) this.close(workspaceId)
+  }
+
+  /** Drop a session record without kill semantics (exited residue being respawned). */
+  private drop(workspaceId: string): void {
+    const session = this.sessions.get(workspaceId)
+    if (!session) return
+    this.cancelKillTimer(session)
+    this.sessions.delete(workspaceId)
+  }
+
+  private cancelKillTimer(session: Session): void {
+    if (session.killTimer === null) return
+    const clearTimeoutFn = this.deps.clearTimeoutFn ?? clearTimeout
+    clearTimeoutFn(session.killTimer)
+    session.killTimer = null
+  }
+}
+
+/**
+ * Cap the reattach buffer, trimming at a line boundary past the cap so a replay
+ * never opens mid-line (mirrors t3code's line-capped history, char-budgeted here
+ * to avoid re-counting lines on every chunk).
+ */
+export function capScrollback(buffer: string): string {
+  if (buffer.length <= MAX_SCROLLBACK_CHARS) return buffer
+  const cut = buffer.length - MAX_SCROLLBACK_CHARS
+  const newline = buffer.indexOf('\n', cut)
+  return newline === -1 ? buffer.slice(cut) : buffer.slice(newline + 1)
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -22,6 +22,12 @@ import {
   type FilesListResult,
   type FilesReadArgs,
   type FilesReadResult,
+  type TerminalCloseArgs,
+  type TerminalEvent,
+  type TerminalOpenArgs,
+  type TerminalOpenResult,
+  type TerminalResizeArgs,
+  type TerminalWriteArgs,
   type GitStatusEvent,
   type GitStatusSubscriptionArgs,
   type ListMetadataResult,
@@ -120,7 +126,16 @@ const api = {
   revealPath: (args: RevealPathArgs): Promise<void> => ipcRenderer.invoke(IPC.revealPath, args),
   filesList: (args: FilesListArgs): Promise<FilesListResult> => ipcRenderer.invoke(IPC.filesList, args),
   filesRead: (args: FilesReadArgs): Promise<FilesReadResult> => ipcRenderer.invoke(IPC.filesRead, args),
+  terminalOpen: (args: TerminalOpenArgs): Promise<TerminalOpenResult> =>
+    ipcRenderer.invoke(IPC.terminalOpen, args),
+  terminalWrite: (args: TerminalWriteArgs): Promise<void> =>
+    ipcRenderer.invoke(IPC.terminalWrite, args),
+  terminalResize: (args: TerminalResizeArgs): Promise<void> =>
+    ipcRenderer.invoke(IPC.terminalResize, args),
+  terminalClose: (args: TerminalCloseArgs): Promise<void> =>
+    ipcRenderer.invoke(IPC.terminalClose, args),
   onAcpEvent: subscribe<AcpEvent>(IPC.acpEvent),
+  onTerminalEvent: subscribe<TerminalEvent>(IPC.terminalEvent),
   onThreadBound: subscribe<ThreadBoundEvent>(IPC.threadBound),
   onThreadStatus: subscribe<ThreadStatusEvent>(IPC.threadStatus),
   onThreadTitle: subscribe<ThreadTitleEvent>(IPC.threadTitle),

--- a/src/renderer/src/side-panel/SurfacePanel.tsx
+++ b/src/renderer/src/side-panel/SurfacePanel.tsx
@@ -17,6 +17,7 @@ import {
 import { ChangesPanel } from '../git/ChangesPanel'
 import { FilesSurface } from './FilesSurface'
 import { FilePreview } from './FilePreview'
+import { TerminalSurface } from './TerminalSurface'
 import { surfaceForChord } from './surface-keys'
 import { basename } from '../lib/paths'
 import {
@@ -28,6 +29,7 @@ import {
   closeWorkspaceSurfacesToRight,
   openWorkspaceFileSurface,
   openWorkspaceSurface,
+  openWorkspaceTerminalSurface,
   toggleWorkspaceSurface,
   useWorkspacePanel,
   type SingletonKind,
@@ -49,7 +51,8 @@ const NARROW_QUERY = '(max-width: 980px)'
  * active id) lives in the shared `side-panel-store`; this component renders it and drives
  * ⌘P/⌃⇧G. Open Surfaces show as a TAB STRIP; with zero open, the panel shows the launcher
  * CARDS (its empty state). Review re-homes the git Changes panel behavior-identical
- * (#84–#88, ADR-0008); Files is the searchable tree (#188); Terminal/Browser are inert.
+ * (#84–#88, ADR-0008); Files is the searchable tree (#188); Terminal is the Workspace
+ * shell (ADR-0014); Browser stays inert/reserved.
  *
  * Presentation is DUAL: inline beside the conversation on wide windows — a full-height,
  * flush, `border-l`-separated column (t3code's editor-panel chrome) whose width is
@@ -211,6 +214,39 @@ function PanelBody({
 
   const active = panel.surfaces.find((s) => s.id === panel.activeSurfaceId) ?? null
 
+  // A close op is a VIEW op for every Surface except terminal, whose tab IS the
+  // session's lifetime (ADR-0014): unmount keeps the shell (reattach later), but
+  // explicitly closing the tab kills the PTY. Each close path first kills the
+  // sessions its store op is about to remove (one per Workspace this slice, so
+  // any removed terminal Surface maps to the one `terminalClose`).
+  function killTerminalsAmong(removed: Surface[]): void {
+    if (removed.some((surface) => surface.kind === 'terminal')) {
+      void window.api.terminalClose({ workspaceId })
+    }
+  }
+  function closeSurfaceAndKill(id: string): void {
+    killTerminalsAmong(panel.surfaces.filter((surface) => surface.id === id))
+    closeWorkspaceSurface(workspaceId, id)
+  }
+  function closeOthersAndKill(id: string): void {
+    killTerminalsAmong(panel.surfaces.filter((surface) => surface.id !== id))
+    closeOtherWorkspaceSurfaces(workspaceId, id)
+  }
+  function closeToRightAndKill(id: string): void {
+    const index = panel.surfaces.findIndex((surface) => surface.id === id)
+    if (index >= 0) killTerminalsAmong(panel.surfaces.slice(index + 1))
+    closeWorkspaceSurfacesToRight(workspaceId, id)
+  }
+  function closeAllAndKill(): void {
+    killTerminalsAmong(panel.surfaces)
+    closeAllWorkspaceSurfaces(workspaceId)
+  }
+  /** A launcher card / "+"-menu target: singletons via the store op, terminal via its own. */
+  function openCardTarget(target: CardDef['target']): void {
+    if (target === 'terminal') openWorkspaceTerminalSurface(workspaceId)
+    else if (target !== 'browser') openWorkspaceSurface(workspaceId, target)
+  }
+
   return (
     <aside
       aria-label="Side panel"
@@ -239,18 +275,18 @@ function PanelBody({
         />
       )}
       {panel.surfaces.length === 0 ? (
-        <LauncherGrid onOpen={(kind) => openWorkspaceSurface(workspaceId, kind)} />
+        <LauncherGrid onOpen={openCardTarget} />
       ) : (
         <>
           <SurfaceTabStrip
             surfaces={panel.surfaces}
             activeSurfaceId={panel.activeSurfaceId}
             onActivate={(id) => activateWorkspaceSurface(workspaceId, id)}
-            onClose={(id) => closeWorkspaceSurface(workspaceId, id)}
-            onCloseOthers={(id) => closeOtherWorkspaceSurfaces(workspaceId, id)}
-            onCloseToRight={(id) => closeWorkspaceSurfacesToRight(workspaceId, id)}
-            onCloseAll={() => closeAllWorkspaceSurfaces(workspaceId)}
-            onOpen={(kind) => openWorkspaceSurface(workspaceId, kind)}
+            onClose={closeSurfaceAndKill}
+            onCloseOthers={closeOthersAndKill}
+            onCloseToRight={closeToRightAndKill}
+            onCloseAll={closeAllAndKill}
+            onOpen={openCardTarget}
           />
           <div className="flex min-h-0 flex-1 flex-col">
             {active?.kind === 'review' && (
@@ -273,6 +309,12 @@ function PanelBody({
                 agentId={agentId}
                 onOpenFile={(relativePath) => openWorkspaceFileSurface(workspaceId, relativePath)}
               />
+            )}
+            {active?.kind === 'terminal' && (
+              // The Workspace's shell (ADR-0014). Keyed by the surface id so a future
+              // multi-terminal slice remounts per session; the SESSION lives in main —
+              // this view detaching (tab switch) leaves the shell running.
+              <TerminalSurface key={active.id} workspaceId={workspaceId} agentId={agentId} />
             )}
             {active?.kind === 'file' && (
               // A read-only file preview tab (#189): fetches the confined `files:read` and renders
@@ -333,7 +375,7 @@ function SurfaceTabStrip({
   onCloseOthers: (id: string) => void
   onCloseToRight: (id: string) => void
   onCloseAll: () => void
-  onOpen: (kind: SingletonKind) => void
+  onOpen: (target: CardDef['target']) => void
 }): JSX.Element {
   return (
     <div
@@ -412,7 +454,7 @@ function SurfaceTabStrip({
             <MenuItem
               key={card.label}
               disabled={!card.live}
-              onClick={card.live ? () => onOpen(card.target as SingletonKind) : undefined}
+              onClick={card.live ? () => onOpen(card.target) : undefined}
             >
               <span className="flex items-center gap-2 [&_svg]:size-4 [&_svg]:shrink-0 [&_svg]:text-muted">
                 {card.icon}
@@ -453,7 +495,7 @@ const CARDS: readonly CardDef[] = [
     label: 'Terminal',
     description: 'Run commands in the Workspace.',
     icon: <SquareTerminal aria-hidden />,
-    live: false,
+    live: true,
   },
   {
     target: 'browser',
@@ -480,7 +522,7 @@ const CARDS: readonly CardDef[] = [
  * Browser cards are disabled + tagged "Soon" (the sidebar PlaceholderNav precedent).
  * Opening one replaces the grid with the tab strip; closing the last tab returns here.
  */
-function LauncherGrid({ onOpen }: { onOpen: (kind: SingletonKind) => void }): JSX.Element {
+function LauncherGrid({ onOpen }: { onOpen: (target: CardDef['target']) => void }): JSX.Element {
   return (
     <div className="flex min-h-0 flex-1 items-center justify-center overflow-y-auto p-6">
       <div className="w-full max-w-xl">
@@ -493,7 +535,7 @@ function LauncherGrid({ onOpen }: { onOpen: (kind: SingletonKind) => void }): JS
             <LauncherCard
               key={card.label}
               card={card}
-              onClick={card.live ? () => onOpen(card.target as SingletonKind) : undefined}
+              onClick={card.live ? () => onOpen(card.target) : undefined}
             />
           ))}
         </div>

--- a/src/renderer/src/side-panel/TerminalSurface.tsx
+++ b/src/renderer/src/side-panel/TerminalSurface.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useRef, useState, type JSX } from 'react'
+import { Terminal } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import '@xterm/xterm/css/xterm.css'
+
+/**
+ * The Terminal Surface (ADR-0014): an xterm.js view over the Workspace's shell
+ * session hosted in MAIN. The view is DISPOSABLE — the PTY and its scrollback
+ * live behind the `terminal:*` IPC, so mounting is open-OR-REATTACH (the reply's
+ * snapshot replays the buffer) and unmounting (tab switch / panel close) leaves
+ * the shell running. Only the tab's explicit close × kills it (SurfacePanel
+ * invokes `terminalClose` alongside the store op).
+ *
+ * t3code parity choices (their ThreadTerminalDrawer): FitAddon only (no webgl/
+ * search), 12px mono, 5k scrollback, theme read off our design tokens via
+ * computed style at mount (live re-theme is slice 4), fit-then-resize on mount
+ * and container resize.
+ */
+export function TerminalSurface({
+  workspaceId,
+  agentId,
+}: {
+  workspaceId: string
+  /** The warm agent whose Workspace dir becomes the shell's cwd (#188 F3 addressing). */
+  agentId: string
+}): JSX.Element {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  // A spawn failure (no usable shell / cold agent) renders as a notice instead of a dead grid.
+  const [openError, setOpenError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const styles = getComputedStyle(container)
+    const terminal = new Terminal({
+      cursorBlink: true,
+      fontSize: 12,
+      fontFamily: '"SF Mono", Monaco, Menlo, Consolas, "Liberation Mono", monospace',
+      scrollback: 5_000,
+      theme: {
+        background: styles.backgroundColor,
+        foreground: styles.color,
+      },
+    })
+    const fit = new FitAddon()
+    terminal.loadAddon(fit)
+    terminal.open(container)
+    fit.fit()
+
+    let disposed = false
+    let exited = false
+
+    // Subscribe BEFORE the open resolves so no output slips between the snapshot
+    // and the live tail; filter to THIS Workspace's session (the acp:event pattern).
+    const unsubscribe = window.api.onTerminalEvent((e) => {
+      if (e.workspaceId !== workspaceId) return
+      if (e.event.type === 'output') {
+        terminal.write(e.event.data)
+        return
+      }
+      // exited: banner + stop accepting input (the session's scrollback is
+      // retained main-side; reopening the tab respawns a fresh shell).
+      exited = true
+      terminal.write(`\r\n\u001b[2m[terminal] Process exited (code ${e.event.exitCode})\u001b[0m\r\n`)
+    })
+
+    void window.api
+      .terminalOpen({ agentId, workspaceId, cols: terminal.cols, rows: terminal.rows })
+      .then((result) => {
+        if (disposed) return
+        if (!result.ok) {
+          setOpenError(result.error)
+          return
+        }
+        if (result.snapshot.length > 0) terminal.write(result.snapshot)
+        // A reattach can land with a stale size (the panel was resized while the
+        // view was unmounted) — refit and tell the PTY.
+        fit.fit()
+        void window.api.terminalResize({ workspaceId, cols: terminal.cols, rows: terminal.rows })
+      })
+
+    const dataDisposable = terminal.onData((data) => {
+      if (exited) return
+      void window.api.terminalWrite({ workspaceId, data })
+    })
+
+    // Follow the panel's drag-resize / window resize: refit the grid, then push
+    // the new dimensions to the PTY so full-screen programs reflow.
+    const resizeObserver = new ResizeObserver(() => {
+      if (disposed) return
+      fit.fit()
+      void window.api.terminalResize({ workspaceId, cols: terminal.cols, rows: terminal.rows })
+    })
+    resizeObserver.observe(container)
+
+    terminal.focus()
+
+    return () => {
+      // View teardown ONLY — the session keeps running for the next reattach.
+      disposed = true
+      resizeObserver.disconnect()
+      dataDisposable.dispose()
+      unsubscribe()
+      terminal.dispose()
+    }
+  }, [workspaceId, agentId])
+
+  return (
+    <div className="relative flex min-h-0 flex-1 flex-col bg-panel">
+      <div ref={containerRef} className="min-h-0 flex-1 px-2 py-1.5" />
+      {openError && (
+        <div className="absolute inset-0 flex items-center justify-center bg-panel p-6">
+          <p className="max-w-sm text-center text-xs leading-relaxed text-muted">{openError}</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/side-panel/side-panel-store.test.ts
+++ b/src/renderer/src/side-panel/side-panel-store.test.ts
@@ -13,6 +13,7 @@ import {
   getWorkspacePanel,
   openFileSurface,
   openSurface,
+  openTerminalSurface,
   openWorkspaceFileSurface,
   openWorkspaceSurface,
   readPanelMap,
@@ -107,6 +108,25 @@ describe('openFileSurface', () => {
     const withFile = openFileSurface(withReview, 'src/app.ts')
     expect(withFile.surfaces).toEqual([REVIEW, APP])
     expect(withFile.activeSurfaceId).toBe('file:src/app.ts')
+  })
+})
+
+describe('openTerminalSurface (ADR-0014)', () => {
+  const TERM: Surface = { id: 'terminal:term-1', kind: 'terminal', resourceId: 'term-1' }
+
+  it('opens the term-1 terminal tab and activates it, opening the panel', () => {
+    expect(openTerminalSurface(empty())).toEqual({
+      isOpen: true,
+      activeSurfaceId: 'terminal:term-1',
+      surfaces: [TERM],
+    })
+  })
+
+  it('re-activates the already-open terminal instead of duplicating (fixed resource id)', () => {
+    const withOthers = openSurface(openTerminalSurface(empty()), 'review')
+    const again = openTerminalSurface(withOthers)
+    expect(again.surfaces).toEqual([TERM, REVIEW])
+    expect(again.activeSurfaceId).toBe('terminal:term-1')
   })
 })
 
@@ -361,8 +381,19 @@ describe('coerceSurface', () => {
     expect(coerceSurface({ id: 'file:5', kind: 'file', relativePath: 5 })).toBeNull() // non-string
   })
 
+  it('accepts the slice-1 terminal singleton and drops any other terminal blob', () => {
+    expect(coerceSurface({ id: 'terminal:term-1', kind: 'terminal', resourceId: 'term-1' })).toEqual({
+      id: 'terminal:term-1',
+      kind: 'terminal',
+      resourceId: 'term-1',
+    })
+    expect(coerceSurface({ kind: 'terminal' })).toBeNull() // no id/resource
+    expect(coerceSurface({ id: 'terminal:term-2', kind: 'terminal', resourceId: 'term-2' })).toBeNull() // future multi-terminal blob
+    expect(coerceSurface({ id: 'terminal:term-1', kind: 'terminal', resourceId: 'term-9' })).toBeNull() // mismatched
+  })
+
   it('drops not-yet-implemented / unknown / malformed descriptors', () => {
-    expect(coerceSurface({ kind: 'terminal' })).toBeNull()
+    expect(coerceSurface({ kind: 'browser' })).toBeNull()
     expect(coerceSurface({ kind: 'nope' })).toBeNull()
     expect(coerceSurface(null)).toBeNull()
     expect(coerceSurface('review')).toBeNull()

--- a/src/renderer/src/side-panel/side-panel-store.ts
+++ b/src/renderer/src/side-panel/side-panel-store.ts
@@ -116,6 +116,31 @@ export function openFileSurface(state: WorkspacePanelState, relativePath: string
 }
 
 /**
+ * This slice's single per-Workspace terminal session id (ADR-0014; t3code's
+ * client-chosen `term-1`). Slice 3 mints `term-2`… for additional tabs.
+ */
+export const DEFAULT_TERMINAL_RESOURCE_ID = 'term-1'
+
+/** The slice-1 terminal descriptor: one session per Workspace, id keyed by the resource. */
+function terminalSurface(): Surface {
+  return {
+    id: `terminal:${DEFAULT_TERMINAL_RESOURCE_ID}`,
+    kind: 'terminal',
+    resourceId: DEFAULT_TERMINAL_RESOURCE_ID,
+  }
+}
+
+/**
+ * Open (or re-activate) the Workspace's terminal Surface (ADR-0014). Effectively a
+ * singleton this slice — the fixed `term-1` resource id makes `upsertSurface` dedupe
+ * it — but deliberately NOT a `SingletonKind`: the descriptor already carries the
+ * resource id, so slice 3's multi-terminal tabs extend this without a shape change.
+ */
+export function openTerminalSurface(state: WorkspacePanelState): WorkspacePanelState {
+  return upsertSurface(state, terminalSurface())
+}
+
+/**
  * The ⌘P / ⌃⇧G semantics (t3code `toggle`): if the panel is open AND this kind is the
  * ACTIVE tab, hide the panel (keep the tabs + active id). Otherwise open/activate the
  * singleton — which also OPENS a closed panel. So one chord opens, a second (while it's
@@ -236,6 +261,17 @@ export function coerceSurface(raw: unknown): Surface | null {
     const id = (raw as { id?: unknown }).id
     if (typeof relativePath === 'string' && relativePath.length > 0 && id === `file:${relativePath}`) {
       return { id: `file:${relativePath}`, kind: 'file', relativePath }
+    }
+    return null
+  }
+  if (kind === 'terminal') {
+    // A persisted terminal tab restores ONLY as this slice's fixed `term-1` singleton
+    // (activating it opens a fresh shell — the session itself never persists). Any
+    // other resource id is a future multi-terminal blob — dropped, not trusted.
+    const resourceId = (raw as { resourceId?: unknown }).resourceId
+    const id = (raw as { id?: unknown }).id
+    if (resourceId === DEFAULT_TERMINAL_RESOURCE_ID && id === `terminal:${resourceId}`) {
+      return { id: `terminal:${resourceId}`, kind: 'terminal', resourceId }
     }
     return null
   }
@@ -367,6 +403,7 @@ function bindWorkspaceOp<A extends unknown[]>(
 
 export const openWorkspaceSurface = bindWorkspaceOp(openSurface)
 export const openWorkspaceFileSurface = bindWorkspaceOp(openFileSurface)
+export const openWorkspaceTerminalSurface = bindWorkspaceOp(openTerminalSurface)
 export const toggleWorkspaceSurface = bindWorkspaceOp(toggleSurface)
 export const activateWorkspaceSurface = bindWorkspaceOp(activateSurface)
 export const closeWorkspaceSurface = bindWorkspaceOp(closeSurface)

--- a/src/shared/ipc/index.ts
+++ b/src/shared/ipc/index.ts
@@ -15,6 +15,7 @@ import { authChannels } from './auth'
 import { gitChannels } from './git'
 import { ghChannels } from './gh'
 import { filesChannels } from './files'
+import { terminalChannels } from './terminal'
 
 /**
  * The one typed channel map. ONE exported object — the channel names are the wire
@@ -28,6 +29,7 @@ export const IPC = {
   ...gitChannels,
   ...ghChannels,
   ...filesChannels,
+  ...terminalChannels,
 } as const
 
 export * from './core'
@@ -36,3 +38,4 @@ export * from './auth'
 export * from './git'
 export * from './gh'
 export * from './files'
+export * from './terminal'

--- a/src/shared/ipc/terminal.ts
+++ b/src/shared/ipc/terminal.ts
@@ -1,0 +1,90 @@
+/**
+ * Terminal domain of the shared IPC contract (ADR-0014): the side panel's Terminal
+ * Surface drives a real PTY shell hosted in the MAIN process. Deliberately a FULL,
+ * UNCONFINED user shell — CLI parity, the ADR-0004 posture, in contrast to the
+ * confined `files:*` reads — so the safety boundary is ADDRESSING, not confinement:
+ * `terminal:open` is `agentId`-addressed (#188 F3 model), the cwd is resolved
+ * main-side from the warm agent's own `workspaceDir`, and the renderer can only
+ * open a shell in a CONNECTED Workspace. Keep this file free of Node/DOM imports.
+ */
+
+/** The terminal channel entries, merged into the single `IPC` const in `./index`. */
+export const terminalChannels = {
+  /** Open — or REATTACH to — the Workspace's shell session; replies with the scrollback snapshot. */
+  terminalOpen: 'terminal:open',
+  /** Forward keystrokes/paste bytes to the session's PTY. */
+  terminalWrite: 'terminal:write',
+  /** Resize the PTY to the xterm viewport's cols × rows. */
+  terminalResize: 'terminal:resize',
+  /** Kill the session's PTY (explicit tab close / Workspace teardown). */
+  terminalClose: 'terminal:close',
+  /** Main -> renderer: a session's live stream — see {@link TerminalEvent}. */
+  terminalEvent: 'terminal:event',
+} as const
+
+/**
+ * Bounds, mirrored from t3code's schema caps: one write is at most 64 KiB of
+ * UTF-16 units (a paste larger than this is rejected main-side, never split —
+ * the renderer chunks if it ever needs to), and cols/rows are clamped to sane
+ * PTY ranges so a hostile/buggy resize can't wedge the pty layer.
+ */
+export const MAX_TERMINAL_WRITE_CHARS = 65_536
+export const MIN_TERMINAL_COLS = 1
+export const MAX_TERMINAL_COLS = 1_000
+export const MIN_TERMINAL_ROWS = 1
+export const MAX_TERMINAL_ROWS = 500
+
+/**
+ * This slice's single per-Workspace session id (t3code's client-chosen `term-1`
+ * convention). Multiple terminals per Workspace (slice 3) mint `term-2`… and lift
+ * the id into the args; every event already carries it so the stream shape is
+ * forward-compatible.
+ */
+export const DEFAULT_TERMINAL_ID = 'term-1'
+
+export interface TerminalOpenArgs {
+  /** The warm agent whose Workspace dir becomes the shell's cwd (pool-resolved, #188 F3). */
+  agentId: string
+  /** Our Workspace id — the session key all later calls address. */
+  workspaceId: string
+  /** The xterm viewport's initial size (already fitted before open). */
+  cols: number
+  rows: number
+}
+
+export type TerminalOpenResult =
+  // `snapshot` is the session's buffered scrollback: empty for a fresh spawn, the
+  // replay buffer when REATTACHING to a shell that kept running behind a closed
+  // tab/panel. `terminalId` tags which session the stream events will carry.
+  | { ok: true; terminalId: string; snapshot: string; exited: boolean }
+  // Unknown/cold agent, spawn failure (no usable shell), or a bad cwd.
+  | { ok: false; error: string }
+
+export interface TerminalWriteArgs {
+  workspaceId: string
+  /** Raw bytes from `xterm.onData` (UTF-8 text, control sequences included). */
+  data: string
+}
+
+export interface TerminalResizeArgs {
+  workspaceId: string
+  cols: number
+  rows: number
+}
+
+export interface TerminalCloseArgs {
+  workspaceId: string
+}
+
+/**
+ * One live-stream event on the `terminal:event` channel, tagged by Workspace +
+ * session so the renderer filters exactly like `acp:event` payloads route by
+ * session. `output` is a verbatim UTF-8 chunk for `xterm.write`; `exited`
+ * reports the shell's end (the Surface renders a banner and stops writing —
+ * the session's scrollback is retained main-side until the tab closes).
+ */
+export interface TerminalEvent {
+  workspaceId: string
+  terminalId: string
+  event: { type: 'output'; data: string } | { type: 'exited'; exitCode: number }
+}


### PR DESCRIPTION
## Summary

Terminal-dock epic, **slice 1/4**: the reserved Terminal card in the side panel goes live as an xterm.js Surface over a real PTY hosted in the **main process** (t3code's `TerminalManager` mapped onto our no-server architecture).

- **Main-owned PTY** (`src/main/terminal/`): `node-pty ^1.1.0` behind an injected `spawnPty` seam (native module stays out of the unit-test import graph). Shell = `$SHELL`→zsh→bash→sh fallback; env = the `shell-env` login probe minus an Electron/dev blocklist (denylist, not allowlist — PATH survives). Kill = SIGTERM → 1s → SIGKILL.
- **One session per Workspace** (`term-1`), deliberately a **full unconfined user shell** — CLI parity, the opposite of the confined `files:*` reads and documented as such in ADR-0014. Safety boundary is **addressing**: `terminal:open` is `agentId`-addressed, cwd resolved main-side from the pool, so only a connected Workspace can host a shell.
- **Disposable view**: open is open-OR-REATTACH (capped in-memory scrollback replays on remount), so tab switches / panel closes keep the shell running; only the tab's explicit close kills it. Sessions are independent of warm-agent eviction; Workspace removal and app quit tear them down.
- **IPC** (`src/shared/ipc/terminal.ts`): `terminal:open/write/resize/close` + one streamed `terminal:event` channel, UTF-8, 64KB write cap, cols/rows clamps.
- Docs: **ADR-0014** + CONTEXT.md "Terminal session" term.
- **Packaging gotcha fixed**: `bun install` drops the exec bit on node-pty's prebuilt darwin `spawn-helper` (`posix_spawnp failed`) — restored by a project `postinstall` (`scripts/fix-node-pty-perms.mjs`). node-pty 1.x is N-API-stable, so no electron-rebuild.

## Verification

- Gates green: lint + typecheck + build + **966 tests / 78 files** (+15 new: TerminalManager 14, side-panel store).
- **App-verified end to end over CDP**: real zsh (p10k prompt) in the Workspace cwd; command round-trip; same-PID reattach with scrollback replay across tab switches; exit banner; tab-close SIGTERM kill confirmed via `ps`; bad-`agentId` open refused.
- **Security review (HITL, slice plan requirement)**: no HIGH/MEDIUM findings — argv-exec (no shell string), cwd strictly pool-resolved (no traversal), `ELECTRON_RUN_AS_NODE` stripped, xterm writes to canvas (no XSS), fan-out matches the accepted `acp:event` single-window pattern.

Deferred to later slices (choices, not gaps): sequence-numbered attach protocol + output coalescing (2), multiple terminals per Workspace (3), link provider / selection-to-composer / live re-theme (4); splits, disk history, subprocess-name labels, Windows/WSL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)