### PR TITLE
Sign-in persist-failure surfacing + restart-agent recovery + persistent missing-CLI banner

### DIFF
--- a/docs/acp-capture.md
+++ b/docs/acp-capture.md
@@ -250,6 +250,13 @@ authenticate(method_id, **kwargs) -> AuthenticateResponse
    attempt by `attemptId`); `complete` requires that `attemptId` (else `InvalidRequestError`), calls
    `complete_attempt()` (blocks until the browser flow resolves), then persists to the keyring. So `start`
    is cheap/non-blocking and `complete` is the long-poll — orchestrate accordingly.
+
+   ⚠️ **`persistResult` carries failures IN-BAND** (`api_key_persistence.py`, source-read 2026-07-02): a
+   failed credential save does NOT raise — `complete` still resolves with `status:"completed"` and
+   `persistResult` set to an error detail (`"env_var_error:<env key>"` = nothing was saved anywhere;
+   `"save_error:<err>"` = keyring AND env-file both failed, only the agent process's env holds the key).
+   A client that ignores `persistResult` reports sign-in success while `_auth/status` (and every other
+   `vibe` process) stays signed out. Check it (`classifyPersistFailure`, `assertCredentialPersisted`).
    **This delegated mode is the right fit for vibe-mistro** (we open the URL via the system opener,
    show progress, stay non-blocking) — it mirrors CodexMonitor's `login/start → open authUrl → complete`,
    and is the **primary** path per ADR-0003 (blocking `browser-auth` is the fallback).

--- a/src/main/auth/auth-state.test.ts
+++ b/src/main/auth/auth-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { classifyAuthError, classifyAuthStatus } from './auth-state'
+import { classifyAuthError, classifyAuthStatus, classifyPersistFailure } from './auth-state'
 
 /**
  * Seam 1: the pure auth-state classifier. It maps an ACP failure/outcome to an
@@ -41,5 +41,29 @@ describe('classifyAuthStatus', () => {
     // Defensive: never guess sign-in state from a shape we don't recognize.
     expect(classifyAuthStatus({})).toBe('unknown')
     expect(classifyAuthStatus({ authState: 'os_keyring' })).toBe('unknown')
+  })
+})
+
+describe('classifyPersistFailure', () => {
+  it('passes a completed persist', () => {
+    expect(classifyPersistFailure('completed')).toBeNull()
+  })
+
+  it('surfaces the in-band failure detail (no JSON-RPC error accompanies it)', () => {
+    // The real shapes from vibe/setup/auth/api_key_persistence.py: the browser
+    // flow succeeded but NOTHING was saved (env_var_error) or only the process
+    // env was (save_error) — the exact "browser says signed in, app and terminal
+    // say signed out" stranding this classifier exists to prevent.
+    expect(classifyPersistFailure('env_var_error:MISTRAL_API_KEY')).toBe(
+      'env_var_error:MISTRAL_API_KEY',
+    )
+    expect(classifyPersistFailure('save_error:read-only file system')).toBe(
+      'save_error:read-only file system',
+    )
+  })
+
+  it('does not fail sign-in when the field is absent (older vibe-acp)', () => {
+    expect(classifyPersistFailure(undefined)).toBeNull()
+    expect(classifyPersistFailure(null)).toBeNull()
   })
 })

--- a/src/main/auth/auth-state.ts
+++ b/src/main/auth/auth-state.ts
@@ -33,6 +33,22 @@ export function classifyAuthStatus(status: unknown): AuthState {
 }
 
 /**
+ * Vibe's `authenticate` responses report credential-persist failures IN-BAND:
+ * `_meta[method].persistResult` is `"completed"` on success, or an error detail
+ * (`"env_var_error:…"`, `"save_error:…"`) with NO JSON-RPC error — the browser
+ * flow itself succeeded but the key was never saved to env/keyring
+ * (vibe/setup/auth/api_key_persistence.py). Ignoring it leaves every follow-up
+ * `_auth/status` signed out with only a vague "did not complete" to show for it.
+ * Returns the failure detail to surface, or null when the persist succeeded —
+ * or when the field is absent (older vibe-acp), which must not fail sign-in.
+ * This reads a save-status string, never a credential (ADR-0003 still holds).
+ */
+export function classifyPersistFailure(persistResult: unknown): string | null {
+  if (typeof persistResult !== 'string' || persistResult === 'completed') return null
+  return persistResult
+}
+
+/**
  * Whether `_auth/status` reports sign-out is available (`signOutAvailable`).
  * Gates the renderer's Sign-out control — only `true` enables it (acp-capture §8;
  * `_auth/signOut` errors -32602 when it's false).

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -776,6 +776,14 @@ function registerIpc(deps: MainDeps): void {
     activity.beginAuth(args.agentId)
     try {
       const authState = await agent.signIn(args.methodId)
+      if (authState !== 'signed-in') {
+        // complete + persist both reported success yet status still isn't
+        // signed-in — per Vibe's source this shouldn't be reachable, so leave a
+        // loud breadcrumb: it means a contract change we need to hear about.
+        console.error(
+          `[vibe-mistro:auth] sign-in completed but status reports '${authState}' (agent ${args.agentId})`,
+        )
+      }
       return { ok: true, authState }
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err)

--- a/src/main/vibe-detect.ts
+++ b/src/main/vibe-detect.ts
@@ -1,6 +1,7 @@
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import type { VibeDetectResult } from '../shared/ipc'
+import { INSTALL_HINT } from '../shared/install-guidance'
 import { getShellEnv } from './shell-env'
 
 const execFileAsync = promisify(execFile)
@@ -47,12 +48,12 @@ export async function detectVibe(): Promise<VibeDetectResult> {
       }
     }
 
+    // Specific first sentence + the ONE canonical install hint (shared/install-guidance)
+    // — the same copy every missing-CLI surface shows (first-run screen, banner, spawn error).
     if (!result.vibeFound) {
-      result.error =
-        'Mistral Vibe CLI not found. Install it and ensure `vibe` is on your PATH (see https://docs.mistral.ai/vibe/code/cli/install-setup).'
+      result.error = `Mistral Vibe CLI not found. ${INSTALL_HINT}`
     } else if (!result.vibeAcpFound) {
-      result.error =
-        '`vibe` was found but `vibe-acp` is not on PATH. The ACP server is required to drive Vibe from this app.'
+      result.error = `\`vibe\` was found but \`vibe-acp\` is not on PATH. ${INSTALL_HINT}`
     }
   } catch (err) {
     result.error = err instanceof Error ? err.message : String(err)

--- a/src/main/workspace-agent.test.ts
+++ b/src/main/workspace-agent.test.ts
@@ -380,6 +380,48 @@ describe('WorkspaceAgent — sign in (browser-auth-delegated)', () => {
     expect(agent.authState).toBe('signed-in')
   })
 
+  it('rejects (recoverably) when complete reports an in-band persist failure', async () => {
+    const fake = makeCapturingFake()
+    const agent = await connectSignedOut(fake, () => {})
+
+    const signingIn = agent.signIn(DELEGATED)
+    signingIn.catch(() => {}) // avoid an unhandled rejection before we assert
+
+    await new Promise((r) => setTimeout(r, 0))
+    const startReq = authSent(fake).find((m) => m.params?.action === 'start')
+    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: startReq?.id, result: startResult() }) + '\n')
+
+    await new Promise((r) => setTimeout(r, 0))
+    const completeReq = authSent(fake).find((m) => m.params?.action === 'complete')
+    // Vibe reports a failed credential save IN-BAND: `status:"completed"` with a
+    // persistResult error and NO JSON-RPC error (api_key_persistence.py). The
+    // browser said "signed in" but nothing reached env/keyring — swallowing this
+    // (the pre-fix behavior) strands the user at a vague "did not complete".
+    fake.feed(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: completeReq?.id,
+        result: {
+          _meta: {
+            [DELEGATED]: {
+              attemptId: ATTEMPT_ID,
+              persistResult: 'env_var_error:MISTRAL_API_KEY',
+              status: 'completed',
+            },
+          },
+        },
+      }) + '\n',
+    )
+
+    const err = await signingIn.catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(WorkspaceAgentError)
+    expect((err as WorkspaceAgentError).message).toContain('could not save the credential')
+    expect((err as WorkspaceAgentError).message).toContain('env_var_error:MISTRAL_API_KEY')
+    expect((err as WorkspaceAgentError).hint).toBe(AUTH_HINT)
+    // No _auth/status round-trip after a failed persist — state stays signed-out.
+    expect(agent.authState).toBe('not-signed-in')
+  })
+
   it('rejects (recoverably) when complete fails for an expired/unknown attempt (-32602)', async () => {
     const fake = makeCapturingFake()
     const agent = await connectSignedOut(fake, () => {})

--- a/src/main/workspace-agent.ts
+++ b/src/main/workspace-agent.ts
@@ -2,8 +2,14 @@ import { EventEmitter } from 'node:events'
 import { AcpClient, type SpawnFn } from './acp/client'
 import { handleFsReadTextFile, type ReadTextFn } from './acp/fs-read'
 import { handleFsWriteTextFile, type WriteTextFn } from './acp/fs-write'
-import { classifyAuthError, classifyAuthStatus, extractSignOutAvailable } from './auth/auth-state'
+import {
+  classifyAuthError,
+  classifyAuthStatus,
+  classifyPersistFailure,
+  extractSignOutAvailable,
+} from './auth/auth-state'
 import { BLOCKING_AUTH_METHOD_ID, DELEGATED_AUTH_METHOD_ID } from '../shared/ipc'
+import { INSTALL_HINT } from '../shared/install-guidance'
 import type {
   AuthMethod,
   AuthState,
@@ -42,8 +48,9 @@ const PRIMARY_SESSION_OPEN_TIMEOUT_MS = 5000
 
 export const AUTH_HINT =
   'Run `vibe` to sign in, or `vibe --setup` to configure your Mistral Vibe account.'
-export const SPAWN_HINT =
-  'Install Mistral Vibe and ensure `vibe-acp` is on your PATH, then run `vibe` to sign in.'
+// The canonical install hint (shared/install-guidance) — the same copy the
+// first-run screen and the persistent banner show for the same root cause.
+export const SPAWN_HINT = INSTALL_HINT
 
 /** A failure surfaced to the renderer, optionally with an actionable hint. */
 export class WorkspaceAgentError extends Error {
@@ -383,7 +390,10 @@ export class WorkspaceAgent extends EventEmitter {
    * primary; acp-capture §8). Non-blocking `start` mints a `signInUrl` we open in
    * the system browser; the long-poll `complete` awaits the user finishing and
    * persists the key to Vibe's keyring; we then re-query `_auth/status` to
-   * confirm. Rejects (recoverably) on an expired/unknown attempt (-32602).
+   * confirm. Rejects (recoverably) on an expired/unknown attempt (-32602) — and
+   * on an in-band persist failure: Vibe reports a failed credential save in the
+   * `complete` response's `persistResult` WITHOUT a JSON-RPC error, so ignoring
+   * it would report the vague "did not complete" while nothing was ever saved.
    *
    * Unlike start(), this does NOT race `earlyFailure`; its no-wedge property
    * relies on AcpClient.rejectAllPending firing on `exit`/`stop`, which rejects
@@ -399,14 +409,40 @@ export class WorkspaceAgent extends EventEmitter {
     }
     if (meta.signInUrl) this.openUrl?.(meta.signInUrl)
 
-    await this.client.request('authenticate', {
+    const completed = await this.client.request('authenticate', {
       methodId,
       action: 'complete',
       attemptId: meta.attemptId,
     })
+    // Diagnostic breadcrumbs (main stderr; no credentials — these are status
+    // strings): the browser-says-signed-in-but-app-disagrees failure has hit
+    // live twice, and only the RAW complete/status payloads can decide between
+    // a persist failure, a stale keyring cache, and a contract change.
+    const completedMeta = extractDelegatedMeta(completed, methodId)
+    console.error(
+      `[vibe-mistro:auth] delegated complete: status=${String(completedMeta?.status)} persistResult=${String(completedMeta?.persistResult)}`,
+    )
+    this.assertCredentialPersisted(completed, methodId)
 
     const status = await this.client.request('_auth/status')
+    console.error(`[vibe-mistro:auth] post-sign-in _auth/status: ${JSON.stringify(status)}`)
     return this.applyAuthStatus(status)
+  }
+
+  /**
+   * Fail a sign-in whose `authenticate` response reports an in-band persist
+   * failure (`persistResult` !== "completed" — a save-status string, never a
+   * credential). Without this the browser flow "succeeds", nothing reaches the
+   * keyring, and the user is stranded signed-out with no reason shown.
+   */
+  private assertCredentialPersisted(response: unknown, methodId: string): void {
+    const failure = classifyPersistFailure(extractDelegatedMeta(response, methodId)?.persistResult)
+    if (failure) {
+      throw new WorkspaceAgentError(
+        `Browser sign-in finished, but Vibe could not save the credential (${failure}).`,
+        AUTH_HINT,
+      )
+    }
   }
 
   /**
@@ -414,9 +450,10 @@ export class WorkspaceAgent extends EventEmitter {
    * acp-capture §8) — used when the delegated method is not advertised. A SINGLE
    * `authenticate({methodId})` with NO `action`/`attemptId`: the AGENT opens the
    * browser and the call BLOCKS until the user finishes, then persists the key to
-   * Vibe's keyring. We open no URL (the agent does) and discard the response —
-   * `persistResult` is a credential signal we never read (ADR-0003) — then
-   * re-query `_auth/status` to confirm.
+   * Vibe's keyring. We open no URL (the agent does). The response's
+   * `persistResult` is checked like the delegated path's — it's a save-status
+   * string, not a credential (ADR-0003 holds) — then we re-query `_auth/status`
+   * to confirm.
    *
    * Like `signInDelegated`'s `complete`, this blocking call cannot be cancelled
    * over ACP; its no-wedge property relies on AcpClient.rejectAllPending firing on
@@ -424,7 +461,8 @@ export class WorkspaceAgent extends EventEmitter {
    * Keep that on refactor.
    */
   private async signInBlocking(methodId: string): Promise<AuthState> {
-    await this.client.request('authenticate', { methodId })
+    const completed = await this.client.request('authenticate', { methodId })
+    this.assertCredentialPersisted(completed, methodId)
     const status = await this.client.request('_auth/status')
     return this.applyAuthStatus(status)
   }
@@ -922,13 +960,18 @@ function formatAuthFailure(action: string, detail: string, code: number | null):
 interface DelegatedMeta {
   attemptId?: string
   signInUrl?: string
+  /** Save-status of the credential persist ("completed" or an error detail). */
+  persistResult?: unknown
+  /** Flow status ("completed" on a resolved complete). */
+  status?: unknown
 }
 
 /**
- * Pull the `browser-auth-delegated` payload out of an `authenticate` response.
- * The agent keys its `_meta` by the method id (acp-capture §8): both `start`
- * (`{attemptId, signInUrl, expiresAt}`) and `complete` (`{attemptId, status}`)
- * use this envelope.
+ * Pull the auth payload out of an `authenticate` response. The agent keys its
+ * `_meta` by the method id (acp-capture §8): delegated `start`
+ * (`{attemptId, signInUrl, expiresAt}`), delegated `complete`
+ * (`{attemptId, persistResult, status}`), and blocking `browser-auth`
+ * (`{persistResult, status}`) all use this envelope.
  */
 function extractDelegatedMeta(response: unknown, methodId: string): DelegatedMeta | null {
   const meta = (response as { _meta?: Record<string, unknown> } | null)?._meta

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -34,7 +34,9 @@ import { ArrowLeft, ArrowRight, Maximize2, PanelLeft, PanelRight, Terminal } fro
 import { IconButton } from './ui/icon-button'
 import { Shell, type WorkspaceFlags } from './shell/Shell'
 import { firstRunState } from './shell/first-run'
-import { initialNavState, navReducer } from './shell/nav-reducer'
+import { installBannerMessage } from './shell/install-banner'
+import { InstallBanner } from './shell/InstallBanner'
+import { findSelectedThread, initialNavState, navReducer } from './shell/nav-reducer'
 import {
   getSidebarCollapsed,
   setSidebarCollapsed as setSidebarCollapsedStore,
@@ -356,6 +358,20 @@ export function App(): JSX.Element {
     }
   }
 
+  /**
+   * Restart recovery for a stale warm agent: Vibe caches keyring reads
+   * PER-PROCESS (acp-capture §8), so a warm agent that started signed-out never
+   * sees an out-of-band sign-in (terminal, another process) — its `_auth/status`
+   * answers from the stale cache forever. Dispose the child, then re-run the
+   * normal connect flow: the FRESH process re-reads the keychain, landing
+   * connected if signed in or back at the sign-in panel if genuinely not.
+   * `stopAgent` is awaited so `startThread` can't reuse the stale agent.
+   */
+  async function restartAgent(workspaceId: string, agentId: string): Promise<void> {
+    await window.api.stopAgent(agentId)
+    await connectWorkspace(workspaceId)
+  }
+
   async function openProject(): Promise<void> {
     const workspaceDir = await window.api.openWorkspaceDialog()
     if (!workspaceDir) return
@@ -555,6 +571,17 @@ export function App(): JSX.Element {
   // so each NON-connected view re-adds the old p-6 breathing room via a wrapper here;
   // the connected view spends it inside its chat column (ConnectedWorkspace) instead.
   const inSettings = nav.view === 'settings'
+  // Persistent missing-CLI banner (visibility is the pure `installBannerMessage`):
+  // spans the shell under the window chrome so a selected Workspace / open Thread
+  // still surfaces the missing toolchain; suppressed where the fuller guidance is
+  // already on screen (the needs-install first-run outlet, Settings' Environment).
+  const emptyOutletVisible =
+    !inSettings && selected.status === 'idle' && !findSelectedThread(recents, nav)
+  const installBanner = installBannerMessage({
+    detect,
+    inSettings,
+    installOutletVisible: emptyOutletVisible,
+  })
   const outlet = (
     <>
       {connectedIds.map((wid) => {
@@ -609,6 +636,7 @@ export function App(): JSX.Element {
               connect={selected}
               onContinueToThread={(agentId) => void continueToThread(selectedWs ?? '', agentId)}
               onRetry={() => selectedWs && void connectWorkspace(selectedWs)}
+              onRestartAgent={(agentId) => selectedWs && void restartAgent(selectedWs, agentId)}
             />
           ) : (
             <ColdOutlet
@@ -695,6 +723,10 @@ export function App(): JSX.Element {
           </IconButton>
         </div>
       </header>
+
+      {installBanner && (
+        <InstallBanner message={installBanner} loading={loading} onRecheck={() => void runDetect()} />
+      )}
 
       <Shell
         collapsed={sidebarCollapsed}

--- a/src/renderer/src/auth/SignInPanel.tsx
+++ b/src/renderer/src/auth/SignInPanel.tsx
@@ -15,10 +15,19 @@ export function SignInPanel({
   agentId,
   authMethods,
   onSignedIn,
+  onRestartAgent,
 }: {
   agentId: string
   authMethods: AuthMethod[]
   onSignedIn: () => void
+  /**
+   * Stale-cache recovery: Vibe caches keyring reads per-process, so this warm
+   * agent can keep reporting signed-out after an out-of-band sign-in (terminal
+   * or another process). Disposes the agent and re-runs the connect flow — the
+   * fresh process re-reads the keychain. Offered from the recoverable error
+   * state (a failed sign-in or a still-not-signed-in check).
+   */
+  onRestartAgent: () => void
 }): JSX.Element {
   const [state, dispatch] = useReducer(authReducer, authMethods, initialAuthViewState)
   // Generation counter: bumped on every attempt start and on cancel. Neither the
@@ -41,7 +50,13 @@ export function SignInPanel({
     } else {
       dispatch({
         type: 'sign-in-error',
-        message: result.ok ? 'Sign-in did not complete. Please try again.' : result.error,
+        // ok-but-not-signed-in: Vibe said the browser flow AND the credential
+        // save succeeded, yet its status still reports signed out — a state its
+        // source says is unreachable, so point at the recovery affordances
+        // rather than a bare "try again".
+        message: result.ok
+          ? 'Vibe reported sign-in complete, but its status still shows signed out. Try "Already signed in? Check status", or sign in with `vibe` in a terminal.'
+          : result.error,
       })
     }
   }
@@ -66,7 +81,8 @@ export function SignInPanel({
     } else if (result.ok) {
       dispatch({
         type: 'sign-in-error',
-        message: 'Still not signed in. Finish signing in (in your browser or via `vibe`), then check again.',
+        message:
+          'Still not signed in. Finish signing in (in your browser or via `vibe`), then check again — or use "Restart agent" if you signed in elsewhere and it isn\'t picked up.',
       })
     } else {
       dispatch({ type: 'sign-in-error', message: result.error })
@@ -128,6 +144,15 @@ export function SignInPanel({
         <Button variant="ghost" onClick={() => void checkStatus()}>
           Already signed in? Check status
         </Button>
+        {view.kind === 'error' && (
+          <Button
+            variant="ghost"
+            onClick={onRestartAgent}
+            title="Stop and respawn this Workspace's agent — a fresh process re-reads the keychain, picking up a sign-in done in a terminal or another window"
+          >
+            Restart agent
+          </Button>
+        )}
       </div>
     </SignInCard>
   )

--- a/src/renderer/src/settings/Environment.tsx
+++ b/src/renderer/src/settings/Environment.tsx
@@ -1,6 +1,8 @@
 import type { JSX } from 'react'
 import type { VibeDetectResult } from '../../../shared/ipc'
+import { INSTALL_DOCS_URL } from '../../../shared/install-guidance'
 import { Button } from '../ui/button'
+import { CodeText } from '../ui/code-text'
 
 /** The environment check: whether `vibe` / `vibe-acp` are installed + reachable. */
 export function Environment({
@@ -28,7 +30,14 @@ export function Environment({
             <span className="status__label">version</span>
             <span className="status__value">{detect.vibeVersion ?? '—'}</span>
           </li>
-          {detect.error && <li className="status__error">{detect.error}</li>}
+          {detect.error && (
+            <li className="status__error">
+              <CodeText text={detect.error} />{' '}
+              <a className="underline" href={INSTALL_DOCS_URL} target="_blank" rel="noreferrer">
+                Install guide
+              </a>
+            </li>
+          )}
         </ul>
       )}
     </div>

--- a/src/renderer/src/shell/EmptyState.tsx
+++ b/src/renderer/src/shell/EmptyState.tsx
@@ -1,6 +1,8 @@
 import type { JSX } from 'react'
 import type { VibeDetectResult } from '../../../shared/ipc'
+import { INSTALL_DOCS_URL, INSTALL_HINT } from '../../../shared/install-guidance'
 import { Button } from '../ui/button'
+import { CodeText } from '../ui/code-text'
 import { Environment } from '../settings/Environment'
 import { Logo } from './logo'
 import { heroHeadline } from './hero-headline'
@@ -37,9 +39,13 @@ export function EmptyState({
         <div className="text-[15px] font-semibold text-text-strong">
           Install Mistral Vibe to get started
         </div>
+        {/* Same canonical copy as the spawn-error hint + the persistent banner
+            (shared/install-guidance) — one root cause, one message. */}
         <p className="hint">
-          vibe-mistro drives the <code>vibe-acp</code> ACP server. Install the Mistral Vibe CLI and{' '}
-          <code>vibe-acp</code>, then re-check below.
+          vibe-mistro drives the <code>vibe-acp</code> ACP server. <CodeText text={INSTALL_HINT} />{' '}
+          <a className="underline" href={INSTALL_DOCS_URL} target="_blank" rel="noreferrer">
+            Install guide
+          </a>
         </p>
         <Environment detect={detect} loading={loading} onRecheck={onRecheck} />
       </div>

--- a/src/renderer/src/shell/InstallBanner.tsx
+++ b/src/renderer/src/shell/InstallBanner.tsx
@@ -1,0 +1,40 @@
+import type { JSX } from 'react'
+import { TriangleAlert } from 'lucide-react'
+import { INSTALL_DOCS_URL } from '../../../shared/install-guidance'
+import { Button } from '../ui/button'
+import { CodeText } from '../ui/code-text'
+
+/**
+ * The persistent missing-CLI banner (t3code's provider-status banner, ours):
+ * a full-width strip under the window chrome, shown whenever detection says
+ * `vibe` / `vibe-acp` is missing and the fuller needs-install outlet isn't
+ * already on screen (visibility is the pure `installBannerMessage`). Same
+ * canonical copy as the first-run screen and main's spawn-failure hint.
+ */
+export function InstallBanner({
+  message,
+  loading,
+  onRecheck,
+}: {
+  message: string
+  loading: boolean
+  onRecheck: () => void
+}): JSX.Element {
+  return (
+    <div
+      role="alert"
+      className="flex flex-none items-center gap-2.5 border-b border-[var(--bad-tint-border)] bg-[var(--bad-tint)] px-4 py-1.5 text-[13px] text-text"
+    >
+      <TriangleAlert className="size-4 flex-none text-bad" aria-hidden />
+      <span className="min-w-0 flex-1">
+        <CodeText text={message} />{' '}
+        <a className="underline" href={INSTALL_DOCS_URL} target="_blank" rel="noreferrer">
+          Install guide
+        </a>
+      </span>
+      <Button variant="outline" size="xs" className="flex-none" onClick={onRecheck} disabled={loading}>
+        {loading ? 'Checking…' : 'Re-check'}
+      </Button>
+    </div>
+  )
+}

--- a/src/renderer/src/shell/Outlet.tsx
+++ b/src/renderer/src/shell/Outlet.tsx
@@ -14,10 +14,14 @@ export function TransientOutlet({
   connect,
   onContinueToThread,
   onRetry,
+  onRestartAgent,
 }: {
   connect: ConnectState
   onContinueToThread: (agentId: string) => void
   onRetry: () => void
+  /** Dispose this agent and re-run the connect flow — the sign-in panel's
+   * stale-keyring-cache recovery (a fresh process re-reads the keychain). */
+  onRestartAgent: (agentId: string) => void
 }): JSX.Element | null {
   switch (connect.status) {
     case 'connecting':
@@ -38,6 +42,7 @@ export function TransientOutlet({
           agentId={connect.agentId}
           authMethods={connect.authMethods}
           onSignedIn={() => onContinueToThread(connect.agentId)}
+          onRestartAgent={() => onRestartAgent(connect.agentId)}
         />
       )
     case 'error':

--- a/src/renderer/src/shell/install-banner.test.ts
+++ b/src/renderer/src/shell/install-banner.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import type { VibeDetectResult } from '../../../shared/ipc'
+import { INSTALL_HINT } from '../../../shared/install-guidance'
+import { installBannerMessage } from './install-banner'
+
+function detectResult(overrides: Partial<VibeDetectResult> = {}): VibeDetectResult {
+  return {
+    vibeFound: true,
+    vibeAcpFound: true,
+    vibeVersion: '1.0.0',
+    vibeAcpPath: '/usr/local/bin/vibe-acp',
+    error: null,
+    ...overrides,
+  }
+}
+
+const HIDDEN = { inSettings: false, installOutletVisible: false }
+
+describe('installBannerMessage', () => {
+  it('hides while detection is still pending (no flash before the check resolves)', () => {
+    expect(installBannerMessage({ detect: null, ...HIDDEN })).toBeNull()
+  })
+
+  it('hides when both binaries are found', () => {
+    expect(installBannerMessage({ detect: detectResult(), ...HIDDEN })).toBeNull()
+  })
+
+  it('shows the detect error when vibe is missing', () => {
+    const detect = detectResult({ vibeFound: false, vibeAcpFound: false, error: 'nope' })
+    expect(installBannerMessage({ detect, ...HIDDEN })).toBe('nope')
+  })
+
+  it('shows when only vibe-acp is missing', () => {
+    const detect = detectResult({ vibeAcpFound: false, error: 'acp missing' })
+    expect(installBannerMessage({ detect, ...HIDDEN })).toBe('acp missing')
+  })
+
+  it('falls back to the canonical hint when detect carries no error string', () => {
+    const detect = detectResult({ vibeFound: false, error: null })
+    expect(installBannerMessage({ detect, ...HIDDEN })).toContain(INSTALL_HINT)
+  })
+
+  it('hides on the Settings page (Environment panel already shows the status)', () => {
+    const detect = detectResult({ vibeFound: false, error: 'nope' })
+    expect(
+      installBannerMessage({ detect, inSettings: true, installOutletVisible: false }),
+    ).toBeNull()
+  })
+
+  it('hides when the needs-install first-run outlet is already on screen', () => {
+    const detect = detectResult({ vibeFound: false, error: 'nope' })
+    expect(
+      installBannerMessage({ detect, inSettings: false, installOutletVisible: true }),
+    ).toBeNull()
+  })
+})

--- a/src/renderer/src/shell/install-banner.ts
+++ b/src/renderer/src/shell/install-banner.ts
@@ -1,0 +1,21 @@
+import type { VibeDetectResult } from '../../../shared/ipc'
+import { INSTALL_HINT } from '../../../shared/install-guidance'
+
+/**
+ * Pure derivation (no React, no IPC) of the persistent missing-CLI banner: the
+ * message to show, or null to hide. Visible whenever detection says `vibe` /
+ * `vibe-acp` is missing, EXCEPT where a fuller version of the same guidance is
+ * already on screen — the needs-install first-run outlet and the Settings page
+ * (Environment panel). A still-pending detection (null) never shows the banner
+ * (same no-flash rule as `firstRunState`).
+ */
+export function installBannerMessage(args: {
+  detect: VibeDetectResult | null
+  inSettings: boolean
+  installOutletVisible: boolean
+}): string | null {
+  const { detect, inSettings, installOutletVisible } = args
+  if (detect === null || (detect.vibeFound && detect.vibeAcpFound)) return null
+  if (inSettings || installOutletVisible) return null
+  return detect.error ?? `Mistral Vibe CLI not found. ${INSTALL_HINT}`
+}

--- a/src/renderer/src/ui/code-text.tsx
+++ b/src/renderer/src/ui/code-text.tsx
@@ -1,0 +1,17 @@
+import type { JSX } from 'react'
+
+/**
+ * Render a copy string with `backtick` spans as inline <code> — so plain-string
+ * copy shared with main (e.g. shared/install-guidance) keeps its code styling
+ * in JSX surfaces without duplicating the wording per surface.
+ */
+export function CodeText({ text }: { text: string }): JSX.Element {
+  const parts = text.split('`')
+  return (
+    <>
+      {parts.map((part, i) =>
+        i % 2 === 1 ? <code key={i}>{part}</code> : <span key={i}>{part}</span>,
+      )}
+    </>
+  )
+}

--- a/src/shared/install-guidance.ts
+++ b/src/shared/install-guidance.ts
@@ -1,0 +1,13 @@
+/**
+ * Canonical missing-CLI copy, shared by every surface that tells the user to
+ * install Mistral Vibe: main's spawn-failure hint, the first-run screen, the
+ * Environment panel, and the persistent shell banner. One root cause, one
+ * message — these surfaces must not drift apart again. Must stay free of
+ * Node/DOM imports (imported from both main and renderer).
+ */
+
+export const INSTALL_DOCS_URL = 'https://docs.mistral.ai/vibe/code/cli/install-setup'
+
+/** The one actionable install hint. Backtick spans render as inline code in the UI. */
+export const INSTALL_HINT =
+  'Install the Mistral Vibe CLI and ensure `vibe-acp` is on your PATH, then run `vibe` to sign in.'


### PR DESCRIPTION
## Why

Live bug: sign-in from the app opened the browser, the user finished there, yet the app (and the terminal CLI) stayed signed out — with only a vague "Sign-in did not complete." Diagnosed against Vibe's installed source:

1. **Vibe reports credential-persist failures in-band** — `authenticate complete` resolves with `status:"completed"` and the failure only in `persistResult` (no JSON-RPC error). We discarded that response, so a failed save looked like success (`vibe/setup/auth/api_key_persistence.py`).
2. **Vibe caches keyring reads per-process** (`vibe/core/utils/keyring.py`) — a warm agent that started signed-out answers `_auth/status` from a stale cache forever, so an out-of-band sign-in (terminal, another window) is invisible until the process restarts. This broke the #80 "Check status" recovery.

## What

**Auth**
- `classifyPersistFailure` (pure, tested) + `assertCredentialPersisted` on both the delegated and blocking sign-in paths — a failed persist now rejects recoverably with Vibe's exact reason instead of a vague message.
- **"Restart agent"** button on the sign-in panel's error state: dispose the warm agent + normal reconnect → fresh process re-reads the keychain (thread history survives by design).
- `[vibe-mistro:auth]` diagnostics: raw `complete` outcome + raw post-sign-in `_auth/status` (status strings only, never credentials) to main stderr, so the next live failure is decidable.
- Contract documented in `docs/acp-capture.md` §8.

**Missing-CLI UX (t3code parity)**
- One canonical install hint in `src/shared/install-guidance.ts`, reused by the ENOENT spawn hint, `detectVibe` errors, the first-run screen, and Settings → Environment (each previously had drifting copy).
- Persistent `InstallBanner` strip under the window chrome whenever `vibe`/`vibe-acp` is missing — visible even with a workspace open; suppressed where the fuller guidance is already on screen (pure `installBannerMessage`, unit-tested).

## Verification

`bun run lint && bun run typecheck && bun run build && bun run test` — all green, 960 tests (12 new: persist classifier, in-band persist-failure rejection, banner visibility). Live smoke of a real failed persist isn't reproducible on demand; the new diagnostics exist precisely to catch the next occurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)