### PR TITLE
feat(composer): pending-context chips — skill, file & element attachments flattened to text at send (#229 #230 #231)

### DIFF
--- a/docs/adr/0017-pending-context-chips-flatten-to-text.md
+++ b/docs/adr/0017-pending-context-chips-flatten-to-text.md
@@ -1,0 +1,63 @@
+# Pending-context chips: structured composer attachments, flattened to plain text at send
+
+**Status: ACCEPTED** (2026-07-03). Builds on **ADR-0002** (thin orchestrator — no client-side
+expansion, no new wire shapes), **ADR-0009** (queue payload unchanged), **ADR-0013** decision 2
+(Files-preview insert channel), **ADR-0016** (element picker — its output re-homed here). PRD
+#228; slices #229 (skill), #230 (file), #231 (element). Reference: t3code's composer, whose
+**attachment pattern** we adopt and whose **Lexical inline-chip editor** we deliberately do not.
+
+## Context
+
+Selecting context in the composer used to collapse straight into draft text: a `/` accept spliced
+`/name ` into the prose, an `@` accept spliced `@path `, and a Browser Surface element pick pasted
+a multi-line annotation into the draft. The user couldn't see at a glance what a prompt carried,
+couldn't remove one attachment without hand-editing text, and the draft stopped being theirs to
+edit.
+
+t3code solves the in-text version of this with a ~1,700-line Lexical editor whose decorator nodes
+render inline chips. But its browser **element contexts** — the closest analogue to our picker —
+do NOT go through that editor: they are structured drafts rendered as removable chips *outside*
+the text field, flattened into a trailing plain-text block at send. Inline positional chips are
+only needed when a token must sit mid-sentence; none of ours do.
+
+## Decision
+
+1. **Chips live BESIDE the draft, never inline in it.** The composer stays a plain textarea; a
+   `PendingContext` discriminated union (`skill` / `file` / `element`, `pending-contexts.ts`)
+   is separate state with the same lifecycle as staged images (#100): ephemeral, cleared on
+   send/enqueue, restored on a failed send.
+
+2. **The draft string stays the single source of truth for prose; the wire stays plain text.**
+   `serializeForSend(text, contexts)` flattens at the moment of send or enqueue:
+   - skill → leading `/name ` (the agent parses it server-side; at most ONE chip, replace-on-add);
+   - files → a trailing `<attached_files>` block of `@path` mentions (the agent expands them;
+     deduped by path);
+   - elements → a final `<element_context>` block of descriptive lines (the former #224
+     annotation content, whitespace-normalized to stay line-parseable).
+   The follow-up queue's `{text, images}` payload shape is untouched.
+
+3. **Display re-derives chips from the sent text at RENDER time** (`extractPromptContexts`, the
+   exact mirror of the serializer), matching the PR #213 match-at-render decision. Marker blocks
+   are stripped from the visible bubble and rendered as chips. Because everything rides in the
+   prompt text, the JSONL transcript persists context for free and cold replay shows the same
+   chips with zero persistence changes. Extraction only touches TRAILING blocks whose content
+   matches what we write — hand-typed prompts and inline `@path` mentions pass through untouched.
+
+4. **The element pick delivers ONE payload** (metadata + optional screenshot) over a dedicated
+   composer-insert channel; the composer pairs the chip to its staged screenshot by id, so
+   removing the chip removes the screenshot. The picker itself (ADR-0016) is unchanged.
+
+5. **The Terminal Surface's "Add to chat" stays raw text** — multi-line terminal output belongs
+   in the editable draft, not behind a chip.
+
+## Consequences
+
+- No Lexical/contentEditable dependency; composer logic stays pure-module unit-testable (node
+  env, no jsdom). The threshold for revisiting: a token that must sit mid-sentence.
+- Typed `/name` and `@path` flows are unchanged — chips are additive over the same wire format.
+- Chips are ephemeral v1: unlike the old spliced-text mentions, they do not survive a Thread
+  switch/app restart. Persisting a structured draft (`{text, contexts}`) is a recorded follow-up.
+- The agent sees marker elements (`<attached_files>`, `<element_context>`) as plain prose. This
+  is deliberate: they are descriptive fences, not protocol. If a prompt legitimately ends with
+  text matching a fence, extraction only mis-fires if the content also parses (`@`-only lines /
+  `Picked element <…>` entries) — accepted as vanishingly unlikely.

--- a/src/renderer/src/conversation/Composer.tsx
+++ b/src/renderer/src/conversation/Composer.tsx
@@ -8,7 +8,7 @@ import {
   type JSX,
   type KeyboardEvent,
 } from 'react'
-import { ArrowUp, Mic, Plus, Square, X } from 'lucide-react'
+import { ArrowUp, Mic, Plus, Sparkles, Square, X } from 'lucide-react'
 import type {
   FileEntry,
   ThreadConfigAxis,
@@ -30,6 +30,13 @@ import {
   subscribeComposerInsertText,
 } from './composer-insert'
 import { ACCEPTED_IMAGE_TYPES, isAcceptedImageType, parseDataUrl } from './image-attach'
+import {
+  addContext,
+  contextKey,
+  removeContext,
+  serializeForSend,
+  type PendingContext,
+} from './pending-contexts'
 import { nextQueueId, type FollowUpQueue } from './follow-up-queue'
 import { useComposerAutocomplete, CompletionPopover } from './use-composer-autocomplete'
 import { createCommandSource, createPathSource } from './composer-sources'
@@ -109,6 +116,10 @@ export function Composer({
   // this view remounts on a Thread switch (keyed by threadId), so the strip starts
   // empty per Thread. Kept on a failed send so the user can retry / switch model.
   const [pendingImages, setPendingImages] = useState<PendingImage[]>([])
+  // Pending-context chips (#229): structured attachments staged BESIDE the draft
+  // text — a `/` accept stages a skill chip here instead of splicing text in. Same
+  // lifecycle as staged images: ephemeral, cleared on send/enqueue, kept on failure.
+  const [pendingContexts, setPendingContexts] = useState<PendingContext[]>([])
   const inputRef = useRef<HTMLTextAreaElement>(null)
   // The hidden file picker behind the 📎 button (#100).
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -153,7 +164,9 @@ export function Composer({
     [pathEntries],
   )
   const sources = useMemo(() => [commandSource, pathSource], [commandSource, pathSource])
-  const autocomplete = useComposerAutocomplete(sources, draft, writeDraft, inputRef)
+  const autocomplete = useComposerAutocomplete(sources, draft, writeDraft, inputRef, (context) =>
+    setPendingContexts((prev) => addContext(prev, context)),
+  )
 
   // Insert `@path` from the Files preview's action (#189): the side panel is a sibling of
   // this view, so it reaches the composer through the module-level `composer-insert` channel
@@ -239,7 +252,9 @@ export function Composer({
   // end); when idle we send immediately, preserving #100's clear-on-success /
   // keep-on-failure UX (a failed send keeps the text + staged images for retry).
   async function send(): Promise<void> {
-    const text = draft.trim()
+    // Flatten the staged context chips into the wire text (#229): the skill chip
+    // becomes the leading `/name` invocation the agent parses server-side.
+    const text = serializeForSend(draft, pendingContexts)
     const hasContent = text.length > 0 || pendingImages.length > 0
     if (!hasContent) return
     const images = pendingImages.map(({ data, mimeType, previewUrl }) => ({
@@ -256,6 +271,7 @@ export function Composer({
       setDraft('')
       clearDraft(window.localStorage, threadId)
       setPendingImages([])
+      setPendingContexts([])
       return
     }
     // Idle: send now, clearing the composer OPTIMISTICALLY — `submitPrompt` resolves
@@ -265,17 +281,23 @@ export function Composer({
     // the payload for retry (#100's keep-on-failure, e.g. switching to a vision model
     // after -31008) — unless the user started composing something new meanwhile.
     const staged = pendingImages
+    const stagedContexts = pendingContexts
+    const proseBefore = draft
     setPendingImages([])
+    setPendingContexts([])
     setDraft('')
     clearDraft(window.localStorage, threadId)
     const ok = await submitPrompt(text, images)
     if (!ok) {
+      // Restore the PRE-serialize prose + chips (not the flattened wire text), so a
+      // retry re-serializes cleanly instead of double-prepending the invocation.
       setDraft((current) => {
         if (current.length > 0) return current
-        persistDraft(window.localStorage, threadId, text)
-        return text
+        persistDraft(window.localStorage, threadId, proseBefore)
+        return proseBefore
       })
       setPendingImages((current) => (current.length > 0 ? current : staged))
+      setPendingContexts((current) => (current.length > 0 ? current : stagedContexts))
     }
   }
 
@@ -325,6 +347,33 @@ export function Composer({
                     <X className="size-3.5" aria-hidden />
                   </IconButton>
                 </div>
+              ))}
+            </div>
+          )}
+
+          {pendingContexts.length > 0 && (
+            // Pending-context chip row (#229): the structured attachments staged beside
+            // the draft — mirrors the sent-turn invocation chip (PR #213) with a ✕ remove.
+            <div className="mb-3 flex flex-wrap gap-2">
+              {pendingContexts.map((context) => (
+                <span
+                  key={contextKey(context)}
+                  data-pending-context-chip
+                  title={context.description}
+                  className="inline-flex items-center gap-1 rounded-md border border-[var(--accent-tint-border)] bg-[var(--accent-tint)] py-0.5 pr-1 pl-1.5 font-mono text-xs leading-none text-accent-text"
+                >
+                  <Sparkles className="size-3 shrink-0" aria-hidden />/{context.name}
+                  <button
+                    type="button"
+                    aria-label={`Remove /${context.name}`}
+                    onClick={() =>
+                      setPendingContexts((prev) => removeContext(prev, contextKey(context)))
+                    }
+                    className="inline-flex size-3.5 items-center justify-center rounded-sm text-accent-text outline-none hover:bg-[var(--accent-tint-border)]"
+                  >
+                    <X className="size-3" aria-hidden />
+                  </button>
+                </span>
               ))}
             </div>
           )}

--- a/src/renderer/src/conversation/Composer.tsx
+++ b/src/renderer/src/conversation/Composer.tsx
@@ -8,7 +8,7 @@ import {
   type JSX,
   type KeyboardEvent,
 } from 'react'
-import { ArrowUp, File, Mic, Plus, Sparkles, Square, X } from 'lucide-react'
+import { ArrowUp, File, Mic, MousePointerClick, Plus, Sparkles, Square, X } from 'lucide-react'
 import type {
   FileEntry,
   ThreadConfigAxis,
@@ -25,7 +25,7 @@ import { getDraft, setDraft as persistDraft, clearDraft } from './composer-draft
 import {
   appendText,
   subscribeComposerInsert,
-  subscribeComposerInsertImage,
+  subscribeComposerInsertElement,
   subscribeComposerInsertText,
 } from './composer-insert'
 import { ACCEPTED_IMAGE_TYPES, isAcceptedImageType, parseDataUrl } from './image-attach'
@@ -40,8 +40,40 @@ import { nextQueueId, type FollowUpQueue } from './follow-up-queue'
 import { useComposerAutocomplete, CompletionPopover } from './use-composer-autocomplete'
 import { createCommandSource, createPathSource } from './composer-sources'
 
-/** Process-local counter for unique pending-image ids (not Math.random/Date). */
+/** Process-local counters for unique pending-image / element-chip ids (not Math.random/Date). */
 let imageSeq = 0
+let elementSeq = 0
+
+/** A pending-context chip's visible label, per kind. */
+function chipLabel(context: PendingContext): string {
+  switch (context.kind) {
+    case 'skill':
+      return `/${context.name}`
+    case 'file':
+      return context.path
+    case 'element':
+      return context.selector ?? `<${context.tagName}>`
+  }
+}
+
+/** A pending-context chip's hover detail (`title`), per kind. */
+function chipTitle(context: PendingContext): string | undefined {
+  switch (context.kind) {
+    case 'skill':
+      return context.description
+    case 'file':
+      return context.path
+    case 'element':
+      return [
+        `<${context.tagName}>`,
+        context.selector ?? '',
+        context.text.trim(),
+        context.pageUrl,
+      ]
+        .filter((line) => line.length > 0)
+        .join('\n')
+  }
+}
 
 /** The picker's `accept` list — the accepted image mime types, comma-joined. */
 const IMAGE_ACCEPT = ACCEPTED_IMAGE_TYPES.join(',')
@@ -190,12 +222,20 @@ export function Composer({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [threadId])
 
-  // Stage an image from the Browser Surface's element picker (#224): the pre-split
-  // screenshot arrives through the module-level channel keyed by threadId (same sibling→
-  // composer path as text/@), so we just add an id — no FileReader, it's already a data URL.
+  // Stage a Browser Surface element pick (#224/#231): the ONE payload — element metadata
+  // + optional pre-split screenshot — arrives through the module-level channel keyed by
+  // threadId. The screenshot stages as a pending image; the element stages as a chip
+  // carrying that image's id, so removing the chip removes its screenshot with it.
   useEffect(() => {
-    return subscribeComposerInsertImage(threadId, (image) => {
-      setPendingImages((prev) => [...prev, { id: `img:${imageSeq++}`, ...image }])
+    return subscribeComposerInsertElement(threadId, ({ element, image }) => {
+      let imageId: string | null = null
+      if (image) {
+        imageId = `img:${imageSeq++}`
+        setPendingImages((prev) => [...prev, { id: imageId as string, ...image }])
+      }
+      setPendingContexts((prev) =>
+        addContext(prev, { kind: 'element', id: `el:${elementSeq++}`, ...element, imageId }),
+      )
       inputRef.current?.focus()
     })
   }, [threadId])
@@ -349,30 +389,36 @@ export function Composer({
           )}
 
           {pendingContexts.length > 0 && (
-            // Pending-context chip row (#229/#230): the structured attachments staged
+            // Pending-context chip row (#229/#230/#231): the structured attachments staged
             // beside the draft — mirrors the sent-turn chips with a ✕ remove per chip.
+            // Removing an ELEMENT chip also removes its paired screenshot (one payload in,
+            // one gesture out); removing the thumbnail alone keeps the chip (screenshot is
+            // optional context, the pick isn't).
             <div className="mb-3 flex flex-wrap gap-2">
               {pendingContexts.map((context) => (
                 <span
                   key={contextKey(context)}
                   data-pending-context-chip
-                  title={context.kind === 'skill' ? context.description : context.path}
+                  title={chipTitle(context)}
                   className="inline-flex max-w-full items-center gap-1 rounded-md border border-[var(--accent-tint-border)] bg-[var(--accent-tint)] py-0.5 pr-1 pl-1.5 font-mono text-xs leading-none text-accent-text"
                 >
                   {context.kind === 'skill' ? (
                     <Sparkles className="size-3 shrink-0" aria-hidden />
-                  ) : (
+                  ) : context.kind === 'file' ? (
                     <File className="size-3 shrink-0" aria-hidden />
+                  ) : (
+                    <MousePointerClick className="size-3 shrink-0" aria-hidden />
                   )}
-                  <span className="truncate">
-                    {context.kind === 'skill' ? `/${context.name}` : context.path}
-                  </span>
+                  <span className="truncate">{chipLabel(context)}</span>
                   <button
                     type="button"
-                    aria-label={`Remove ${context.kind === 'skill' ? `/${context.name}` : context.path}`}
-                    onClick={() =>
+                    aria-label={`Remove ${chipLabel(context)}`}
+                    onClick={() => {
                       setPendingContexts((prev) => removeContext(prev, contextKey(context)))
-                    }
+                      if (context.kind === 'element' && context.imageId) {
+                        removeImage(context.imageId)
+                      }
+                    }}
                     className="inline-flex size-3.5 shrink-0 items-center justify-center rounded-sm text-accent-text outline-none hover:bg-[var(--accent-tint-border)]"
                   >
                     <X className="size-3" aria-hidden />

--- a/src/renderer/src/conversation/Composer.tsx
+++ b/src/renderer/src/conversation/Composer.tsx
@@ -8,7 +8,7 @@ import {
   type JSX,
   type KeyboardEvent,
 } from 'react'
-import { ArrowUp, Mic, Plus, Sparkles, Square, X } from 'lucide-react'
+import { ArrowUp, File, Mic, Plus, Sparkles, Square, X } from 'lucide-react'
 import type {
   FileEntry,
   ThreadConfigAxis,
@@ -23,7 +23,6 @@ import { Textarea } from '../ui/textarea'
 import type { AcpCommand } from './reducer'
 import { getDraft, setDraft as persistDraft, clearDraft } from './composer-draft-store'
 import {
-  appendMention,
   appendText,
   subscribeComposerInsert,
   subscribeComposerInsertImage,
@@ -168,18 +167,16 @@ export function Composer({
     setPendingContexts((prev) => addContext(prev, context)),
   )
 
-  // Insert `@path` from the Files preview's action (#189): the side panel is a sibling of
-  // this view, so it reaches the composer through the module-level `composer-insert` channel
-  // keyed by threadId. We append to the CURRENT persisted draft (kept in lockstep with
-  // `draft` state on every keystroke below), then write state + persisted draft together —
-  // the same write-through the textarea's onChange uses. Plain text only: the agent expands
-  // `@path` itself (ADR-0002).
+  // Insert from the Files preview's action (#189): the side panel is a sibling of this
+  // view, so it reaches the composer through the module-level `composer-insert` channel
+  // keyed by threadId. The path stages as a pending-context FILE chip (#230) — same as an
+  // `@` autocomplete accept — and is re-serialized to a plain-text `@path` mention at send
+  // (the agent expands it itself, ADR-0002).
   useEffect(() => {
     return subscribeComposerInsert(threadId, (relativePath) => {
-      writeDraft(appendMention(getDraft(window.localStorage, threadId), relativePath))
+      setPendingContexts((prev) => addContext(prev, { kind: 'file', path: relativePath }))
       inputRef.current?.focus()
     })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [threadId])
 
   // Insert RAW text from the Terminal Surface's "Add to chat" (ADR-0014 slice 4): the
@@ -352,24 +349,31 @@ export function Composer({
           )}
 
           {pendingContexts.length > 0 && (
-            // Pending-context chip row (#229): the structured attachments staged beside
-            // the draft — mirrors the sent-turn invocation chip (PR #213) with a ✕ remove.
+            // Pending-context chip row (#229/#230): the structured attachments staged
+            // beside the draft — mirrors the sent-turn chips with a ✕ remove per chip.
             <div className="mb-3 flex flex-wrap gap-2">
               {pendingContexts.map((context) => (
                 <span
                   key={contextKey(context)}
                   data-pending-context-chip
-                  title={context.description}
-                  className="inline-flex items-center gap-1 rounded-md border border-[var(--accent-tint-border)] bg-[var(--accent-tint)] py-0.5 pr-1 pl-1.5 font-mono text-xs leading-none text-accent-text"
+                  title={context.kind === 'skill' ? context.description : context.path}
+                  className="inline-flex max-w-full items-center gap-1 rounded-md border border-[var(--accent-tint-border)] bg-[var(--accent-tint)] py-0.5 pr-1 pl-1.5 font-mono text-xs leading-none text-accent-text"
                 >
-                  <Sparkles className="size-3 shrink-0" aria-hidden />/{context.name}
+                  {context.kind === 'skill' ? (
+                    <Sparkles className="size-3 shrink-0" aria-hidden />
+                  ) : (
+                    <File className="size-3 shrink-0" aria-hidden />
+                  )}
+                  <span className="truncate">
+                    {context.kind === 'skill' ? `/${context.name}` : context.path}
+                  </span>
                   <button
                     type="button"
-                    aria-label={`Remove /${context.name}`}
+                    aria-label={`Remove ${context.kind === 'skill' ? `/${context.name}` : context.path}`}
                     onClick={() =>
                       setPendingContexts((prev) => removeContext(prev, contextKey(context)))
                     }
-                    className="inline-flex size-3.5 items-center justify-center rounded-sm text-accent-text outline-none hover:bg-[var(--accent-tint-border)]"
+                    className="inline-flex size-3.5 shrink-0 items-center justify-center rounded-sm text-accent-text outline-none hover:bg-[var(--accent-tint-border)]"
                   >
                     <X className="size-3" aria-hidden />
                   </button>

--- a/src/renderer/src/conversation/command-autocomplete.test.ts
+++ b/src/renderer/src/conversation/command-autocomplete.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import {
-  applyCommand,
   filterCommands,
   getCommandQuery,
   matchInvokedCommand,
   moveSelection,
+  removeCommandToken,
 } from './command-autocomplete'
 import type { AcpCommand } from './reducer'
 
@@ -102,29 +102,6 @@ describe('filterCommands — prefix then substring, case-insensitive', () => {
   })
 })
 
-describe('applyCommand — insertion transform', () => {
-  it('replaces the `/query` token with `/<name> ` and places the caret after', () => {
-    expect(applyCommand('/re', 0, 3, 'rewind')).toEqual({ value: '/rewind ', caret: 8 })
-  })
-
-  it('expands a bare slash', () => {
-    expect(applyCommand('/', 0, 1, 'init')).toEqual({ value: '/init ', caret: 6 })
-  })
-
-  it('keeps text after the caret intact', () => {
-    // Accepting at the start line of a two-line draft keeps the second line.
-    const out = applyCommand('/re\nkeep', 0, 3, 'review')
-    expect(out.value).toBe('/review \nkeep')
-    expect(out.caret).toBe(8)
-  })
-
-  it('applies to a token that starts mid-value (a later line)', () => {
-    const out = applyCommand('hi\n/re', 3, 6, 'rewind')
-    expect(out.value).toBe('hi\n/rewind ')
-    expect(out.caret).toBe(11)
-  })
-})
-
 describe('moveSelection — wrapping', () => {
   it('advances within range', () => {
     expect(moveSelection(0, 3, 1)).toBe(1)
@@ -187,5 +164,19 @@ describe('matchInvokedCommand — sent-message skill/command detection', () => {
 
   it('splits the name on any whitespace, including a newline', () => {
     expect(matchInvokedCommand('/init\ndo it', COMMANDS)?.name).toBe('init')
+  })
+})
+
+describe('removeCommandToken — chip-accept transform (#229)', () => {
+  it('removes the `/query` token and rests the caret where it began', () => {
+    expect(removeCommandToken('/tea', 0, 4)).toEqual({ value: '', caret: 0 })
+  })
+
+  it('keeps text after the caret intact', () => {
+    expect(removeCommandToken('/re\nkeep', 0, 3)).toEqual({ value: '\nkeep', caret: 0 })
+  })
+
+  it('removes a token that starts mid-value (a later line)', () => {
+    expect(removeCommandToken('hi\n/re', 3, 6)).toEqual({ value: 'hi\n', caret: 3 })
   })
 })

--- a/src/renderer/src/conversation/command-autocomplete.ts
+++ b/src/renderer/src/conversation/command-autocomplete.ts
@@ -20,7 +20,7 @@ import type { AcpCommand } from './reducer'
  * The result of probing the composer value + caret for an active `/` trigger.
  * `active` gates the popover; `query` is the text after the `/` up to the caret
  * (lower-cased matching happens in `filterCommands`); `start` is the index of the
- * `/` so `applyCommand` knows where the token begins.
+ * `/` so `removeCommandToken` knows where the token begins.
  */
 export interface CommandTrigger {
   active: boolean
@@ -82,20 +82,13 @@ export interface CommandInsertion {
 }
 
 /**
- * Replace the `/query` token (from `start` up to `caret`) with `/<name> ` — a
- * trailing space so the user types the command's argument straight after — and
- * report the caret position just past that space. Text after the caret is kept, so
- * accepting mid-line splices the command in without eating what follows.
+ * Remove the `/query` token (from `start` up to `caret`) outright — the chip-accept
+ * transform (#229): the accepted skill becomes a pending-context chip BESIDE the text,
+ * so nothing is spliced in. Text after the caret is kept; the caret rests where the
+ * token began.
  */
-export function applyCommand(
-  value: string,
-  start: number,
-  caret: number,
-  name: string,
-): CommandInsertion {
-  const insert = `/${name} `
-  const nextValue = value.slice(0, start) + insert + value.slice(caret)
-  return { value: nextValue, caret: start + insert.length }
+export function removeCommandToken(value: string, start: number, caret: number): CommandInsertion {
+  return { value: value.slice(0, start) + value.slice(caret), caret: start }
 }
 
 /**

--- a/src/renderer/src/conversation/composer-insert.test.ts
+++ b/src/renderer/src/conversation/composer-insert.test.ts
@@ -2,11 +2,12 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   appendText,
   emitComposerInsert,
-  emitComposerInsertImage,
+  emitComposerInsertElement,
   emitComposerInsertText,
   subscribeComposerInsert,
-  subscribeComposerInsertImage,
+  subscribeComposerInsertElement,
   subscribeComposerInsertText,
+  type ComposerInsertElement,
   type ComposerInsertImage,
 } from './composer-insert'
 
@@ -32,6 +33,37 @@ describe('composer-insert channel', () => {
     const off = subscribeComposerInsert('thread-a', listener)
     off()
     emitComposerInsert('thread-a', 'x.ts')
+    expect(listener).not.toHaveBeenCalled()
+  })
+})
+
+describe('composer-insert ELEMENT channel (#231 pick-to-chat)', () => {
+  it('delivers the pick payload — element metadata + optional screenshot — to the Thread\'s subscriber', () => {
+    const listener = vi.fn()
+    const off = subscribeComposerInsertElement('thread-a', listener)
+    const payload: ComposerInsertElement = {
+      element: { tagName: 'button', selector: '#go', text: 'Go', pageUrl: 'http://localhost:3000/' },
+      image: null,
+    }
+    emitComposerInsertElement('thread-a', payload)
+    expect(listener).toHaveBeenCalledWith(payload)
+    off()
+  })
+
+  it('is a no-op without a subscriber and stops after unsubscribe', () => {
+    const listener = vi.fn()
+    expect(() =>
+      emitComposerInsertElement('nobody', {
+        element: { tagName: 'div', selector: null, text: '', pageUrl: 'x' },
+        image: null,
+      }),
+    ).not.toThrow()
+    const off = subscribeComposerInsertElement('thread-a', listener)
+    off()
+    emitComposerInsertElement('thread-a', {
+      element: { tagName: 'div', selector: null, text: '', pageUrl: 'x' },
+      image: null,
+    })
     expect(listener).not.toHaveBeenCalled()
   })
 })
@@ -76,46 +108,44 @@ describe('composer-insert TEXT channel (raw)', () => {
   })
 })
 
-describe('composer-insert IMAGE channel (#224 element picker)', () => {
+describe('composer-insert ELEMENT channel — screenshot payload riding along', () => {
   const img: ComposerInsertImage = {
     data: 'AAAA',
     mimeType: 'image/png',
-    name: 'picked-element.png',
+    name: 'element-button.png',
     previewUrl: 'data:image/png;base64,AAAA',
   }
 
-  it('delivers an image payload to the Thread\'s subscriber, isolated from text/mention', () => {
-    const image = vi.fn()
+  it('delivers the screenshot inside the pick payload, isolated from the text channel', () => {
+    const element = vi.fn()
     const text = vi.fn()
-    const offImage = subscribeComposerInsertImage('thread-a', image)
+    const offElement = subscribeComposerInsertElement('thread-a', element)
     const offText = subscribeComposerInsertText('thread-a', text)
 
-    emitComposerInsertImage('thread-a', img)
-    expect(image).toHaveBeenCalledWith(img)
+    const payload: ComposerInsertElement = {
+      element: { tagName: 'button', selector: '#go', text: 'Go', pageUrl: 'http://localhost:3000/' },
+      image: img,
+    }
+    emitComposerInsertElement('thread-a', payload)
+    expect(element).toHaveBeenCalledWith(payload)
     expect(text).not.toHaveBeenCalled() // separate channel
 
-    offImage()
+    offElement()
     offText()
   })
 
   it('delivers only to the target Thread', () => {
     const a = vi.fn()
     const b = vi.fn()
-    const offA = subscribeComposerInsertImage('thread-a', a)
-    const offB = subscribeComposerInsertImage('thread-b', b)
-    emitComposerInsertImage('thread-a', img)
-    expect(a).toHaveBeenCalledWith(img)
+    const offA = subscribeComposerInsertElement('thread-a', a)
+    const offB = subscribeComposerInsertElement('thread-b', b)
+    emitComposerInsertElement('thread-a', {
+      element: { tagName: 'div', selector: null, text: '', pageUrl: 'x' },
+      image: img,
+    })
+    expect(a).toHaveBeenCalled()
     expect(b).not.toHaveBeenCalled()
     offA()
     offB()
-  })
-
-  it('is a no-op with no subscriber, and stops after unsubscribe', () => {
-    expect(() => emitComposerInsertImage('nobody', img)).not.toThrow()
-    const listener = vi.fn()
-    const off = subscribeComposerInsertImage('thread-a', listener)
-    off()
-    emitComposerInsertImage('thread-a', img)
-    expect(listener).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/conversation/composer-insert.test.ts
+++ b/src/renderer/src/conversation/composer-insert.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
-  appendMention,
   appendText,
   emitComposerInsert,
   emitComposerInsertImage,
@@ -10,21 +9,6 @@ import {
   subscribeComposerInsertText,
   type ComposerInsertImage,
 } from './composer-insert'
-
-describe('appendMention', () => {
-  it('inserts into an empty draft with a trailing space', () => {
-    expect(appendMention('', 'src/app.ts')).toBe('@src/app.ts ')
-  })
-
-  it('adds a separating space when the draft does not end in whitespace', () => {
-    expect(appendMention('see', 'src/app.ts')).toBe('see @src/app.ts ')
-  })
-
-  it('does not double the space when the draft already ends in whitespace', () => {
-    expect(appendMention('see ', 'src/app.ts')).toBe('see @src/app.ts ')
-    expect(appendMention('see\n', 'src/app.ts')).toBe('see\n@src/app.ts ')
-  })
-})
 
 describe('composer-insert channel', () => {
   it('delivers an emit to the subscriber for that Thread only', () => {

--- a/src/renderer/src/conversation/composer-insert.ts
+++ b/src/renderer/src/conversation/composer-insert.ts
@@ -1,11 +1,11 @@
 /**
- * A tiny module-level channel for the Files preview's "Insert @path into composer" action (#189,
+ * A tiny module-level channel for the Files preview's "Insert into composer" action (#189,
  * ADR-0013 decision 2). The preview lives in the side panel — a SIBLING of the conversation, not
  * a parent — so it can't reach the composer through props/context. Instead it EMITS an insert for
  * a Thread id here; the mounted `Conversation` for that Thread SUBSCRIBES (keyed by its own
- * `threadId`) and appends the plain-text `@path` to its draft (which stays in lockstep with the
- * #60 composer-draft store). Renderer-only, no IPC: the wire format is untouched — the agent
- * expands the plain-text `@path` itself server-side (ADR-0002; we add no client-side expansion).
+ * `threadId`) and stages the path as a pending-context FILE chip (#230), re-serialized to a
+ * plain-text `@path` mention at send. Renderer-only, no IPC: the wire format is untouched — the
+ * agent expands the plain-text `@path` itself server-side (ADR-0002; no client-side expansion).
  *
  * If no composer is mounted for the target Thread (e.g. the active Thread is a cold replay), the
  * emit is a harmless no-op — there is no subscriber to receive it. Reveal-in-Finder does not go
@@ -33,19 +33,6 @@ const listenersByThread = new Map<string, Set<InsertListener>>()
 const textListenersByThread = new Map<string, Set<InsertListener>>()
 const imageListenersByThread = new Map<string, Set<ImageListener>>()
 
-/**
- * Append a plain-text `@path` reference to `draft`, keeping it space-separated: a trailing space
- * is added after the mention (so the next token starts clean), and a separating space is inserted
- * before it unless the draft is empty or already ends in whitespace. Pure — the composer computes
- * the next value with this, then writes state + persisted draft together.
- */
-export function appendMention(draft: string, relativePath: string): string {
-  const mention = `@${relativePath}`
-  if (draft.length === 0) return `${mention} `
-  const separator = /\s$/.test(draft) ? '' : ' '
-  return `${draft}${separator}${mention} `
-}
-
 /** Subscribe a Thread's composer to insert requests; returns an unsubscribe. */
 export function subscribeComposerInsert(threadId: string, listener: InsertListener): () => void {
   let set = listenersByThread.get(threadId)
@@ -71,8 +58,8 @@ export function emitComposerInsert(threadId: string, relativePath: string): void
 
 /**
  * Append RAW text to `draft` (the Terminal Surface's "Add to chat", ADR-0014 slice 4):
- * unlike {@link appendMention} there is no `@` prefix and no forced trailing space — the
- * selection is inserted verbatim. A newline separates it from prior draft content
+ * no `@` prefix, no chip, no forced trailing space — the selection is inserted verbatim
+ * (deliberately NOT a pending-context chip, #230). A newline separates it from prior draft content
  * (terminal selections are often multi-line), unless the draft is empty or already ends
  * in whitespace. Pure — the composer writes state + persisted draft together with the result.
  */

--- a/src/renderer/src/conversation/composer-insert.ts
+++ b/src/renderer/src/conversation/composer-insert.ts
@@ -27,11 +27,48 @@ export interface ComposerInsertImage {
   previewUrl: string
 }
 
-type ImageListener = (image: ComposerInsertImage) => void
+/**
+ * A Browser Surface element pick to stage in a Thread's composer (#231): the picker's DOM
+ * metadata plus the optional cropped screenshot, delivered as ONE payload so the composer
+ * can pair the element chip to its staged image atomically (removing the chip removes the
+ * screenshot). The composer mints the chip/image ids.
+ */
+export interface ComposerInsertElement {
+  element: { tagName: string; selector: string | null; text: string; pageUrl: string }
+  image: ComposerInsertImage | null
+}
+
+type ElementListener = (payload: ComposerInsertElement) => void
 
 const listenersByThread = new Map<string, Set<InsertListener>>()
 const textListenersByThread = new Map<string, Set<InsertListener>>()
-const imageListenersByThread = new Map<string, Set<ImageListener>>()
+const elementListenersByThread = new Map<string, Set<ElementListener>>()
+
+/** Subscribe a Thread's composer to element-pick payloads (#231); returns an unsubscribe. */
+export function subscribeComposerInsertElement(
+  threadId: string,
+  listener: ElementListener,
+): () => void {
+  let set = elementListenersByThread.get(threadId)
+  if (!set) {
+    set = new Set()
+    elementListenersByThread.set(threadId, set)
+  }
+  set.add(listener)
+  return () => {
+    const current = elementListenersByThread.get(threadId)
+    if (!current) return
+    current.delete(listener)
+    if (current.size === 0) elementListenersByThread.delete(threadId)
+  }
+}
+
+/** Deliver a Browser Surface pick to the Thread's composer; a no-op if none is mounted. */
+export function emitComposerInsertElement(threadId: string, payload: ComposerInsertElement): void {
+  const set = elementListenersByThread.get(threadId)
+  if (!set) return
+  for (const listener of set) listener(payload)
+}
 
 /** Subscribe a Thread's composer to insert requests; returns an unsubscribe. */
 export function subscribeComposerInsert(threadId: string, listener: InsertListener): () => void {
@@ -92,30 +129,3 @@ export function emitComposerInsertText(threadId: string, text: string): void {
   for (const listener of set) listener(text)
 }
 
-/**
- * Subscribe a Thread's composer to IMAGE insert requests (#224): the Browser Surface's
- * element picker stages a screenshot as a pending image through here — a side-panel
- * sibling reaching the composer, keyed by threadId, exactly like the text/@ channels.
- * Returns an unsubscribe.
- */
-export function subscribeComposerInsertImage(threadId: string, listener: ImageListener): () => void {
-  let set = imageListenersByThread.get(threadId)
-  if (!set) {
-    set = new Set()
-    imageListenersByThread.set(threadId, set)
-  }
-  set.add(listener)
-  return () => {
-    const current = imageListenersByThread.get(threadId)
-    if (!current) return
-    current.delete(listener)
-    if (current.size === 0) imageListenersByThread.delete(threadId)
-  }
-}
-
-/** Request the given Thread's composer stage `image`; a no-op if none is mounted. */
-export function emitComposerInsertImage(threadId: string, image: ComposerInsertImage): void {
-  const set = imageListenersByThread.get(threadId)
-  if (!set) return
-  for (const listener of set) listener(image)
-}

--- a/src/renderer/src/conversation/composer-sources.tsx
+++ b/src/renderer/src/conversation/composer-sources.tsx
@@ -2,7 +2,7 @@ import { File, Folder } from 'lucide-react'
 import type { FileEntry } from '../../../shared/ipc'
 import type { AcpCommand } from './reducer'
 import { filterCommands, getCommandQuery, removeCommandToken } from './command-autocomplete'
-import { applyPath, filterPaths, getPathQuery } from './path-autocomplete'
+import { applyPath, filterPaths, getPathQuery, removePathToken } from './path-autocomplete'
 import type { CompletionSource } from './use-composer-autocomplete'
 
 /**
@@ -51,9 +51,11 @@ export function createCommandSource(commands: readonly AcpCommand[]): Completion
 }
 
 /**
- * The `@` file-path source (#190): mid-sentence, closes on a FILE (trailing space) but
- * REOPENS on a DIRECTORY (trailing slash) so completion drills into it. `onOpen` kicks the
- * lazy `files:list` fetch on first trigger. Rows show a dir/file icon + the relative path.
+ * The `@` file-path source (#190): mid-sentence. Accepting a FILE stages it as a
+ * pending-context CHIP (#230) — token removed, chip rides back through `apply`'s
+ * `context`, the `@path` mention re-serialized at send. Accepting a DIRECTORY keeps
+ * today's in-text drill-down (trailing slash re-derives the trigger into it). `onOpen`
+ * kicks the lazy `files:list` fetch on first trigger. Rows show a dir/file icon + path.
  */
 export function createPathSource({
   entries,
@@ -74,7 +76,10 @@ export function createPathSource({
       return filterPaths(entries, query)
     },
     rowKey: (entry) => entry.path,
-    apply: (value, start, caret, entry) => applyPath(value, start, caret, entry),
+    apply: (value, start, caret, entry) =>
+      entry.kind === 'directory'
+        ? applyPath(value, start, caret, entry)
+        : { ...removePathToken(value, start, caret), context: { kind: 'file', path: entry.path } },
     closeOnAccept: (entry) => entry.kind !== 'directory',
     onOpen: onFirstOpen,
     renderRow: (entry) => (

--- a/src/renderer/src/conversation/composer-sources.tsx
+++ b/src/renderer/src/conversation/composer-sources.tsx
@@ -1,7 +1,7 @@
 import { File, Folder } from 'lucide-react'
 import type { FileEntry } from '../../../shared/ipc'
 import type { AcpCommand } from './reducer'
-import { applyCommand, filterCommands, getCommandQuery } from './command-autocomplete'
+import { filterCommands, getCommandQuery, removeCommandToken } from './command-autocomplete'
 import { applyPath, filterPaths, getPathQuery } from './path-autocomplete'
 import type { CompletionSource } from './use-composer-autocomplete'
 
@@ -14,8 +14,10 @@ import type { CompletionSource } from './use-composer-autocomplete'
  */
 
 /**
- * The `/` slash-command source (#95): start-anchored, always closes on accept (a command
- * gets a trailing space, never re-derives). Rows show `/name` + an optional description.
+ * The `/` slash-command source (#95): start-anchored, always closes on accept. Accepting
+ * stages the skill as a pending-context CHIP (#229) — the trigger token is removed from
+ * the text and the chip rides back through `apply`'s `context`; the invocation is
+ * re-prepended to the wire text at send. Rows show `/name` + an optional description.
  */
 export function createCommandSource(commands: readonly AcpCommand[]): CompletionSource<AcpCommand> {
   return {
@@ -30,7 +32,10 @@ export function createCommandSource(commands: readonly AcpCommand[]): Completion
       return filterCommands(commands as AcpCommand[], query)
     },
     rowKey: (command) => command.name,
-    apply: (value, start, caret, command) => applyCommand(value, start, caret, command.name),
+    apply: (value, start, caret, command) => ({
+      ...removeCommandToken(value, start, caret),
+      context: { kind: 'skill', name: command.name, description: command.description },
+    }),
     closeOnAccept: () => true,
     renderRow: (command) => (
       <>

--- a/src/renderer/src/conversation/items/message-rows.tsx
+++ b/src/renderer/src/conversation/items/message-rows.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useRef, useState, type JSX } from 'react'
-import { Check, Copy, RotateCcw, Sparkles, ThumbsDown, ThumbsUp } from 'lucide-react'
+import { Check, Copy, File, RotateCcw, Sparkles, ThumbsDown, ThumbsUp } from 'lucide-react'
 import { IconButton } from '../../ui/icon-button'
 import { Response } from '../Response'
 import { matchInvokedCommand } from '../command-autocomplete'
+import { extractAttachedFiles } from '../pending-contexts'
 import type { AcpCommand, AssistantItem, UserItem } from '../reducer'
 
 export function UserRow({
@@ -13,24 +14,44 @@ export function UserRow({
   /** The session's slash commands/skills — a leading `/name` match renders a chip. */
   availableCommands?: readonly AcpCommand[]
 }): JSX.Element {
+  // Attached-files extraction (#230): a prompt sent with pending file chips carries a
+  // trailing `<attached_files>` marker block; strip it back into chips at RENDER time so
+  // the bubble shows the clean prose — live and on JSONL replay, which ride the same
+  // text. User-typed inline `@path` mentions pass through untouched.
+  const { cleanText, files } = extractAttachedFiles(item.text)
   // Skill/command chip: vibe-acp invokes a skill when the prompt opens with a
   // known `/name`, but gives NO wire-level acknowledgment — so we surface the
   // match ourselves. Matched at RENDER time against the CURRENT list (not stamped
   // at send): a draft's first prompt is sent before `available_commands_update`
   // streams, so the chip appears retroactively once the list arrives.
-  const command = matchInvokedCommand(item.text, availableCommands ?? [])
+  const command = matchInvokedCommand(cleanText, availableCommands ?? [])
   // User turn (#114): a right-aligned rounded bubble, capped so long prose wraps
   // instead of spanning the pane. Echoed attachments (#100) re-home into the bubble.
   return (
     <div className="flex flex-col items-end gap-1.5">
-      {command && (
-        <span
-          data-command-chip
-          title={command.description}
-          className="inline-flex items-center gap-1 rounded-md border border-[var(--accent-tint-border)] bg-[var(--accent-tint)] px-1.5 py-0.5 font-mono text-xs leading-none text-accent-text"
-        >
-          <Sparkles className="size-3 shrink-0" aria-hidden />/{command.name}
-        </span>
+      {(command || files.length > 0) && (
+        <div className="flex max-w-[80%] flex-wrap justify-end gap-1.5">
+          {command && (
+            <span
+              data-command-chip
+              title={command.description}
+              className="inline-flex items-center gap-1 rounded-md border border-[var(--accent-tint-border)] bg-[var(--accent-tint)] px-1.5 py-0.5 font-mono text-xs leading-none text-accent-text"
+            >
+              <Sparkles className="size-3 shrink-0" aria-hidden />/{command.name}
+            </span>
+          )}
+          {files.map((file) => (
+            <span
+              key={file.path}
+              data-file-chip
+              title={file.path}
+              className="inline-flex max-w-full items-center gap-1 rounded-md border border-[var(--accent-tint-border)] bg-[var(--accent-tint)] px-1.5 py-0.5 font-mono text-xs leading-none text-accent-text"
+            >
+              <File className="size-3 shrink-0" aria-hidden />
+              <span className="truncate">{file.path}</span>
+            </span>
+          ))}
+        </div>
       )}
       <div className="max-w-[80%] rounded-2xl border border-border bg-surface px-3.5 py-2.5 text-[15px] leading-relaxed break-words whitespace-pre-wrap text-text-body">
         {item.images && item.images.length > 0 && (
@@ -45,7 +66,7 @@ export function UserRow({
             ))}
           </div>
         )}
-        {item.text}
+        {cleanText}
       </div>
     </div>
   )

--- a/src/renderer/src/conversation/items/message-rows.tsx
+++ b/src/renderer/src/conversation/items/message-rows.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useRef, useState, type JSX } from 'react'
-import { Check, Copy, File, RotateCcw, Sparkles, ThumbsDown, ThumbsUp } from 'lucide-react'
+import { Check, Copy, File, MousePointerClick, RotateCcw, Sparkles, ThumbsDown, ThumbsUp } from 'lucide-react'
 import { IconButton } from '../../ui/icon-button'
 import { Response } from '../Response'
 import { matchInvokedCommand } from '../command-autocomplete'
-import { extractAttachedFiles } from '../pending-contexts'
+import { extractPromptContexts } from '../pending-contexts'
 import type { AcpCommand, AssistantItem, UserItem } from '../reducer'
 
 export function UserRow({
@@ -14,11 +14,11 @@ export function UserRow({
   /** The session's slash commands/skills — a leading `/name` match renders a chip. */
   availableCommands?: readonly AcpCommand[]
 }): JSX.Element {
-  // Attached-files extraction (#230): a prompt sent with pending file chips carries a
-  // trailing `<attached_files>` marker block; strip it back into chips at RENDER time so
-  // the bubble shows the clean prose — live and on JSONL replay, which ride the same
-  // text. User-typed inline `@path` mentions pass through untouched.
-  const { cleanText, files } = extractAttachedFiles(item.text)
+  // Context extraction (#230/#231): a prompt sent with pending chips carries trailing
+  // `<attached_files>` / `<element_context>` marker blocks; strip them back into chips at
+  // RENDER time so the bubble shows the clean prose — live and on JSONL replay, which
+  // ride the same text. User-typed inline `@path` mentions pass through untouched.
+  const { cleanText, files, elements } = extractPromptContexts(item.text)
   // Skill/command chip: vibe-acp invokes a skill when the prompt opens with a
   // known `/name`, but gives NO wire-level acknowledgment — so we surface the
   // match ourselves. Matched at RENDER time against the CURRENT list (not stamped
@@ -29,7 +29,7 @@ export function UserRow({
   // instead of spanning the pane. Echoed attachments (#100) re-home into the bubble.
   return (
     <div className="flex flex-col items-end gap-1.5">
-      {(command || files.length > 0) && (
+      {(command || files.length > 0 || elements.length > 0) && (
         <div className="flex max-w-[80%] flex-wrap justify-end gap-1.5">
           {command && (
             <span
@@ -49,6 +49,19 @@ export function UserRow({
             >
               <File className="size-3 shrink-0" aria-hidden />
               <span className="truncate">{file.path}</span>
+            </span>
+          ))}
+          {elements.map((element) => (
+            <span
+              key={element.id}
+              data-element-chip
+              title={[`<${element.tagName}>`, element.selector ?? '', element.text, element.pageUrl]
+                .filter((line) => line.length > 0)
+                .join('\n')}
+              className="inline-flex max-w-full items-center gap-1 rounded-md border border-[var(--accent-tint-border)] bg-[var(--accent-tint)] px-1.5 py-0.5 font-mono text-xs leading-none text-accent-text"
+            >
+              <MousePointerClick className="size-3 shrink-0" aria-hidden />
+              <span className="truncate">{element.selector ?? `<${element.tagName}>`}</span>
             </span>
           ))}
         </div>

--- a/src/renderer/src/conversation/path-autocomplete.test.ts
+++ b/src/renderer/src/conversation/path-autocomplete.test.ts
@@ -4,6 +4,7 @@ import {
   filterPaths,
   getPathQuery,
   moveSelection,
+  removePathToken,
   MAX_PATH_RESULTS,
 } from './path-autocomplete'
 import type { FileEntry } from '../../../shared/ipc'
@@ -155,6 +156,16 @@ describe('applyPath — plain-text insertion transform', () => {
     const out = applyPath('see @sr done', 4, 7, { path: 'src', kind: 'directory' })
     expect(out.value).toBe('see @src/ done')
     expect(out.caret).toBe(9)
+  })
+})
+
+describe('removePathToken — chip-accept transform (#230)', () => {
+  it('removes the `@query` token and rests the caret where it began', () => {
+    expect(removePathToken('@re', 0, 3)).toEqual({ value: '', caret: 0 })
+  })
+
+  it('removes a mid-sentence token, keeping text either side intact', () => {
+    expect(removePathToken('see @re done', 4, 7)).toEqual({ value: 'see  done', caret: 4 })
   })
 })
 

--- a/src/renderer/src/conversation/path-autocomplete.ts
+++ b/src/renderer/src/conversation/path-autocomplete.ts
@@ -128,3 +128,13 @@ export function applyPath(
   const nextValue = value.slice(0, start) + insert + value.slice(caret)
   return { value: nextValue, caret: start + insert.length }
 }
+
+/**
+ * Remove the `@query` token (from `start` up to `caret`) outright — the chip-accept
+ * transform (#230): an accepted FILE becomes a pending-context chip beside the text
+ * (a directory still drills down in-text via {@link applyPath}). Text after the caret
+ * is kept; the caret rests where the token began.
+ */
+export function removePathToken(value: string, start: number, caret: number): PathInsertion {
+  return { value: value.slice(0, start) + value.slice(caret), caret: start }
+}

--- a/src/renderer/src/conversation/pending-contexts.test.ts
+++ b/src/renderer/src/conversation/pending-contexts.test.ts
@@ -3,6 +3,7 @@ import {
   addContext,
   contextKey,
   extractAttachedFiles,
+  extractPromptContexts,
   removeContext,
   serializeForSend,
   type PendingContext,
@@ -12,6 +13,15 @@ const teach: PendingContext = { kind: 'skill', name: 'teach', description: 'Teac
 const review: PendingContext = { kind: 'skill', name: 'review' }
 const reducerFile: PendingContext = { kind: 'file', path: 'src/renderer/src/conversation/reducer.ts' }
 const composerFile: PendingContext = { kind: 'file', path: 'src/renderer/src/conversation/Composer.tsx' }
+const button: PendingContext = {
+  kind: 'element',
+  id: 'el:1',
+  tagName: 'button',
+  selector: '#submit',
+  text: 'Sign  in\nnow',
+  pageUrl: 'http://localhost:3000/login',
+  imageId: 'img:0',
+}
 
 describe('serializeForSend', () => {
   it('prepends the skill invocation to the prose', () => {
@@ -44,6 +54,27 @@ describe('serializeForSend', () => {
       '/teach explain this\n\n<attached_files>\n@src/renderer/src/conversation/reducer.ts\n</attached_files>',
     )
   })
+
+  it('appends a picked element as a trailing element_context block, whitespace-normalized', () => {
+    expect(serializeForSend('style this', [button])).toBe(
+      'style this\n\n<element_context>\nPicked element <button>\nselector: #submit\ntext: Sign in now\nhttp://localhost:3000/login\n</element_context>',
+    )
+  })
+
+  it('omits absent selector/text lines and places the element block AFTER the files block', () => {
+    const bare: PendingContext = {
+      kind: 'element',
+      id: 'el:2',
+      tagName: 'div',
+      selector: null,
+      text: '',
+      pageUrl: 'http://localhost:5173/',
+      imageId: null,
+    }
+    expect(serializeForSend('', [bare, reducerFile])).toBe(
+      '<attached_files>\n@src/renderer/src/conversation/reducer.ts\n</attached_files>\n\n<element_context>\nPicked element <div>\nhttp://localhost:5173/\n</element_context>',
+    )
+  })
 })
 
 describe('extractAttachedFiles — display mirror of serializeForSend', () => {
@@ -70,6 +101,52 @@ describe('extractAttachedFiles — display mirror of serializeForSend', () => {
   it('keeps a leading invocation in the clean text (the #213 chip matches it there)', () => {
     const wire = serializeForSend('explain', [teach, reducerFile])
     expect(extractAttachedFiles(wire).cleanText).toBe('/teach explain')
+  })
+})
+
+describe('extractPromptContexts — display mirror for the full payload', () => {
+  it('round-trips a prompt carrying files AND elements back into chips', () => {
+    const wire = serializeForSend('style this', [teach, reducerFile, button])
+    expect(extractPromptContexts(wire)).toEqual({
+      cleanText: '/teach style this',
+      files: [reducerFile],
+      elements: [
+        {
+          kind: 'element',
+          id: 'el-extract:0',
+          tagName: 'button',
+          selector: '#submit',
+          text: 'Sign in now',
+          pageUrl: 'http://localhost:3000/login',
+          imageId: null,
+        },
+      ],
+    })
+  })
+
+  it('recovers multiple picked elements from one block', () => {
+    const second: PendingContext = {
+      kind: 'element',
+      id: 'el:9',
+      tagName: 'nav',
+      selector: null,
+      text: '',
+      pageUrl: 'http://localhost:3000/',
+      imageId: null,
+    }
+    const { elements } = extractPromptContexts(serializeForSend('', [button, second]))
+    expect(elements.map((e) => [e.tagName, e.selector, e.pageUrl])).toEqual([
+      ['button', '#submit', 'http://localhost:3000/login'],
+      ['nav', null, 'http://localhost:3000/'],
+    ])
+  })
+
+  it('leaves a prompt without marker blocks untouched', () => {
+    expect(extractPromptContexts('just prose with @src/typed.ts')).toEqual({
+      cleanText: 'just prose with @src/typed.ts',
+      files: [],
+      elements: [],
+    })
   })
 })
 

--- a/src/renderer/src/conversation/pending-contexts.test.ts
+++ b/src/renderer/src/conversation/pending-contexts.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import {
+  addContext,
+  contextKey,
+  removeContext,
+  serializeForSend,
+  type PendingContext,
+} from './pending-contexts'
+
+const teach: PendingContext = { kind: 'skill', name: 'teach', description: 'Teach mode' }
+const review: PendingContext = { kind: 'skill', name: 'review' }
+
+describe('serializeForSend', () => {
+  it('prepends the skill invocation to the prose', () => {
+    expect(serializeForSend('explain closures', [teach])).toBe('/teach explain closures')
+  })
+
+  it('sends a bare invocation when there is no prose', () => {
+    expect(serializeForSend('', [teach])).toBe('/teach')
+    expect(serializeForSend('   ', [teach])).toBe('/teach')
+  })
+
+  it('passes the prose through untouched when nothing is staged', () => {
+    expect(serializeForSend('fix the login bug', [])).toBe('fix the login bug')
+  })
+})
+
+describe('addContext', () => {
+  it('replaces an already-staged skill — the agent only honors one leading invocation', () => {
+    const staged = addContext([], teach)
+    expect(addContext(staged, review)).toEqual([review])
+  })
+})
+
+describe('removeContext', () => {
+  it('removes the chip whose key matches, leaving the rest', () => {
+    const staged = addContext([], teach)
+    expect(removeContext(staged, contextKey(teach))).toEqual([])
+    expect(removeContext(staged, contextKey(review))).toEqual(staged)
+  })
+})

--- a/src/renderer/src/conversation/pending-contexts.test.ts
+++ b/src/renderer/src/conversation/pending-contexts.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   addContext,
   contextKey,
+  extractAttachedFiles,
   removeContext,
   serializeForSend,
   type PendingContext,
@@ -9,6 +10,8 @@ import {
 
 const teach: PendingContext = { kind: 'skill', name: 'teach', description: 'Teach mode' }
 const review: PendingContext = { kind: 'skill', name: 'review' }
+const reducerFile: PendingContext = { kind: 'file', path: 'src/renderer/src/conversation/reducer.ts' }
+const composerFile: PendingContext = { kind: 'file', path: 'src/renderer/src/conversation/Composer.tsx' }
 
 describe('serializeForSend', () => {
   it('prepends the skill invocation to the prose', () => {
@@ -23,12 +26,67 @@ describe('serializeForSend', () => {
   it('passes the prose through untouched when nothing is staged', () => {
     expect(serializeForSend('fix the login bug', [])).toBe('fix the login bug')
   })
+
+  it('appends staged files as an @-mention marker block after the prose', () => {
+    expect(serializeForSend('refactor these', [reducerFile, composerFile])).toBe(
+      'refactor these\n\n<attached_files>\n@src/renderer/src/conversation/reducer.ts\n@src/renderer/src/conversation/Composer.tsx\n</attached_files>',
+    )
+  })
+
+  it('sends a bare marker block when there is no prose', () => {
+    expect(serializeForSend('', [reducerFile])).toBe(
+      '<attached_files>\n@src/renderer/src/conversation/reducer.ts\n</attached_files>',
+    )
+  })
+
+  it('orders a full payload: leading invocation, prose, trailing files', () => {
+    expect(serializeForSend('explain this', [reducerFile, teach])).toBe(
+      '/teach explain this\n\n<attached_files>\n@src/renderer/src/conversation/reducer.ts\n</attached_files>',
+    )
+  })
+})
+
+describe('extractAttachedFiles — display mirror of serializeForSend', () => {
+  it('round-trips: strips the trailing block back into file chips', () => {
+    const wire = serializeForSend('refactor these', [reducerFile, composerFile])
+    expect(extractAttachedFiles(wire)).toEqual({
+      cleanText: 'refactor these',
+      files: [reducerFile, composerFile],
+    })
+  })
+
+  it('leaves a prompt without a block untouched', () => {
+    expect(extractAttachedFiles('plain prompt with @src/typed.ts inline')).toEqual({
+      cleanText: 'plain prompt with @src/typed.ts inline',
+      files: [],
+    })
+  })
+
+  it('only strips a TRAILING block — text after the marker keeps everything intact', () => {
+    const notTrailing = '<attached_files>\n@a.ts\n</attached_files>\nand then more prose'
+    expect(extractAttachedFiles(notTrailing)).toEqual({ cleanText: notTrailing, files: [] })
+  })
+
+  it('keeps a leading invocation in the clean text (the #213 chip matches it there)', () => {
+    const wire = serializeForSend('explain', [teach, reducerFile])
+    expect(extractAttachedFiles(wire).cleanText).toBe('/teach explain')
+  })
 })
 
 describe('addContext', () => {
   it('replaces an already-staged skill — the agent only honors one leading invocation', () => {
     const staged = addContext([], teach)
     expect(addContext(staged, review)).toEqual([review])
+  })
+
+  it('accumulates distinct files and keeps a staged skill', () => {
+    const staged = addContext(addContext(addContext([], teach), reducerFile), composerFile)
+    expect(staged).toEqual([teach, reducerFile, composerFile])
+  })
+
+  it('dedupes a re-selected file path', () => {
+    const staged = addContext(addContext([], reducerFile), reducerFile)
+    expect(staged).toEqual([reducerFile])
   })
 })
 

--- a/src/renderer/src/conversation/pending-contexts.ts
+++ b/src/renderer/src/conversation/pending-contexts.ts
@@ -1,0 +1,54 @@
+/**
+ * Pending-context chips (#229, PRD #228) — the PURE core of the composer's structured
+ * attachments. A context is a chip the user staged BESIDE the draft text (never inline
+ * in it); it flattens into plain prompt text only at send, so the wire stays a plain
+ * `session/prompt` text block (ADR-0002 — the agent parses a leading `/name` itself).
+ * No DOM, no IPC: list operations + the serialize transform, unit-tested as plain data.
+ */
+
+/** A skill invocation staged as a chip — at most one (the agent parses only a LEADING `/name`). */
+export interface SkillContext {
+  kind: 'skill'
+  name: string
+  description?: string
+}
+
+/** A context chip staged in the composer awaiting send. File/element kinds follow (#230/#231). */
+export type PendingContext = SkillContext
+
+/** The stable identity of a chip — the React key and the remove handle. */
+export function contextKey(context: PendingContext): string {
+  return `${context.kind}:${context.name}`
+}
+
+/** Drop the chip whose {@link contextKey} matches; a miss returns the list unchanged. */
+export function removeContext(
+  contexts: readonly PendingContext[],
+  key: string,
+): PendingContext[] {
+  return contexts.filter((c) => contextKey(c) !== key)
+}
+
+/**
+ * Stage a context, returning the new list. A skill REPLACES any staged skill — the
+ * agent parses only the leading `/name`, so the composer never stages an invocation
+ * it can't honor.
+ */
+export function addContext(
+  contexts: readonly PendingContext[],
+  context: PendingContext,
+): PendingContext[] {
+  return [...contexts.filter((c) => c.kind !== context.kind), context]
+}
+
+/**
+ * Flatten the staged contexts into the outgoing prompt text: a skill chip becomes the
+ * leading `/name ` invocation (bare `/name` when there is no prose). The prose itself
+ * is trimmed exactly like the send path trims the draft.
+ */
+export function serializeForSend(text: string, contexts: readonly PendingContext[]): string {
+  const prose = text.trim()
+  const skill = contexts.find((c) => c.kind === 'skill')
+  if (!skill) return prose
+  return prose.length > 0 ? `/${skill.name} ${prose}` : `/${skill.name}`
+}

--- a/src/renderer/src/conversation/pending-contexts.ts
+++ b/src/renderer/src/conversation/pending-contexts.ts
@@ -13,12 +13,18 @@ export interface SkillContext {
   description?: string
 }
 
-/** A context chip staged in the composer awaiting send. File/element kinds follow (#230/#231). */
-export type PendingContext = SkillContext
+/** A Workspace-relative file mention staged as a chip — sent as an `@path` the agent expands. */
+export interface FileContext {
+  kind: 'file'
+  path: string
+}
 
-/** The stable identity of a chip — the React key and the remove handle. */
+/** A context chip staged in the composer awaiting send. The element kind follows (#231). */
+export type PendingContext = SkillContext | FileContext
+
+/** The stable identity of a chip — the React key, the remove handle, and the dedupe key. */
 export function contextKey(context: PendingContext): string {
-  return `${context.kind}:${context.name}`
+  return context.kind === 'skill' ? `skill:${context.name}` : `file:${context.path}`
 }
 
 /** Drop the chip whose {@link contextKey} matches; a miss returns the list unchanged. */
@@ -32,23 +38,68 @@ export function removeContext(
 /**
  * Stage a context, returning the new list. A skill REPLACES any staged skill — the
  * agent parses only the leading `/name`, so the composer never stages an invocation
- * it can't honor.
+ * it can't honor. Files ACCUMULATE, deduped by path (re-selecting is a no-op).
  */
 export function addContext(
   contexts: readonly PendingContext[],
   context: PendingContext,
 ): PendingContext[] {
-  return [...contexts.filter((c) => c.kind !== context.kind), context]
+  const kept =
+    context.kind === 'skill'
+      ? contexts.filter((c) => c.kind !== 'skill')
+      : contexts.filter((c) => contextKey(c) !== contextKey(context))
+  return [...kept, context]
+}
+
+/** The marker element fencing chip-staged `@path` mentions in the wire text (#230). It keeps
+ *  the display-side extraction unambiguous against user-TYPED inline mentions; the agent reads
+ *  it as plain prose and expands the `@path` tokens inside it like any others. */
+const ATTACHED_FILES_OPEN = '<attached_files>'
+const ATTACHED_FILES_CLOSE = '</attached_files>'
+
+/** The prose + recovered file chips of a sent prompt — {@link extractAttachedFiles}. */
+export interface ExtractedAttachedFiles {
+  cleanText: string
+  files: FileContext[]
+}
+
+/**
+ * The display mirror of {@link serializeForSend} (#230): detect (and strip) a TRAILING
+ * `<attached_files>` block so the user-turn row renders the original prose and the file
+ * chips separately — live and on JSONL replay, since both ride the same prompt text.
+ * Anything else — no block, a block mid-text, user-typed inline `@path` mentions —
+ * passes through untouched. Non-`@` lines inside a candidate block disqualify it (it
+ * wasn't ours).
+ */
+export function extractAttachedFiles(text: string): ExtractedAttachedFiles {
+  const trimmed = text.trimEnd()
+  if (!trimmed.endsWith(ATTACHED_FILES_CLOSE)) return { cleanText: text, files: [] }
+  const open = trimmed.lastIndexOf(ATTACHED_FILES_OPEN)
+  if (open === -1) return { cleanText: text, files: [] }
+  const inner = trimmed.slice(open + ATTACHED_FILES_OPEN.length, trimmed.length - ATTACHED_FILES_CLOSE.length)
+  const lines = inner.split('\n').filter((line) => line.trim().length > 0)
+  if (lines.length === 0 || !lines.every((line) => line.trim().startsWith('@'))) {
+    return { cleanText: text, files: [] }
+  }
+  return {
+    cleanText: trimmed.slice(0, open).replace(/\n+$/, ''),
+    files: lines.map((line) => ({ kind: 'file', path: line.trim().slice(1) })),
+  }
 }
 
 /**
  * Flatten the staged contexts into the outgoing prompt text: a skill chip becomes the
- * leading `/name ` invocation (bare `/name` when there is no prose). The prose itself
- * is trimmed exactly like the send path trims the draft.
+ * leading `/name ` invocation (bare `/name` when there is no prose); file chips become
+ * a TRAILING `<attached_files>` block of `@path` mentions the agent expands itself
+ * (ADR-0002 — plain text, no client-side expansion). The prose itself is trimmed
+ * exactly like the send path trims the draft.
  */
 export function serializeForSend(text: string, contexts: readonly PendingContext[]): string {
   const prose = text.trim()
   const skill = contexts.find((c) => c.kind === 'skill')
-  if (!skill) return prose
-  return prose.length > 0 ? `/${skill.name} ${prose}` : `/${skill.name}`
+  const body = skill ? (prose.length > 0 ? `/${skill.name} ${prose}` : `/${skill.name}`) : prose
+  const files = contexts.filter((c) => c.kind === 'file')
+  if (files.length === 0) return body
+  const block = [ATTACHED_FILES_OPEN, ...files.map((f) => `@${f.path}`), ATTACHED_FILES_CLOSE].join('\n')
+  return body.length > 0 ? `${body}\n\n${block}` : block
 }

--- a/src/renderer/src/conversation/pending-contexts.ts
+++ b/src/renderer/src/conversation/pending-contexts.ts
@@ -19,12 +19,35 @@ export interface FileContext {
   path: string
 }
 
-/** A context chip staged in the composer awaiting send. The element kind follows (#231). */
-export type PendingContext = SkillContext | FileContext
+/**
+ * A Browser Surface element pick staged as a chip (#231, upgrading #224/ADR-0016): the
+ * picker's DOM metadata, plus `imageId` pairing it to its staged screenshot so removing
+ * the chip removes the screenshot with it. `id` is minted by the composer (each pick is
+ * its own chip — no dedupe; picking twice deliberately stages twice).
+ */
+export interface ElementContext {
+  kind: 'element'
+  id: string
+  tagName: string
+  selector: string | null
+  text: string
+  pageUrl: string
+  imageId: string | null
+}
+
+/** A context chip staged in the composer awaiting send. */
+export type PendingContext = SkillContext | FileContext | ElementContext
 
 /** The stable identity of a chip — the React key, the remove handle, and the dedupe key. */
 export function contextKey(context: PendingContext): string {
-  return context.kind === 'skill' ? `skill:${context.name}` : `file:${context.path}`
+  switch (context.kind) {
+    case 'skill':
+      return `skill:${context.name}`
+    case 'file':
+      return `file:${context.path}`
+    case 'element':
+      return `element:${context.id}`
+  }
 }
 
 /** Drop the chip whose {@link contextKey} matches; a miss returns the list unchanged. */
@@ -57,6 +80,23 @@ export function addContext(
 const ATTACHED_FILES_OPEN = '<attached_files>'
 const ATTACHED_FILES_CLOSE = '</attached_files>'
 
+/** The marker element fencing picked-element context in the wire text (#231) — descriptive
+ *  prose the agent reads naturally (the former #224 draft-text annotation, relocated). */
+const ELEMENT_CONTEXT_OPEN = '<element_context>'
+const ELEMENT_CONTEXT_CLOSE = '</element_context>'
+
+/** One element's lines inside the block — `Picked element <tag>` (the entry delimiter),
+ *  optional `selector:`/`text:` lines (text whitespace-normalized so entries stay line-
+ *  parseable), then the page URL. Mirrors the former `formatPickAnnotation` content. */
+function formatElementEntry(element: ElementContext): string[] {
+  const lines = [`Picked element <${element.tagName}>`]
+  if (element.selector) lines.push(`selector: ${element.selector}`)
+  const text = element.text.replace(/\s+/g, ' ').trim()
+  if (text.length > 0) lines.push(`text: ${text}`)
+  lines.push(element.pageUrl)
+  return lines
+}
+
 /** The prose + recovered file chips of a sent prompt — {@link extractAttachedFiles}. */
 export interface ExtractedAttachedFiles {
   cleanText: string
@@ -87,19 +127,85 @@ export function extractAttachedFiles(text: string): ExtractedAttachedFiles {
   }
 }
 
+/** One entry's parsed lines inside an `<element_context>` block — the extraction inverse
+ *  of {@link formatElementEntry}. Returns null on a shape we didn't write. */
+function parseElementEntry(lines: string[], index: number): ElementContext | null {
+  const head = /^Picked element <([^>]+)>$/.exec(lines[0] ?? '')
+  if (!head || lines.length < 2) return null
+  const pageUrl = lines[lines.length - 1]
+  let selector: string | null = null
+  let text = ''
+  for (const line of lines.slice(1, -1)) {
+    if (line.startsWith('selector: ')) selector = line.slice('selector: '.length)
+    else if (line.startsWith('text: ')) text = line.slice('text: '.length)
+    else return null
+  }
+  return { kind: 'element', id: `el-extract:${index}`, tagName: head[1], selector, text, pageUrl, imageId: null }
+}
+
+/** The prose + recovered chips of a sent prompt — {@link extractPromptContexts}. */
+export interface ExtractedPromptContexts {
+  cleanText: string
+  files: FileContext[]
+  elements: ElementContext[]
+}
+
+/**
+ * The FULL display mirror of {@link serializeForSend} (#230/#231): strip a trailing
+ * `<element_context>` block, then a (now-)trailing `<attached_files>` block, recovering
+ * the chips the prompt was sent with. Each stage passes text through untouched when its
+ * marker is absent or malformed, so hand-typed prompts are never altered. Extracted
+ * element ids are render-local (`el-extract:<n>`) — pairing to a live screenshot exists
+ * only pre-send.
+ */
+export function extractPromptContexts(text: string): ExtractedPromptContexts {
+  let working = text
+  let elements: ElementContext[] = []
+  const trimmed = working.trimEnd()
+  if (trimmed.endsWith(ELEMENT_CONTEXT_CLOSE)) {
+    const open = trimmed.lastIndexOf(ELEMENT_CONTEXT_OPEN)
+    if (open !== -1) {
+      const inner = trimmed.slice(open + ELEMENT_CONTEXT_OPEN.length, trimmed.length - ELEMENT_CONTEXT_CLOSE.length)
+      const lines = inner.split('\n').filter((line) => line.trim().length > 0)
+      // Split into entries on each `Picked element <…>` head line.
+      const entries: string[][] = []
+      for (const line of lines) {
+        if (line.startsWith('Picked element <') || entries.length === 0) entries.push([line])
+        else entries[entries.length - 1].push(line)
+      }
+      const parsed = entries.map((entry, i) => parseElementEntry(entry, i))
+      if (parsed.length > 0 && parsed.every((p) => p !== null)) {
+        elements = parsed
+        working = trimmed.slice(0, open).replace(/\n+$/, '')
+      }
+    }
+  }
+  const { cleanText, files } = extractAttachedFiles(working)
+  return { cleanText, files, elements }
+}
+
 /**
  * Flatten the staged contexts into the outgoing prompt text: a skill chip becomes the
  * leading `/name ` invocation (bare `/name` when there is no prose); file chips become
  * a TRAILING `<attached_files>` block of `@path` mentions the agent expands itself
- * (ADR-0002 — plain text, no client-side expansion). The prose itself is trimmed
- * exactly like the send path trims the draft.
+ * (ADR-0002 — plain text, no client-side expansion); element chips become a final
+ * `<element_context>` block of descriptive prose. The prose itself is trimmed exactly
+ * like the send path trims the draft.
  */
 export function serializeForSend(text: string, contexts: readonly PendingContext[]): string {
   const prose = text.trim()
   const skill = contexts.find((c) => c.kind === 'skill')
   const body = skill ? (prose.length > 0 ? `/${skill.name} ${prose}` : `/${skill.name}`) : prose
+  const parts = [body]
   const files = contexts.filter((c) => c.kind === 'file')
-  if (files.length === 0) return body
-  const block = [ATTACHED_FILES_OPEN, ...files.map((f) => `@${f.path}`), ATTACHED_FILES_CLOSE].join('\n')
-  return body.length > 0 ? `${body}\n\n${block}` : block
+  if (files.length > 0) {
+    parts.push([ATTACHED_FILES_OPEN, ...files.map((f) => `@${f.path}`), ATTACHED_FILES_CLOSE].join('\n'))
+  }
+  const elements = contexts.filter((c) => c.kind === 'element')
+  if (elements.length > 0) {
+    parts.push(
+      [ELEMENT_CONTEXT_OPEN, ...elements.flatMap(formatElementEntry), ELEMENT_CONTEXT_CLOSE].join('\n'),
+    )
+  }
+  return parts.filter((p) => p.length > 0).join('\n\n')
 }

--- a/src/renderer/src/conversation/use-composer-autocomplete.tsx
+++ b/src/renderer/src/conversation/use-composer-autocomplete.tsx
@@ -9,6 +9,7 @@ import {
 import { cn } from '../lib/utils'
 import { moveSelection } from './command-autocomplete'
 import { resolveAutocomplete, type ActiveTrigger, type Detection } from './autocomplete-machine'
+import type { PendingContext } from './pending-contexts'
 
 /**
  * One completion mechanism for the composer (quality-review slice 4a): the `/` command
@@ -36,8 +37,15 @@ export interface CompletionSource<Row = unknown> {
   rows(query: string): readonly Row[]
   /** A stable React key for a row. */
   rowKey(row: Row): string
-  /** Splice the accepted row over its `@`/`/` token; return the new value + caret. */
-  apply(value: string, start: number, caret: number, row: Row): { value: string; caret: number }
+  /** Splice the accepted row over its `@`/`/` token; return the new value + caret. A source
+   *  whose accept stages a pending-context CHIP (#229) instead of inline text removes the
+   *  token and returns the chip as `context` — the hook hands it to `onContext`. */
+  apply(
+    value: string,
+    start: number,
+    caret: number,
+    row: Row,
+  ): { value: string; caret: number; context?: PendingContext }
   /** Whether accepting this row CLOSES the popover. False re-derives the trigger to drill in
    *  (a directory reopens on its new fragment). */
   closeOnAccept(row: Row): boolean
@@ -80,6 +88,8 @@ export function useComposerAutocomplete(
   value: string,
   setValue: (next: string) => void,
   inputRef: RefObject<HTMLTextAreaElement | null>,
+  /** Receives the pending-context chip when an accepted row stages one (#229). */
+  onContext?: (context: PendingContext) => void,
 ): ComposerAutocomplete {
   const [trigger, setTrigger] = useState<ActiveTrigger | null>(null)
   const [index, setIndex] = useState(0)
@@ -132,6 +142,7 @@ export function useComposerAutocomplete(
     const caret = node ? node.selectionStart : value.length
     const next = source.apply(value, trigger.start, caret, row)
     setValue(next.value)
+    if (next.context) onContext?.(next.context)
     setIndex(0)
     if (source.closeOnAccept(row)) {
       dismissedRef.current[trigger.sourceIndex] = null

--- a/src/renderer/src/side-panel/BrowserSurface.tsx
+++ b/src/renderer/src/side-panel/BrowserSurface.tsx
@@ -1,14 +1,9 @@
 import { useCallback, useEffect, useRef, useState, type FormEvent, type JSX } from 'react'
 import { ArrowLeft, ArrowRight, Code, ExternalLink, Globe, Loader2, MousePointerClick, RefreshCw, RotateCw, TriangleAlert } from 'lucide-react'
 import type { DevServer } from '../../../shared/ipc'
-import { emitComposerInsertImage, emitComposerInsertText } from '../conversation/composer-insert'
+import { emitComposerInsertElement, type ComposerInsertImage } from '../conversation/composer-insert'
 import { parseDataUrl } from '../conversation/image-attach'
-import {
-  buildPickerScript,
-  coercePickedElement,
-  cropRectForElement,
-  formatPickAnnotation,
-} from './browser-picker'
+import { buildPickerScript, coercePickedElement, cropRectForElement } from './browser-picker'
 import { cn } from '../lib/utils'
 import {
   buildWebviewPreferencesAttribute,
@@ -117,10 +112,11 @@ export function BrowserSurface({
     view?.openDevTools()
   }
 
-  // Pick an element to chat (#224, ADR-0016): inject the picker into the guest via
+  // Pick an element to chat (#224/#231, ADR-0016): inject the picker into the guest via
   // executeJavaScript (isolated world — no preload, isolation stays ON), await the click,
-  // screenshot the element, and drop a screenshot + text annotation into the active
-  // Thread's composer. A no-op without a mounted composer (Thread) or webview.
+  // screenshot the element, and deliver ONE payload — the element metadata + optional
+  // screenshot — to the active Thread's composer, which stages it as a pending-context
+  // ELEMENT chip paired to the staged image. A no-op without a mounted composer or webview.
   async function pickElement(): Promise<void> {
     if (!view || !activeThreadId || picking) return
     setPicking(true)
@@ -132,23 +128,28 @@ export function BrowserSurface({
       // Screenshot AFTER the picker overlay is gone (the injected script tore it down
       // before resolving), so the crop is the page, not the picker chrome.
       const crop = cropRectForElement(picked.rect, { width: view.offsetWidth, height: view.offsetHeight }, { padding: 8 })
+      let image: ComposerInsertImage | null = null
       if (crop) {
         try {
-          const image = await view.capturePage(crop)
-          const parsed = parseDataUrl(image.toDataURL())
+          const captured = await view.capturePage(crop)
+          const parsed = parseDataUrl(captured.toDataURL())
           if (parsed) {
-            emitComposerInsertImage(activeThreadId, {
-              ...parsed,
-              name: `element-${picked.tagName}.png`,
-              previewUrl: image.toDataURL(),
-            })
+            image = { ...parsed, name: `element-${picked.tagName}.png`, previewUrl: captured.toDataURL() }
           }
         } catch (err) {
-          // A capture failure is non-fatal — the text annotation still lands.
+          // A capture failure is non-fatal — the element chip still lands, screenshot-less.
           console.error('[browser] element screenshot failed', err)
         }
       }
-      emitComposerInsertText(activeThreadId, formatPickAnnotation(picked))
+      emitComposerInsertElement(activeThreadId, {
+        element: {
+          tagName: picked.tagName,
+          selector: picked.selector,
+          text: picked.text,
+          pageUrl: picked.pageUrl,
+        },
+        image,
+      })
     } catch (err) {
       // executeJavaScript rejects if the guest navigated mid-pick — treat as a cancel.
       console.error('[browser] pick cancelled', err)

--- a/src/renderer/src/side-panel/browser-picker.test.ts
+++ b/src/renderer/src/side-panel/browser-picker.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import {
-  buildPickerScript,
-  coercePickedElement,
-  cropRectForElement,
-  formatPickAnnotation,
-} from './browser-picker'
+import { buildPickerScript, coercePickedElement, cropRectForElement } from './browser-picker'
 
 describe('cropRectForElement', () => {
   const viewport = { width: 1000, height: 800 }
@@ -77,34 +72,6 @@ describe('coercePickedElement (untrusted guest JSON)', () => {
     const long = 'x'.repeat(500)
     const p = coercePickedElement({ ...valid, text: long })
     expect(p!.text.length).toBeLessThanOrEqual(200)
-  })
-})
-
-describe('formatPickAnnotation', () => {
-  it('renders a compact, human+agent readable block with tag, selector, text, url', () => {
-    const text = formatPickAnnotation({
-      pageUrl: 'http://localhost:5173/pricing',
-      tagName: 'button',
-      selector: 'button.cta',
-      text: 'Get started',
-      rect: { x: 0, y: 0, width: 1, height: 1 },
-    })
-    expect(text).toContain('<button>')
-    expect(text).toContain('button.cta')
-    expect(text).toContain('Get started')
-    expect(text).toContain('http://localhost:5173/pricing')
-  })
-
-  it('omits the selector and text lines when they are absent', () => {
-    const text = formatPickAnnotation({
-      pageUrl: 'http://localhost:5173/',
-      tagName: 'div',
-      selector: null,
-      text: '',
-      rect: { x: 0, y: 0, width: 1, height: 1 },
-    })
-    expect(text).toContain('<div>')
-    expect(text).not.toContain('selector')
   })
 })
 

--- a/src/renderer/src/side-panel/browser-picker.ts
+++ b/src/renderer/src/side-panel/browser-picker.ts
@@ -148,20 +148,6 @@ export function buildPickerScript(config: { accent: string }): string {
 }
 
 /**
- * Format a picked element as a compact composer annotation — a `<tag>` line, then optional
- * `selector:` and `text:` lines, then the page URL. Inserted as plain, editable composer
- * text (reusing the existing text channel) so the agent gets precise context alongside the
- * screenshot. Absent selector/text lines are omitted.
- */
-export function formatPickAnnotation(element: PickedElement): string {
-  const lines = [`Picked element <${element.tagName}>`]
-  if (element.selector) lines.push(`selector: ${element.selector}`)
-  if (element.text.trim().length > 0) lines.push(`text: ${element.text.trim()}`)
-  lines.push(element.pageUrl)
-  return lines.join('\n')
-}
-
-/**
  * The crop rect for the picked element's screenshot: pad the element's bounding rect,
  * clamp it to the viewport, and round to integer pixels. Returns null for a zero-area
  * element (nothing to capture). Coordinates stay in CSS pixels — Electron's


### PR DESCRIPTION
Implements PRD #228 in three tracer-bullet slices (one commit each).

Closes #229, closes #230, closes #231.

## What changed

- **New pure core `pending-contexts.ts`** (TDD, 19 tests): the `PendingContext` union (skill/file/element), staging ops (skill replaces skill, files dedupe by path, each element pick is its own chip), `serializeForSend` (leading `/name` → prose → `<attached_files>` @-mentions → `<element_context>` block) and the exact display mirror `extractPromptContexts`.
- **`/` accept** stages a removable skill chip (token removed from the draft); the invocation is re-prepended at send. `applyCommand` superseded by `removeCommandToken`.
- **`@` FILE accept + Files-preview "Insert into chat"** stage deduped file chips; directory drill-down stays in-text. `appendMention` superseded.
- **Browser element pick (#224)** now delivers ONE payload (metadata + optional screenshot) over a new element insert channel; the chip is paired to its screenshot — removing the chip removes the screenshot. The draft-text annotation and standalone image channel are superseded.
- **Sent user turns** strip the marker blocks at render time and show the chips (mirrors the PR #213 match-at-render decision) — works identically on cold JSONL replay, zero persistence changes.
- **ADR-0017** records the pattern (attachment model, no Lexical; flatten-to-text keeps ADR-0002 intact).
- Terminal "Add to chat" deliberately unchanged (raw text). Typed `/name` / `@path` flows unchanged.

## Gates

`bun run lint && bun run typecheck && bun run build && bun run test` — all green, **1154 tests** (was 1134).

## Not yet done

- Live app-driving verification (agent actually invoking the skill / expanding the mentions end-to-end) — the wire text is probe-verified by design (PR #213 / ADR-0002 findings), but a manual smoke of the three flows before merge is recommended.
- Chips are ephemeral v1 (like staged images); persisting a structured draft is a recorded follow-up (PRD #228 Out of Scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)