### PR TITLE
feat(conversation): skill/command chip on user messages

### DIFF
--- a/src/renderer/src/conversation/Conversation.tsx
+++ b/src/renderer/src/conversation/Conversation.tsx
@@ -387,6 +387,7 @@ export function Conversation({
               // history's "Thinking" blocks (they belong to prior, settled turns).
               streaming={state.isProcessing && idx > lastUserIndex}
               onPermission={respondPermission}
+              availableCommands={state.availableCommands}
             />
           ))}
           {/* Working indicator (#115): while a turn is in flight, a self-ticking

--- a/src/renderer/src/conversation/command-autocomplete.test.ts
+++ b/src/renderer/src/conversation/command-autocomplete.test.ts
@@ -3,6 +3,7 @@ import {
   applyCommand,
   filterCommands,
   getCommandQuery,
+  matchInvokedCommand,
   moveSelection,
 } from './command-autocomplete'
 import type { AcpCommand } from './reducer'
@@ -139,5 +140,52 @@ describe('moveSelection — wrapping', () => {
 
   it('clamps to 0 for an empty list', () => {
     expect(moveSelection(0, 0, 1)).toBe(0)
+  })
+})
+
+describe('matchInvokedCommand — sent-message skill/command detection', () => {
+  it('matches a bare `/name` prompt', () => {
+    expect(matchInvokedCommand('/init', COMMANDS)).toEqual({ name: 'init', description: 'Initialise' })
+  })
+
+  it('matches `/name` followed by extra instructions', () => {
+    expect(matchInvokedCommand('/review the composer changes', COMMANDS)?.name).toBe('review')
+  })
+
+  it('tolerates surrounding whitespace (the composer trims, but mirror the server anyway)', () => {
+    expect(matchInvokedCommand('  /clear  ', COMMANDS)?.name).toBe('clear')
+  })
+
+  it('tolerates whitespace between the slash and the name (Python split(None) semantics)', () => {
+    expect(matchInvokedCommand('/ init', COMMANDS)?.name).toBe('init')
+  })
+
+  it('matches case-insensitively', () => {
+    expect(matchInvokedCommand('/REVIEW now', COMMANDS)?.name).toBe('review')
+  })
+
+  it('rejects a name that is not in the list', () => {
+    expect(matchInvokedCommand('/unknown', COMMANDS)).toBeNull()
+  })
+
+  it('rejects text that does not open with a slash', () => {
+    expect(matchInvokedCommand('run /init please', COMMANDS)).toBeNull()
+  })
+
+  it('rejects a prefix of a command name (no partial matches)', () => {
+    expect(matchInvokedCommand('/rev', COMMANDS)).toBeNull()
+  })
+
+  it('rejects a bare slash and an empty message', () => {
+    expect(matchInvokedCommand('/', COMMANDS)).toBeNull()
+    expect(matchInvokedCommand('', COMMANDS)).toBeNull()
+  })
+
+  it('rejects everything against an empty commands list (pre-bind draft)', () => {
+    expect(matchInvokedCommand('/init', [])).toBeNull()
+  })
+
+  it('splits the name on any whitespace, including a newline', () => {
+    expect(matchInvokedCommand('/init\ndo it', COMMANDS)?.name).toBe('init')
   })
 })

--- a/src/renderer/src/conversation/command-autocomplete.ts
+++ b/src/renderer/src/conversation/command-autocomplete.ts
@@ -99,6 +99,26 @@ export function applyCommand(
 }
 
 /**
+ * Match a SENT message against the commands list, mirroring vibe-acp's own
+ * server-side parse (`SkillManager.parse_skill_command` + the builtin-command
+ * normalization): the whole text, after trim, must open with `/`, and the first
+ * whitespace-delimited word (lowercased, leading whitespace after the `/`
+ * tolerated — Python's `split(None)` semantics) must equal a command name.
+ * Returns the matched command or null. This is how the user-message row knows a
+ * prompt invoked a skill/command — the agent gives no wire-level signal.
+ */
+export function matchInvokedCommand(
+  text: string,
+  commands: readonly AcpCommand[],
+): AcpCommand | null {
+  const stripped = text.trim()
+  if (!stripped.startsWith('/')) return null
+  const name = stripped.slice(1).trimStart().split(TOKEN_WHITESPACE, 1)[0]?.toLowerCase()
+  if (!name) return null
+  return commands.find((command) => command.name.toLowerCase() === name) ?? null
+}
+
+/**
  * Move a wrapping selection index by `delta` (typically ±1 for ↑/↓) over a list of
  * `length` rows, wrapping past either end. An empty list clamps to 0 so callers can
  * pass the result back without a special case.

--- a/src/renderer/src/conversation/items/Item.tsx
+++ b/src/renderer/src/conversation/items/Item.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from 'react'
-import type { ConversationItem, PermissionItem, PermissionOption } from '../reducer'
+import type { AcpCommand, ConversationItem, PermissionItem, PermissionOption } from '../reducer'
 import { AssistantRow, UserRow } from './message-rows'
 import { ReasoningRow } from './ReasoningRow'
 import { ToolRow } from './ToolRow'
@@ -10,15 +10,18 @@ export function Item({
   item,
   streaming,
   onPermission,
+  availableCommands,
 }: {
   item: ConversationItem
   /** True while this Thread's turn is in flight (#115) — drives reasoning auto-open. */
   streaming: boolean
   onPermission: (item: PermissionItem, option: PermissionOption) => void
+  /** The session's slash commands/skills — user rows chip a leading `/name` match. */
+  availableCommands?: readonly AcpCommand[]
 }): JSX.Element {
   switch (item.kind) {
     case 'user':
-      return <UserRow item={item} />
+      return <UserRow item={item} availableCommands={availableCommands} />
     case 'reasoning':
       return <ReasoningRow item={item} streaming={streaming} />
     case 'assistant':

--- a/src/renderer/src/conversation/items/message-rows.tsx
+++ b/src/renderer/src/conversation/items/message-rows.tsx
@@ -1,14 +1,37 @@
 import { useEffect, useRef, useState, type JSX } from 'react'
-import { Check, Copy, RotateCcw, ThumbsDown, ThumbsUp } from 'lucide-react'
+import { Check, Copy, RotateCcw, Sparkles, ThumbsDown, ThumbsUp } from 'lucide-react'
 import { IconButton } from '../../ui/icon-button'
 import { Response } from '../Response'
-import type { AssistantItem, UserItem } from '../reducer'
+import { matchInvokedCommand } from '../command-autocomplete'
+import type { AcpCommand, AssistantItem, UserItem } from '../reducer'
 
-export function UserRow({ item }: { item: UserItem }): JSX.Element {
+export function UserRow({
+  item,
+  availableCommands,
+}: {
+  item: UserItem
+  /** The session's slash commands/skills — a leading `/name` match renders a chip. */
+  availableCommands?: readonly AcpCommand[]
+}): JSX.Element {
+  // Skill/command chip: vibe-acp invokes a skill when the prompt opens with a
+  // known `/name`, but gives NO wire-level acknowledgment — so we surface the
+  // match ourselves. Matched at RENDER time against the CURRENT list (not stamped
+  // at send): a draft's first prompt is sent before `available_commands_update`
+  // streams, so the chip appears retroactively once the list arrives.
+  const command = matchInvokedCommand(item.text, availableCommands ?? [])
   // User turn (#114): a right-aligned rounded bubble, capped so long prose wraps
   // instead of spanning the pane. Echoed attachments (#100) re-home into the bubble.
   return (
     <div className="flex flex-col items-end gap-1.5">
+      {command && (
+        <span
+          data-command-chip
+          title={command.description}
+          className="inline-flex items-center gap-1 rounded-md border border-[var(--accent-tint-border)] bg-[var(--accent-tint)] px-1.5 py-0.5 font-mono text-xs leading-none text-accent-text"
+        >
+          <Sparkles className="size-3 shrink-0" aria-hidden />/{command.name}
+        </span>
+      )}
       <div className="max-w-[80%] rounded-2xl border border-border bg-surface px-3.5 py-2.5 text-[15px] leading-relaxed break-words whitespace-pre-wrap text-text-body">
         {item.images && item.images.length > 0 && (
           <div className="mb-2 flex flex-wrap justify-end gap-2">


### PR DESCRIPTION
## Why

vibe-acp invokes a skill when a prompt opens with a known `/name`, but gives **no wire-level acknowledgment** — the reply silently follows the skill body, so an invoked skill is indistinguishable from an ignored one in the transcript (observed live: a `/teach …` prompt clearly ran the skill, yet nothing in the UI said so).

## What

A small accent-tinted chip above the user bubble naming the invoked skill/command (description as tooltip). The raw message text stays verbatim.

- `matchInvokedCommand` (pure, in `command-autocomplete.ts`) mirrors the server's own parse rule (`SkillManager.parse_skill_command` + builtin normalization): trim, leading `/`, first whitespace-delimited word lowercased, exact name match. Rule verified against the live binary — a probe skill sent as a plain `session/prompt` text block WAS invoked.
- Matched at **render time** against the current `availableCommands`, not stamped at send: a draft's first prompt is sent before `available_commands_update` streams, so the chip appears retroactively once the list arrives; replay folds the same events through the same reducer, so reopened Threads show it too.
- `UserRow` renders the chip; `availableCommands` threaded `Conversation` → `Item` → `UserRow`.

## Tests

12 new cases for `matchInvokedCommand` (args, case, whitespace/`split(None)` tolerance, partial-name rejection, empty-list draft). Full suite: 1048 passed; lint (changed files), typecheck, build all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)