### PR TITLE
feat(conversation): auto-linkify bare file paths in prose into FileChips (#185)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.564",
+    "mdast-util-find-and-replace": "^3.0.2",
     "node-pty": "^1.1.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
@@ -50,6 +51,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "^1.61.1",
+    "@types/mdast": "^4.0.4",
     "@types/node": "^22.10.0",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",

--- a/src/renderer/src/conversation/Response.test.ts
+++ b/src/renderer/src/conversation/Response.test.ts
@@ -89,6 +89,87 @@ describe('Response — the wrapped harden still runs (#168 guard liveness)', () 
   })
 })
 
+describe('Response — bare file paths in prose render as chips (#185)', () => {
+  const barePathCases: ReadonlyArray<[string, string]> = [
+    ['relative path with line ref', 'fix src/main/agent-pool.ts:42 now'],
+    ['dot-relative path', 'open ./rel/path.md please'],
+    ['home-relative path', 'open ~/x/y.ts please'],
+    // The next two are scheme-shaped for rehype-sanitize (colon before any slash) and only
+    // chip because `schemeSafeUrl` percent-encodes the colon — see prose-file-links.ts.
+    ['bare filename with line ref', 'check package.json:12 please'],
+    ['windows drive path', 'open C:\\repo\\a.ts now'],
+    ['parenthesised path with trailing punctuation', 'worth a look (see src/x.ts:42).'],
+  ]
+
+  for (const [name, input] of barePathCases) {
+    it(`chips a ${name} without an explicit markdown link`, () => {
+      const html = render(input)
+      expect(html).toContain('data-file-chip')
+      expect(html).not.toContain('[blocked]')
+      expect(html).not.toContain('Blocked URL')
+    })
+  }
+
+  it('renders the auto-linkified chip with the parsed line ref (L42)', () => {
+    const html = render('fix src/main/agent-pool.ts:42 now')
+    expect(html).toContain('data-file-chip')
+    expect(html).toContain('L42')
+  })
+
+  it('disambiguates colliding basenames across prose-detected paths (shared label pool)', () => {
+    const html = render('compare src/a/reducer.ts:1 with src/b/reducer.ts:2')
+    expect(html).toContain('reducer.ts · a')
+    expect(html).toContain('reducer.ts · b')
+  })
+})
+
+describe('Response — auto-linkify never fires inside code (#185)', () => {
+  it('leaves a path inside inline code as plain code', () => {
+    const html = render('run `src/foo.ts:42` here')
+    expect(html).not.toContain('data-file-chip')
+    expect(html).toContain('src/foo.ts:42')
+  })
+
+  it('leaves a path inside a fenced code block as plain code', () => {
+    const html = render('```\nsrc/foo.ts:42\n```')
+    expect(html).not.toContain('data-file-chip')
+  })
+})
+
+describe('Response — auto-linkify false positives stay plain prose (#185)', () => {
+  it('does not chip or link slashed/dotted prose', () => {
+    const html = render('use and/or, e.g. v1.2.3 on Node.js')
+    expect(html).not.toContain('data-file-chip')
+    expect(html).not.toContain('<a')
+  })
+
+  it('does not chip or link a scheme-less domain path', () => {
+    const html = render('see github.com/foo/bar.ts there')
+    expect(html).not.toContain('data-file-chip')
+    expect(html).not.toContain('<a')
+  })
+})
+
+describe('Response — GFM survives the remarkPlugins replacement (#185 regression)', () => {
+  // The `remarkPlugins` prop REPLACES streamdown's defaults; `response-remark.ts` re-supplies
+  // them. If it ever stops, these break loudly rather than tables/autolinks dying silently.
+  it('still renders a GFM table', () => {
+    const html = render('| a | b |\n| - | - |\n| 1 | 2 |')
+    expect(html).toContain('<table')
+  })
+
+  it('still renders GFM strikethrough', () => {
+    const html = render('this is ~~gone~~ now')
+    expect(html).toContain('<del')
+  })
+
+  it('still autolinks a bare URL — as a real anchor, never a chip', () => {
+    const html = render('see https://github.com/a/b.ts now')
+    expect(html).toContain('href="https://github.com/a/b.ts"')
+    expect(html).not.toContain('data-file-chip')
+  })
+})
+
 describe('Response — raw HTML is sanitized, not skipped', () => {
   it('drops a raw <script> tag', () => {
     const html = render('Hello <script>alert(1)</script> world')

--- a/src/renderer/src/conversation/Response.tsx
+++ b/src/renderer/src/conversation/Response.tsx
@@ -4,7 +4,9 @@ import { code } from '@streamdown/code'
 import { cn } from '../lib/utils'
 import { extractLinkHrefs, fileLinkLabels, isSafeExternalHref, parseFileLink } from './file-link'
 import { FileChip } from './FileChip'
+import { findProsePathMatches } from './prose-file-links'
 import { responseRehypePlugins } from './response-rehype'
+import { responseRemarkPlugins } from './response-remark'
 
 /**
  * Renders agent-authored text as streaming-safe Markdown (#114, spike #112). Wraps
@@ -33,6 +35,13 @@ import { responseRehypePlugins } from './response-rehype'
  * **do NOT drop `raw`/`sanitize` from that list** — either would reintroduce raw-HTML/href XSS.
  * Do not remove `skipHtml` either.
  *
+ * `remarkPlugins` (#185) has the same REPLACES-defaults hazard, solved the same way: see
+ * `response-remark.ts`, which re-supplies streamdown's `gfm`/`codeMeta` and appends
+ * `remarkProseFileLinks` — a markdown-AST transform that turns bare file paths in prose into
+ * standard `link` nodes. Those run UPSTREAM of the whole sanitize/harden chain above, so an
+ * auto-linkified path is secured exactly like an authored `[label](path)` link. Never inline
+ * either plugin array — streamdown memoizes blocks by the arrays' identities.
+ *
  * Three `components` overrides:
  *  - `inlineCode` — resolves the spike's `muted` token collision: streamdown's default
  *    inline code is `bg-muted`, but our `--color-muted` is a text-grey, so we repaint
@@ -56,6 +65,11 @@ export function Response({ text, className }: { text: string; className?: string
       const link = parseFileLink(href)
       if (link) paths.push(link.path)
     }
+    // Bare paths auto-linkified by `remarkProseFileLinks` (#185) must disambiguate in the
+    // same pool. This raw-text scan also sees paths inside code fences the transform will
+    // never touch — harmless: a pooled-but-unchipped path can only add a `· parent` suffix
+    // to a colliding chip label, never render a wrong chip.
+    for (const { link } of findProsePathMatches(text)) paths.push(link.path)
     const labels = fileLinkLabels(paths)
 
     // Only bind the props we forward — leaving `node` (and other react-markdown
@@ -106,6 +120,7 @@ export function Response({ text, className }: { text: string; className?: string
       plugins={{ code }}
       controls={{ code: { copy: true } }}
       rehypePlugins={responseRehypePlugins}
+      remarkPlugins={responseRemarkPlugins}
       parseIncompleteMarkdown
       skipHtml
       components={components}

--- a/src/renderer/src/conversation/prose-file-links.test.ts
+++ b/src/renderer/src/conversation/prose-file-links.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import { findProsePathMatches } from './prose-file-links'
+
+/**
+ * Pure detection contract for #185 — the false-positive budget lives here. The remark
+ * transform and the label-pool scan share `classifyCandidate`, so these tests pin the
+ * behaviour of both; the end-to-end render (chips in real markdown, code exclusion via
+ * mdast structure) is covered in `Response.test.ts`.
+ */
+describe('findProsePathMatches — true positives', () => {
+  it('detects a relative path with a line ref, with exact offsets', () => {
+    const text = 'The bug is in src/main/agent-pool.ts:42 today'
+    const matches = findProsePathMatches(text)
+    expect(matches).toHaveLength(1)
+    const match = matches[0]!
+    expect(match.href).toBe('src/main/agent-pool.ts:42')
+    expect(match.link.path).toBe('src/main/agent-pool.ts')
+    expect(match.link.line).toBe(42)
+    expect(match.start).toBe(text.indexOf('src/'))
+    expect(match.end).toBe(text.indexOf('src/') + 'src/main/agent-pool.ts:42'.length)
+  })
+
+  const positives: ReadonlyArray<[string, string, string]> = [
+    ['dot-relative path', 'open ./rel/path.md please', './rel/path.md'],
+    ['parent-relative path', 'open ../up/x.ts please', '../up/x.ts'],
+    ['home-relative path', 'open ~/x/y.ts please', '~/x/y.ts'],
+    ['dot-relative dir without extension', 'output lands in ./build now', './build'],
+    ['absolute path with line', 'see /Users/me/project/x.ts:3 there', '/Users/me/project/x.ts:3'],
+    ['windows drive path', 'open C:\\repo\\a.ts now', 'C:\\repo\\a.ts'],
+    ['bare filename with line ref', 'check package.json:12 please', 'package.json:12'],
+    ['bare filename with line ref at string start', 'package.json:12 has it', 'package.json:12'],
+    ['bare filename with line ref at string end', 'it is in package.json:12', 'package.json:12'],
+    ['multi-dot filename with line ref', 'see vite.config.ts:7 there', 'vite.config.ts:7'],
+  ]
+  for (const [name, text, expected] of positives) {
+    it(`detects a ${name}`, () => {
+      const matches = findProsePathMatches(text)
+      expect(matches.map((m) => m.href)).toEqual([expected])
+    })
+  }
+
+  it('parses line and column', () => {
+    const [match] = findProsePathMatches('at src/a.ts:10:5 exactly')
+    expect(match?.link.path).toBe('src/a.ts')
+    expect(match?.link.line).toBe(10)
+    expect(match?.link.column).toBe(5)
+  })
+
+  const trims: ReadonlyArray<[string, string]> = [
+    ['see src/foo.ts.', 'src/foo.ts'],
+    ['see src/foo.ts, then', 'src/foo.ts'],
+    ['(src/main/agent-pool.ts:42)', 'src/main/agent-pool.ts:42'],
+    ['[src/foo.ts]', 'src/foo.ts'],
+    ['in src/foo.ts: the bug', 'src/foo.ts'],
+    ['see /Users/me/x.ts:42).', '/Users/me/x.ts:42'],
+    ['what about src/foo.ts?', 'src/foo.ts'],
+  ]
+  for (const [text, expected] of trims) {
+    it(`trims trailing delimiters: ${JSON.stringify(text)}`, () => {
+      expect(findProsePathMatches(text).map((m) => m.href)).toEqual([expected])
+    })
+  }
+
+  it('keeps balanced parens that belong to the path', () => {
+    expect(findProsePathMatches('see /Users/me/(x)/y.ts now').map((m) => m.href)).toEqual([
+      '/Users/me/(x)/y.ts',
+    ])
+  })
+
+  it('detects multiple paths in one string, in order', () => {
+    const matches = findProsePathMatches('compare src/a/reducer.ts:1 with src/b/reducer.ts:2')
+    expect(matches.map((m) => m.href)).toEqual(['src/a/reducer.ts:1', 'src/b/reducer.ts:2'])
+    expect(matches.map((m) => m.link.path)).toEqual(['src/a/reducer.ts', 'src/b/reducer.ts'])
+  })
+})
+
+describe('findProsePathMatches — false positives stay plain', () => {
+  const negatives: ReadonlyArray<[string, string]> = [
+    ['slashed prose', 'use and/or here'],
+    ['either/or', 'pick either/or now'],
+    ['I/O', 'heavy I/O load'],
+    ['24/7', 'runs 24/7 fine'],
+    ['e.g without dot', 'like e.g this'],
+    ['e.g. with dot', 'like e.g. this'],
+    ['i.e.', 'that is i.e. this'],
+    ['version number', 'bump to v1.2.3 now'],
+    ['Node.js', 'runs on Node.js fine'],
+    ['Next.js', 'built with Next.js today'],
+    ['bare filename without line ref', 'check package.json please'],
+    ['https URL with path-like tail', 'see https://github.com/a/b.ts there'],
+    ['www URL with path-like tail', 'see www.example.com/a/b.ts there'],
+    ['scheme-less domain path', 'see github.com/foo/bar there'],
+    ['scheme-less domain path with extension', 'see github.com/foo/bar.ts there'],
+    ['email-adjacent path', 'mail user@host.com/x.ts please'],
+    ['slash command', 'run /code-review now'],
+    ['absolute dir without extension or line', 'look in /etc/hosts today'],
+    ['inline-code span in raw markdown', 'run `src/foo.ts:42` here'],
+    ['glob pattern', 'matches src/**/*.ts files'],
+  ]
+  for (const [name, text] of negatives) {
+    it(`does not match ${name}`, () => {
+      expect(findProsePathMatches(text)).toEqual([])
+    })
+  }
+
+  it('never rescues a rejected candidate via a suffix retry', () => {
+    // findAndReplace retries a rejected match at start+1; every suffix of a rejected
+    // token starts after a path character and must die on the boundary guard.
+    expect(findProsePathMatches('xgithub.com/a/b.ts')).toEqual([])
+    expect(findProsePathMatches('see github.com/a/b.ts here')).toEqual([])
+  })
+})

--- a/src/renderer/src/conversation/prose-file-links.ts
+++ b/src/renderer/src/conversation/prose-file-links.ts
@@ -1,0 +1,232 @@
+/**
+ * Bare file paths in prose → FileChips (#185, slice 2 of #168).
+ *
+ * Agents rarely emit `[label](path)` markdown links — they write bare paths in prose
+ * (`src/main/agent-pool.ts:42`). {@link remarkProseFileLinks} is a remark (mdast) transform
+ * that detects file-ish paths in plain TEXT nodes and replaces them with standard `link`
+ * nodes, so they flow through the UNTOUCHED `[raw, sanitize, guarded-harden]` rehype chain
+ * and the existing `a` override → `parseFileLink` → `FileChip` pipeline exactly like an
+ * explicitly authored link. The rehype/security posture of #168 (PR #184) is not modified.
+ *
+ * Code is excluded structurally: `mdast-util-find-and-replace` visits only `text` nodes,
+ * and inline/fenced code are `inlineCode`/`code` LITERALS whose values are never text
+ * nodes; existing links are skipped via `ignore: ['link', 'linkReference']`.
+ *
+ * Detection is pure and shared: {@link findProsePathMatches} runs the same candidate
+ * regex + classification over a raw string, so `Response` can feed prose-detected paths
+ * into the same `fileLinkLabels` disambiguation pool the chips read from.
+ *
+ * Provenance: candidate regex, trailing-delimiter trimming, and URL-first precedence are
+ * ported from t3code's terminal linkifier (`terminal-links.ts`). t3code never chips bare
+ * prose, so the STRICTNESS GATE below is ours: their patterns alone would chip `and/or`.
+ * False-positive budget over recall — a missed path costs a click, a wrong chip is noise:
+ *  - relative paths need a real extension on the final segment (`and/or`, `I/O` → plain);
+ *  - bare filenames chip only with a `:line` suffix (`package.json:12` yes, `Node.js`,
+ *    `e.g.`, `v1.2.3`, plain `package.json` no);
+ *  - domain-shaped first segments are rejected (`github.com/foo/bar.ts` → plain; known
+ *    false negative: `next.js/docs/x.ts`);
+ *  - candidates inside URLs are rejected (schemed URLs are already `link` nodes at
+ *    transform time — GFM autolinks at parse time — but the raw-text scan needs it).
+ */
+import type { PhrasingContent, Root } from 'mdast'
+import { findAndReplace, type RegExpMatchObject } from 'mdast-util-find-and-replace'
+import { parseFileLink, type FileLink } from './file-link'
+
+/** A bare path detected in prose text. `end` is exclusive and reflects the trimmed span. */
+export interface ProsePathMatch {
+  start: number
+  end: number
+  /** The trimmed candidate, used verbatim as the link destination (may carry `:line:col`). */
+  href: string
+  /** `parseFileLink(href)` — the same shape the chip pipeline consumes. */
+  link: FileLink
+}
+
+/**
+ * Candidate scanner (fresh instance per scan — matching mutates `lastIndex`). NO capture
+ * groups: `findAndReplace` spreads captures into the replace callback, so the signature
+ * must stay `(value, match)`. Three alternatives:
+ *  1. prefixed: `~/`, `./`, `../`, absolute `/`, Windows drive/UNC — then any non-space
+ *     run (t3code; `*` additionally excluded so globs and `**bold**` tails never match);
+ *  2. relative with ≥1 slash + optional `:line[:col]` (t3code);
+ *  3. bare filename WITH a mandatory `:line[:col]` (ours — alt 2 requires a slash, and a
+ *     positionless bare filename is below the false-positive budget).
+ */
+function candidatePattern(): RegExp {
+  return /(?:~\/|\.{1,2}\/|\/|[A-Za-z]:[\\/]|\\\\)[^\s"'`<>*]+|[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)+(?::\d+){0,2}|[A-Za-z0-9._-]+\.[A-Za-z0-9_-]+:\d+(?::\d+)?/g
+}
+
+/** Spans of anything URL-shaped; path candidates overlapping one are rejected.
+ *  Fresh instance per scan, like {@link candidatePattern} — `exec` mutates `lastIndex`. */
+function urlPattern(): RegExp {
+  return /\bhttps?:\/\/[^\s<>"'`]+|\bwww\.[^\s<>"'`]+/gi
+}
+
+const TRAILING_PUNCTUATION_PATTERN = /[.,;:!?]+$/
+const POSITION_SUFFIX_PATTERN = /:\d+(?::\d+)?$/
+const RELATIVE_PREFIX_PATTERN = /^(?:\.{1,2}\/|~\/)/
+/** A real extension: letter-first (kills `x.3`), 1–8 chars. Applied to the basename. */
+const EXTENSION_PATTERN = /\.[A-Za-z][A-Za-z0-9]{0,7}$/
+/** TLD-shaped first segment of a relative candidate (`github.com`, `api.example.com`). */
+const DOMAIN_SEGMENT_PATTERN = /^[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*\.[A-Za-z]{2,}$/
+const WINDOWS_PREFIX_PATTERN = /^(?:[A-Za-z]:[\\/]|\\\\)/
+/** Chars that may legitimately precede a path in prose (whitespace, open brackets, quotes,
+ *  `*` for bold). NOT `.`/`:`/`/`/`@`/backtick — a candidate starting after one of those is
+ *  the tail of a larger token (URL innards, e-mail hosts, `` `code` `` spans). This guard is
+ *  what makes rejection safe under `findAndReplace`'s retry-at-`start+1` semantics: every
+ *  suffix of a rejected token starts after a path character and is rejected here too. */
+const BOUNDARY_PATTERN = /[\s([{"'*]/
+
+interface Span {
+  start: number
+  end: number
+}
+
+function findUrlSpans(input: string): Span[] {
+  const spans: Span[] = []
+  const pattern = urlPattern()
+  let match: RegExpExecArray | null
+  while ((match = pattern.exec(input)) !== null) {
+    spans.push({ start: match.index, end: match.index + match[0].length })
+  }
+  return spans
+}
+
+/** t3code's `trimClosingDelimiters`: trailing punctuation, then closing brackets that are
+ *  unbalanced WITHIN the candidate — `(src/x.ts:42)` sheds the `)`, `dir/(x)/y.ts` keeps its own. */
+function trimTrailingDelimiters(value: string): string {
+  let output = value.replace(TRAILING_PUNCTUATION_PATTERN, '')
+  const trimUnbalanced = (open: string, close: string): void => {
+    while (output.endsWith(close)) {
+      const opens = output.split(open).length - 1
+      const closes = output.split(close).length - 1
+      if (opens >= closes) return
+      output = output.slice(0, -1)
+    }
+  }
+  trimUnbalanced('(', ')')
+  trimUnbalanced('[', ']')
+  trimUnbalanced('{', '}')
+  return output.replace(TRAILING_PUNCTUATION_PATTERN, '')
+}
+
+function lastSegment(path: string): string {
+  const separatorIndex = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'))
+  return separatorIndex >= 0 ? path.slice(separatorIndex + 1) : path
+}
+
+/**
+ * The shared classification core: boundary guard → URL exclusion → trailing trim →
+ * strictness gate → domain rejection → `parseFileLink` as final validation. Returns the
+ * trimmed href + parsed link, or null. Both consumers (the remark transform and the raw
+ * label-pool scan) run the exact same pipeline so they can never disagree on what chips.
+ */
+function classifyCandidate(
+  input: string,
+  start: number,
+  raw: string,
+  urlSpans: readonly Span[],
+): { href: string; link: FileLink } | null {
+  if (start > 0 && !BOUNDARY_PATTERN.test(input[start - 1] ?? '')) return null
+
+  const end = start + raw.length
+  if (urlSpans.some((span) => start < span.end && span.start < end)) return null
+
+  const href = trimTrailingDelimiters(raw)
+  if (href.length === 0) return null
+
+  const positionMatch = href.match(POSITION_SUFFIX_PATTERN)
+  const pathPart = positionMatch ? href.slice(0, -positionMatch[0].length) : href
+  const hasRelativePrefix = RELATIVE_PREFIX_PATTERN.test(pathPart)
+  const hasSlash = pathPart.includes('/') || pathPart.includes('\\')
+  const hasExtension = EXTENSION_PATTERN.test(lastSegment(pathPart))
+  const gatePasses =
+    hasRelativePrefix ||
+    (hasSlash && hasExtension) ||
+    (positionMatch !== null && (hasSlash || hasExtension))
+  if (!gatePasses) return null
+
+  if (
+    hasSlash &&
+    !hasRelativePrefix &&
+    !pathPart.startsWith('/') &&
+    !WINDOWS_PREFIX_PATTERN.test(pathPart)
+  ) {
+    const firstSegment = pathPart.split('/')[0] ?? ''
+    if (DOMAIN_SEGMENT_PATTERN.test(firstSegment)) return null
+  }
+
+  const link = parseFileLink(href)
+  if (!link) return null
+  return { href, link }
+}
+
+/**
+ * Pure scan of a raw string for chippable bare paths. Mirrors `findAndReplace`'s cursor
+ * semantics exactly (rejected candidate → resume at `start + 1`; accepted → after the
+ * trimmed span) so the transform and this scan detect the same set.
+ */
+export function findProsePathMatches(text: string): ProsePathMatch[] {
+  const urlSpans = findUrlSpans(text)
+  const pattern = candidatePattern()
+  const matches: ProsePathMatch[] = []
+  let match: RegExpExecArray | null
+  while ((match = pattern.exec(text)) !== null) {
+    const classified = classifyCandidate(text, match.index, match[0], urlSpans)
+    if (!classified) {
+      pattern.lastIndex = match.index + 1
+      continue
+    }
+    matches.push({
+      start: match.index,
+      end: match.index + classified.href.length,
+      href: classified.href,
+      link: classified.link,
+    })
+    pattern.lastIndex = match.index + classified.href.length
+  }
+  return matches
+}
+
+/** A colon before the first (back)slash — `package.json:12`, `C:\repo\a.ts` — makes
+ *  `rehype-sanitize` read the head as a URL SCHEME (`package.json:`) and strip the href,
+ *  after which harden renders `[blocked]` INTO the prose. Percent-encode the colons for
+ *  such candidates: sanitize then sees a scheme-less relative href, and `parseFileLink`
+ *  (which `safeDecode`s every href it classifies) still parses the identical path, so the
+ *  chip pipeline and the label pool agree. Slash-first paths (`src/x.ts:42`) never trip
+ *  the scheme check and stay byte-for-byte as authored explicit links always have. */
+function schemeSafeUrl(href: string): string {
+  return /^[^/\\]*:/.test(href) ? href.replaceAll(':', '%3A') : href
+}
+
+function replaceCandidate(
+  value: string,
+  match: RegExpMatchObject,
+): PhrasingContent[] | false {
+  const classified = classifyCandidate(match.input, match.index, value, findUrlSpans(match.input))
+  if (!classified) return false
+  const nodes: PhrasingContent[] = [
+    {
+      type: 'link',
+      url: schemeSafeUrl(classified.href),
+      children: [{ type: 'text', value: classified.href }],
+    },
+  ]
+  // The trim may have shed trailing punctuation/brackets — restore them as plain text.
+  const rest = value.slice(classified.href.length)
+  if (rest.length > 0) nodes.push({ type: 'text', value: rest })
+  return nodes
+}
+
+/**
+ * The remark plugin. MUST stay a NAMED function: streamdown's processor cache keys on the
+ * plugin function's `name`, and an anonymous entry can collide across Streamdown instances.
+ */
+export function remarkProseFileLinks(): (tree: Root) => undefined {
+  return function transformProseFileLinks(tree: Root): undefined {
+    findAndReplace(tree, [candidatePattern(), replaceCandidate], {
+      ignore: ['link', 'linkReference'],
+    })
+    return undefined
+  }
+}

--- a/src/renderer/src/conversation/response-remark.test.ts
+++ b/src/renderer/src/conversation/response-remark.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { defaultRemarkPlugins } from 'streamdown'
+import { responseRemarkPlugins } from './response-remark'
+import { remarkProseFileLinks } from './prose-file-links'
+
+/**
+ * Structural pins for the #185 remark chain, mirroring `response-rehype.test.ts`. The
+ * behaviour (bare paths chip, GFM survives, code stays plain) is exercised through the real
+ * SSR pipeline in `Response.test.ts`; these guard the property review hinges on: streamdown's
+ * `remarkPlugins` prop REPLACES its defaults, so the list must re-supply `gfm` and `codeMeta`
+ * BY REFERENCE and only append our plugin.
+ */
+describe('responseRemarkPlugins', () => {
+  it('is the [gfm, codeMeta, remarkProseFileLinks] chain in order', () => {
+    expect(responseRemarkPlugins).toHaveLength(3)
+  })
+
+  it("re-uses streamdown's gfm and codeMeta entries by reference (unchanged)", () => {
+    const defaults = defaultRemarkPlugins as Record<'gfm' | 'codeMeta', unknown>
+    expect(responseRemarkPlugins[0]).toBe(defaults.gfm)
+    expect(responseRemarkPlugins[1]).toBe(defaults.codeMeta)
+  })
+
+  it('appends our NAMED plugin (streamdown caches processors by plugin function name)', () => {
+    expect(responseRemarkPlugins[2]).toBe(remarkProseFileLinks)
+    expect((responseRemarkPlugins[2] as { name: string }).name).toBe('remarkProseFileLinks')
+  })
+})

--- a/src/renderer/src/conversation/response-remark.ts
+++ b/src/renderer/src/conversation/response-remark.ts
@@ -1,0 +1,30 @@
+import { defaultRemarkPlugins } from 'streamdown'
+import type { Pluggable, PluggableList } from 'unified'
+import { remarkProseFileLinks } from './prose-file-links'
+
+/**
+ * The remark (markdown-AST) plugin chain for {@link Response} (#185) — the exact remark-side
+ * counterpart of `response-rehype.ts`: the `remarkPlugins` prop REPLACES streamdown's defaults
+ * (it does not append), so this list re-supplies them UNCHANGED and only appends ours.
+ *
+ * Streamdown 2.5.0's defaults (`defaultRemarkPlugins`, a `Record<'gfm'|'codeMeta', Pluggable>`):
+ *  - `gfm`      — `remark-gfm`: tables, strikethrough, task lists, URL autolinks. Dropping it
+ *                 silently loses all of those.
+ *  - `codeMeta` — copies a fence's `meta` onto `hProperties.metastring`, which `@streamdown/code`
+ *                 reads; dropping it breaks the code block title/controls.
+ *  - `remarkProseFileLinks` (#185) then turns bare file paths in prose text into standard `link`
+ *    nodes. It runs UPSTREAM of the whole `[raw, sanitize, guarded-harden]` rehype chain, so an
+ *    auto-linkified path is secured exactly like an explicitly authored `[label](path)` link —
+ *    the #168/#184 posture is untouched.
+ *
+ * Both entries are pulled by KEY and verified at module load — fail loud on a streamdown
+ * upgrade that renames them, rather than silently shipping without GFM or code metadata.
+ * MUST stay a module-level constant: streamdown's Block memo compares `remarkPlugins` by
+ * identity, so an inline array would re-render every completed block on each streaming token.
+ */
+const { gfm, codeMeta } = defaultRemarkPlugins as Record<'gfm' | 'codeMeta', Pluggable>
+if (!gfm || !codeMeta) {
+  throw new Error('streamdown defaultRemarkPlugins is missing the expected gfm/codeMeta entries')
+}
+
+export const responseRemarkPlugins: PluggableList = [gfm, codeMeta, remarkProseFileLinks]


### PR DESCRIPTION
Closes #185 — slice 2 of #168 (the harden fix shipped in #184; this is the second half).

## What

Agents rarely emit `[label](path)` markdown links — they write bare paths in prose (`src/main/agent-pool.ts:42`). A remark (mdast) text transform now detects file-ish paths in plain prose text and replaces them with standard `link` nodes, which then flow through the **untouched** `[raw, sanitize, guarded-harden]` rehype chain and the existing `a` override → `parseFileLink` → `FileChip` → `revealPath` pipeline. An auto-linkified path is secured exactly like an explicitly authored link; the #184 posture is not modified.

## How

- **`prose-file-links.ts`** — pure, DOM-free detection shared by the remark plugin and the label pool. Candidate regex, trailing-delimiter trimming, and URL-first precedence ported from t3code's terminal linkifier, plus a stricter prose gate t3code doesn't have (they never chip bare prose): relative paths need a real extension on the final segment, bare filenames chip only with a `:line` suffix, domain-shaped first segments are rejected. `and/or`, `e.g.`, `v1.2.3`, `Node.js`, URLs, `github.com/...`, globs, and slash-commands stay plain. Code is excluded structurally — `mdast-util-find-and-replace` only visits `text` nodes, and inline/fenced code are literals.
- **`response-remark.ts`** — streamdown's `remarkPlugins` prop REPLACES its defaults (same hazard `response-rehype.ts` solved on the rehype side): re-supplies `gfm`/`codeMeta` by key with a fail-loud guard, appends the named plugin, module-level constant for Block-memo identity.
- **`schemeSafeUrl`** — a colon before the first slash (`package.json:12`, `C:\repo\a.ts`) reads as a URL *scheme* to rehype-sanitize, which strips the href and harden then renders `[blocked]` into the prose; those colons are percent-encoded (`parseFileLink` safeDecodes, so the chip path is identical).
- **`Response.tsx`** — prose-detected paths join the same basename-disambiguation label pool as explicit links (`reducer.ts · a` vs `reducer.ts · b`).

## Tests

- `prose-file-links.test.ts` — pure detection matrix: true positives (offsets, `:line:col`, trims, windows, `~/`), false-positive budget (all cases from the issue and more).
- `response-remark.test.ts` — structural pins mirroring `response-rehype.test.ts` (defaults re-supplied BY REFERENCE, named plugin).
- `Response.test.ts` — SSR through the real pipeline: bare paths chip, code spans/fences never chip, false positives stay plain, GFM-survival regressions (table/strikethrough/autolink), existing #168/#184 suites unchanged (harden-liveness guard included).

## Verification

All four gates green (`lint`, `typecheck`, `build`, `test` — 1037 tests). Verified live in the app: bare path in agent prose renders as a chip and reveal-in-Finder works. Playwright e2e: 3/4 pass; the `live-panel-launcher` snapshot failure is pre-existing on main (baseline predates the Terminal tile from #208) and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)