### PR TITLE
feat(browser): slice 2 — states, actions & URL persistence (#217)

### DIFF
--- a/src/renderer/src/side-panel/BrowserSurface.tsx
+++ b/src/renderer/src/side-panel/BrowserSurface.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type FormEvent, type JSX } from 'react'
-import { ArrowLeft, ArrowRight, RotateCw } from 'lucide-react'
+import { ArrowLeft, ArrowRight, Code, ExternalLink, Loader2, RotateCw, TriangleAlert } from 'lucide-react'
 import { cn } from '../lib/utils'
 import {
   buildWebviewPreferencesAttribute,
@@ -16,57 +16,72 @@ import {
   pushNav,
   type NavState,
 } from './browser-nav-history'
+import { INITIAL_LOAD, onFailLoad, onStartLoad, onStopLoad, type LoadState } from './browser-load-state'
 
 /**
- * The Browser Surface (#216, ADR-0015): an embedded dev-server preview on the Electron
- * `<webview>` tag — a real DOM node, so it lays out/clips/resizes inside the panel like
- * any other Surface (the t3code "Preview" decision, minus their root-mounted overlay:
- * our view is DISPOSABLE — unmounting discards the page; the URL survives in the store
- * for slice 2's persistence).
+ * The Browser Surface (#216 embed, #217 states/persistence; ADR-0015): an embedded
+ * dev-server preview on the Electron `<webview>` tag — a real DOM node, so it lays
+ * out/clips/resizes inside the panel like any other Surface. Navigation is
+ * RENDERER-DRIVEN (the component talks to the element directly); main's involvement is
+ * the `will-attach-webview` clamp and guest popup/nav guards. Every URL the webview is
+ * asked to load passes `normalizeBrowserUrl` first — http/https only.
  *
- * Navigation is RENDERER-DRIVEN: the component talks to the webview element directly
- * (loadURL/goBack/events); main's involvement is the `will-attach-webview` clamp and
- * guest popup routing. Every URL the webview is asked to load passes
- * `normalizeBrowserUrl` first — http/https only, schemes like `file:` refused.
+ * Slice 2 rounds it into a real browser: a loading indicator, a friendly unreachable
+ * state with Retry (built on the pure load-state machine that handles the
+ * did-stop-after-did-fail ordering gotcha), the page title in the chrome, open-in-system-
+ * browser + DevTools actions, and last-URL persistence via the store (`persistedUrl` in,
+ * `onUrlChange` out) so a reopen/restart reloads where the user left off.
  */
-export function BrowserSurface({ workspaceDir }: { workspaceDir: string }): JSX.Element {
+export function BrowserSurface({
+  workspaceDir,
+  persistedUrl,
+  onUrlChange,
+}: {
+  workspaceDir: string
+  /** The last-visited URL restored from the store (#217), or undefined for a fresh tab. */
+  persistedUrl?: string
+  /** Report a committed guest URL up to the store so it persists. */
+  onUrlChange: (url: string) => void
+}): JSX.Element {
   // The mounted webview as STATE (not a ref): the `setView` setter is identity-stable,
   // so React invokes the callback ref only on real mount/unmount — an inline-closure
   // ref would re-fire per render and leak one listener pair each time.
   const [view, setView] = useState<WebviewElement | null>(null)
   const addressInputRef = useRef<HTMLInputElement | null>(null)
   // The first blessed URL becomes the webview's `src`; later submissions go through
-  // `loadURL`. `null` = nothing loaded yet → the URL-entry empty state.
-  const [initialUrl, setInitialUrl] = useState<string | null>(null)
-  const [address, setAddress] = useState('')
+  // `loadURL`. Seeded from the persisted URL so a reopened tab auto-loads; `null` = a
+  // fresh tab showing the URL-entry empty state.
+  const [initialUrl, setInitialUrl] = useState<string | null>(persistedUrl ?? null)
+  const [address, setAddress] = useState(persistedUrl ?? '')
+  const [title, setTitle] = useState('')
+  const [load, setLoad] = useState<LoadState>(INITIAL_LOAD)
   // Back/forward availability is tracked from navigation EVENTS via the pure model —
-  // the webview element's own canGoBack()/canGoForward() are unreliable (they report
-  // false against a genuine multi-entry history). `pending` records that the NEXT
-  // did-navigate is the result of our own back/forward/reload, so the handler shifts
-  // (or ignores) the cursor instead of pushing a fresh entry.
+  // the webview element's own canGoBack()/canGoForward() are unreliable. `pending`
+  // records that the NEXT did-navigate is our own back/forward/reload, so the handler
+  // shifts (or ignores) the cursor instead of pushing a fresh entry.
   const [nav, setNav] = useState<NavState>(INITIAL_NAV)
   const pending = useRef<'back' | 'forward' | 'reload' | null>(null)
+
+  function load_(url: string): void {
+    void view?.loadURL(url).catch((err: unknown) => {
+      // A superseded load rejects benignly; a real failure surfaces via did-fail-load
+      // (the unreachable state). Nothing actionable here beyond a log.
+      console.error('[browser] loadURL failed', url, err)
+    })
+  }
 
   function submitAddress(e: FormEvent<HTMLFormElement>): void {
     e.preventDefault()
     const url = normalizeBrowserUrl(address)
     if (!url) return
     setAddress(url)
-    if (initialUrl === null) {
-      setInitialUrl(url)
-      return
-    }
-    void view?.loadURL(url).catch((err: unknown) => {
-      // A load superseded by a newer navigation rejects benignly, but so do real
-      // failures — log rather than swallow (#217 turns this into an unreachable state).
-      console.error('[browser] loadURL failed', url, err)
-    })
+    if (initialUrl === null) setInitialUrl(url)
+    else load_(url)
   }
 
-  // NB: navigate by OFFSET, not goBack()/goForward() — the webview tag's goBack/
-  // goForward (and canGoBack) are broken in Electron's <webview> (they no-op against
-  // a genuine multi-entry history), but goToOffset works. Our own nav model is the
-  // source of truth for whether an offset is available.
+  // NB: navigate by OFFSET, not goBack()/goForward() — the webview tag's goBack/goForward
+  // (and canGoBack) are broken in Electron's <webview>, but goToOffset works. Our nav
+  // model is the source of truth for whether an offset is available.
   function goBack(): void {
     pending.current = 'back'
     view?.goToOffset(-1)
@@ -79,15 +94,27 @@ export function BrowserSurface({ workspaceDir }: { workspaceDir: string }): JSX.
     pending.current = 'reload'
     view?.reload()
   }
+  function retry(): void {
+    if (load.status === 'failed') load_(load.url)
+  }
+  function openExternal(): void {
+    if (address) void window.api.openExternal({ url: address })
+  }
+  function openDevTools(): void {
+    view?.openDevTools()
+  }
 
-  // The webview only exposes its state through DOM events — wire them once per
-  // mounted element, unwiring on unmount/remount.
+  // The webview only exposes its state through DOM events — wire them once per mounted
+  // element, unwiring on unmount/remount.
   useEffect(() => {
     if (!view) return
     const onNavigate = (): void => {
+      const url = view.getURL()
       // Never clobber an address the user is mid-typing: the guest can navigate
-      // (redirects, SPA pushState) while the bar has focus.
-      if (document.activeElement !== addressInputRef.current) setAddress(view.getURL())
+      // (redirects, SPA pushState) while the bar has focus. Persistence is independent
+      // of the visible input — always report the committed URL.
+      if (document.activeElement !== addressInputRef.current) setAddress(url)
+      onUrlChange(url)
       // Advance the cursor per what caused this navigation. A reload adds no entry.
       const cause = pending.current
       pending.current = null
@@ -96,26 +123,34 @@ export function BrowserSurface({ workspaceDir }: { workspaceDir: string }): JSX.
         cause === 'back' ? goBackNav(s) : cause === 'forward' ? goForwardNav(s) : pushNav(s),
       )
     }
-    const logFailure = (event: Event): void => {
+    const onStart = (): void => setLoad(onStartLoad)
+    const onStop = (): void => setLoad(onStopLoad)
+    const onFail = (event: Event): void => {
       pending.current = null
-      const { errorCode, errorDescription, validatedURL } = event as unknown as {
+      const { errorCode, validatedURL } = event as unknown as {
         errorCode?: number
-        errorDescription?: string
         validatedURL?: string
       }
-      // -3 is Chromium's ERR_ABORTED — a superseded/cancelled load, not a failure.
-      if (errorCode === -3) return
-      console.error('[browser] load failed', validatedURL, errorCode, errorDescription)
+      setLoad((s) => onFailLoad(s, validatedURL ?? view.getURL(), errorCode ?? 0))
+    }
+    const onTitle = (event: Event): void => {
+      setTitle((event as unknown as { title?: string }).title ?? '')
     }
     view.addEventListener('did-navigate', onNavigate)
     view.addEventListener('did-navigate-in-page', onNavigate)
-    view.addEventListener('did-fail-load', logFailure)
+    view.addEventListener('did-start-loading', onStart)
+    view.addEventListener('did-stop-loading', onStop)
+    view.addEventListener('did-fail-load', onFail)
+    view.addEventListener('page-title-updated', onTitle)
     return () => {
       view.removeEventListener('did-navigate', onNavigate)
       view.removeEventListener('did-navigate-in-page', onNavigate)
-      view.removeEventListener('did-fail-load', logFailure)
+      view.removeEventListener('did-start-loading', onStart)
+      view.removeEventListener('did-stop-loading', onStop)
+      view.removeEventListener('did-fail-load', onFail)
+      view.removeEventListener('page-title-updated', onTitle)
     }
-  }, [view])
+  }, [view, onUrlChange])
 
   const canGoBack = canGoBackNav(nav)
   const canGoForward = canGoForwardNav(nav)
@@ -159,7 +194,7 @@ export function BrowserSurface({ workspaceDir }: { workspaceDir: string }): JSX.
         <BrowserAction label="Reload" onClick={reload}>
           <RotateCw aria-hidden />
         </BrowserAction>
-        <form onSubmit={submitAddress} className="min-w-0 flex-1">
+        <form onSubmit={submitAddress} className="relative min-w-0 flex-1">
           <input
             ref={addressInputRef}
             value={address}
@@ -169,22 +204,66 @@ export function BrowserSurface({ workspaceDir }: { workspaceDir: string }): JSX.
             autoCapitalize="off"
             autoCorrect="off"
             className={cn(
-              'w-full rounded-md border border-transparent bg-accent/5 px-2.5 py-1 text-xs text-text',
+              'w-full rounded-md border border-transparent bg-accent/5 px-2.5 py-1 pr-7 text-xs text-text',
               'placeholder:text-faint focus:outline-none focus-visible:border-accent/60 focus-visible:bg-surface',
             )}
           />
+          {load.status === 'loading' && (
+            <Loader2
+              aria-label="Loading"
+              className="pointer-events-none absolute right-2 top-1/2 size-3.5 -translate-y-1/2 animate-spin text-muted"
+            />
+          )}
         </form>
+        <BrowserAction label="Open in browser" onClick={openExternal}>
+          <ExternalLink aria-hidden />
+        </BrowserAction>
+        <BrowserAction label="Developer tools" onClick={openDevTools}>
+          <Code aria-hidden />
+        </BrowserAction>
       </div>
-      {/* The guest page. `partition`/`webpreferences`/`useragent` must be set before
-          attach and never change — main's clamp re-verifies them (webview-clamp.ts). */}
-      <webview
-        ref={setView as (el: HTMLElement | null) => void}
-        src={initialUrl}
-        partition={deriveBrowserPartition(workspaceDir)}
-        webpreferences={buildWebviewPreferencesAttribute()}
-        useragent={stripElectronUserAgent(navigator.userAgent)}
-        className="min-h-0 flex-1 bg-white"
-      />
+      {/* Page title strip (surface chrome) — only when the guest reports one. */}
+      {title && (
+        <div className="shrink-0 truncate border-b border-border px-3 py-1 text-[11px] text-muted" title={title}>
+          {title}
+        </div>
+      )}
+      <div className="relative min-h-0 flex-1">
+        {/* The guest page. `partition`/`webpreferences`/`useragent` must be set before
+            attach and never change — main's clamp re-verifies them (webview-clamp.ts). */}
+        <webview
+          ref={setView as (el: HTMLElement | null) => void}
+          src={initialUrl}
+          partition={deriveBrowserPartition(workspaceDir)}
+          webpreferences={buildWebviewPreferencesAttribute()}
+          useragent={stripElectronUserAgent(navigator.userAgent)}
+          className="size-full bg-white"
+        />
+        {load.status === 'failed' && <UnreachableOverlay url={load.url} onRetry={retry} />}
+      </div>
+    </div>
+  )
+}
+
+/** The "can't reach this page" state over a failed guest, with a one-click Retry. */
+function UnreachableOverlay({ url, onRetry }: { url: string; onRetry: () => void }): JSX.Element {
+  return (
+    <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-panel p-6 text-center">
+      <TriangleAlert aria-hidden className="size-6 text-muted" />
+      <div>
+        <p className="text-sm font-medium text-text-strong">Can’t reach this page</p>
+        <p className="mt-1 max-w-xs truncate text-xs text-muted" title={url}>
+          {url}
+        </p>
+        <p className="mt-1 text-xs text-muted">The dev server may be starting or stopped.</p>
+      </div>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="rounded-md border border-border bg-surface px-3 py-1 text-xs font-medium text-text outline-none transition-colors hover:bg-accent/10 focus-visible:border-accent/60"
+      >
+        Retry
+      </button>
     </div>
   )
 }
