### PR TITLE
feat(browser): slice 3 — local dev-server discovery in the empty state (#218)

### DIFF
--- a/src/main/browser/discover-servers.test.ts
+++ b/src/main/browser/discover-servers.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { discoverDevServers, parseLsofListeners } from './discover-servers'
+
+// A realistic `lsof -iTCP -sTCP:LISTEN -P -n -F pcn` capture: a Vite server on bun
+// (5173) and a node server (3000) are real dev servers; postgres (5432), rapportd
+// (ephemeral 59913), Raycast (7265) and an Electron app (3773) are noise.
+const REAL = `p601
+crapportd
+f8
+n*:59913
+p904
+cpostgres
+f7
+n[::1]:5432
+f8
+n127.0.0.1:5432
+p5436
+cT3 Code (Alpha)
+f17
+n127.0.0.1:3773
+p8335
+cRaycast
+f33
+n127.0.0.1:7265
+p23797
+cbun
+f30
+n[::1]:5173
+p32203
+cnode
+f22
+n127.0.0.1:3000
+f23
+n[::1]:3000
+`
+
+describe('parseLsofListeners', () => {
+  it('keeps only dev-runtime processes in a sane port range', () => {
+    const servers = parseLsofListeners(REAL)
+    expect(servers.map((s) => s.port)).toEqual([3000, 5173])
+    expect(servers.map((s) => s.processName)).toEqual(['node', 'bun'])
+  })
+
+  it('normalizes loopback/unspecified hosts to a localhost URL', () => {
+    const servers = parseLsofListeners(REAL)
+    expect(servers.find((s) => s.port === 5173)?.url).toBe('http://localhost:5173/')
+  })
+
+  it('dedupes a process listening on the same port over IPv4 and IPv6', () => {
+    // node above binds 3000 on both 127.0.0.1 and [::1] — one entry, not two.
+    const threes = parseLsofListeners(REAL).filter((s) => s.port === 3000)
+    expect(threes).toHaveLength(1)
+  })
+
+  it('tolerates garbage / empty input without throwing', () => {
+    expect(parseLsofListeners('')).toEqual([])
+    expect(parseLsofListeners('total nonsense\n???\nnf\n')).toEqual([])
+  })
+})
+
+describe('discoverDevServers (injected exec)', () => {
+  it('returns the parsed servers from the injected lsof output', async () => {
+    const servers = await discoverDevServers(async () => REAL)
+    expect(servers.map((s) => s.port)).toEqual([3000, 5173])
+  })
+
+  it('swallows an lsof failure and returns an empty list (never rejects)', async () => {
+    const servers = await discoverDevServers(async () => {
+      throw new Error('lsof: command not found')
+    })
+    expect(servers).toEqual([])
+  })
+})

--- a/src/main/browser/discover-servers.ts
+++ b/src/main/browser/discover-servers.ts
@@ -1,0 +1,85 @@
+/**
+ * Local dev-server discovery for the Browser Surface's empty state (#218). Parses
+ * `lsof -iTCP -sTCP:LISTEN -P -n -F pcn` field output into loadable dev-server
+ * candidates. The parse + filtering are PURE (unit-tested against real fixtures); the
+ * exec boundary is injected so the native `lsof` stays out of the test import graph
+ * (the terminal-manager `spawnPty`-seam precedent).
+ *
+ * On a real dev machine lsof reports dozens of listeners (databases, menubar apps,
+ * IPC helpers), so filtering by PORT alone is hopeless. The reliable signal is the
+ * OWNING PROCESS: a web dev server is run by a known runtime/tooling command. We keep
+ * ports owned by a dev runtime in a sane range and drop everything else — false
+ * negatives are recoverable (the user can still type a URL), false positives are noise.
+ */
+import type { DevServer } from '../../shared/ipc'
+
+/** Commands that host a web dev server (case-insensitive substring of the lsof `c` field). */
+const DEV_RUNTIME_HINTS = [
+  'node',
+  'bun',
+  'deno',
+  'python',
+  'ruby',
+  'php',
+  'rails',
+  'vite',
+  'next',
+  'webpack',
+  'dotnet',
+  'http-server',
+  'serve',
+]
+
+/** Sane dev-server port window: above privileged ports, below the ephemeral/dynamic range. */
+const MIN_DEV_PORT = 1024
+const MAX_DEV_PORT = 49151
+
+function isDevRuntime(command: string): boolean {
+  const lower = command.toLowerCase()
+  return DEV_RUNTIME_HINTS.some((hint) => lower.includes(hint))
+}
+
+/** Pull the trailing `:<port>` off an lsof name field (`127.0.0.1:5173`, `[::1]:5173`, `*:8000`). */
+function portOf(name: string): number | null {
+  const match = /:(\d+)$/.exec(name)
+  if (!match) return null
+  const port = Number(match[1])
+  return Number.isInteger(port) && port > 0 && port <= 65535 ? port : null
+}
+
+/**
+ * Parse `lsof -F pcn` field output into deduped, filtered, sorted dev-server candidates.
+ * Field lines: `p<pid>` starts a process record, `c<command>` names it, `n<addr:port>`
+ * is a listening address (many per process); `f<fd>` and anything else is ignored.
+ */
+export function parseLsofListeners(output: string): DevServer[] {
+  const byPort = new Map<number, DevServer>()
+  let command = ''
+  for (const raw of output.split('\n')) {
+    const field = raw[0]
+    const value = raw.slice(1)
+    if (field === 'p') command = '' // new process record — reset until its `c` line
+    else if (field === 'c') command = value
+    else if (field === 'n') {
+      const port = portOf(value)
+      if (port === null || byPort.has(port)) continue
+      if (port < MIN_DEV_PORT || port > MAX_DEV_PORT || !isDevRuntime(command)) continue
+      byPort.set(port, { port, url: `http://localhost:${port}/`, processName: command })
+    }
+  }
+  return [...byPort.values()].sort((a, b) => a.port - b.port)
+}
+
+/**
+ * Discover listening dev servers via the injected `runLsof` exec. Best-effort: a missing
+ * `lsof` (non-macOS/Linux) or any exec failure resolves to an empty list — NEVER rejects,
+ * so the empty state degrades to "type a URL" rather than an error.
+ */
+export async function discoverDevServers(runLsof: () => Promise<string>): Promise<DevServer[]> {
+  try {
+    return parseLsofListeners(await runLsof())
+  } catch (err) {
+    console.error(`[vibe-mistro:discover-servers] lsof failed: ${String(err)}`)
+    return []
+  }
+}

--- a/src/main/browser/register-ipc.ts
+++ b/src/main/browser/register-ipc.ts
@@ -1,0 +1,33 @@
+import { ipcMain } from 'electron'
+import { execFile } from 'node:child_process'
+import { IPC, type DiscoverDevServersResult } from '../../shared/ipc'
+import { discoverDevServers } from './discover-servers'
+
+/** Run `lsof` for listening TCP sockets in `-F pcn` field format; reject if it's missing/errors. */
+function runLsof(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      'lsof',
+      ['-iTCP', '-sTCP:LISTEN', '-P', '-n', '-F', 'pcn'],
+      { timeout: 3_000, maxBuffer: 4 * 1024 * 1024 },
+      (err, stdout) => {
+        // lsof exits non-zero when it finds nothing OR when denied some entries, but still
+        // prints usable field output — trust stdout and only reject on a spawn failure
+        // (missing binary / non-macOS-Linux), where stdout is empty.
+        if (err && !stdout) reject(err)
+        else resolve(stdout)
+      },
+    )
+  })
+}
+
+/**
+ * The dev-server discovery IPC handler (#218). One-shot, machine-wide (listening ports
+ * aren't Workspace-scoped) so it needs no `pool`/agent. Best-effort: `discoverDevServers`
+ * swallows an lsof failure to an empty list, so the invoke never rejects.
+ */
+export function registerBrowserIpc(): void {
+  ipcMain.handle(IPC.discoverDevServers, async (): Promise<DiscoverDevServersResult> => {
+    return { servers: await discoverDevServers(runLsof) }
+  })
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -63,6 +63,7 @@ import { chokidarWatchFactory, realClock } from './git/runtime'
 import { registerGitIpc } from './git/register-ipc'
 import { registerFilesIpc } from './files/register-ipc'
 import { createTerminalManager, registerTerminalIpc } from './terminal/register-ipc'
+import { registerBrowserIpc } from './browser/register-ipc'
 import type { TerminalManager } from './terminal/terminal-manager'
 import { FilesListCache, shouldInvalidateFilesCacheOnGitStatus } from './files/cache'
 import { clampWebviewAttachment } from './browser/webview-clamp'
@@ -639,6 +640,7 @@ function registerIpc(deps: MainDeps): void {
   registerFilesIpc({ pool, cache: filesListCache })
   terminalManager = createTerminalManager()
   registerTerminalIpc({ pool, manager: terminalManager })
+  registerBrowserIpc()
 
   ipcMain.handle(IPC.detectVibe, () => detectVibe())
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import {
   IPC,
+  type DiscoverDevServersResult,
   type AcpEvent,
   type AgentEvictedEvent,
   type CancelTurnArgs,
@@ -130,6 +131,8 @@ const api = {
   filesList: (args: FilesListArgs): Promise<FilesListResult> => ipcRenderer.invoke(IPC.filesList, args),
   filesRead: (args: FilesReadArgs): Promise<FilesReadResult> => ipcRenderer.invoke(IPC.filesRead, args),
   openExternal: (args: OpenExternalArgs): Promise<void> => ipcRenderer.invoke(IPC.openExternal, args),
+  discoverDevServers: (): Promise<DiscoverDevServersResult> =>
+    ipcRenderer.invoke(IPC.discoverDevServers),
   terminalOpen: (args: TerminalOpenArgs): Promise<TerminalOpenResult> =>
     ipcRenderer.invoke(IPC.terminalOpen, args),
   terminalWrite: (args: TerminalWriteArgs): Promise<void> =>

--- a/src/renderer/src/side-panel/BrowserSurface.tsx
+++ b/src/renderer/src/side-panel/BrowserSurface.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef, useState, type FormEvent, type JSX } from 'react'
-import { ArrowLeft, ArrowRight, Code, ExternalLink, Loader2, RotateCw, TriangleAlert } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState, type FormEvent, type JSX } from 'react'
+import { ArrowLeft, ArrowRight, Code, ExternalLink, Globe, Loader2, RefreshCw, RotateCw, TriangleAlert } from 'lucide-react'
+import type { DevServer } from '../../../shared/ipc'
 import { cn } from '../lib/utils'
 import {
   buildWebviewPreferencesAttribute,
@@ -155,32 +156,15 @@ export function BrowserSurface({
   const canGoBack = canGoBackNav(nav)
   const canGoForward = canGoForwardNav(nav)
 
-  if (initialUrl === null) {
-    return (
-      <div className="flex min-h-0 flex-1 items-center justify-center overflow-y-auto bg-panel p-6">
-        <form onSubmit={submitAddress} className="w-full max-w-sm text-center">
-          <h3 className="text-sm font-medium text-text-strong">Preview a dev server</h3>
-          <p className="mt-1 text-xs leading-relaxed text-muted">
-            Enter the URL of a local dev server — or any http(s) page.
-          </p>
-          <input
-            value={address}
-            onChange={(e) => setAddress(e.target.value)}
-            aria-label="Address"
-            placeholder="localhost:5173"
-            autoFocus
-            spellCheck={false}
-            autoCapitalize="off"
-            autoCorrect="off"
-            className={cn(
-              'mt-4 w-full rounded-md border border-border bg-surface px-3 py-1.5 text-[13px] text-text',
-              'placeholder:text-faint focus:outline-none focus-visible:border-accent/60',
-            )}
-          />
-        </form>
-      </div>
-    )
+  // Open a blessed URL: from the empty state (first load) it seeds the webview src;
+  // once loaded, later opens go through loadURL.
+  function openUrl(url: string): void {
+    setAddress(url)
+    if (initialUrl === null) setInitialUrl(url)
+    else load_(url)
   }
+
+  if (initialUrl === null) return <BrowserEmptyState onOpenUrl={openUrl} />
 
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-panel">
@@ -240,6 +224,99 @@ export function BrowserSurface({
           className="size-full bg-white"
         />
         {load.status === 'failed' && <UnreachableOverlay url={load.url} onRetry={retry} />}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * The empty state (no page loaded): a URL input plus one-click suggestions for local dev
+ * servers actually listening on the machine (#218). Discovery runs on mount and on an
+ * explicit Refresh — no polling. A chosen suggestion or a typed URL flows out through
+ * `onOpenUrl`, gated by the shared URL policy.
+ */
+function BrowserEmptyState({ onOpenUrl }: { onOpenUrl: (url: string) => void }): JSX.Element {
+  const [input, setInput] = useState('')
+  const [servers, setServers] = useState<DevServer[]>([])
+  const [scanning, setScanning] = useState(true)
+
+  const discover = useCallback(() => {
+    setScanning(true)
+    void window.api
+      .discoverDevServers()
+      .then((r) => setServers(r.servers))
+      .catch(() => setServers([]))
+      .finally(() => setScanning(false))
+  }, [])
+
+  useEffect(() => discover(), [discover])
+
+  function submit(e: FormEvent<HTMLFormElement>): void {
+    e.preventDefault()
+    const url = normalizeBrowserUrl(input)
+    if (url) onOpenUrl(url)
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 items-center justify-center overflow-y-auto bg-panel p-6">
+      <div className="w-full max-w-sm text-center">
+        <h3 className="text-sm font-medium text-text-strong">Preview a dev server</h3>
+        <p className="mt-1 text-xs leading-relaxed text-muted">
+          Enter the URL of a local dev server — or any http(s) page.
+        </p>
+        <form onSubmit={submit}>
+          <input
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            aria-label="Address"
+            placeholder="localhost:5173"
+            autoFocus
+            spellCheck={false}
+            autoCapitalize="off"
+            autoCorrect="off"
+            className={cn(
+              'mt-4 w-full rounded-md border border-border bg-surface px-3 py-1.5 text-[13px] text-text',
+              'placeholder:text-faint focus:outline-none focus-visible:border-accent/60',
+            )}
+          />
+        </form>
+        <div className="mt-5">
+          <div className="mb-2 flex items-center justify-between">
+            <span className="text-[11px] font-medium uppercase tracking-wide text-faint">
+              Running locally
+            </span>
+            <button
+              type="button"
+              onClick={discover}
+              aria-label="Refresh dev servers"
+              title="Refresh"
+              className="flex size-5 items-center justify-center rounded text-muted outline-none transition-colors hover:bg-accent/10 hover:text-text-strong focus-visible:bg-accent/10 [&_svg]:size-3"
+            >
+              <RefreshCw aria-hidden className={scanning ? 'animate-spin' : undefined} />
+            </button>
+          </div>
+          {servers.length > 0 ? (
+            <ul className="flex flex-col gap-1">
+              {servers.map((server) => (
+                <li key={server.port}>
+                  <button
+                    type="button"
+                    onClick={() => onOpenUrl(server.url)}
+                    className="flex w-full items-center gap-2 rounded-md border border-border bg-surface px-2.5 py-1.5 text-left text-xs outline-none transition-colors hover:bg-accent/10 focus-visible:border-accent/60 [&_svg]:size-3.5 [&_svg]:shrink-0 [&_svg]:text-muted"
+                  >
+                    <Globe aria-hidden />
+                    <span className="min-w-0 flex-1 truncate text-text">localhost:{server.port}</span>
+                    <span className="shrink-0 text-faint">{server.processName}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-xs text-faint">
+              {scanning ? 'Scanning…' : 'No dev servers detected.'}
+            </p>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/src/shared/ipc/browser.ts
+++ b/src/shared/ipc/browser.ts
@@ -1,0 +1,33 @@
+/**
+ * Browser domain of the shared IPC contract (#218): local dev-server discovery for the
+ * Browser Surface's empty state. One-shot, machine-wide (listening TCP ports are not
+ * Workspace-scoped), NO polling — the renderer invokes it on mount and on an explicit
+ * Refresh. Keep this file free of Node/DOM imports so both sides can consume it.
+ */
+
+/** The browser channel entries, merged into the single `IPC` const in `./index`. */
+export const browserChannels = {
+  /** Renderer -> main: list listening local dev servers for the empty-state suggestions. */
+  discoverDevServers: 'browser:discover-servers',
+} as const
+
+/**
+ * One discovered dev server. `port` is the listening TCP port; `url` is the loadable
+ * `http://localhost:<port>/` (loopback/unspecified hosts normalized to localhost);
+ * `processName` is the owning command (e.g. `node`, `bun`) for a human-readable chip.
+ */
+export interface DevServer {
+  port: number
+  url: string
+  processName: string
+}
+
+/**
+ * The `discoverDevServers` reply (#218). `servers` is filtered to likely dev servers
+ * (owned by a known dev runtime, sane port range), deduped by port, and sorted. An empty
+ * list also covers "nothing listening" AND a swallowed lsof failure (missing binary,
+ * non-macOS/Linux) — the invoke NEVER rejects.
+ */
+export interface DiscoverDevServersResult {
+  servers: DevServer[]
+}

--- a/src/shared/ipc/index.ts
+++ b/src/shared/ipc/index.ts
@@ -16,6 +16,7 @@ import { gitChannels } from './git'
 import { ghChannels } from './gh'
 import { filesChannels } from './files'
 import { terminalChannels } from './terminal'
+import { browserChannels } from './browser'
 
 /**
  * The one typed channel map. ONE exported object — the channel names are the wire
@@ -30,6 +31,7 @@ export const IPC = {
   ...ghChannels,
   ...filesChannels,
   ...terminalChannels,
+  ...browserChannels,
 } as const
 
 export * from './core'
@@ -39,3 +41,4 @@ export * from './git'
 export * from './gh'
 export * from './files'
 export * from './terminal'
+export * from './browser'


### PR DESCRIPTION
Closes #218 (slice 3 of PRD #215) — the final slice of the Browser Surface epic. Builds on slices 1 (#219) and 2 (#221), both merged.

## What's new

The Browser Surface's empty state now suggests **local dev servers actually listening** on the machine, so opening the running app is one click instead of remembering the port.

- **New `browser` IPC domain** (`browser:discover-servers`) spread into the shared barrel + preload pass-through. A one-shot, machine-wide invoke — no polling.
- **Main lists listening TCP ports** via `lsof -iTCP -sTCP:LISTEN -P -n -F pcn` through an injected exec seam (the terminal-manager seam precedent), so the field-output parser is pure and unit-tested against real fixtures.
- **Filtering by owning process, not just port** — this is the load-bearing decision. On a real dev machine `lsof` reports dozens of listeners (postgres, menubar apps, IPC helpers); only ones owned by a dev runtime (`node`/`bun`/`python`/`deno`/`ruby`/…) in a sane port range are dev servers. Deduped by port (IPv4+IPv6), loopback→`localhost` URL, sorted. Any `lsof` failure (missing binary / non-macOS-Linux) → empty list, never rejects.
- **Empty-state suggestions** — discovered servers render as one-click chips (`localhost:port` + process name) with a **Refresh** affordance; a click loads through the shared URL policy. Sensible "No dev servers detected." when nothing is listening.

## Tests

Pure parser unit-tested against a realistic `lsof` capture (runtime filter, IPv4/IPv6 dedupe, port range, URL normalization, garbage tolerance) + the injected-exec orchestrator (parse + swallow-failure). 6 new; 1120 total.

**Verified in the running app**: a `python http.server` shows up as a suggestion alongside real `node`/`bun` servers while all the machine noise (postgres, Raycast, figma_agent, Electron apps) is filtered out; one-click opens the server; Refresh re-runs the scan. Screenshot confirmed.

All four gates green: lint, typecheck, build, test.

---

This completes PRD #215: the Browser Surface now embeds a sandboxed dev-server preview with navigation, states, URL persistence, ⌘T, and dev-server discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)