### PR TITLE
feat(browser): full-page screenshot to composer

### DIFF
--- a/src/renderer/src/side-panel/BrowserSurface.tsx
+++ b/src/renderer/src/side-panel/BrowserSurface.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type FormEvent, type JSX } from 'react'
-import { ArrowLeft, ArrowRight, Code, ExternalLink, Globe, Loader2, MousePointerClick, RefreshCw, RotateCw, TriangleAlert } from 'lucide-react'
+import { ArrowLeft, ArrowRight, Camera, Code, ExternalLink, Globe, Loader2, MousePointerClick, RefreshCw, RotateCw, TriangleAlert } from 'lucide-react'
 import type { DevServer } from '../../../shared/ipc'
 import { emitComposerInsertImage, emitComposerInsertText } from '../conversation/composer-insert'
 import { parseDataUrl } from '../conversation/image-attach'
@@ -8,6 +8,7 @@ import {
   coercePickedElement,
   cropRectForElement,
   formatPickAnnotation,
+  formatScreenshotAnnotation,
 } from './browser-picker'
 import { cn } from '../lib/utils'
 import {
@@ -115,6 +116,26 @@ export function BrowserSurface({
   }
   function openDevTools(): void {
     view?.openDevTools()
+  }
+
+  // Screenshot the whole visible page into the composer (#226): capture the guest
+  // compositor (no rect = full visible page) and stage it as an image + a title/URL
+  // annotation, reusing the picker's composer-insert path. No-op without a webview or
+  // a mounted composer (Thread).
+  async function screenshotPage(): Promise<void> {
+    if (!view || !activeThreadId) return
+    try {
+      const image = await view.capturePage()
+      const dataUrl = image.toDataURL()
+      const parsed = parseDataUrl(dataUrl)
+      if (parsed) {
+        emitComposerInsertImage(activeThreadId, { ...parsed, name: 'page-screenshot.png', previewUrl: dataUrl })
+        emitComposerInsertText(activeThreadId, formatScreenshotAnnotation({ url: view.getURL(), title }))
+      }
+    } catch (err) {
+      // Best-effort — a capture failure is a logged no-op, never a broken attachment.
+      console.error('[browser] page screenshot failed', err)
+    }
   }
 
   // Pick an element to chat (#224, ADR-0016): inject the picker into the guest via
@@ -258,6 +279,13 @@ export function BrowserSurface({
           active={picking}
         >
           <MousePointerClick aria-hidden />
+        </BrowserAction>
+        <BrowserAction
+          label="Screenshot page to chat"
+          onClick={() => void screenshotPage()}
+          disabled={activeThreadId === null}
+        >
+          <Camera aria-hidden />
         </BrowserAction>
         <BrowserAction label="Open in browser" onClick={openExternal}>
           <ExternalLink aria-hidden />

--- a/src/renderer/src/side-panel/browser-picker.test.ts
+++ b/src/renderer/src/side-panel/browser-picker.test.ts
@@ -4,6 +4,7 @@ import {
   coercePickedElement,
   cropRectForElement,
   formatPickAnnotation,
+  formatScreenshotAnnotation,
 } from './browser-picker'
 
 describe('cropRectForElement', () => {
@@ -105,6 +106,20 @@ describe('formatPickAnnotation', () => {
     })
     expect(text).toContain('<div>')
     expect(text).not.toContain('selector')
+  })
+})
+
+describe('formatScreenshotAnnotation', () => {
+  it('names the page with title and url', () => {
+    expect(formatScreenshotAnnotation({ url: 'http://localhost:5173/pricing', title: 'Pricing' })).toBe(
+      'Screenshot of "Pricing" — http://localhost:5173/pricing',
+    )
+  })
+
+  it('falls back to url only when the title is empty', () => {
+    expect(formatScreenshotAnnotation({ url: 'http://localhost:5173/', title: '' })).toBe(
+      'Screenshot of http://localhost:5173/',
+    )
   })
 })
 

--- a/src/renderer/src/side-panel/browser-picker.ts
+++ b/src/renderer/src/side-panel/browser-picker.ts
@@ -148,6 +148,16 @@ export function buildPickerScript(config: { accent: string }): string {
 }
 
 /**
+ * Format a full-page screenshot's composer annotation (#226): names the page by title +
+ * URL for the agent's context (a screenshot alone doesn't carry its address). Falls back
+ * to URL-only when the guest reports no title.
+ */
+export function formatScreenshotAnnotation(page: { url: string; title: string }): string {
+  const title = page.title.trim()
+  return title.length > 0 ? `Screenshot of "${title}" — ${page.url}` : `Screenshot of ${page.url}`
+}
+
+/**
  * Format a picked element as a compact composer annotation — a `<tag>` line, then optional
  * `selector:` and `text:` lines, then the page URL. Inserted as plain, editable composer
  * text (reusing the existing text channel) so the agent gets precise context alongside the


### PR DESCRIPTION
Closes #226. A small cousin of the element picker (#225) — reuses everything it established.

## What this does

A **camera** button in the Browser Surface toolbar captures the currently-visible preview and drops it into the active Thread's composer as a removable image attachment, plus a one-line annotation naming the page (`Screenshot of "<title>" — <url>`). Type an instruction and send; the agent sees the whole page, not just an element.

## How

- `capturePage()` with no rect on the webview element = the full visible page → `toDataURL()` → `parseDataUrl` → the existing `emitComposerInsertImage` channel (staged as a `PendingImage`, identical to a pasted/picked image); the annotation reuses `emitComposerInsertText`.
- No new IPC, no ACP change, guest security posture untouched. Disabled with no page loaded or no active Thread (same gating as the pick button). A capture failure is a logged no-op — never a broken attachment.

## Tests

Pure annotation formatter unit-tested (title+url, url-only fallback); the DOM/webview-bound capture stays untested per convention.

**Verified in the running app**: camera button → a full-page image thumbnail + `Screenshot of "Vibe Dev Server" — http://127.0.0.1:8521/` land in the composer. Screenshot confirmed the full page (not a crop) was captured.

All four gates green: lint, typecheck, build, test (**1140 passed**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)