@@ -196,6 +275,7 @@ interface WebviewElement extends HTMLElement {
   /** Navigate by history offset — the working primitive (goBack/goForward are broken). */
   goToOffset(offset: number): void
   reload(): void
+  openDevTools(): void
 }
 
 /** A browser toolbar icon button — the TerminalAction idiom. */

--- a/src/renderer/src/side-panel/SurfacePanel.tsx
+++ b/src/renderer/src/side-panel/SurfacePanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type JSX, type PointerEvent, type ReactNode } from 'react'
+import { useCallback, useEffect, useRef, useState, type JSX, type PointerEvent, type ReactNode } from 'react'
 import { FileDiff, FileText, Files, Globe, Plus, SquareTerminal, X } from 'lucide-react'
 import { cn } from '../lib/utils'
 import { useMediaQuery } from '../lib/use-media-query'
@@ -33,6 +33,8 @@ import {
   openWorkspaceFileSurface,
   openWorkspaceSurface,
   openWorkspaceTerminalSurface,
+  setWorkspaceBrowserSurfaceUrl,
+  toggleWorkspaceBrowserSurface,
   terminalSurfaceCount,
   toggleWorkspaceSurface,
   useWorkspacePanel,
@@ -101,7 +103,10 @@ export function SurfacePanel({
       const kind = surfaceForChord(e)
       if (!kind) return
       e.preventDefault()
-      toggleWorkspaceSurface(workspaceId, kind)
+      // Browser is a singleton but not a `SingletonKind` (its descriptor carries a
+      // resourceId + url), so it has its own toggle op; the rest share `toggleSurface`.
+      if (kind === 'browser') toggleWorkspaceBrowserSurface(workspaceId)
+      else toggleWorkspaceSurface(workspaceId, kind)
     }
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
@@ -220,6 +225,11 @@ function PanelBody({
   // The singleton browser tab (if open) — rendered persistently (see below) rather
   // than only when active, so its live <webview> survives tab switches.
   const browserSurface = panel.surfaces.find((s) => s.kind === 'browser') ?? null
+  // Stable so BrowserSurface's event-listener effect doesn't re-subscribe each render.
+  const persistBrowserUrl = useCallback(
+    (url: string) => setWorkspaceBrowserSurfaceUrl(workspaceId, url),
+    [workspaceId],
+  )
 
   // A close op is a VIEW op for every Surface except terminal, whose tab IS the
   // session's lifetime (ADR-0014): unmount keeps the shell (reattach later), but
@@ -356,7 +366,12 @@ function PanelBody({
                 the page). Keyed by id for a future multi-tab browser. */}
             {browserSurface && (
               <div className={cn('flex min-h-0 flex-1 flex-col', active?.kind !== 'browser' && 'hidden')}>
-                <BrowserSurface key={browserSurface.id} workspaceDir={workspaceDir} />
+                <BrowserSurface
+                  key={browserSurface.id}
+                  workspaceDir={workspaceDir}
+                  persistedUrl={browserSurface.url}
+                  onUrlChange={persistBrowserUrl}
+                />
               </div>
             )}
           </div>
@@ -549,9 +564,9 @@ const CARDS: readonly CardDef[] = [
   {
     target: 'browser',
     label: 'Browser',
-    // No shortcut hint until #217 wires the ⌘T chord — advertised chrome must work.
     description: 'Preview a local dev server.',
     icon: <Globe aria-hidden />,
+    hint: '⌘T',
     live: true,
   },
   {

--- a/src/renderer/src/side-panel/browser-load-state.test.ts
+++ b/src/renderer/src/side-panel/browser-load-state.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { INITIAL_LOAD, onFailLoad, onStartLoad, onStopLoad } from './browser-load-state'
+
+describe('browser load-state machine', () => {
+  it('starts idle', () => {
+    expect(INITIAL_LOAD).toEqual({ status: 'idle' })
+  })
+
+  it('a start → stop is a normal successful load', () => {
+    expect(onStopLoad(onStartLoad())).toEqual({ status: 'loaded' })
+  })
+
+  it('a failure records the url + code and enters failed', () => {
+    const s = onFailLoad(onStartLoad(), 'http://localhost:9999/', -102)
+    expect(s).toEqual({ status: 'failed', url: 'http://localhost:9999/', code: -102 })
+  })
+
+  it('the trailing did-stop-loading does NOT clobber a failure (the ordering gotcha)', () => {
+    const failed = onFailLoad(onStartLoad(), 'http://localhost:9999/', -102)
+    expect(onStopLoad(failed)).toEqual(failed)
+  })
+
+  it('a fresh start always yields loading — so a retry clears a prior failure', () => {
+    expect(onStartLoad()).toEqual({ status: 'loading' })
+  })
+
+  it('ignores ERR_ABORTED (-3) — a superseded load is not a failure', () => {
+    const loading = onStartLoad()
+    expect(onFailLoad(loading, 'http://x/', -3)).toBe(loading)
+  })
+})

--- a/src/renderer/src/side-panel/browser-load-state.ts
+++ b/src/renderer/src/side-panel/browser-load-state.ts
@@ -1,0 +1,37 @@
+/**
+ * The Browser Surface's load-state machine (#217). The webview's load lifecycle arrives
+ * as ordered DOM events; this pure reducer turns them into the four UI states (idle /
+ * loading / loaded / failed) so the view is a thin switch. Kept pure + unit-tested
+ * because the ordering has a GOTCHA: Electron fires `did-stop-loading` AFTER
+ * `did-fail-load`, so a naive "stop → loaded" would clobber the failure — `onStopLoad`
+ * must preserve a `failed` state.
+ */
+export type LoadState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'loaded' }
+  | { status: 'failed'; url: string; code: number }
+
+export const INITIAL_LOAD: LoadState = { status: 'idle' }
+
+/** A load began (did-start-loading) — always enters `loading`, clearing a prior failure. */
+export function onStartLoad(): LoadState {
+  return { status: 'loading' }
+}
+
+/**
+ * A load finished (did-stop-loading). Because this fires AFTER `did-fail-load`, it must
+ * NOT overwrite a `failed` state — only a non-failed load resolves to `loaded`.
+ */
+export function onStopLoad(state: LoadState): LoadState {
+  return state.status === 'failed' ? state : { status: 'loaded' }
+}
+
+/**
+ * A load failed (did-fail-load). Chromium's ERR_ABORTED (-3) is a superseded/cancelled
+ * load (the user navigated away mid-load), NOT a reachability failure — ignore it.
+ */
+export function onFailLoad(state: LoadState, url: string, code: number): LoadState {
+  if (code === -3) return state
+  return { status: 'failed', url, code }
+}

--- a/src/renderer/src/side-panel/side-panel-store.test.ts
+++ b/src/renderer/src/side-panel/side-panel-store.test.ts
@@ -13,6 +13,8 @@ import {
   getWorkspacePanel,
   MAX_TERMINALS_PER_WORKSPACE,
   openBrowserSurface,
+  setBrowserSurfaceUrl,
+  toggleBrowserSurface,
   openFileSurface,
   openSurface,
   openTerminalSurface,
@@ -161,6 +163,51 @@ describe('openBrowserSurface (#216, singleton dev-server preview)', () => {
     const again = openBrowserSurface(behindOther)
     expect(again.surfaces.filter((s) => s.kind === 'browser')).toHaveLength(1)
     expect(again.activeSurfaceId).toBe('browser:main')
+  })
+
+  it('preserves a previously-stored url when re-opened (does not wipe it)', () => {
+    const withUrl = setBrowserSurfaceUrl(openBrowserSurface(empty()), 'http://localhost:5173/')
+    const files = openSurface(withUrl, 'files')
+    const reopened = openBrowserSurface(files)
+    const browser = reopened.surfaces.find((s) => s.kind === 'browser')
+    expect(browser).toMatchObject({ kind: 'browser', url: 'http://localhost:5173/' })
+  })
+})
+
+describe('setBrowserSurfaceUrl (#217, per-Workspace URL persistence)', () => {
+  it('records the last visited url on the browser surface', () => {
+    const s = setBrowserSurfaceUrl(openBrowserSurface(empty()), 'http://localhost:3000/app')
+    expect(s.surfaces.find((x) => x.kind === 'browser')).toEqual({
+      id: 'browser:main',
+      kind: 'browser',
+      resourceId: 'main',
+      url: 'http://localhost:3000/app',
+    })
+  })
+
+  it('is a no-op (same ref) when no browser surface is open', () => {
+    const s = openSurface(empty(), 'files')
+    expect(setBrowserSurfaceUrl(s, 'http://x/')).toBe(s)
+  })
+})
+
+describe('toggleBrowserSurface (⌘T semantics, #217)', () => {
+  it('opens/activates the browser when it is not the active tab', () => {
+    const s = toggleBrowserSurface(empty())
+    expect(s.isOpen).toBe(true)
+    expect(s.activeSurfaceId).toBe('browser:main')
+  })
+
+  it('hides the panel when the browser is already the active tab', () => {
+    const open = toggleBrowserSurface(empty())
+    expect(toggleBrowserSurface(open)).toEqual({ ...open, isOpen: false })
+  })
+
+  it('activates the browser (not hide) when another tab is active', () => {
+    const withBoth = openSurface(openBrowserSurface(empty()), 'files') // files active
+    const s = toggleBrowserSurface(withBoth)
+    expect(s.isOpen).toBe(true)
+    expect(s.activeSurfaceId).toBe('browser:main')
   })
 })
 
@@ -440,6 +487,22 @@ describe('coerceSurface', () => {
     expect(coerceSurface({ kind: 'browser' })).toBeNull() // no id/resource
     expect(coerceSurface({ id: 'browser:evil', kind: 'browser', resourceId: 'evil' })).toBeNull() // not the singleton
     expect(coerceSurface({ id: 'browser:main', kind: 'browser', resourceId: 'other' })).toBeNull() // id≠resource
+  })
+
+  it('restores a persisted browser url when it is a valid http(s) URL (#217)', () => {
+    expect(
+      coerceSurface({ id: 'browser:main', kind: 'browser', resourceId: 'main', url: 'http://localhost:5173/' }),
+    ).toEqual({ id: 'browser:main', kind: 'browser', resourceId: 'main', url: 'http://localhost:5173/' })
+  })
+
+  it('drops a bad/unsafe persisted url but keeps the browser surface', () => {
+    for (const url of ['file:///etc/passwd', 'javascript:alert(1)', '', 42, null]) {
+      expect(coerceSurface({ id: 'browser:main', kind: 'browser', resourceId: 'main', url })).toEqual({
+        id: 'browser:main',
+        kind: 'browser',
+        resourceId: 'main',
+      })
+    }
   })
 
   it('drops not-yet-implemented / unknown / malformed descriptors', () => {

--- a/src/renderer/src/side-panel/side-panel-store.ts
+++ b/src/renderer/src/side-panel/side-panel-store.ts
@@ -40,7 +40,7 @@ export type Surface =
   | { id: 'files'; kind: 'files' }
   | { id: `file:${string}`; kind: 'file'; relativePath: string }
   | { id: `terminal:${string}`; kind: 'terminal'; resourceId: string }
-  | { id: `browser:${string}`; kind: 'browser'; resourceId: string }
+  | { id: `browser:${string}`; kind: 'browser'; resourceId: string; url?: string }
 
 /** One Workspace's panel state: open flag + ordered Surfaces + which is active. */
 export interface WorkspacePanelState {
@@ -173,7 +173,32 @@ const BROWSER_SURFACE: Surface = { id: 'browser:main', kind: 'browser', resource
  * own resource-id'd descriptor shape.
  */
 export function openBrowserSurface(state: WorkspacePanelState): WorkspacePanelState {
+  // upsertSurface keeps the EXISTING descriptor when present, so a stored url survives a
+  // re-open — only a first open inserts the bare BROWSER_SURFACE (no url yet).
   return upsertSurface(state, BROWSER_SURFACE)
+}
+
+/**
+ * Record the browser's last-visited url on its descriptor (#217), so a reopen /
+ * app-restart reloads the preview where it left off. A no-op (same ref) when no browser
+ * surface is open. The url is validated on the way BACK IN by `coerceSurface`; here we
+ * trust the component (which only feeds committed guest URLs).
+ */
+export function setBrowserSurfaceUrl(state: WorkspacePanelState, url: string): WorkspacePanelState {
+  let changed = false
+  const surfaces = state.surfaces.map((surface) => {
+    if (surface.kind !== 'browser' || surface.url === url) return surface
+    changed = true
+    return { ...surface, url }
+  })
+  return changed ? { ...state, surfaces } : state
+}
+
+/** Open/activate the singleton Browser Surface, or hide the panel if it's already active (⌘T). */
+export function toggleBrowserSurface(state: WorkspacePanelState): WorkspacePanelState {
+  const active = state.surfaces.find((surface) => surface.id === state.activeSurfaceId)
+  if (state.isOpen && active?.kind === 'browser') return { ...state, isOpen: false }
+  return openBrowserSurface(state)
 }
 
 /**
@@ -279,6 +304,21 @@ export function updateWorkspace(
 // --- Coercion + (de)serialization (defensive against corrupt / legacy blobs) ---
 
 /**
+ * A persisted browser url is trusted ONLY if it's a string that parses to an http/https
+ * URL — mirrors the renderer URL policy so a tampered blob can't seed the webview with a
+ * `file:`/`javascript:` src. Returns the normalized href, or null to drop it.
+ */
+function coerceBrowserUrl(raw: unknown): string | null {
+  if (typeof raw !== 'string' || raw.length === 0) return null
+  try {
+    const url = new URL(raw)
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.href : null
+  } catch {
+    return null
+  }
+}
+
+/**
  * Coerce an untrusted descriptor into a valid `Surface`, or `null` to drop it. Every
  * implemented kind validates its full shape (id/resource conventions) — anything
  * unknown or malformed is dropped rather than trusted.
@@ -311,13 +351,17 @@ export function coerceSurface(raw: unknown): Surface | null {
     return null
   }
   if (kind === 'browser') {
-    // A persisted browser tab restores its slot (the page itself is discarded on
-    // unmount — #217 adds URL persistence). Only the singleton shape exists this
-    // slice; drop anything else.
+    // A persisted browser tab restores its slot AND its last url (#217) — the page
+    // reloads there on reopen. Only the singleton shape exists this slice; drop anything
+    // else. A stored url is restored ONLY if it's a safe http/https URL (an untrusted
+    // blob could carry `file:`/`javascript:`); a bad url is dropped but the tab survives.
     const resourceId = (raw as { resourceId?: unknown }).resourceId
     const id = (raw as { id?: unknown }).id
     if (resourceId === 'main' && id === 'browser:main') {
-      return { id: 'browser:main', kind: 'browser', resourceId: 'main' }
+      const url = coerceBrowserUrl((raw as { url?: unknown }).url)
+      return url
+        ? { id: 'browser:main', kind: 'browser', resourceId: 'main', url }
+        : { id: 'browser:main', kind: 'browser', resourceId: 'main' }
     }
     return null
   }
@@ -451,6 +495,8 @@ export const openWorkspaceSurface = bindWorkspaceOp(openSurface)
 export const openWorkspaceFileSurface = bindWorkspaceOp(openFileSurface)
 export const openWorkspaceTerminalSurface = bindWorkspaceOp(openTerminalSurface)
 export const openWorkspaceBrowserSurface = bindWorkspaceOp(openBrowserSurface)
+export const toggleWorkspaceBrowserSurface = bindWorkspaceOp(toggleBrowserSurface)
+export const setWorkspaceBrowserSurfaceUrl = bindWorkspaceOp(setBrowserSurfaceUrl)
 export const toggleWorkspaceSurface = bindWorkspaceOp(toggleSurface)
 export const activateWorkspaceSurface = bindWorkspaceOp(activateSurface)
 export const closeWorkspaceSurface = bindWorkspaceOp(closeSurface)

--- a/src/renderer/src/side-panel/surface-keys.test.ts
+++ b/src/renderer/src/side-panel/surface-keys.test.ts
@@ -36,11 +36,20 @@ describe('surfaceForChord — ⌃⇧G → Review', () => {
   })
 })
 
-describe('surfaceForChord — unbound chords', () => {
-  it('leaves ⌘T (Browser hint) unbound — the card is inert', () => {
-    expect(surfaceForChord(chord({ key: 't', metaKey: true }))).toBeNull()
+describe('surfaceForChord — ⌘T → Browser (#217)', () => {
+  it('matches meta+t (either case)', () => {
+    expect(surfaceForChord(chord({ key: 't', metaKey: true }))).toBe('browser')
+    expect(surfaceForChord(chord({ key: 'T', metaKey: true }))).toBe('browser')
   })
 
+  it('does not match ⌃T, ⇧T, ⌘⇧T, or bare t', () => {
+    expect(surfaceForChord(chord({ key: 't', ctrlKey: true }))).toBeNull()
+    expect(surfaceForChord(chord({ key: 't', metaKey: true, shiftKey: true }))).toBeNull()
+    expect(surfaceForChord(chord({ key: 't' }))).toBeNull()
+  })
+})
+
+describe('surfaceForChord — unbound chords', () => {
   it('ignores plain typing and unrelated keys', () => {
     expect(surfaceForChord(chord({ key: 'a' }))).toBeNull()
     expect(surfaceForChord(chord({ key: 'Enter' }))).toBeNull()

--- a/src/renderer/src/side-panel/surface-keys.ts
+++ b/src/renderer/src/side-panel/surface-keys.ts
@@ -14,17 +14,21 @@ export interface KeyChord {
  * shortcuts (NO Electron menu accelerators, ADR-0013 decision 1):
  *   - ⌘P  → Files   (the tree-search focus part lands in slice 2)
  *   - ⌃⇧G → Review
- * Browser's ⌘T hint is aspirational chrome — deliberately UNBOUND (the card is inert).
+ *   - ⌘T  → Browser (#217)
  *
- * Both bound chords carry a modifier, so plain typing never matches: a focused text input
- * can be left to type normally EXCEPT these two combos (neither is a typing combo), which
+ * Every bound chord carries a modifier, so plain typing never matches: a focused text
+ * input can be left to type normally EXCEPT these combos (none is a typing combo), which
  * stay live even while a textarea has focus.
  */
-export function surfaceForChord(chord: KeyChord): SingletonKind | null {
+export function surfaceForChord(chord: KeyChord): SingletonKind | 'browser' | null {
   const key = chord.key.toLowerCase()
   // ⌘P → Files. Meta only (no ctrl/alt/shift) so ⌘⇧P and ⌃P stay free.
   if (key === 'p' && chord.metaKey && !chord.ctrlKey && !chord.altKey && !chord.shiftKey) {
     return 'files'
+  }
+  // ⌘T → Browser. Meta only, so ⌘⇧T (reopen-tab muscle memory) and ⌃T stay free.
+  if (key === 't' && chord.metaKey && !chord.ctrlKey && !chord.altKey && !chord.shiftKey) {
+    return 'browser'
   }
   // ⌃⇧G → Review. Ctrl+Shift only (no meta/alt).
   if (key === 'g' && chord.ctrlKey && chord.shiftKey && !chord.metaKey && !chord.altKey) {


### PR DESCRIPTION
Closes #217 (slice 2 of PRD #215). Builds on slice 1 (#219, merged).

Rounds the Browser Surface from "renders a page" into something that behaves like a browser.

## What's new

- **Loading indicator** — a spinner in the address bar while the guest loads, driven by a pure `browser-load-state` machine.
- **Unreachable state + Retry** — `did-fail-load` shows a friendly "Can't reach this page" panel with the failed URL and a one-click Retry, instead of a blank guest. The state machine handles the Electron ordering gotcha (`did-stop-loading` fires *after* `did-fail-load`, so a stop must not clobber the failure) and ignores `ERR_ABORTED` (-3) superseded loads.
- **Page title** in the surface chrome (`page-title-updated`).
- **Open-in-system-browser** (reusing the existing http/https-guarded `openExternal` IPC) and a **DevTools** action.
- **Last URL persistence per Workspace** — `url` on the browser Surface descriptor, written on every committed navigation, restored by coercion (validated http/https only, so a tampered localStorage blob can't seed `file:`/`javascript:`), and seeded into the webview on reopen. Survives panel-close, Workspace-switch, and app-restart.
- **⌘T** opens/toggles the Browser Surface (added to the pure `surface-keys` chord map + its own toggle op, since browser isn't a `SingletonKind`); the card's ⌘T hint is restored.

## Tests

TDD throughout: `browser-load-state` (6), store URL-persistence + toggle ops (7 new), `surface-keys` ⌘T. All pure/colocated, node env.

**Verified in the running app** (Playwright driving the built Electron app against a local dev server): ⌘T opens Browser, the title strip shows the page title, DevTools opens a separate webContents, open-external is present, the unreachable+Retry state renders on a dead port, and the committed URL lands in the persisted store blob. Screenshots confirmed the guest and the states actually paint.

All four gates green: lint, typecheck, build, test (**1114 passed**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)