### PR TITLE
feat(browser): slice 1 — live Browser Surface, webview embed + URL bar/nav + security clamp (ADR-0015)

### DIFF
--- a/docs/adr/0015-browser-surface-webview-embed.md
+++ b/docs/adr/0015-browser-surface-webview-embed.md
@@ -48,9 +48,15 @@ question that decides everything else is the EMBEDDING MECHANISM. Three candidat
    `nodeIntegrationInSubFrames=false`, NO preload. (t3code runs `contextIsolation=false` for
    their element-picker preload; we ship no guest preload, so isolation stays ON.)
    (c) Main's `will-attach-webview` clamp (`src/main/browser/webview-clamp.ts`, pure +
-   unit-tested): an attachment without a `persist:vibe-browser-` partition is REJECTED, and the
-   security prefs are force-overridden (preload stripped) regardless of what the renderer
-   declared — enabling `webviewTag: true` on the host window is compensated by this gate.
+   unit-tested): an attachment is REJECTED unless its partition matches the derived grammar
+   EXACTLY (`persist:vibe-browser-` + 8 hex — never a prefix test; `persist:` names map onto
+   storage directories, so an attacker-chosen suffix could alias another session) AND its
+   initial `src` is http(s)/about:blank (the URL policy re-enforced where a compromised
+   renderer can't reach). The FULL set of security prefs Electron consults is then
+   force-overridden — sandbox/contextIsolation/nodeIntegration(±SubFrames/Worker)/webSecurity/
+   allowRunningInsecureContent/experimentalFeatures/webviewTag, enableBlinkFeatures and any
+   preload stripped — regardless of what the renderer declared. Enabling `webviewTag: true`
+   on the host window is compensated by this gate.
 
 4. **Navigation is RENDERER-DRIVEN; main stays thin.** The component drives the element
    directly (`loadURL`/`goBack`/`reload`/DOM events). No per-navigation IPC, no main-side tab
@@ -61,9 +67,13 @@ question that decides everything else is the EMBEDDING MECHANISM. Three candidat
    `http://`, but only `http:`/`https:` results are blessed — `file:`/`javascript:`/custom
    schemes refuse rather than launder.
 
-5. **Guests never spawn windows.** On `did-attach-webview`, main installs a window-open handler
-   on the guest: deny everything, route http/https targets to the system browser via the
-   existing `safeExternalUrl` guard (the terminal-link posture — guest pages are untrusted).
+5. **Guests never spawn windows — and never leave http/https.** On `did-attach-webview`, main
+   installs a window-open handler on the guest (deny everything, route http/https targets to
+   the system browser via the existing `safeExternalUrl` guard — the terminal-link posture)
+   AND a `will-navigate` guard blocking page-initiated navigation to any non-http(s) scheme
+   (an external-protocol link in untrusted page content must not launch an OS handler). The
+   renderer's URL policy gates what the URL bar submits; these gates cover where the page
+   tries to go on its own.
 
 6. **Singleton per Workspace** (`browser:main`) this slice; the reserved `browser:${resourceId}`
    descriptor shape keeps multi-tab additive. The Electron/app UA tokens are stripped from the

--- a/docs/adr/0015-browser-surface-webview-embed.md
+++ b/docs/adr/0015-browser-surface-webview-embed.md
@@ -59,7 +59,11 @@ question that decides everything else is the EMBEDDING MECHANISM. Three candidat
    on the host window is compensated by this gate.
 
 4. **Navigation is RENDERER-DRIVEN; main stays thin.** The component drives the element
-   directly (`loadURL`/`goBack`/`reload`/DOM events). No per-navigation IPC, no main-side tab
+   directly (`loadURL`/`goToOffset`/`reload`/DOM events). NB: the `<webview>` tag's
+   `goBack`/`goForward`/`canGoBack`/`canGoForward` are broken in the shipped Electron (they
+   no-op / report `false` against a genuine multi-entry history), so back/forward availability
+   is tracked from navigation events via a pure index/length model (`browser-nav-history.ts`)
+   and actioned with `goToOffset(±1)`, which works — verified by driving the real app. No per-navigation IPC, no main-side tab
    registry — t3code's `webContents.fromId` control plane exists to serve agent automation
    (CDP click/type/screencast), which ADR-0002 rules out here: browser automation is an agent
    capability and belongs to Vibe, not the orchestrator. Everything the webview is asked to

--- a/docs/adr/0015-browser-surface-webview-embed.md
+++ b/docs/adr/0015-browser-surface-webview-embed.md
@@ -1,0 +1,83 @@
+# Browser Surface: a sandboxed `<webview>` embed, renderer-driven, clamped by main
+
+**Status: ACCEPTED** (2026-07-03). Builds on **ADR-0002** (thin orchestrator — no agent-facing
+browser automation), **ADR-0013** (the Surface/tab model the Browser Surface slots into),
+**ADR-0014** (the feature-registrar / pure-module-seam precedents). PRD #215; slice ladder
+#216/#217/#218. Reference implementation: t3code's "Preview" (`apps/web/src/browser/` +
+`apps/desktop/src/preview/`) — an Electron `<webview>` driven per-scope, security-clamped at
+attach time.
+
+## Context
+
+The side panel has reserved a Browser card ("Preview a local dev server") since #187/#193. The
+question that decides everything else is the EMBEDDING MECHANISM. Three candidates:
+
+- **`<iframe>`** — pure renderer, but blocked twice over: our CSP (`default-src 'self'`, no
+  `frame-src`) and `X-Frame-Options`/`frame-ancestors` on real sites. Widening the app CSP to
+  un-block it is backwards: the page would also share the renderer's origin-ish context.
+- **`WebContentsView`/`BrowserView`** — Electron's headline recommendation, but it floats ABOVE
+  the DOM in main-owned pixel coordinates: it doesn't clip to flex containers, so the panel's
+  drag-resize, tab switching, the narrow-viewport Sheet, and background-Workspace hiding all
+  become manual bounds-sync IPC. t3code evaluated the same trade and chose the webview tag;
+  their workaround inventory for it (a rect-tracking overlay store) exists precisely because
+  even THEY needed webview's DOM behavior, just with a root-mounted host.
+- **`<webview>` tag** — a real DOM node: composites, clips, and resizes with CSS inside the
+  panel like any other Surface. Electron's docs caution about the tag mostly concern its
+  historical default prefs; every knob it warns about is clampable at attach time.
+
+## Decision
+
+1. **The embed is the `<webview>` tag** (t3code's production-proven choice), declared by
+   `BrowserSurface` with `partition` / `webpreferences` / `useragent` computed by the pure,
+   tested `src/shared/browser-guest.ts`. The `webpreferences` attribute string is locked by
+   test because Electron splits it on `,` WITHOUT trimming and coerces non-boolean-literal
+   values to truthy STRINGS — a malformed string silently weakens the sandbox (t3code's
+   `WebviewPreferences` gotcha).
+
+2. **The view is DISPOSABLE; no root-mounted overlay.** t3code mounts one global webview host
+   over an in-layout slot (rect-tracking store) so the page survives their panel unmounting. We
+   deliberately skip that machinery: the webview lives inside the Surface; unmounting (tab
+   close, Workspace backgrounded) discards the page and the persisted URL (slice 2, #217)
+   reloads it on return. Dev-server pages are cheap to reload; the overlay pattern is the known
+   upgrade path if that assumption fails.
+
+3. **Guest security posture, three layers, stricter than t3code where possible.**
+   (a) Per-Workspace persisted partition `persist:vibe-browser-<fnv1a(workspaceDir)>` — preview
+   cookies/storage survive restarts, never mix across Workspaces or with the app session.
+   (b) Tag prefs: `sandbox=true`, `contextIsolation=true`, `nodeIntegration=false`,
+   `nodeIntegrationInSubFrames=false`, NO preload. (t3code runs `contextIsolation=false` for
+   their element-picker preload; we ship no guest preload, so isolation stays ON.)
+   (c) Main's `will-attach-webview` clamp (`src/main/browser/webview-clamp.ts`, pure +
+   unit-tested): an attachment without a `persist:vibe-browser-` partition is REJECTED, and the
+   security prefs are force-overridden (preload stripped) regardless of what the renderer
+   declared — enabling `webviewTag: true` on the host window is compensated by this gate.
+
+4. **Navigation is RENDERER-DRIVEN; main stays thin.** The component drives the element
+   directly (`loadURL`/`goBack`/`reload`/DOM events). No per-navigation IPC, no main-side tab
+   registry — t3code's `webContents.fromId` control plane exists to serve agent automation
+   (CDP click/type/screencast), which ADR-0002 rules out here: browser automation is an agent
+   capability and belongs to Vibe, not the orchestrator. Everything the webview is asked to
+   load passes the pure URL policy (`side-panel/browser-url.ts`): scheme-less input infers
+   `http://`, but only `http:`/`https:` results are blessed — `file:`/`javascript:`/custom
+   schemes refuse rather than launder.
+
+5. **Guests never spawn windows.** On `did-attach-webview`, main installs a window-open handler
+   on the guest: deny everything, route http/https targets to the system browser via the
+   existing `safeExternalUrl` guard (the terminal-link posture — guest pages are untrusted).
+
+6. **Singleton per Workspace** (`browser:main`) this slice; the reserved `browser:${resourceId}`
+   descriptor shape keeps multi-tab additive. The Electron/app UA tokens are stripped from the
+   guest so dev tooling treats it as ordinary Chrome.
+
+## Consequences
+
+- The panel gains a live Browser card with zero layout special-casing; all Surface chrome
+  (resize, tabs, Sheet) works unmodified.
+- Backgrounding a Workspace or switching tabs reloads the page on return (accepted; see
+  decision 2). Long-lived page state (e.g. a signed-in preview) survives via the partition,
+  not the DOM.
+- `webviewTag: true` is a widened surface on the host window; the attach clamp is the
+  compensating control and is the piece that must never regress (its test file + an
+  adversarial review gate slice 1).
+- Slices 2 (#217: states/persistence/⌘T/DevTools/open-external) and 3 (#218: dev-server
+  discovery over a new `browser` IPC domain) build on this without revisiting the embed.

--- a/src/main/browser/webview-clamp.test.ts
+++ b/src/main/browser/webview-clamp.test.ts
@@ -1,17 +1,32 @@
 import { describe, expect, it } from 'vitest'
-import { deriveBrowserPartition } from '../../shared/browser-guest'
+import { BROWSER_PARTITION_PREFIX, deriveBrowserPartition } from '../../shared/browser-guest'
 import { clampWebviewAttachment, type ClampableWebPreferences } from './webview-clamp'
+
+const PARTITION = deriveBrowserPartition('/Users/me/app')
 
 describe('clampWebviewAttachment', () => {
   it('rejects an attachment whose partition is not a Browser-Surface partition', () => {
-    expect(clampWebviewAttachment({ partition: 'persist:something-else' }, {})).toBe(false)
-    expect(clampWebviewAttachment({ partition: undefined }, {})).toBe(false)
-    expect(clampWebviewAttachment({}, {})).toBe(false)
+    expect(clampWebviewAttachment({ partition: 'persist:something-else', src: 'http://x/' }, {})).toBe(false)
+    expect(clampWebviewAttachment({ partition: undefined, src: 'http://x/' }, {})).toBe(false)
+    expect(clampWebviewAttachment({ src: 'http://x/' }, {})).toBe(false)
   })
 
-  it('allows a derived Workspace partition', () => {
-    const params = { partition: deriveBrowserPartition('/Users/me/app') }
-    expect(clampWebviewAttachment(params, {})).toBe(true)
+  it('rejects a prefix-matching partition with an attacker-chosen suffix (exact grammar)', () => {
+    const traversal = `${BROWSER_PARTITION_PREFIX}../../Partitions/other`
+    expect(clampWebviewAttachment({ partition: traversal, src: 'http://x/' }, {})).toBe(false)
+  })
+
+  it('rejects a non-http(s) initial src — the URL policy enforced main-side', () => {
+    expect(clampWebviewAttachment({ partition: PARTITION, src: 'file:///etc/passwd' }, {})).toBe(false)
+    expect(clampWebviewAttachment({ partition: PARTITION, src: 'javascript:alert(1)' }, {})).toBe(false)
+    expect(clampWebviewAttachment({ partition: PARTITION, src: undefined }, {})).toBe(false)
+    expect(clampWebviewAttachment({ partition: PARTITION }, {})).toBe(false)
+  })
+
+  it('allows a derived partition with an http(s) src (about:blank tolerated pre-navigation)', () => {
+    expect(clampWebviewAttachment({ partition: PARTITION, src: 'http://localhost:5173/' }, {})).toBe(true)
+    expect(clampWebviewAttachment({ partition: PARTITION, src: 'https://example.com/' }, {})).toBe(true)
+    expect(clampWebviewAttachment({ partition: PARTITION, src: 'about:blank' }, {})).toBe(true)
   })
 
   it('force-overrides hostile renderer prefs and strips any preload', () => {
@@ -23,10 +38,7 @@ describe('clampWebviewAttachment', () => {
       preload: '/tmp/evil.js',
       preloadURL: 'file:///tmp/evil.js',
     }
-    const allowed = clampWebviewAttachment(
-      { partition: deriveBrowserPartition('/Users/me/app') },
-      webPreferences,
-    )
+    const allowed = clampWebviewAttachment({ partition: PARTITION, src: 'http://x/' }, webPreferences)
     expect(allowed).toBe(true)
     expect(webPreferences.sandbox).toBe(true)
     expect(webPreferences.nodeIntegration).toBe(false)
@@ -34,5 +46,23 @@ describe('clampWebviewAttachment', () => {
     expect(webPreferences.contextIsolation).toBe(true)
     expect('preload' in webPreferences).toBe(false)
     expect('preloadURL' in webPreferences).toBe(false)
+  })
+
+  it('locks down every other security pref Electron consults, not just the headline four', () => {
+    const webPreferences: ClampableWebPreferences = {
+      webSecurity: false,
+      allowRunningInsecureContent: true,
+      experimentalFeatures: true,
+      enableBlinkFeatures: 'DangerousFeature',
+      nodeIntegrationInWorker: true,
+      webviewTag: true,
+    }
+    expect(clampWebviewAttachment({ partition: PARTITION, src: 'http://x/' }, webPreferences)).toBe(true)
+    expect(webPreferences.webSecurity).toBe(true)
+    expect(webPreferences.allowRunningInsecureContent).toBe(false)
+    expect(webPreferences.experimentalFeatures).toBe(false)
+    expect('enableBlinkFeatures' in webPreferences).toBe(false)
+    expect(webPreferences.nodeIntegrationInWorker).toBe(false)
+    expect(webPreferences.webviewTag).toBe(false)
   })
 })

--- a/src/main/browser/webview-clamp.test.ts
+++ b/src/main/browser/webview-clamp.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { deriveBrowserPartition } from '../../shared/browser-guest'
+import { clampWebviewAttachment, type ClampableWebPreferences } from './webview-clamp'
+
+describe('clampWebviewAttachment', () => {
+  it('rejects an attachment whose partition is not a Browser-Surface partition', () => {
+    expect(clampWebviewAttachment({ partition: 'persist:something-else' }, {})).toBe(false)
+    expect(clampWebviewAttachment({ partition: undefined }, {})).toBe(false)
+    expect(clampWebviewAttachment({}, {})).toBe(false)
+  })
+
+  it('allows a derived Workspace partition', () => {
+    const params = { partition: deriveBrowserPartition('/Users/me/app') }
+    expect(clampWebviewAttachment(params, {})).toBe(true)
+  })
+
+  it('force-overrides hostile renderer prefs and strips any preload', () => {
+    const webPreferences: ClampableWebPreferences = {
+      sandbox: false,
+      nodeIntegration: true,
+      nodeIntegrationInSubFrames: true,
+      contextIsolation: false,
+      preload: '/tmp/evil.js',
+      preloadURL: 'file:///tmp/evil.js',
+    }
+    const allowed = clampWebviewAttachment(
+      { partition: deriveBrowserPartition('/Users/me/app') },
+      webPreferences,
+    )
+    expect(allowed).toBe(true)
+    expect(webPreferences.sandbox).toBe(true)
+    expect(webPreferences.nodeIntegration).toBe(false)
+    expect(webPreferences.nodeIntegrationInSubFrames).toBe(false)
+    expect(webPreferences.contextIsolation).toBe(true)
+    expect('preload' in webPreferences).toBe(false)
+    expect('preloadURL' in webPreferences).toBe(false)
+  })
+})

--- a/src/main/browser/webview-clamp.ts
+++ b/src/main/browser/webview-clamp.ts
@@ -2,38 +2,66 @@
  * The `will-attach-webview` clamp (#216, ADR-0015; t3code `DesktopWindow` precedent):
  * defense-in-depth behind the renderer's own `<webview>` attributes. Enabling
  * `webviewTag` widens the window's attack surface, so main independently gates EVERY
- * attachment — only guests carrying a Browser-Surface partition may attach, and their
- * security prefs are force-overridden no matter what the renderer asked for. Pure
- * (no Electron in the import graph) so it's unit-tested like `terminal-manager`.
+ * attachment — only guests carrying an exact Browser-Surface partition AND an
+ * http(s) initial URL may attach, and the full set of security prefs Electron
+ * consults is force-overridden no matter what the renderer asked for. Pure (no
+ * Electron in the import graph) so it's unit-tested like `terminal-manager`.
  */
-import { BROWSER_PARTITION_PREFIX } from '../../shared/browser-guest'
+import { isBrowserPartition } from '../../shared/browser-guest'
 
 /** The slice of Electron's `WebPreferences` the clamp rules on (structural, no import). */
 export interface ClampableWebPreferences {
   sandbox?: boolean
   nodeIntegration?: boolean
   nodeIntegrationInSubFrames?: boolean
+  nodeIntegrationInWorker?: boolean
   contextIsolation?: boolean
+  webSecurity?: boolean
+  allowRunningInsecureContent?: boolean
+  experimentalFeatures?: boolean
+  enableBlinkFeatures?: string
+  webviewTag?: boolean
   preload?: string
   preloadURL?: string
+}
+
+/** Whether an attachment's initial URL is one the Browser Surface may load. */
+function isAllowedSrc(src: unknown): boolean {
+  if (typeof src !== 'string') return false
+  // Electron may attach before the first real navigation lands.
+  if (src === 'about:blank') return true
+  try {
+    const url = new URL(src)
+    return url.protocol === 'http:' || url.protocol === 'https:'
+  } catch {
+    return false
+  }
 }
 
 /**
  * Gate + clamp one attachment: returns whether to allow it (`false` → the caller
  * `event.preventDefault()`s), and — Electron's contract — MUTATES `webPreferences`
- * in place to the locked-down posture.
+ * in place to the locked-down posture. Gates: the partition must match the derived
+ * grammar EXACTLY (never a prefix test — a `persist:` suffix maps onto storage
+ * directories), and the initial `src` must be http(s) — the renderer's URL policy,
+ * re-enforced where a compromised renderer can't reach.
  */
 export function clampWebviewAttachment(
-  params: { partition?: unknown },
+  params: { partition?: unknown; src?: unknown },
   webPreferences: ClampableWebPreferences,
 ): boolean {
-  if (typeof params.partition !== 'string' || !params.partition.startsWith(BROWSER_PARTITION_PREFIX)) {
-    return false
-  }
+  if (typeof params.partition !== 'string' || !isBrowserPartition(params.partition)) return false
+  if (!isAllowedSrc(params.src)) return false
   webPreferences.sandbox = true
   webPreferences.nodeIntegration = false
   webPreferences.nodeIntegrationInSubFrames = false
+  webPreferences.nodeIntegrationInWorker = false
   webPreferences.contextIsolation = true
+  webPreferences.webSecurity = true
+  webPreferences.allowRunningInsecureContent = false
+  webPreferences.experimentalFeatures = false
+  webPreferences.webviewTag = false
+  delete webPreferences.enableBlinkFeatures
   // The Browser Surface ships NO guest preload — anything asking for one is hostile.
   delete webPreferences.preload
   delete webPreferences.preloadURL

--- a/src/main/browser/webview-clamp.ts
+++ b/src/main/browser/webview-clamp.ts
@@ -1,0 +1,41 @@
+/**
+ * The `will-attach-webview` clamp (#216, ADR-0015; t3code `DesktopWindow` precedent):
+ * defense-in-depth behind the renderer's own `<webview>` attributes. Enabling
+ * `webviewTag` widens the window's attack surface, so main independently gates EVERY
+ * attachment — only guests carrying a Browser-Surface partition may attach, and their
+ * security prefs are force-overridden no matter what the renderer asked for. Pure
+ * (no Electron in the import graph) so it's unit-tested like `terminal-manager`.
+ */
+import { BROWSER_PARTITION_PREFIX } from '../../shared/browser-guest'
+
+/** The slice of Electron's `WebPreferences` the clamp rules on (structural, no import). */
+export interface ClampableWebPreferences {
+  sandbox?: boolean
+  nodeIntegration?: boolean
+  nodeIntegrationInSubFrames?: boolean
+  contextIsolation?: boolean
+  preload?: string
+  preloadURL?: string
+}
+
+/**
+ * Gate + clamp one attachment: returns whether to allow it (`false` → the caller
+ * `event.preventDefault()`s), and — Electron's contract — MUTATES `webPreferences`
+ * in place to the locked-down posture.
+ */
+export function clampWebviewAttachment(
+  params: { partition?: unknown },
+  webPreferences: ClampableWebPreferences,
+): boolean {
+  if (typeof params.partition !== 'string' || !params.partition.startsWith(BROWSER_PARTITION_PREFIX)) {
+    return false
+  }
+  webPreferences.sandbox = true
+  webPreferences.nodeIntegration = false
+  webPreferences.nodeIntegrationInSubFrames = false
+  webPreferences.contextIsolation = true
+  // The Browser Surface ships NO guest preload — anything asking for one is hostile.
+  delete webPreferences.preload
+  delete webPreferences.preloadURL
+  return true
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -608,9 +608,15 @@ function createWindow(): void {
 
   // The guest never spawns windows: popups/window.open are denied, with http/https
   // targets handed to the system browser (guest pages are untrusted content — the
-  // terminal-output-link posture, `safeExternalUrl`). In-page navigation is
-  // unaffected; the renderer's URL policy governs what the webview itself loads.
+  // terminal-output-link posture, `safeExternalUrl`). And the guest never LEAVES
+  // http/https either: page-initiated navigation to any other scheme (an
+  // external-protocol link like vscode://, a crafted redirect) is blocked main-side —
+  // the renderer's URL policy only gates what the URL bar submits, not where the
+  // page then tries to go.
   win.webContents.on('did-attach-webview', (_event, guest) => {
+    guest.on('will-navigate', (event, url) => {
+      if (!safeExternalUrl(url)) event.preventDefault()
+    })
     guest.setWindowOpenHandler(({ url }) => {
       const safe = safeExternalUrl(url)
       if (safe) void shell.openExternal(safe)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -65,6 +65,8 @@ import { registerFilesIpc } from './files/register-ipc'
 import { createTerminalManager, registerTerminalIpc } from './terminal/register-ipc'
 import type { TerminalManager } from './terminal/terminal-manager'
 import { FilesListCache, shouldInvalidateFilesCacheOnGitStatus } from './files/cache'
+import { clampWebviewAttachment } from './browser/webview-clamp'
+import { safeExternalUrl } from './files/safe-external-url'
 
 // Test seam (e2e smoke): point the whole persisted profile (metadata.json +
 // transcripts) at a throwaway dir so the suite launches against a KNOWN state
@@ -584,6 +586,9 @@ function createWindow(): void {
       sandbox: false,
       contextIsolation: true,
       nodeIntegration: false,
+      // The Browser Surface's embed (#216, ADR-0015). Enabling the tag widens the
+      // window's attack surface, so EVERY attachment is gated by the clamp below.
+      webviewTag: true,
     },
   })
 
@@ -592,6 +597,25 @@ function createWindow(): void {
   win.webContents.setWindowOpenHandler(({ url }) => {
     shell.openExternal(url)
     return { action: 'deny' }
+  })
+
+  // Defense-in-depth for the Browser Surface guest (webview-clamp.ts): only
+  // Browser-partition guests may attach, with their security prefs force-overridden
+  // no matter what the renderer declared on the tag.
+  win.webContents.on('will-attach-webview', (event, webPreferences, params) => {
+    if (!clampWebviewAttachment(params, webPreferences)) event.preventDefault()
+  })
+
+  // The guest never spawns windows: popups/window.open are denied, with http/https
+  // targets handed to the system browser (guest pages are untrusted content — the
+  // terminal-output-link posture, `safeExternalUrl`). In-page navigation is
+  // unaffected; the renderer's URL policy governs what the webview itself loads.
+  win.webContents.on('did-attach-webview', (_event, guest) => {
+    guest.setWindowOpenHandler(({ url }) => {
+      const safe = safeExternalUrl(url)
+      if (safe) void shell.openExternal(safe)
+      return { action: 'deny' }
+    })
   })
 
   if (process.env.ELECTRON_RENDERER_URL) {

--- a/src/renderer/src/side-panel/BrowserSurface.tsx
+++ b/src/renderer/src/side-panel/BrowserSurface.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type FormEvent, type JSX } from 'react'
+import { useEffect, useRef, useState, type FormEvent, type JSX } from 'react'
 import { ArrowLeft, ArrowRight, RotateCw } from 'lucide-react'
 import { cn } from '../lib/utils'
 import {
@@ -21,7 +21,11 @@ import { normalizeBrowserUrl } from './browser-url'
  * `normalizeBrowserUrl` first — http/https only, schemes like `file:` refused.
  */
 export function BrowserSurface({ workspaceDir }: { workspaceDir: string }): JSX.Element {
-  const webviewRef = useRef<WebviewElement | null>(null)
+  // The mounted webview as STATE (not a ref): the `setView` setter is identity-stable,
+  // so React invokes the callback ref only on real mount/unmount — an inline-closure
+  // ref would re-fire per render and leak one listener pair each time.
+  const [view, setView] = useState<WebviewElement | null>(null)
+  const addressInputRef = useRef<HTMLInputElement | null>(null)
   // The first blessed URL becomes the webview's `src`; later submissions go through
   // `loadURL`. `null` = nothing loaded yet → the URL-entry empty state.
   const [initialUrl, setInitialUrl] = useState<string | null>(null)
@@ -38,25 +42,43 @@ export function BrowserSurface({ workspaceDir }: { workspaceDir: string }): JSX.
       setInitialUrl(url)
       return
     }
-    void webviewRef.current?.loadURL(url).catch(() => {
-      // A load interrupted by a newer navigation rejects — the did-navigate
-      // listener is the source of truth, nothing to do here.
+    void view?.loadURL(url).catch((err: unknown) => {
+      // A load superseded by a newer navigation rejects benignly, but so do real
+      // failures — log rather than swallow (#217 turns this into an unreachable state).
+      console.error('[browser] loadURL failed', url, err)
     })
   }
 
-  // The webview only exposes its state through DOM events — wire them via a callback
-  // ref (the element mounts late, only once a first URL exists).
-  function attachWebview(el: WebviewElement | null): void {
-    webviewRef.current = el
-    if (!el) return
+  // The webview only exposes its state through DOM events — wire them once per
+  // mounted element, unwiring on unmount/remount.
+  useEffect(() => {
+    if (!view) return
     const sync = (): void => {
-      setAddress(el.getURL())
-      setCanGoBack(el.canGoBack())
-      setCanGoForward(el.canGoForward())
+      // Never clobber an address the user is mid-typing: the guest can navigate
+      // (redirects, SPA pushState) while the bar has focus.
+      if (document.activeElement !== addressInputRef.current) setAddress(view.getURL())
+      setCanGoBack(view.canGoBack())
+      setCanGoForward(view.canGoForward())
     }
-    el.addEventListener('did-navigate', sync)
-    el.addEventListener('did-navigate-in-page', sync)
-  }
+    const logFailure = (event: Event): void => {
+      const { errorCode, errorDescription, validatedURL } = event as unknown as {
+        errorCode?: number
+        errorDescription?: string
+        validatedURL?: string
+      }
+      // -3 is Chromium's ERR_ABORTED — a superseded/cancelled load, not a failure.
+      if (errorCode === -3) return
+      console.error('[browser] load failed', validatedURL, errorCode, errorDescription)
+    }
+    view.addEventListener('did-navigate', sync)
+    view.addEventListener('did-navigate-in-page', sync)
+    view.addEventListener('did-fail-load', logFailure)
+    return () => {
+      view.removeEventListener('did-navigate', sync)
+      view.removeEventListener('did-navigate-in-page', sync)
+      view.removeEventListener('did-fail-load', logFailure)
+    }
+  }, [view])
 
   if (initialUrl === null) {
     return (
@@ -88,21 +110,18 @@ export function BrowserSurface({ workspaceDir }: { workspaceDir: string }): JSX.
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-panel">
       <div className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-1">
-        <BrowserAction label="Back" onClick={() => webviewRef.current?.goBack()} disabled={!canGoBack}>
+        <BrowserAction label="Back" onClick={() => view?.goBack()} disabled={!canGoBack}>
           <ArrowLeft aria-hidden />
         </BrowserAction>
-        <BrowserAction
-          label="Forward"
-          onClick={() => webviewRef.current?.goForward()}
-          disabled={!canGoForward}
-        >
+        <BrowserAction label="Forward" onClick={() => view?.goForward()} disabled={!canGoForward}>
           <ArrowRight aria-hidden />
         </BrowserAction>
-        <BrowserAction label="Reload" onClick={() => webviewRef.current?.reload()}>
+        <BrowserAction label="Reload" onClick={() => view?.reload()}>
           <RotateCw aria-hidden />
         </BrowserAction>
         <form onSubmit={submitAddress} className="min-w-0 flex-1">
           <input
+            ref={addressInputRef}
             value={address}
             onChange={(e) => setAddress(e.target.value)}
             aria-label="Address"
@@ -119,7 +138,7 @@ export function BrowserSurface({ workspaceDir }: { workspaceDir: string }): JSX.
       {/* The guest page. `partition`/`webpreferences`/`useragent` must be set before
           attach and never change — main's clamp re-verifies them (webview-clamp.ts). */}
       <webview
-        ref={attachWebview}
+        ref={setView as (el: HTMLElement | null) => void}
         src={initialUrl}
         partition={deriveBrowserPartition(workspaceDir)}
         webpreferences={buildWebviewPreferencesAttribute()}

--- a/src/renderer/src/side-panel/BrowserSurface.tsx
+++ b/src/renderer/src/side-panel/BrowserSurface.tsx
@@ -1,0 +1,173 @@
+import { useRef, useState, type FormEvent, type JSX } from 'react'
+import { ArrowLeft, ArrowRight, RotateCw } from 'lucide-react'
+import { cn } from '../lib/utils'
+import {
+  buildWebviewPreferencesAttribute,
+  deriveBrowserPartition,
+  stripElectronUserAgent,
+} from '../../../shared/browser-guest'
+import { normalizeBrowserUrl } from './browser-url'
+
+/**
+ * The Browser Surface (#216, ADR-0015): an embedded dev-server preview on the Electron
+ * `<webview>` tag — a real DOM node, so it lays out/clips/resizes inside the panel like
+ * any other Surface (the t3code "Preview" decision, minus their root-mounted overlay:
+ * our view is DISPOSABLE — unmounting discards the page; the URL survives in the store
+ * for slice 2's persistence).
+ *
+ * Navigation is RENDERER-DRIVEN: the component talks to the webview element directly
+ * (loadURL/goBack/events); main's involvement is the `will-attach-webview` clamp and
+ * guest popup routing. Every URL the webview is asked to load passes
+ * `normalizeBrowserUrl` first — http/https only, schemes like `file:` refused.
+ */
+export function BrowserSurface({ workspaceDir }: { workspaceDir: string }): JSX.Element {
+  const webviewRef = useRef<WebviewElement | null>(null)
+  // The first blessed URL becomes the webview's `src`; later submissions go through
+  // `loadURL`. `null` = nothing loaded yet → the URL-entry empty state.
+  const [initialUrl, setInitialUrl] = useState<string | null>(null)
+  const [address, setAddress] = useState('')
+  const [canGoBack, setCanGoBack] = useState(false)
+  const [canGoForward, setCanGoForward] = useState(false)
+
+  function submitAddress(e: FormEvent<HTMLFormElement>): void {
+    e.preventDefault()
+    const url = normalizeBrowserUrl(address)
+    if (!url) return
+    setAddress(url)
+    if (initialUrl === null) {
+      setInitialUrl(url)
+      return
+    }
+    void webviewRef.current?.loadURL(url).catch(() => {
+      // A load interrupted by a newer navigation rejects — the did-navigate
+      // listener is the source of truth, nothing to do here.
+    })
+  }
+
+  // The webview only exposes its state through DOM events — wire them via a callback
+  // ref (the element mounts late, only once a first URL exists).
+  function attachWebview(el: WebviewElement | null): void {
+    webviewRef.current = el
+    if (!el) return
+    const sync = (): void => {
+      setAddress(el.getURL())
+      setCanGoBack(el.canGoBack())
+      setCanGoForward(el.canGoForward())
+    }
+    el.addEventListener('did-navigate', sync)
+    el.addEventListener('did-navigate-in-page', sync)
+  }
+
+  if (initialUrl === null) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center overflow-y-auto bg-panel p-6">
+        <form onSubmit={submitAddress} className="w-full max-w-sm text-center">
+          <h3 className="text-sm font-medium text-text-strong">Preview a dev server</h3>
+          <p className="mt-1 text-xs leading-relaxed text-muted">
+            Enter the URL of a local dev server — or any http(s) page.
+          </p>
+          <input
+            value={address}
+            onChange={(e) => setAddress(e.target.value)}
+            aria-label="Address"
+            placeholder="localhost:5173"
+            autoFocus
+            spellCheck={false}
+            autoCapitalize="off"
+            autoCorrect="off"
+            className={cn(
+              'mt-4 w-full rounded-md border border-border bg-surface px-3 py-1.5 text-[13px] text-text',
+              'placeholder:text-faint focus:outline-none focus-visible:border-accent/60',
+            )}
+          />
+        </form>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col bg-panel">
+      <div className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-1">
+        <BrowserAction label="Back" onClick={() => webviewRef.current?.goBack()} disabled={!canGoBack}>
+          <ArrowLeft aria-hidden />
+        </BrowserAction>
+        <BrowserAction
+          label="Forward"
+          onClick={() => webviewRef.current?.goForward()}
+          disabled={!canGoForward}
+        >
+          <ArrowRight aria-hidden />
+        </BrowserAction>
+        <BrowserAction label="Reload" onClick={() => webviewRef.current?.reload()}>
+          <RotateCw aria-hidden />
+        </BrowserAction>
+        <form onSubmit={submitAddress} className="min-w-0 flex-1">
+          <input
+            value={address}
+            onChange={(e) => setAddress(e.target.value)}
+            aria-label="Address"
+            spellCheck={false}
+            autoCapitalize="off"
+            autoCorrect="off"
+            className={cn(
+              'w-full rounded-md border border-transparent bg-accent/5 px-2.5 py-1 text-xs text-text',
+              'placeholder:text-faint focus:outline-none focus-visible:border-accent/60 focus-visible:bg-surface',
+            )}
+          />
+        </form>
+      </div>
+      {/* The guest page. `partition`/`webpreferences`/`useragent` must be set before
+          attach and never change — main's clamp re-verifies them (webview-clamp.ts). */}
+      <webview
+        ref={attachWebview}
+        src={initialUrl}
+        partition={deriveBrowserPartition(workspaceDir)}
+        webpreferences={buildWebviewPreferencesAttribute()}
+        useragent={stripElectronUserAgent(navigator.userAgent)}
+        className="min-h-0 flex-1 bg-white"
+      />
+    </div>
+  )
+}
+
+/** The slice of Electron's WebviewTag the Surface drives (renderer must not import electron). */
+interface WebviewElement extends HTMLElement {
+  loadURL(url: string): Promise<void>
+  getURL(): string
+  goBack(): void
+  goForward(): void
+  reload(): void
+  canGoBack(): boolean
+  canGoForward(): boolean
+}
+
+/** A browser toolbar icon button — the TerminalAction idiom. */
+function BrowserAction({
+  label,
+  onClick,
+  disabled,
+  children,
+}: {
+  label: string
+  onClick: () => void
+  disabled?: boolean
+  children: JSX.Element
+}): JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={label}
+      title={label}
+      className={cn(
+        'flex size-6 shrink-0 items-center justify-center rounded text-muted outline-none transition-colors',
+        'hover:bg-accent/10 hover:text-text-strong focus-visible:bg-accent/10',
+        'disabled:pointer-events-none disabled:opacity-40',
+        '[&_svg]:size-3.5 [&_svg]:shrink-0',
+      )}
+    >
+      {children}
+    </button>
+  )
+}

--- a/src/renderer/src/side-panel/BrowserSurface.tsx
+++ b/src/renderer/src/side-panel/BrowserSurface.tsx
@@ -7,6 +7,15 @@ import {
   stripElectronUserAgent,
 } from '../../../shared/browser-guest'
 import { normalizeBrowserUrl } from './browser-url'
+import {
+  canGoBackNav,
+  canGoForwardNav,
+  goBackNav,
+  goForwardNav,
+  INITIAL_NAV,
+  pushNav,
+  type NavState,
+} from './browser-nav-history'
 
 /**
  * The Browser Surface (#216, ADR-0015): an embedded dev-server preview on the Electron
@@ -30,8 +39,13 @@ export function BrowserSurface({ workspaceDir }: { workspaceDir: string }): JSX.
   // `loadURL`. `null` = nothing loaded yet → the URL-entry empty state.
   const [initialUrl, setInitialUrl] = useState<string | null>(null)
   const [address, setAddress] = useState('')
-  const [canGoBack, setCanGoBack] = useState(false)
-  const [canGoForward, setCanGoForward] = useState(false)
+  // Back/forward availability is tracked from navigation EVENTS via the pure model —
+  // the webview element's own canGoBack()/canGoForward() are unreliable (they report
+  // false against a genuine multi-entry history). `pending` records that the NEXT
+  // did-navigate is the result of our own back/forward/reload, so the handler shifts
+  // (or ignores) the cursor instead of pushing a fresh entry.
+  const [nav, setNav] = useState<NavState>(INITIAL_NAV)
+  const pending = useRef<'back' | 'forward' | 'reload' | null>(null)
 
   function submitAddress(e: FormEvent<HTMLFormElement>): void {
     e.preventDefault()
@@ -49,18 +63,41 @@ export function BrowserSurface({ workspaceDir }: { workspaceDir: string }): JSX.
     })
   }
 
+  // NB: navigate by OFFSET, not goBack()/goForward() — the webview tag's goBack/
+  // goForward (and canGoBack) are broken in Electron's <webview> (they no-op against
+  // a genuine multi-entry history), but goToOffset works. Our own nav model is the
+  // source of truth for whether an offset is available.
+  function goBack(): void {
+    pending.current = 'back'
+    view?.goToOffset(-1)
+  }
+  function goForward(): void {
+    pending.current = 'forward'
+    view?.goToOffset(1)
+  }
+  function reload(): void {
+    pending.current = 'reload'
+    view?.reload()
+  }
+
   // The webview only exposes its state through DOM events — wire them once per
   // mounted element, unwiring on unmount/remount.
   useEffect(() => {
     if (!view) return
-    const sync = (): void => {
+    const onNavigate = (): void => {
       // Never clobber an address the user is mid-typing: the guest can navigate
       // (redirects, SPA pushState) while the bar has focus.
       if (document.activeElement !== addressInputRef.current) setAddress(view.getURL())
-      setCanGoBack(view.canGoBack())
-      setCanGoForward(view.canGoForward())
+      // Advance the cursor per what caused this navigation. A reload adds no entry.
+      const cause = pending.current
+      pending.current = null
+      if (cause === 'reload') return
+      setNav((s) =>
+        cause === 'back' ? goBackNav(s) : cause === 'forward' ? goForwardNav(s) : pushNav(s),
+      )
     }
     const logFailure = (event: Event): void => {
+      pending.current = null
       const { errorCode, errorDescription, validatedURL } = event as unknown as {
         errorCode?: number
         errorDescription?: string
@@ -70,15 +107,18 @@ export function BrowserSurface({ workspaceDir }: { workspaceDir: string }): JSX.
       if (errorCode === -3) return
       console.error('[browser] load failed', validatedURL, errorCode, errorDescription)
     }
-    view.addEventListener('did-navigate', sync)
-    view.addEventListener('did-navigate-in-page', sync)
+    view.addEventListener('did-navigate', onNavigate)
+    view.addEventListener('did-navigate-in-page', onNavigate)
     view.addEventListener('did-fail-load', logFailure)
     return () => {
-      view.removeEventListener('did-navigate', sync)
-      view.removeEventListener('did-navigate-in-page', sync)
+      view.removeEventListener('did-navigate', onNavigate)
+      view.removeEventListener('did-navigate-in-page', onNavigate)
       view.removeEventListener('did-fail-load', logFailure)
     }
   }, [view])
+
+  const canGoBack = canGoBackNav(nav)
+  const canGoForward = canGoForwardNav(nav)
 
   if (initialUrl === null) {
     return (
@@ -110,13 +150,13 @@ export function BrowserSurface({ workspaceDir }: { workspaceDir: string }): JSX.
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-panel">
       <div className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-1">
-        <BrowserAction label="Back" onClick={() => view?.goBack()} disabled={!canGoBack}>
+        <BrowserAction label="Back" onClick={goBack} disabled={!canGoBack}>
           <ArrowLeft aria-hidden />
         </BrowserAction>
-        <BrowserAction label="Forward" onClick={() => view?.goForward()} disabled={!canGoForward}>
+        <BrowserAction label="Forward" onClick={goForward} disabled={!canGoForward}>
           <ArrowRight aria-hidden />
         </BrowserAction>
-        <BrowserAction label="Reload" onClick={() => view?.reload()}>
+        <BrowserAction label="Reload" onClick={reload}>
           <RotateCw aria-hidden />
         </BrowserAction>
         <form onSubmit={submitAddress} className="min-w-0 flex-1">
@@ -153,11 +193,9 @@ export function BrowserSurface({ workspaceDir }: { workspaceDir: string }): JSX.
 interface WebviewElement extends HTMLElement {
   loadURL(url: string): Promise<void>
   getURL(): string
-  goBack(): void
-  goForward(): void
+  /** Navigate by history offset — the working primitive (goBack/goForward are broken). */
+  goToOffset(offset: number): void
   reload(): void
-  canGoBack(): boolean
-  canGoForward(): boolean
 }
 
 /** A browser toolbar icon button — the TerminalAction idiom. */

--- a/src/renderer/src/side-panel/SurfacePanel.tsx
+++ b/src/renderer/src/side-panel/SurfacePanel.tsx
@@ -540,9 +540,9 @@ const CARDS: readonly CardDef[] = [
   {
     target: 'browser',
     label: 'Browser',
+    // No shortcut hint until #217 wires the ⌘T chord — advertised chrome must work.
     description: 'Preview a local dev server.',
     icon: <Globe aria-hidden />,
-    hint: '⌘T',
     live: true,
   },
   {

--- a/src/renderer/src/side-panel/SurfacePanel.tsx
+++ b/src/renderer/src/side-panel/SurfacePanel.tsx
@@ -18,6 +18,7 @@ import { ChangesPanel } from '../git/ChangesPanel'
 import { FilesSurface } from './FilesSurface'
 import { FilePreview } from './FilePreview'
 import { TerminalSurface } from './TerminalSurface'
+import { BrowserSurface } from './BrowserSurface'
 import { surfaceForChord } from './surface-keys'
 import { basename } from '../lib/paths'
 import {
@@ -28,6 +29,7 @@ import {
   closeWorkspaceSurface,
   closeWorkspaceSurfacesToRight,
   MAX_TERMINALS_PER_WORKSPACE,
+  openWorkspaceBrowserSurface,
   openWorkspaceFileSurface,
   openWorkspaceSurface,
   openWorkspaceTerminalSurface,
@@ -54,7 +56,7 @@ const NARROW_QUERY = '(max-width: 980px)'
  * ⌘P/⌃⇧G. Open Surfaces show as a TAB STRIP; with zero open, the panel shows the launcher
  * CARDS (its empty state). Review re-homes the git Changes panel behavior-identical
  * (#84–#88, ADR-0008); Files is the searchable tree (#188); Terminal is the Workspace
- * shell (ADR-0014); Browser stays inert/reserved.
+ * shell (ADR-0014); Browser is the embedded dev-server preview (#216, ADR-0015).
  *
  * Presentation is DUAL: inline beside the conversation on wide windows — a full-height,
  * flush, `border-l`-separated column (t3code's editor-panel chrome) whose width is
@@ -245,10 +247,11 @@ function PanelBody({
     killTerminalsAmong(panel.surfaces)
     closeAllWorkspaceSurfaces(workspaceId)
   }
-  /** A launcher card / "+"-menu target: singletons via the store op, terminal via its own. */
+  /** A launcher card / "+"-menu target: singletons via the store op, terminal/browser via their own. */
   function openCardTarget(target: CardDef['target']): void {
     if (target === 'terminal') openWorkspaceTerminalSurface(workspaceId)
-    else if (target !== 'browser') openWorkspaceSurface(workspaceId, target)
+    else if (target === 'browser') openWorkspaceBrowserSurface(workspaceId)
+    else openWorkspaceSurface(workspaceId, target)
   }
   // At the per-Workspace terminal cap, the Terminal affordance disables (its store
   // op no-ops anyway — this keeps the button from reading as broken).
@@ -329,6 +332,12 @@ function PanelBody({
                 agentId={agentId}
                 activeThreadId={activeThreadId}
               />
+            )}
+            {active?.kind === 'browser' && (
+              // The embedded dev-server preview (#216, ADR-0015). Keyed by the surface id
+              // so a future multi-tab browser remounts per tab; the view is disposable —
+              // closing/switching discards the page (URL persistence is slice 2, #217).
+              <BrowserSurface key={active.id} workspaceDir={workspaceDir} />
             )}
             {active?.kind === 'file' && (
               // A read-only file preview tab (#189): fetches the confined `files:read` and renders
@@ -507,7 +516,7 @@ interface CardDef {
   label: string
   description: string
   icon: ReactNode
-  /** The keyboard-shortcut hint (aspirational chrome for the inert Browser card). */
+  /** The keyboard-shortcut hint (⌘T stays aspirational chrome until #217 wires it). */
   hint?: string
   live: boolean
 }
@@ -534,7 +543,7 @@ const CARDS: readonly CardDef[] = [
     description: 'Preview a local dev server.',
     icon: <Globe aria-hidden />,
     hint: '⌘T',
-    live: false,
+    live: true,
   },
   {
     target: 'files',
@@ -549,8 +558,8 @@ const CARDS: readonly CardDef[] = [
 /**
  * The launcher EMPTY STATE (panel open, zero Surfaces) — t3code's `RightPanelEmptyState`:
  * a centered "Open a surface" heading over a 2-column grid of cards (leading icon, label +
- * shortcut hint, a short description). Live cards open their Surface; the inert Terminal/
- * Browser cards are disabled + tagged "Soon" (the sidebar PlaceholderNav precedent).
+ * shortcut hint, a short description). Live cards open their Surface; an inert card is
+ * disabled + tagged "Soon" (the sidebar PlaceholderNav precedent) — all four are live now.
  * Opening one replaces the grid with the tab strip; closing the last tab returns here.
  */
 function LauncherGrid({

--- a/src/renderer/src/side-panel/browser-nav-history.test.ts
+++ b/src/renderer/src/side-panel/browser-nav-history.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import {
+  canGoBackNav,
+  canGoForwardNav,
+  goBackNav,
+  goForwardNav,
+  INITIAL_NAV,
+  pushNav,
+} from './browser-nav-history'
+
+describe('browser nav-history model', () => {
+  // The webview element's own canGoBack()/canGoForward() are unreliable in Electron's
+  // <webview> tag (they return false with a genuine multi-entry history), so #216
+  // tracks availability from navigation EVENTS through this pure index/length model.
+
+  it('starts empty — nowhere to go', () => {
+    expect(canGoBackNav(INITIAL_NAV)).toBe(false)
+    expect(canGoForwardNav(INITIAL_NAV)).toBe(false)
+  })
+
+  it('a first navigation lands on a single entry with no back/forward', () => {
+    const s = pushNav(INITIAL_NAV)
+    expect(canGoBackNav(s)).toBe(false)
+    expect(canGoForwardNav(s)).toBe(false)
+  })
+
+  it('a second navigation enables Back but not Forward', () => {
+    const s = pushNav(pushNav(INITIAL_NAV))
+    expect(canGoBackNav(s)).toBe(true)
+    expect(canGoForwardNav(s)).toBe(false)
+  })
+
+  it('going back enables Forward and (from the middle) keeps Back', () => {
+    const s = goBackNav(pushNav(pushNav(pushNav(INITIAL_NAV)))) // 3 entries, index 2 → 1
+    expect(canGoBackNav(s)).toBe(true)
+    expect(canGoForwardNav(s)).toBe(true)
+  })
+
+  it('going back to the first entry disables Back', () => {
+    const s = goBackNav(pushNav(pushNav(INITIAL_NAV))) // 2 entries, index 1 → 0
+    expect(canGoBackNav(s)).toBe(false)
+    expect(canGoForwardNav(s)).toBe(true)
+  })
+
+  it('back then forward returns to the tip', () => {
+    const s = goForwardNav(goBackNav(pushNav(pushNav(INITIAL_NAV))))
+    expect(canGoBackNav(s)).toBe(true)
+    expect(canGoForwardNav(s)).toBe(false)
+  })
+
+  it('a new navigation after going back truncates the forward entries', () => {
+    // 3 entries, back to index 1, then a fresh navigation replaces the tail.
+    const middle = goBackNav(pushNav(pushNav(pushNav(INITIAL_NAV)))) // index 1, length 3
+    const s = pushNav(middle) // index 2, length 3 — forward is gone
+    expect(canGoBackNav(s)).toBe(true)
+    expect(canGoForwardNav(s)).toBe(false)
+  })
+
+  it('goBack/goForward at the ends are no-ops (same state)', () => {
+    expect(goBackNav(INITIAL_NAV)).toBe(INITIAL_NAV)
+    const tip = pushNav(pushNav(INITIAL_NAV))
+    expect(goForwardNav(tip)).toBe(tip)
+  })
+})

--- a/src/renderer/src/side-panel/browser-nav-history.ts
+++ b/src/renderer/src/side-panel/browser-nav-history.ts
@@ -1,0 +1,46 @@
+/**
+ * A pure back/forward availability model for the Browser Surface (#216). The Electron
+ * `<webview>` tag's own `canGoBack()`/`canGoForward()` are unreliable (they report
+ * `false` against a genuine multi-entry history), so we track availability from
+ * navigation EVENTS instead: a simple `{index, length}` cursor the component advances
+ * on each new navigation and shifts on back/forward. Deliberately a small pure module
+ * so the edge cases (truncate-on-branch, end-of-list no-ops) are unit-tested DOM-free.
+ */
+export interface NavState {
+  /** The active entry's 0-based position, or -1 before the first navigation. */
+  index: number
+  /** How many entries the history holds. */
+  length: number
+}
+
+/** Before any navigation: nowhere to go. */
+export const INITIAL_NAV: NavState = { index: -1, length: 0 }
+
+/**
+ * A brand-new navigation (first load, URL-bar submit, link click, guest redirect):
+ * truncate any forward entries and push a new tip, landing on it.
+ */
+export function pushNav(state: NavState): NavState {
+  const index = state.index + 1
+  return { index, length: index + 1 }
+}
+
+/** Move back one entry (a no-op — same reference — at the first entry). */
+export function goBackNav(state: NavState): NavState {
+  return state.index > 0 ? { ...state, index: state.index - 1 } : state
+}
+
+/** Move forward one entry (a no-op — same reference — at the tip). */
+export function goForwardNav(state: NavState): NavState {
+  return state.index < state.length - 1 ? { ...state, index: state.index + 1 } : state
+}
+
+/** Whether a Back is possible. */
+export function canGoBackNav(state: NavState): boolean {
+  return state.index > 0
+}
+
+/** Whether a Forward is possible. */
+export function canGoForwardNav(state: NavState): boolean {
+  return state.index < state.length - 1
+}

--- a/src/renderer/src/side-panel/browser-url.test.ts
+++ b/src/renderer/src/side-panel/browser-url.test.ts
@@ -27,4 +27,9 @@ describe('normalizeBrowserUrl', () => {
   it('trims surrounding whitespace before parsing', () => {
     expect(normalizeBrowserUrl('  localhost:3000  ')).toBe('http://localhost:3000/')
   })
+
+  it('treats host:port followed by a query or fragment as a URL, not a scheme', () => {
+    expect(normalizeBrowserUrl('localhost:5173?debug=1')).toBe('http://localhost:5173/?debug=1')
+    expect(normalizeBrowserUrl('localhost:3000#section')).toBe('http://localhost:3000/#section')
+  })
 })

--- a/src/renderer/src/side-panel/browser-url.test.ts
+++ b/src/renderer/src/side-panel/browser-url.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeBrowserUrl } from './browser-url'
+
+describe('normalizeBrowserUrl', () => {
+  it('normalizes scheme-less host:port input to http', () => {
+    expect(normalizeBrowserUrl('localhost:5173')).toBe('http://localhost:5173/')
+  })
+
+  it('keeps an explicit http/https scheme as typed', () => {
+    expect(normalizeBrowserUrl('https://example.com/app')).toBe('https://example.com/app')
+    expect(normalizeBrowserUrl('http://127.0.0.1:3000')).toBe('http://127.0.0.1:3000/')
+  })
+
+  it('refuses non-http(s) schemes instead of coercing them', () => {
+    expect(normalizeBrowserUrl('file:///etc/passwd')).toBeNull()
+    expect(normalizeBrowserUrl('javascript:alert(1)')).toBeNull()
+    expect(normalizeBrowserUrl('vscode://open?file=x')).toBeNull()
+    expect(normalizeBrowserUrl('mailto:a@b.com')).toBeNull()
+  })
+
+  it('refuses empty and unparseable input', () => {
+    expect(normalizeBrowserUrl('')).toBeNull()
+    expect(normalizeBrowserUrl('   ')).toBeNull()
+    expect(normalizeBrowserUrl('not a url at all')).toBeNull()
+  })
+
+  it('trims surrounding whitespace before parsing', () => {
+    expect(normalizeBrowserUrl('  localhost:3000  ')).toBe('http://localhost:3000/')
+  })
+})

--- a/src/renderer/src/side-panel/browser-url.ts
+++ b/src/renderer/src/side-panel/browser-url.ts
@@ -1,0 +1,26 @@
+/**
+ * URL policy for the Browser Surface (#216, ADR-0015): everything the webview is asked
+ * to load passes through here first. Accepts what a user would naturally type into a
+ * URL bar (`localhost:5173`, `example.com/path`) by inferring `http://`, but blesses
+ * ONLY `http:`/`https:` results — `file:`, `javascript:`, `vscode:` and friends are
+ * refused (`null`), mirroring `safeExternalUrl`'s posture for the opposite direction.
+ */
+export function normalizeBrowserUrl(input: string): string | null {
+  const raw = input.trim()
+  if (!raw) return null
+  // A leading `scheme:` means the user MEANT a scheme — parse as-is so a non-http(s)
+  // one is refused rather than laundered into `http://file:...`. The one ambiguity is
+  // `host:port` (`localhost:5173`), which the scheme grammar also matches: a colon
+  // followed by digits reads as a port, so it takes the infer-http path instead.
+  const hasScheme = /^[a-z][a-z0-9+.-]*:/i.test(raw) && !/^[a-z][a-z0-9+.-]*:\d+(\/|$)/i.test(raw)
+  return parseHttpUrl(hasScheme ? raw : `http://${raw}`)
+}
+
+function parseHttpUrl(raw: string): string | null {
+  try {
+    const url = new URL(raw)
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.href : null
+  } catch {
+    return null
+  }
+}

--- a/src/renderer/src/side-panel/browser-url.ts
+++ b/src/renderer/src/side-panel/browser-url.ts
@@ -11,8 +11,9 @@ export function normalizeBrowserUrl(input: string): string | null {
   // A leading `scheme:` means the user MEANT a scheme — parse as-is so a non-http(s)
   // one is refused rather than laundered into `http://file:...`. The one ambiguity is
   // `host:port` (`localhost:5173`), which the scheme grammar also matches: a colon
-  // followed by digits reads as a port, so it takes the infer-http path instead.
-  const hasScheme = /^[a-z][a-z0-9+.-]*:/i.test(raw) && !/^[a-z][a-z0-9+.-]*:\d+(\/|$)/i.test(raw)
+  // followed by digits then a path/query/fragment (or nothing) reads as a port, so it
+  // takes the infer-http path instead.
+  const hasScheme = /^[a-z][a-z0-9+.-]*:/i.test(raw) && !/^[a-z][a-z0-9+.-]*:\d+([/?#]|$)/i.test(raw)
   return parseHttpUrl(hasScheme ? raw : `http://${raw}`)
 }
 

--- a/src/renderer/src/side-panel/side-panel-store.test.ts
+++ b/src/renderer/src/side-panel/side-panel-store.test.ts
@@ -431,8 +431,18 @@ describe('coerceSurface', () => {
     expect(coerceSurface({ id: 'terminal:term-1', kind: 'terminal', resourceId: 'term-9' })).toBeNull() // id≠resource
   })
 
+  it('accepts the singleton browser tab and drops malformed browser blobs (#216)', () => {
+    expect(coerceSurface({ id: 'browser:main', kind: 'browser', resourceId: 'main' })).toEqual({
+      id: 'browser:main',
+      kind: 'browser',
+      resourceId: 'main',
+    })
+    expect(coerceSurface({ kind: 'browser' })).toBeNull() // no id/resource
+    expect(coerceSurface({ id: 'browser:evil', kind: 'browser', resourceId: 'evil' })).toBeNull() // not the singleton
+    expect(coerceSurface({ id: 'browser:main', kind: 'browser', resourceId: 'other' })).toBeNull() // id≠resource
+  })
+
   it('drops not-yet-implemented / unknown / malformed descriptors', () => {
-    expect(coerceSurface({ kind: 'browser' })).toBeNull()
     expect(coerceSurface({ kind: 'nope' })).toBeNull()
     expect(coerceSurface(null)).toBeNull()
     expect(coerceSurface('review')).toBeNull()

--- a/src/renderer/src/side-panel/side-panel-store.test.ts
+++ b/src/renderer/src/side-panel/side-panel-store.test.ts
@@ -12,6 +12,7 @@ import {
   EMPTY_PANEL_STATE,
   getWorkspacePanel,
   MAX_TERMINALS_PER_WORKSPACE,
+  openBrowserSurface,
   openFileSurface,
   openSurface,
   openTerminalSurface,
@@ -140,6 +141,26 @@ describe('openTerminalSurface (ADR-0014, slice 3 multi-terminal)', () => {
     for (let i = 0; i < MAX_TERMINALS_PER_WORKSPACE; i++) state = openTerminalSurface(state)
     expect(terminalSurfaceCount(state)).toBe(MAX_TERMINALS_PER_WORKSPACE)
     expect(openTerminalSurface(state)).toBe(state) // same ref — capped
+  })
+})
+
+describe('openBrowserSurface (#216, singleton dev-server preview)', () => {
+  const B: Surface = { id: 'browser:main', kind: 'browser', resourceId: 'main' }
+
+  it('opens the singleton browser tab, activating it and opening the panel', () => {
+    expect(openBrowserSurface(empty())).toEqual({
+      isOpen: true,
+      activeSurfaceId: 'browser:main',
+      surfaces: [B],
+    })
+  })
+
+  it('re-activates rather than duplicates when already open (singleton semantics)', () => {
+    const withBrowser = openBrowserSurface(empty())
+    const behindOther = openSurface(withBrowser, 'files')
+    const again = openBrowserSurface(behindOther)
+    expect(again.surfaces.filter((s) => s.kind === 'browser')).toHaveLength(1)
+    expect(again.activeSurfaceId).toBe('browser:main')
   })
 })
 

--- a/src/renderer/src/side-panel/side-panel-store.ts
+++ b/src/renderer/src/side-panel/side-panel-store.ts
@@ -161,6 +161,22 @@ export function terminalSurfaceCount(state: WorkspacePanelState): number {
 }
 
 /**
+ * The Browser Surface's fixed resource id (#216): a per-Workspace SINGLETON this slice,
+ * so the descriptor is constant — the reserved `browser:${resourceId}` id shape stays
+ * ready for a future multi-tab browser without a coercion break.
+ */
+const BROWSER_SURFACE: Surface = { id: 'browser:main', kind: 'browser', resourceId: 'main' }
+
+/**
+ * Open (or re-activate) the Workspace's singleton Browser Surface (#216, ADR-0015),
+ * opening the panel — the singleton semantics of `openSurface`, under the browser's
+ * own resource-id'd descriptor shape.
+ */
+export function openBrowserSurface(state: WorkspacePanelState): WorkspacePanelState {
+  return upsertSurface(state, BROWSER_SURFACE)
+}
+
+/**
  * The ⌘P / ⌃⇧G semantics (t3code `toggle`): if the panel is open AND this kind is the
  * ACTIVE tab, hide the panel (keep the tabs + active id). Otherwise open/activate the
  * singleton — which also OPENS a closed panel. So one chord opens, a second (while it's
@@ -424,6 +440,7 @@ function bindWorkspaceOp<A extends unknown[]>(
 export const openWorkspaceSurface = bindWorkspaceOp(openSurface)
 export const openWorkspaceFileSurface = bindWorkspaceOp(openFileSurface)
 export const openWorkspaceTerminalSurface = bindWorkspaceOp(openTerminalSurface)
+export const openWorkspaceBrowserSurface = bindWorkspaceOp(openBrowserSurface)
 export const toggleWorkspaceSurface = bindWorkspaceOp(toggleSurface)
 export const activateWorkspaceSurface = bindWorkspaceOp(activateSurface)
 export const closeWorkspaceSurface = bindWorkspaceOp(closeSurface)

--- a/src/renderer/src/side-panel/side-panel-store.ts
+++ b/src/renderer/src/side-panel/side-panel-store.ts
@@ -279,10 +279,9 @@ export function updateWorkspace(
 // --- Coercion + (de)serialization (defensive against corrupt / legacy blobs) ---
 
 /**
- * Coerce an untrusted descriptor into a valid `Surface`, or `null` to drop it. Only the
- * IMPLEMENTED singleton kinds are accepted this slice; a `file`/`terminal`/`browser`
- * blob (or anything unknown) is dropped rather than trusted — #189 extends this when the
- * `file` shape lands.
+ * Coerce an untrusted descriptor into a valid `Surface`, or `null` to drop it. Every
+ * implemented kind validates its full shape (id/resource conventions) — anything
+ * unknown or malformed is dropped rather than trusted.
  */
 export function coerceSurface(raw: unknown): Surface | null {
   if (typeof raw !== 'object' || raw === null) return null
@@ -308,6 +307,17 @@ export function coerceSurface(raw: unknown): Surface | null {
     const id = (raw as { id?: unknown }).id
     if (typeof resourceId === 'string' && /^term-\d+$/.test(resourceId) && id === `terminal:${resourceId}`) {
       return { id: `terminal:${resourceId}`, kind: 'terminal', resourceId }
+    }
+    return null
+  }
+  if (kind === 'browser') {
+    // A persisted browser tab restores its slot (the page itself is discarded on
+    // unmount — #217 adds URL persistence). Only the singleton shape exists this
+    // slice; drop anything else.
+    const resourceId = (raw as { resourceId?: unknown }).resourceId
+    const id = (raw as { id?: unknown }).id
+    if (resourceId === 'main' && id === 'browser:main') {
+      return { id: 'browser:main', kind: 'browser', resourceId: 'main' }
     }
     return null
   }

--- a/src/shared/browser-guest.test.ts
+++ b/src/shared/browser-guest.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import {
+  BROWSER_PARTITION_PREFIX,
+  buildWebviewPreferencesAttribute,
+  deriveBrowserPartition,
+  stripElectronUserAgent,
+} from './browser-guest'
+
+const ELECTRON_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) vibe-mistro/1.0.0 Chrome/134.0.0.0 Electron/35.1.0 Safari/537.36'
+
+describe('deriveBrowserPartition', () => {
+  it('derives a persist: partition stable for the same Workspace directory', () => {
+    const a = deriveBrowserPartition('/Users/me/projects/app')
+    expect(a).toBe(deriveBrowserPartition('/Users/me/projects/app'))
+    expect(a.startsWith(BROWSER_PARTITION_PREFIX)).toBe(true)
+    expect(BROWSER_PARTITION_PREFIX.startsWith('persist:')).toBe(true)
+  })
+
+  it('isolates different Workspace directories into different partitions', () => {
+    expect(deriveBrowserPartition('/Users/me/projects/app')).not.toBe(
+      deriveBrowserPartition('/Users/me/projects/other'),
+    )
+  })
+})
+
+describe('buildWebviewPreferencesAttribute', () => {
+  // Electron parses this attribute by splitting on `,` WITHOUT trimming, and a value
+  // that isn't a recognised boolean literal coerces to a truthy STRING (the t3code
+  // WebviewPreferences gotcha) — so a stray space or a `yes`/`no` value silently
+  // weakens the sandbox. This test locks the exact grammar, not just the intent.
+  it('locks the guest security prefs: sandboxed, no Node, isolated, no spaces', () => {
+    const attr = buildWebviewPreferencesAttribute()
+    expect(attr).toContain('sandbox=true')
+    expect(attr).toContain('nodeIntegration=false')
+    expect(attr).toContain('nodeIntegrationInSubFrames=false')
+    expect(attr).toContain('contextIsolation=true')
+    expect(attr).not.toMatch(/\s/)
+    for (const pair of attr.split(',')) {
+      expect(pair).toMatch(/^[A-Za-z]+=(true|false)$/)
+    }
+  })
+})
+
+describe('stripElectronUserAgent', () => {
+  it('removes the Electron and app-name tokens so the guest reads as a normal browser', () => {
+    const stripped = stripElectronUserAgent(ELECTRON_UA)
+    expect(stripped).not.toContain('Electron/')
+    expect(stripped).not.toContain('vibe-mistro/')
+    expect(stripped).toContain('Chrome/134.0.0.0')
+    expect(stripped).not.toMatch(/ {2}/)
+  })
+
+  it('leaves an already-ordinary UA untouched', () => {
+    const plain =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36'
+    expect(stripElectronUserAgent(plain)).toBe(plain)
+  })
+})

--- a/src/shared/browser-guest.test.ts
+++ b/src/shared/browser-guest.test.ts
@@ -3,6 +3,7 @@ import {
   BROWSER_PARTITION_PREFIX,
   buildWebviewPreferencesAttribute,
   deriveBrowserPartition,
+  isBrowserPartition,
   stripElectronUserAgent,
 } from './browser-guest'
 
@@ -21,6 +22,23 @@ describe('deriveBrowserPartition', () => {
     expect(deriveBrowserPartition('/Users/me/projects/app')).not.toBe(
       deriveBrowserPartition('/Users/me/projects/other'),
     )
+  })
+})
+
+describe('isBrowserPartition', () => {
+  it('accepts exactly what deriveBrowserPartition emits', () => {
+    expect(isBrowserPartition(deriveBrowserPartition('/Users/me/app'))).toBe(true)
+  })
+
+  it('rejects prefix-only matches with attacker-chosen suffixes (exact grammar, not startsWith)', () => {
+    // Electron maps `persist:` names onto storage directories — a traversal-shaped
+    // suffix must never pass just because the prefix does.
+    expect(isBrowserPartition(`${BROWSER_PARTITION_PREFIX}../../Partitions/other`)).toBe(false)
+    expect(isBrowserPartition(`${BROWSER_PARTITION_PREFIX}deadbeef/evil`)).toBe(false)
+    expect(isBrowserPartition(`${BROWSER_PARTITION_PREFIX}DEADBEEF`)).toBe(false)
+    expect(isBrowserPartition(`${BROWSER_PARTITION_PREFIX}deadbee`)).toBe(false)
+    expect(isBrowserPartition('persist:something-else')).toBe(false)
+    expect(isBrowserPartition('')).toBe(false)
   })
 })
 

--- a/src/shared/browser-guest.ts
+++ b/src/shared/browser-guest.ts
@@ -30,6 +30,16 @@ export function deriveBrowserPartition(workspaceDir: string): string {
 }
 
 /**
+ * Whether a partition is EXACTLY one this module derives — prefix + 8 hex chars, the
+ * full grammar, not a `startsWith`. Electron maps `persist:` names onto storage
+ * directories, so the clamp must never admit an attacker-chosen suffix (a
+ * traversal-shaped name could alias another session's storage).
+ */
+export function isBrowserPartition(partition: string): boolean {
+  return new RegExp(`^${BROWSER_PARTITION_PREFIX}[0-9a-f]{8}$`).test(partition)
+}
+
+/**
  * The `<webview webpreferences>` attribute value. Electron splits on `,` WITHOUT
  * trimming and treats non-boolean-literal values as truthy strings (the t3code
  * gotcha), so this is built as one exact, space-free string of `key=true|false`

--- a/src/shared/browser-guest.ts
+++ b/src/shared/browser-guest.ts
@@ -1,0 +1,52 @@
+/**
+ * The Browser Surface's guest (webview) configuration, shared by BOTH sides (#216,
+ * ADR-0015): the renderer declares these on the `<webview>` tag; main's
+ * `will-attach-webview` clamp independently verifies/enforces them. Pure TS — no Node,
+ * no DOM — so it compiles under both tsconfig projects and tests in the node env.
+ *
+ * The partition scheme is t3code's: a `persist:` partition per SCOPE (our Workspace
+ * directory), so preview cookies/storage survive restarts but never mix across
+ * Workspaces or with the app's own session. The hash is FNV-1a (no `crypto` — this
+ * module must load in the renderer): partitions need stable UNIQUENESS, not
+ * collision-resistance against an adversary who already controls the input.
+ */
+
+/** Every Browser-Surface guest partition starts with this; the clamp rejects the rest. */
+export const BROWSER_PARTITION_PREFIX = 'persist:vibe-browser-'
+
+/** 32-bit FNV-1a over UTF-16 code units, hex-encoded. */
+function fnv1a(input: string): string {
+  let hash = 0x811c9dc5
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193) >>> 0
+  }
+  return hash.toString(16).padStart(8, '0')
+}
+
+/** The Workspace's isolated, persisted guest partition. */
+export function deriveBrowserPartition(workspaceDir: string): string {
+  return `${BROWSER_PARTITION_PREFIX}${fnv1a(workspaceDir)}`
+}
+
+/**
+ * The `<webview webpreferences>` attribute value. Electron splits on `,` WITHOUT
+ * trimming and treats non-boolean-literal values as truthy strings (the t3code
+ * gotcha), so this is built as one exact, space-free string of `key=true|false`
+ * pairs and locked by test. Stricter than t3code: contextIsolation stays ON — we
+ * inject no preload, so nothing needs the guest's globals.
+ */
+export function buildWebviewPreferencesAttribute(): string {
+  return 'sandbox=true,contextIsolation=true,nodeIntegration=false,nodeIntegrationInSubFrames=false'
+}
+
+/**
+ * Strip the `Electron/x` and `vibe-mistro/x` product tokens from a User-Agent (t3code
+ * precedent) so dev servers and sites treat the preview as the ordinary Chrome it is.
+ */
+export function stripElectronUserAgent(userAgent: string): string {
+  return userAgent
+    .replace(/\s?\b(?:Electron|vibe-mistro)\/\S+/g, '')
+    .replace(/ {2,}/g, ' ')
+    .trim()
+}


### PR DESCRIPTION
Closes #216 (slice 1 of PRD #215).

## What this does

The reserved Browser launcher card becomes live: a **singleton per-Workspace Browser Surface** embedding an Electron `<webview>` for previewing local dev servers (any http/https URL). URL bar with scheme inference (`localhost:5173` → `http://…`), Back/Forward/Reload tracking real navigation state, empty state prompting for a URL.

## Security posture (the review-worthy part)

This flips `webviewTag: true` on the host window, compensated by three layers (ADR-0015, included):

1. **Per-Workspace `persist:vibe-browser-<hash>` partition** — preview storage isolated across Workspaces and from the app (`src/shared/browser-guest.ts`, tested).
2. **Locked `webpreferences` tag string** — `sandbox=true,contextIsolation=true,nodeIntegration=false,nodeIntegrationInSubFrames=false`, built by a tested pure module (Electron's comma/boolean-literal parsing gotcha is locked by test). Stricter than t3code: no guest preload, so contextIsolation stays ON.
3. **Main-side `will-attach-webview` clamp** (`src/main/browser/webview-clamp.ts`, pure + tested) — rejects any attachment without our partition prefix; force-overrides security prefs and strips preloads regardless of renderer input.

Plus: guest popups/`window.open` denied and routed to the system browser via the existing `safeExternalUrl` guard; only http/https URLs blessed by the pure URL-policy module (`browser-url.ts`) ever reach the webview; Electron/app UA tokens stripped.

## Deliberate simplifications (per ADR-0015)

- No t3code root-mounted overlay: the view is disposable; tab close / Workspace switch discards the page. URL persistence, loading/unreachable states, DevTools, open-external and ⌘T land in slice 2 (#217); dev-server discovery in slice 3 (#218).
- No agent-facing browser automation — ADR-0002 (thin orchestrator) rules it out.

## Tests

TDD throughout: 13 new tests across `browser-url`, `browser-guest`, `webview-clamp`, and the store's `openBrowserSurface` op. All four gates green: lint, typecheck, build, test (**1084 passed**).

## Review notes

Per #216's acceptance criteria this slice carries an **adversarial security review before merge** (clamp + URL policy + partition scheme). Draft until that review and a manual smoke (open Browser card → load a dev server) happen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)