### PR TITLE
fix(browser): keep the webview mounted across surface-tab switches

### DIFF
--- a/docs/adr/0015-browser-surface-webview-embed.md
+++ b/docs/adr/0015-browser-surface-webview-embed.md
@@ -36,10 +36,13 @@ question that decides everything else is the EMBEDDING MECHANISM. Three candidat
 
 2. **The view is DISPOSABLE; no root-mounted overlay.** t3code mounts one global webview host
    over an in-layout slot (rect-tracking store) so the page survives their panel unmounting. We
-   deliberately skip that machinery: the webview lives inside the Surface; unmounting (tab
-   close, Workspace backgrounded) discards the page and the persisted URL (slice 2, #217)
-   reloads it on return. Dev-server pages are cheap to reload; the overlay pattern is the known
-   upgrade path if that assumption fails.
+   skip that machinery but keep the WEBVIEW ELEMENT mounted across surface-TAB switches (hidden,
+   not unmounted, when another tab is active — verified that `display:none` does not detach the
+   guest), so the live page (scroll, form state, JS) survives switching tabs. The page is
+   discarded only on a heavier context change — closing the tab or backgrounding the Workspace
+   (the whole panel unmounts) — where the persisted URL (slice 2, #217) reloads it on return.
+   The t3code root-mounted overlay is the known upgrade path if even Workspace-switch reload
+   proves too costly.
 
 3. **Guest security posture, three layers, stricter than t3code where possible.**
    (a) Per-Workspace persisted partition `persist:vibe-browser-<fnv1a(workspaceDir)>` — preview

--- a/src/renderer/src/side-panel/SurfacePanel.tsx
+++ b/src/renderer/src/side-panel/SurfacePanel.tsx
@@ -217,6 +217,9 @@ function PanelBody({
   }
 
   const active = panel.surfaces.find((s) => s.id === panel.activeSurfaceId) ?? null
+  // The singleton browser tab (if open) — rendered persistently (see below) rather
+  // than only when active, so its live <webview> survives tab switches.
+  const browserSurface = panel.surfaces.find((s) => s.kind === 'browser') ?? null
 
   // A close op is a VIEW op for every Surface except terminal, whose tab IS the
   // session's lifetime (ADR-0014): unmount keeps the shell (reattach later), but
@@ -333,12 +336,6 @@ function PanelBody({
                 activeThreadId={activeThreadId}
               />
             )}
-            {active?.kind === 'browser' && (
-              // The embedded dev-server preview (#216, ADR-0015). Keyed by the surface id
-              // so a future multi-tab browser remounts per tab; the view is disposable —
-              // closing/switching discards the page (URL persistence is slice 2, #217).
-              <BrowserSurface key={active.id} workspaceDir={workspaceDir} />
-            )}
             {active?.kind === 'file' && (
               // A read-only file preview tab (#189): fetches the confined `files:read` and renders
               // the highlighted content (or a binary/too-large/error notice), keyed by the path so a
@@ -349,6 +346,18 @@ function PanelBody({
                 relativePath={active.relativePath}
                 activeThreadId={activeThreadId}
               />
+            )}
+            {/* The embedded dev-server preview (#216, ADR-0015). Unlike the other
+                surfaces it stays MOUNTED whenever its tab is open — only HIDDEN when
+                another tab is active — because the live page lives in the renderer's
+                <webview> (no main-side session to reattach, unlike Terminal), so
+                unmounting on a tab switch would drop it back to the URL-entry state.
+                Closing the tab removes it from `surfaces`, unmounting it (discarding
+                the page). Keyed by id for a future multi-tab browser. */}
+            {browserSurface && (
+              <div className={cn('flex min-h-0 flex-1 flex-col', active?.kind !== 'browser' && 'hidden')}>
+                <BrowserSurface key={browserSurface.id} workspaceDir={workspaceDir} />
+              </div>
             )}
           </div>
         </>


### PR DESCRIPTION
Follow-up to #219 (merged). A bug reported from real use: open a page in the Browser tab, switch to another surface tab (Files/Review/Terminal), return to Browser — it reset to the URL-entry empty state and lost the page.

## Cause

`SurfacePanel` rendered only the **active** surface, so switching tabs unmounted `BrowserSurface`, and its component-local `initialUrl` reset to `null` on remount. Terminal survives this because its session lives in the main process and reattaches; the browser's live page lives in the renderer's `<webview>`, so unmounting discards it.

## Fix

Render the singleton browser surface **persistently** whenever its tab is open — hidden (not unmounted) when another tab is active. The other surfaces still mount only when active.

Verified by driving the built app end-to-end: while hidden, the guest webContents stays alive (`display:none` does **not** detach it — the known Electron gotcha), and on return the **same live page** is intact — random page marker unchanged (not a reload) and text typed into the guest's input preserved. Closing the tab or backgrounding the Workspace still discards the page (where slice 2's URL persistence, #217, will reload it).

ADR-0015 decision 2 updated to describe the corrected lifecycle. All gates green (1099 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)