### PR TITLE
feat(browser): element picker — "pick to chat" via executeJavaScript isolated world (ADR-0016)

### DIFF
--- a/docs/adr/0016-browser-element-picker-executejavascript-isolated-world.md
+++ b/docs/adr/0016-browser-element-picker-executejavascript-isolated-world.md
@@ -1,0 +1,68 @@
+# Browser element picker: injected via executeJavaScript in the guest's isolated world
+
+**Status: ACCEPTED** (2026-07-03). Builds on **ADR-0015** (Browser Surface webview embed +
+guest security posture — this preserves it) and **ADR-0002** (thin orchestrator — the picker is
+a USER affordance, not an agent tool). PRD #223; slice #224. Reference implementation: t3code's
+"pick to chat" (`apps/desktop/src/preview/PickPreload.ts`), whose approach we deliberately do NOT
+copy — see below.
+
+## Context
+
+The Browser Surface previews a dev server. When the user spots something to change, describing it
+in words ("the blue button top-right") is slow and imprecise. "Pick to chat" lets them click the
+element in the preview and hand it to the agent as a screenshot + metadata.
+
+t3code implements this with a **guest preload running at `contextIsolation=false`**, so
+react-grab/bippy can read the page's `__REACT_DEVTOOLS_GLOBAL_HOOK__` and attribute a React
+component name + source frames to the picked element. That is exactly the posture ADR-0015 and its
+adversarial security review locked DOWN: our guest runs `contextIsolation=true`, sandboxed, with
+**no preload**, and the `will-attach-webview` clamp force-strips any preload from an attaching
+guest. Matching t3code would mean reopening that attack surface.
+
+## Decision
+
+1. **Inject via the webview element's `executeJavaScript`, which runs in the guest's ISOLATED
+   WORLD** — a separate JS context that shares the page's DOM but not its JS globals. The injected
+   picker draws a highlight overlay, hit-tests with `elementsFromPoint`, reads
+   `getBoundingClientRect`/`textContent`, and builds a best-effort CSS selector — all DOM
+   operations, all it needs. It CANNOT read the page's `__REACT_DEVTOOLS_GLOBAL_HOOK__`, so there
+   is **no React component-name / source-frame attribution**. That capability is the price of the
+   sandbox, and we pay it: the guest security posture is UNCHANGED — no preload, no isolation
+   relaxation, no clamp change.
+
+2. **One round-trip through the return value.** `executeJavaScript` resolves with the injected
+   script's last expression and awaits it if it's a Promise. The picker is a single IIFE that
+   returns a Promise resolving with the picked-element payload on click (or null on Esc / page
+   navigation). No new IPC channel, no `ipc-message` (needs a preload we don't ship), no
+   `console-message` hack. The injected-script string is built by a pure, tested module; config
+   values are JSON-encoded, never raw-interpolated, so a hostile page/accent can't break out.
+
+3. **Screenshot in the renderer via `capturePage(rect)`** on the webview element, cropped to the
+   picked element's padded, viewport-clamped bounding rect (a pure crop-rect helper; coords stay
+   in CSS px, which `capturePage` expects). The overlay is torn down before capture, so the shot
+   is the page, not the picker chrome. A capture failure is non-fatal — the text annotation still
+   lands. No main-process involvement and no `browser:*` IPC: the guest webContents is not needed.
+
+4. **Result lands in the composer via the existing sibling→composer pub/sub.** A picked screenshot
+   is staged as a pending image through a new `emitComposerInsertImage` channel (symmetric to the
+   `emitComposerInsertText` / `@path` channels); the annotation (tag, selector, text snippet, URL)
+   reuses the existing text channel verbatim. The send path and the ACP image-block boundary
+   (snake_case `mime_type`, bare base64, images before text) are UNCHANGED — a picked shot is
+   byte-identical in shape to a pasted one.
+
+5. **DOM-level payload, defensively coerced.** The untrusted JSON the guest returns is validated by
+   a pure coercion module (the `coerceSurface` / `safe-external-url` pattern) — requires a string
+   `pageUrl`/`tagName` and a numeric `rect`, lowercases the tag, tolerates a null selector / empty
+   text, truncates the snippet; a malformed return drops the pick rather than crashing.
+
+## Consequences
+
+- The entire feature is renderer-only and adds ZERO to the guest's attack surface — the reason it's
+  a small, contained slice rather than a security re-litigation.
+- No React component names (the deliberate deviation from t3code). If a future "trusted preview"
+  posture is ever introduced, component attribution could return — but that is its own ADR, not a
+  quiet relaxation here.
+- The picker is single-element, one pick at a time; t3code's annotation studio (multi-select,
+  draw, region, live-CSS-edit, comment box) is out of scope (PRD #223).
+- Capture uses CSS-px coordinates end to end; if a future need arises for device-pixel-accurate
+  crops the helper is the single place to adjust.

--- a/src/renderer/src/conversation/Composer.tsx
+++ b/src/renderer/src/conversation/Composer.tsx
@@ -22,7 +22,13 @@ import { IconButton } from '../ui/icon-button'
 import { Textarea } from '../ui/textarea'
 import type { AcpCommand } from './reducer'
 import { getDraft, setDraft as persistDraft, clearDraft } from './composer-draft-store'
-import { appendMention, appendText, subscribeComposerInsert, subscribeComposerInsertText } from './composer-insert'
+import {
+  appendMention,
+  appendText,
+  subscribeComposerInsert,
+  subscribeComposerInsertImage,
+  subscribeComposerInsertText,
+} from './composer-insert'
 import { ACCEPTED_IMAGE_TYPES, isAcceptedImageType, parseDataUrl } from './image-attach'
 import { nextQueueId, type FollowUpQueue } from './follow-up-queue'
 import { useComposerAutocomplete, CompletionPopover } from './use-composer-autocomplete'
@@ -172,6 +178,16 @@ export function Composer({
       inputRef.current?.focus()
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [threadId])
+
+  // Stage an image from the Browser Surface's element picker (#224): the pre-split
+  // screenshot arrives through the module-level channel keyed by threadId (same sibling→
+  // composer path as text/@), so we just add an id — no FileReader, it's already a data URL.
+  useEffect(() => {
+    return subscribeComposerInsertImage(threadId, (image) => {
+      setPendingImages((prev) => [...prev, { id: `img:${imageSeq++}`, ...image }])
+      inputRef.current?.focus()
+    })
   }, [threadId])
 
   // Read a pasted/picked image blob to a data URL (DOM: FileReader lives here, not

--- a/src/renderer/src/conversation/composer-insert.test.ts
+++ b/src/renderer/src/conversation/composer-insert.test.ts
@@ -3,9 +3,12 @@ import {
   appendMention,
   appendText,
   emitComposerInsert,
+  emitComposerInsertImage,
   emitComposerInsertText,
   subscribeComposerInsert,
+  subscribeComposerInsertImage,
   subscribeComposerInsertText,
+  type ComposerInsertImage,
 } from './composer-insert'
 
 describe('appendMention', () => {
@@ -85,6 +88,50 @@ describe('composer-insert TEXT channel (raw)', () => {
     const off = subscribeComposerInsertText('thread-a', listener)
     off()
     emitComposerInsertText('thread-a', 'x')
+    expect(listener).not.toHaveBeenCalled()
+  })
+})
+
+describe('composer-insert IMAGE channel (#224 element picker)', () => {
+  const img: ComposerInsertImage = {
+    data: 'AAAA',
+    mimeType: 'image/png',
+    name: 'picked-element.png',
+    previewUrl: 'data:image/png;base64,AAAA',
+  }
+
+  it('delivers an image payload to the Thread\'s subscriber, isolated from text/mention', () => {
+    const image = vi.fn()
+    const text = vi.fn()
+    const offImage = subscribeComposerInsertImage('thread-a', image)
+    const offText = subscribeComposerInsertText('thread-a', text)
+
+    emitComposerInsertImage('thread-a', img)
+    expect(image).toHaveBeenCalledWith(img)
+    expect(text).not.toHaveBeenCalled() // separate channel
+
+    offImage()
+    offText()
+  })
+
+  it('delivers only to the target Thread', () => {
+    const a = vi.fn()
+    const b = vi.fn()
+    const offA = subscribeComposerInsertImage('thread-a', a)
+    const offB = subscribeComposerInsertImage('thread-b', b)
+    emitComposerInsertImage('thread-a', img)
+    expect(a).toHaveBeenCalledWith(img)
+    expect(b).not.toHaveBeenCalled()
+    offA()
+    offB()
+  })
+
+  it('is a no-op with no subscriber, and stops after unsubscribe', () => {
+    expect(() => emitComposerInsertImage('nobody', img)).not.toThrow()
+    const listener = vi.fn()
+    const off = subscribeComposerInsertImage('thread-a', listener)
+    off()
+    emitComposerInsertImage('thread-a', img)
     expect(listener).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/conversation/composer-insert.ts
+++ b/src/renderer/src/conversation/composer-insert.ts
@@ -15,8 +15,23 @@
 /** A subscriber receiving the plain-text fragment to append to its Thread's composer draft. */
 type InsertListener = (mention: string) => void
 
+/**
+ * A pre-split image to stage in a Thread's composer (#224 element picker): `data` is BARE
+ * base64 (sent to the agent), `previewUrl` the full data URL (thumbnail + echoed turn) —
+ * the exact shape the composer's `PendingImage` needs, so the subscriber just adds an id.
+ */
+export interface ComposerInsertImage {
+  data: string
+  mimeType: string
+  name: string
+  previewUrl: string
+}
+
+type ImageListener = (image: ComposerInsertImage) => void
+
 const listenersByThread = new Map<string, Set<InsertListener>>()
 const textListenersByThread = new Map<string, Set<InsertListener>>()
+const imageListenersByThread = new Map<string, Set<ImageListener>>()
 
 /**
  * Append a plain-text `@path` reference to `draft`, keeping it space-separated: a trailing space
@@ -88,4 +103,32 @@ export function emitComposerInsertText(threadId: string, text: string): void {
   const set = textListenersByThread.get(threadId)
   if (!set) return
   for (const listener of set) listener(text)
+}
+
+/**
+ * Subscribe a Thread's composer to IMAGE insert requests (#224): the Browser Surface's
+ * element picker stages a screenshot as a pending image through here — a side-panel
+ * sibling reaching the composer, keyed by threadId, exactly like the text/@ channels.
+ * Returns an unsubscribe.
+ */
+export function subscribeComposerInsertImage(threadId: string, listener: ImageListener): () => void {
+  let set = imageListenersByThread.get(threadId)
+  if (!set) {
+    set = new Set()
+    imageListenersByThread.set(threadId, set)
+  }
+  set.add(listener)
+  return () => {
+    const current = imageListenersByThread.get(threadId)
+    if (!current) return
+    current.delete(listener)
+    if (current.size === 0) imageListenersByThread.delete(threadId)
+  }
+}
+
+/** Request the given Thread's composer stage `image`; a no-op if none is mounted. */
+export function emitComposerInsertImage(threadId: string, image: ComposerInsertImage): void {
+  const set = imageListenersByThread.get(threadId)
+  if (!set) return
+  for (const listener of set) listener(image)
 }

--- a/src/renderer/src/side-panel/BrowserSurface.tsx
+++ b/src/renderer/src/side-panel/BrowserSurface.tsx
@@ -1,6 +1,14 @@
 import { useCallback, useEffect, useRef, useState, type FormEvent, type JSX } from 'react'
-import { ArrowLeft, ArrowRight, Code, ExternalLink, Globe, Loader2, RefreshCw, RotateCw, TriangleAlert } from 'lucide-react'
+import { ArrowLeft, ArrowRight, Code, ExternalLink, Globe, Loader2, MousePointerClick, RefreshCw, RotateCw, TriangleAlert } from 'lucide-react'
 import type { DevServer } from '../../../shared/ipc'
+import { emitComposerInsertImage, emitComposerInsertText } from '../conversation/composer-insert'
+import { parseDataUrl } from '../conversation/image-attach'
+import {
+  buildPickerScript,
+  coercePickedElement,
+  cropRectForElement,
+  formatPickAnnotation,
+} from './browser-picker'
 import { cn } from '../lib/utils'
 import {
   buildWebviewPreferencesAttribute,
@@ -37,12 +45,15 @@ export function BrowserSurface({
   workspaceDir,
   persistedUrl,
   onUrlChange,
+  activeThreadId,
 }: {
   workspaceDir: string
   /** The last-visited URL restored from the store (#217), or undefined for a fresh tab. */
   persistedUrl?: string
   /** Report a committed guest URL up to the store so it persists. */
   onUrlChange: (url: string) => void
+  /** The live Thread whose composer a picked element targets (#224); null when none. */
+  activeThreadId: string | null
 }): JSX.Element {
   // The mounted webview as STATE (not a ref): the `setView` setter is identity-stable,
   // so React invokes the callback ref only on real mount/unmount — an inline-closure
@@ -55,6 +66,7 @@ export function BrowserSurface({
   const [initialUrl, setInitialUrl] = useState<string | null>(persistedUrl ?? null)
   const [address, setAddress] = useState(persistedUrl ?? '')
   const [title, setTitle] = useState('')
+  const [picking, setPicking] = useState(false)
   const [load, setLoad] = useState<LoadState>(INITIAL_LOAD)
   // Back/forward availability is tracked from navigation EVENTS via the pure model —
   // the webview element's own canGoBack()/canGoForward() are unreliable. `pending`
@@ -103,6 +115,46 @@ export function BrowserSurface({
   }
   function openDevTools(): void {
     view?.openDevTools()
+  }
+
+  // Pick an element to chat (#224, ADR-0016): inject the picker into the guest via
+  // executeJavaScript (isolated world — no preload, isolation stays ON), await the click,
+  // screenshot the element, and drop a screenshot + text annotation into the active
+  // Thread's composer. A no-op without a mounted composer (Thread) or webview.
+  async function pickElement(): Promise<void> {
+    if (!view || !activeThreadId || picking) return
+    setPicking(true)
+    try {
+      const accent = getComputedStyle(document.documentElement).getPropertyValue('--accent').trim() || '#e8833a'
+      const raw: unknown = await view.executeJavaScript(buildPickerScript({ accent }), true)
+      const picked = coercePickedElement(raw)
+      if (!picked) return // cancelled (Esc/nav) or a malformed return — nothing to send
+      // Screenshot AFTER the picker overlay is gone (the injected script tore it down
+      // before resolving), so the crop is the page, not the picker chrome.
+      const crop = cropRectForElement(picked.rect, { width: view.offsetWidth, height: view.offsetHeight }, { padding: 8 })
+      if (crop) {
+        try {
+          const image = await view.capturePage(crop)
+          const parsed = parseDataUrl(image.toDataURL())
+          if (parsed) {
+            emitComposerInsertImage(activeThreadId, {
+              ...parsed,
+              name: `element-${picked.tagName}.png`,
+              previewUrl: image.toDataURL(),
+            })
+          }
+        } catch (err) {
+          // A capture failure is non-fatal — the text annotation still lands.
+          console.error('[browser] element screenshot failed', err)
+        }
+      }
+      emitComposerInsertText(activeThreadId, formatPickAnnotation(picked))
+    } catch (err) {
+      // executeJavaScript rejects if the guest navigated mid-pick — treat as a cancel.
+      console.error('[browser] pick cancelled', err)
+    } finally {
+      setPicking(false)
+    }
   }
 
   // The webview only exposes its state through DOM events — wire them once per mounted
@@ -199,6 +251,14 @@ export function BrowserSurface({
             />
           )}
         </form>
+        <BrowserAction
+          label="Pick an element to chat"
+          onClick={() => void pickElement()}
+          disabled={activeThreadId === null || picking}
+          active={picking}
+        >
+          <MousePointerClick aria-hidden />
+        </BrowserAction>
         <BrowserAction label="Open in browser" onClick={openExternal}>
           <ExternalLink aria-hidden />
         </BrowserAction>
@@ -345,6 +405,14 @@ function UnreachableOverlay({ url, onRetry }: { url: string; onRetry: () => void
   )
 }
 
+/**
+ * A minimal Electron `NativeImage` — only `toDataURL`, which the picker uses to turn a
+ * `capturePage` crop into a `data:` URL for the composer.
+ */
+interface NativeImageLike {
+  toDataURL(): string
+}
+
 /** The slice of Electron's WebviewTag the Surface drives (renderer must not import electron). */
 interface WebviewElement extends HTMLElement {
   loadURL(url: string): Promise<void>
@@ -353,6 +421,10 @@ interface WebviewElement extends HTMLElement {
   goToOffset(offset: number): void
   reload(): void
   openDevTools(): void
+  /** Run code in the guest's ISOLATED world; resolves with the last expression (awaited if a Promise). */
+  executeJavaScript(code: string, userGesture?: boolean): Promise<unknown>
+  /** Capture a crop of the live guest compositor (rect in CSS/DIP px). */
+  capturePage(rect?: { x: number; y: number; width: number; height: number }): Promise<NativeImageLike>
 }
 
 /** A browser toolbar icon button — the TerminalAction idiom. */
@@ -360,11 +432,13 @@ function BrowserAction({
   label,
   onClick,
   disabled,
+  active,
   children,
 }: {
   label: string
   onClick: () => void
   disabled?: boolean
+  active?: boolean
   children: JSX.Element
 }): JSX.Element {
   return (
@@ -373,12 +447,14 @@ function BrowserAction({
       onClick={onClick}
       disabled={disabled}
       aria-label={label}
+      aria-pressed={active}
       title={label}
       className={cn(
-        'flex size-6 shrink-0 items-center justify-center rounded text-muted outline-none transition-colors',
+        'flex size-6 shrink-0 items-center justify-center rounded outline-none transition-colors',
         'hover:bg-accent/10 hover:text-text-strong focus-visible:bg-accent/10',
         'disabled:pointer-events-none disabled:opacity-40',
         '[&_svg]:size-3.5 [&_svg]:shrink-0',
+        active ? 'bg-accent/15 text-accent-text' : 'text-muted',
       )}
     >
       {children}

--- a/src/renderer/src/side-panel/SurfacePanel.tsx
+++ b/src/renderer/src/side-panel/SurfacePanel.tsx
@@ -371,6 +371,7 @@ function PanelBody({
                   workspaceDir={workspaceDir}
                   persistedUrl={browserSurface.url}
                   onUrlChange={persistBrowserUrl}
+                  activeThreadId={activeThreadId}
                 />
               </div>
             )}

--- a/src/renderer/src/side-panel/browser-picker.test.ts
+++ b/src/renderer/src/side-panel/browser-picker.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildPickerScript,
+  coercePickedElement,
+  cropRectForElement,
+  formatPickAnnotation,
+} from './browser-picker'
+
+describe('cropRectForElement', () => {
+  const viewport = { width: 1000, height: 800 }
+
+  it('pads the element rect and rounds to integers', () => {
+    const rect = cropRectForElement({ x: 100, y: 200, width: 50, height: 30 }, viewport, { padding: 8 })
+    expect(rect).toEqual({ x: 92, y: 192, width: 66, height: 46 })
+  })
+
+  it('clamps a padded rect to the viewport (no negative origin, no overflow)', () => {
+    const rect = cropRectForElement({ x: 2, y: 1, width: 40, height: 20 }, viewport, { padding: 8 })!
+    expect(rect.x).toBe(0)
+    expect(rect.y).toBe(0)
+    // right/bottom edges stay within the viewport
+    expect(rect.x + rect.width).toBeLessThanOrEqual(viewport.width)
+    expect(rect.y + rect.height).toBeLessThanOrEqual(viewport.height)
+  })
+
+  it('clamps the far edges when the element sits against the bottom-right', () => {
+    const rect = cropRectForElement({ x: 960, y: 780, width: 60, height: 40 }, viewport, { padding: 8 })!
+    expect(rect.x + rect.width).toBeLessThanOrEqual(viewport.width)
+    expect(rect.y + rect.height).toBeLessThanOrEqual(viewport.height)
+    expect(rect.width).toBeGreaterThan(0)
+    expect(rect.height).toBeGreaterThan(0)
+  })
+
+  it('returns null for a zero-area element (nothing to crop)', () => {
+    expect(cropRectForElement({ x: 10, y: 10, width: 0, height: 0 }, viewport, { padding: 8 })).toBeNull()
+  })
+})
+
+describe('coercePickedElement (untrusted guest JSON)', () => {
+  const valid = {
+    pageUrl: 'http://localhost:5173/pricing',
+    tagName: 'BUTTON',
+    selector: 'button.cta',
+    text: 'Get started',
+    rect: { x: 10, y: 20, width: 100, height: 40 },
+  }
+
+  it('accepts a well-formed payload and lowercases the tag', () => {
+    expect(coercePickedElement(valid)).toEqual({
+      pageUrl: 'http://localhost:5173/pricing',
+      tagName: 'button',
+      selector: 'button.cta',
+      text: 'Get started',
+      rect: { x: 10, y: 20, width: 100, height: 40 },
+    })
+  })
+
+  it('tolerates a null selector and empty text', () => {
+    const p = coercePickedElement({ ...valid, selector: null, text: '' })
+    expect(p?.selector).toBeNull()
+    expect(p?.text).toBe('')
+  })
+
+  it('drops a payload missing a valid rect or tag', () => {
+    expect(coercePickedElement({ ...valid, rect: null })).toBeNull()
+    expect(coercePickedElement({ ...valid, rect: { x: 1, y: 2, width: 'x', height: 3 } })).toBeNull()
+    expect(coercePickedElement({ ...valid, tagName: 42 })).toBeNull()
+  })
+
+  it('drops non-objects', () => {
+    expect(coercePickedElement(null)).toBeNull()
+    expect(coercePickedElement('nope')).toBeNull()
+    expect(coercePickedElement(undefined)).toBeNull()
+  })
+
+  it('truncates an over-long text snippet', () => {
+    const long = 'x'.repeat(500)
+    const p = coercePickedElement({ ...valid, text: long })
+    expect(p!.text.length).toBeLessThanOrEqual(200)
+  })
+})
+
+describe('formatPickAnnotation', () => {
+  it('renders a compact, human+agent readable block with tag, selector, text, url', () => {
+    const text = formatPickAnnotation({
+      pageUrl: 'http://localhost:5173/pricing',
+      tagName: 'button',
+      selector: 'button.cta',
+      text: 'Get started',
+      rect: { x: 0, y: 0, width: 1, height: 1 },
+    })
+    expect(text).toContain('<button>')
+    expect(text).toContain('button.cta')
+    expect(text).toContain('Get started')
+    expect(text).toContain('http://localhost:5173/pricing')
+  })
+
+  it('omits the selector and text lines when they are absent', () => {
+    const text = formatPickAnnotation({
+      pageUrl: 'http://localhost:5173/',
+      tagName: 'div',
+      selector: null,
+      text: '',
+      rect: { x: 0, y: 0, width: 1, height: 1 },
+    })
+    expect(text).toContain('<div>')
+    expect(text).not.toContain('selector')
+  })
+})
+
+describe('buildPickerScript', () => {
+  it('produces a single IIFE expression that resolves a Promise', () => {
+    const script = buildPickerScript({ accent: '#ff8800' })
+    expect(script.trimStart().startsWith('(')).toBe(true)
+    expect(script).toContain('new Promise')
+  })
+
+  it('embeds the accent color as a safely-quoted string', () => {
+    const script = buildPickerScript({ accent: '#ff8800' })
+    expect(script).toContain(JSON.stringify('#ff8800'))
+  })
+
+  it('wires the load-bearing picker mechanics (hover, capture-phase click, Esc)', () => {
+    const script = buildPickerScript({ accent: '#ff8800' })
+    expect(script).toContain('elementsFromPoint')
+    expect(script).toContain('getBoundingClientRect')
+    expect(script).toContain('preventDefault')
+    expect(script).toContain("'Escape'")
+    // capture-phase listeners so the guest app never sees the pick
+    expect(script).toContain('true')
+  })
+
+  it('is resistant to a hostile accent value (JSON-encoded, quote escaped)', () => {
+    const script = buildPickerScript({ accent: '";alert(1)//' })
+    // JSON-encoding embeds the value as an escaped string literal — the `"` becomes `\"`,
+    // so it can't break out of the string context into executable code.
+    expect(script).toContain(JSON.stringify('";alert(1)//'))
+    expect(script).toContain('\\"') // the double-quote is backslash-escaped, not raw
+  })
+})

--- a/src/renderer/src/side-panel/browser-picker.ts
+++ b/src/renderer/src/side-panel/browser-picker.ts
@@ -1,0 +1,182 @@
+/**
+ * Pure helpers for the Browser Surface's element picker (#224, ADR-0016). The picker
+ * runs in the guest via `executeJavaScript` (isolated world — no preload, no relaxed
+ * isolation), so the only things worth unit-testing are the string/geometry pieces
+ * either side of that boundary: the crop-rect math for the screenshot, the coercion of
+ * the untrusted payload the guest returns, and the annotation text. The injected script
+ * itself runs only in a real browser world (exercised by driving the app).
+ */
+
+/** A rectangle in viewport CSS pixels — the coordinate space of `getBoundingClientRect`. */
+export interface Rect {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+/**
+ * The DOM-level metadata captured for a picked element (#224). NO React component name /
+ * source frames — those need the page's DevTools hook, unreachable from the isolated world
+ * we inject into (the deliberate deviation from t3code; ADR-0016). `selector` is best-effort
+ * (null if uncomputable); `text` is a truncated snippet; `rect` is the viewport bounding box.
+ */
+export interface PickedElement {
+  pageUrl: string
+  tagName: string
+  selector: string | null
+  text: string
+  rect: Rect
+}
+
+/** Longest text snippet kept from a picked element (keeps the annotation compact). */
+const MAX_TEXT = 200
+
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v)
+}
+
+function coerceRect(raw: unknown): Rect | null {
+  if (typeof raw !== 'object' || raw === null) return null
+  const r = raw as Record<string, unknown>
+  if (!isFiniteNumber(r.x) || !isFiniteNumber(r.y) || !isFiniteNumber(r.width) || !isFiniteNumber(r.height)) {
+    return null
+  }
+  return { x: r.x, y: r.y, width: r.width, height: r.height }
+}
+
+/**
+ * Coerce the untrusted JSON the guest returns into a valid {@link PickedElement}, or null
+ * to drop it — the guest page could return anything, so validate structurally (the
+ * `coerceSurface`/`safe-external-url` defensive-coercion pattern). Requires a string
+ * `pageUrl`/`tagName` and a numeric `rect`; lowercases the tag; tolerates a null selector
+ * and empty text; truncates the snippet.
+ */
+export function coercePickedElement(raw: unknown): PickedElement | null {
+  if (typeof raw !== 'object' || raw === null) return null
+  const o = raw as Record<string, unknown>
+  if (typeof o.pageUrl !== 'string' || typeof o.tagName !== 'string') return null
+  const rect = coerceRect(o.rect)
+  if (!rect) return null
+  const selector = typeof o.selector === 'string' && o.selector.length > 0 ? o.selector : null
+  const text = typeof o.text === 'string' ? o.text.slice(0, MAX_TEXT) : ''
+  return { pageUrl: o.pageUrl, tagName: o.tagName.toLowerCase(), selector, text, rect }
+}
+
+/**
+ * Build the picker script injected into the guest via `executeJavaScript` (#224, ADR-0016).
+ * Runs in the guest's ISOLATED WORLD: it manipulates the shared DOM (draws a highlight box +
+ * label, hit-tests with `elementsFromPoint`, reads `getBoundingClientRect`) but has no access
+ * to the page's JS globals — hence DOM metadata only, no React component names. Returns a
+ * single IIFE EXPRESSION resolving a Promise, so `executeJavaScript` awaits it and hands back
+ * the picked-element JSON (or null on Esc/cancel). Config values are JSON-encoded, never raw-
+ * interpolated, so a hostile accent can't break out of the string context. Capture-phase
+ * listeners + a click `preventDefault`/`stopPropagation` mean the guest app never sees the pick;
+ * overlay nodes are marked so they're excluded from hit-testing (never self-picked). The whole
+ * script runs only in a real browser world — unit tests cover its SHAPE, not its behavior (the
+ * app-driving verification exercises the behavior).
+ */
+export function buildPickerScript(config: { accent: string }): string {
+  const accent = JSON.stringify(config.accent)
+  const marker = JSON.stringify('data-vibe-pick-ui')
+  return `(() => {
+  const ACCENT = ${accent};
+  const MARKER = ${marker};
+  return new Promise((resolve) => {
+    const box = document.createElement('div');
+    box.setAttribute(MARKER, '');
+    Object.assign(box.style, { position: 'fixed', zIndex: '2147483646', pointerEvents: 'none', boxSizing: 'border-box', border: '2px solid ' + ACCENT, background: ACCENT + '22', borderRadius: '2px', display: 'none' });
+    const label = document.createElement('div');
+    label.setAttribute(MARKER, '');
+    Object.assign(label.style, { position: 'fixed', zIndex: '2147483647', pointerEvents: 'none', background: ACCENT, color: '#fff', font: '11px/1.5 ui-monospace, monospace', padding: '1px 5px', borderRadius: '3px', display: 'none', maxWidth: '60vw', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' });
+    document.body.appendChild(box);
+    document.body.appendChild(label);
+    document.body.style.cursor = 'crosshair';
+    let current = null;
+    const isUi = (el) => !!(el && el.getAttribute && el.getAttribute(MARKER) !== null);
+    const elementAt = (x, y) => {
+      for (const el of document.elementsFromPoint(x, y)) {
+        if (!isUi(el) && el !== document.documentElement && el !== document.body) return el;
+      }
+      return null;
+    };
+    const describe = (el) => {
+      const id = el.id ? '#' + el.id : '';
+      const cls = (typeof el.className === 'string' && el.className.trim()) ? '.' + el.className.trim().split(/\\s+/).join('.') : '';
+      return el.tagName.toLowerCase() + id + cls;
+    };
+    const onMove = (e) => {
+      const el = elementAt(e.clientX, e.clientY);
+      current = el;
+      if (!el) { box.style.display = 'none'; label.style.display = 'none'; return; }
+      const r = el.getBoundingClientRect();
+      Object.assign(box.style, { display: 'block', left: r.left + 'px', top: r.top + 'px', width: r.width + 'px', height: r.height + 'px' });
+      label.textContent = describe(el);
+      Object.assign(label.style, { display: 'block', left: r.left + 'px', top: Math.max(0, r.top - 18) + 'px' });
+    };
+    const cleanup = () => {
+      window.removeEventListener('pointermove', onMove, true);
+      window.removeEventListener('click', onClick, true);
+      window.removeEventListener('keydown', onKey, true);
+      window.removeEventListener('pagehide', onCancel, true);
+      document.body.style.cursor = '';
+      box.remove();
+      label.remove();
+    };
+    const payloadFor = (el) => {
+      const r = el.getBoundingClientRect();
+      const text = (el.textContent || '').replace(/\\s+/g, ' ').trim().slice(0, 200);
+      let selector = null;
+      try { selector = describe(el); } catch (_) { selector = null; }
+      return { pageUrl: location.href, tagName: el.tagName, selector, text, rect: { x: r.x, y: r.y, width: r.width, height: r.height } };
+    };
+    const onClick = (e) => {
+      const el = current || elementAt(e.clientX, e.clientY);
+      e.preventDefault();
+      e.stopPropagation();
+      cleanup();
+      resolve(el ? payloadFor(el) : null);
+    };
+    const onKey = (e) => { if (e.key === 'Escape') { e.preventDefault(); cleanup(); resolve(null); } };
+    const onCancel = () => { cleanup(); resolve(null); };
+    window.addEventListener('pointermove', onMove, true);
+    window.addEventListener('click', onClick, true);
+    window.addEventListener('keydown', onKey, true);
+    window.addEventListener('pagehide', onCancel, true);
+  });
+})()`
+}
+
+/**
+ * Format a picked element as a compact composer annotation — a `<tag>` line, then optional
+ * `selector:` and `text:` lines, then the page URL. Inserted as plain, editable composer
+ * text (reusing the existing text channel) so the agent gets precise context alongside the
+ * screenshot. Absent selector/text lines are omitted.
+ */
+export function formatPickAnnotation(element: PickedElement): string {
+  const lines = [`Picked element <${element.tagName}>`]
+  if (element.selector) lines.push(`selector: ${element.selector}`)
+  if (element.text.trim().length > 0) lines.push(`text: ${element.text.trim()}`)
+  lines.push(element.pageUrl)
+  return lines.join('\n')
+}
+
+/**
+ * The crop rect for the picked element's screenshot: pad the element's bounding rect,
+ * clamp it to the viewport, and round to integer pixels. Returns null for a zero-area
+ * element (nothing to capture). Coordinates stay in CSS pixels — Electron's
+ * `capturePage(rect)` expects DIP/CSS px and handles devicePixelRatio internally, so no
+ * DPR scaling is applied here.
+ */
+export function cropRectForElement(
+  rect: Rect,
+  viewport: { width: number; height: number },
+  opts: { padding: number },
+): Rect | null {
+  if (rect.width <= 0 || rect.height <= 0) return null
+  const left = Math.max(0, Math.round(rect.x - opts.padding))
+  const top = Math.max(0, Math.round(rect.y - opts.padding))
+  const right = Math.min(viewport.width, Math.round(rect.x + rect.width + opts.padding))
+  const bottom = Math.min(viewport.height, Math.round(rect.y + rect.height + opts.padding))
+  return { x: left, y: top, width: right - left, height: bottom - top }
+}


### PR DESCRIPTION
Closes #224 (from PRD #223). A follow-up to the completed Browser Surface epic (#215).

## What this does

Turns the dev-server preview from a viewer into an input device. Click the **pick** button in the Browser toolbar, hover to highlight elements, click one — and a **cropped screenshot** of it plus a **text annotation** (tag, CSS selector, text snippet, page URL) land in the active Thread's composer. Type an instruction and send; the agent sees both the picture and the precise element context. Esc (or a page navigation mid-pick) cancels cleanly.

## The key decision (ADR-0016, included)

t3code's picker reads React component names by running a guest preload at `contextIsolation=false` — exactly the posture ADR-0015's security review locked down. We **don't** touch it. Instead the picker is injected via the webview's **`executeJavaScript`**, which runs in the guest's **isolated world** and returns its value:

- The injected script draws the highlight overlay, hit-tests with `elementsFromPoint`, reads `getBoundingClientRect`, wires a capture-phase click (so the guest app never sees it) and Esc/cancel, and **returns a Promise** resolving with the picked-element payload — one `await`, no new IPC, no preload, no `ipc-message`/`console-message` hacks.
- The guest security posture is **unchanged**: contextIsolation stays ON, no preload, the `will-attach-webview` clamp is untouched.
- The trade: no React component-name attribution (needs the page's DevTools hook, unreachable from the isolated world). That's the price of keeping the sandbox, and it's the right one.

Config values in the injected script are JSON-encoded, never raw-interpolated (a hostile accent/page can't break out). The untrusted payload the guest returns is defensively coerced (the `coerceSurface`/`safe-external-url` pattern).

## Screenshot + composer landing

- `capturePage(rect)` on the element's padded, viewport-clamped bounds (captured after the overlay is torn down, so it's the page not the picker chrome); a capture failure still delivers the annotation.
- Reuses the established sibling→composer pub/sub: a new `emitComposerInsertImage` channel stages the shot as a `PendingImage` (byte-identical to a pasted image — the send path and ACP `mime_type` boundary are unchanged); the annotation reuses the existing text channel. `activeThreadId` is threaded into `BrowserSurface`; pick disables with no page or no active Thread.

## Tests

TDD, all pure/colocated (18 new): crop-rect math, payload coercion, annotation formatter, injected-script builder (shape + injection-safety), and the image-insert channel.

**Verified in the running app** (Playwright `_electron`): pick button → hover-highlight → click a dev-server button → a cropped screenshot + `selector: button#signup.cta` / `text: Get started now` / URL land in the composer as an image attachment + editable text. Screenshot confirmed the crop and annotation render.

All four gates green: lint, typecheck, build, test (**1138 passed**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)