### PR TITLE
feat(git): slice 1 — stacked-action engine with Push & Pull in the Review Surface (#234)

### DIFF
--- a/src/main/git/register-ipc.ts
+++ b/src/main/git/register-ipc.ts
@@ -13,10 +13,14 @@ import {
   type GhCreateResult,
   type GhCurrentPrArgs,
   type GhPrResult,
+  type GitActionProgressEvent,
+  type GitStackedActionArgs,
+  type GitStackedActionResult,
   type GitStatusSubscriptionArgs,
 } from '../../shared/ipc'
 import { readGitDiff } from './diff'
 import { gitCommit } from './commit'
+import { runStackedAction } from './stacked-action'
 import { gitBranches, gitCheckout, gitCreateBranch } from './branches'
 import { ghCreatePr, ghCurrentPr } from './github'
 import type { GitStatusManager } from './status-stream'
@@ -28,7 +32,11 @@ import type { GitStatusManager } from './status-stream'
  * so a git read/write never keeps a warm agent alive past its idle window (TB5 #50).
  * Every operation swallows its failure into a typed result (never throws).
  */
-export function registerGitIpc(deps: { gitStatus: GitStatusManager }): void {
+export function registerGitIpc(deps: {
+  gitStatus: GitStatusManager
+  /** Broadcast one stacked-action progress event to every window (#234) — wired to `webContents.send` in `index.ts`, like `gitStatus.emit`. */
+  emitGitActionProgress: (event: GitActionProgressEvent) => void
+}): void {
   /**
    * Settle a mutating git/gh op: on success optionally re-read the Workspace's streamed
    * status (a commit/switch touches only `.git/`, which the working-tree fs watcher
@@ -99,6 +107,23 @@ export function registerGitIpc(deps: { gitStatus: GitStatusManager }): void {
       args.workspaceDir,
     )
   })
+
+  ipcMain.handle(
+    IPC.gitRunStackedAction,
+    async (_event, args: GitStackedActionArgs): Promise<GitStackedActionResult> => {
+      // Run a stacked git action — slice 1: push / pull (#234). Progress streams over
+      // `gitActionProgress` while this invoke is in flight; the resolve is the final
+      // word. On success re-read status: a push moves ahead/behind + upstream, a pull
+      // rewrites the working tree — both are `.git`-side moves the watcher may miss.
+      const result = await runStackedAction(args, deps.emitGitActionProgress)
+      if (result.ok) {
+        deps.gitStatus.refresh(args.workspaceDir)
+      } else {
+        console.error(`[vibe-mistro:git] ${args.action} failed (${args.workspaceDir}): ${result.error}`)
+      }
+      return result
+    },
+  )
 
   ipcMain.handle(IPC.ghCurrentPr, (_event, args: GhCurrentPrArgs): Promise<GhPrResult> => {
     // Read the current branch's GitHub PR via `gh` (#88). A NETWORK call, but read-only.

--- a/src/main/git/stacked-action.test.ts
+++ b/src/main/git/stacked-action.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest'
+import { runStackedAction } from './stacked-action'
+import type { GitRun } from './run'
+import type { GitActionProgressEvent } from '../../shared/ipc'
+
+/**
+ * `runStackedAction` is the stacked git-action engine (#234, PRD #233): an ordered
+ * chain of phases over the injected `GitRun` seam, streaming tagged progress events
+ * through `emit` and resolving with a typed result. Like `gitCommit`'s tests, the
+ * testable seam is the COMMAND SEQUENCE + the EVENT ORDER — no test shells real git.
+ */
+
+/** A fake runner: records every `args` and returns a per-call canned `{stdout,stderr,code}`. */
+function fakeRun(
+  seen: string[][],
+  responses: { stdout?: string; stderr?: string; code: number }[] = [],
+): GitRun {
+  let i = 0
+  return (args) => {
+    seen.push(args)
+    const r = responses[i++] ?? { code: 0 }
+    return Promise.resolve({ stdout: r.stdout ?? '', stderr: r.stderr ?? '', code: r.code })
+  }
+}
+
+/** Collect emitted progress events for order assertions. */
+function collect(): { events: GitActionProgressEvent[]; emit: (e: GitActionProgressEvent) => void } {
+  const events: GitActionProgressEvent[] = []
+  return { events, emit: (e) => events.push(e) }
+}
+
+describe('runStackedAction: push', () => {
+  it('with an existing upstream: checks @{upstream} then plain `git push`, {ok:true}, ordered events', async () => {
+    const seen: string[][] = []
+    const { events, emit } = collect()
+    const result = await runStackedAction(
+      { workspaceDir: '/repo', actionId: 'a1', action: 'push' },
+      emit,
+      fakeRun(seen, [
+        { stdout: 'origin/main\n', code: 0 }, // upstream exists
+        { code: 0 }, // push
+      ]),
+    )
+    expect(result).toEqual({ ok: true })
+    expect(seen).toEqual([
+      ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'],
+      ['push'],
+    ])
+    expect(events.map((e) => e.kind)).toEqual([
+      'actionStarted',
+      'phaseStarted',
+      'phaseFinished',
+      'actionFinished',
+    ])
+    // Every event is tagged for renderer-side filtering.
+    for (const e of events) {
+      expect(e.workspaceDir).toBe('/repo')
+      expect(e.actionId).toBe('a1')
+    }
+  })
+
+  it('with NO upstream: sets it on the primary remote — `push -u origin <branch>`', async () => {
+    const seen: string[][] = []
+    const { emit } = collect()
+    const result = await runStackedAction(
+      { workspaceDir: '/repo', actionId: 'a1', action: 'push' },
+      emit,
+      fakeRun(seen, [
+        { stderr: 'fatal: no upstream configured for branch', code: 128 }, // no upstream
+        { stdout: 'feat/x\n', code: 0 }, // current branch
+        { stdout: 'origin\n', code: 0 }, // remotes
+        { code: 0 }, // push -u
+      ]),
+    )
+    expect(result).toEqual({ ok: true })
+    expect(seen).toEqual([
+      ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'],
+      ['symbolic-ref', '--short', 'HEAD'],
+      ['remote'],
+      ['push', '-u', 'origin', 'feat/x'],
+    ])
+  })
+
+  it('detached HEAD (no upstream, symbolic-ref fails): fails the push phase with git’s reason, never pushes', async () => {
+    const seen: string[][] = []
+    const { events, emit } = collect()
+    const result = await runStackedAction(
+      { workspaceDir: '/repo', actionId: 'a1', action: 'push' },
+      emit,
+      fakeRun(seen, [
+        { stderr: 'fatal: no upstream', code: 128 },
+        { stderr: 'fatal: ref HEAD is not a symbolic ref', code: 128 }, // detached
+      ]),
+    )
+    expect(result).toEqual({ ok: false, phase: 'push', error: 'fatal: ref HEAD is not a symbolic ref' })
+    expect(seen.some((args) => args[0] === 'push')).toBe(false)
+    expect(events.at(-1)).toMatchObject({ kind: 'actionFailed', phase: 'push' })
+  })
+
+  it('no configured remote (no upstream): fails the push phase with an actionable reason, never pushes', async () => {
+    const seen: string[][] = []
+    const { emit } = collect()
+    const result = await runStackedAction(
+      { workspaceDir: '/repo', actionId: 'a1', action: 'push' },
+      emit,
+      fakeRun(seen, [
+        { stderr: 'fatal: no upstream', code: 128 },
+        { stdout: 'feat/x\n', code: 0 },
+        { stdout: '', code: 0 }, // `git remote` lists nothing
+      ]),
+    )
+    expect(result).toEqual({ ok: false, phase: 'push', error: 'No remote configured — add one with `git remote add`.' })
+    expect(seen.some((args) => args[0] === 'push')).toBe(false)
+  })
+
+  it('a REJECTED push surfaces git’s stderr reason and closes with actionFailed (no actionFinished)', async () => {
+    const { events, emit } = collect()
+    const result = await runStackedAction(
+      { workspaceDir: '/repo', actionId: 'a1', action: 'push' },
+      emit,
+      fakeRun([], [
+        { stdout: 'origin/main\n', code: 0 },
+        { stderr: '! [rejected] main -> main (non-fast-forward)', code: 1 },
+      ]),
+    )
+    expect(result).toEqual({ ok: false, phase: 'push', error: '! [rejected] main -> main (non-fast-forward)' })
+    expect(events.map((e) => e.kind)).toEqual(['actionStarted', 'phaseStarted', 'actionFailed'])
+  })
+})
+
+describe('runStackedAction: pull', () => {
+  it('runs `git pull --ff-only` and resolves {ok:true} with ordered events', async () => {
+    const seen: string[][] = []
+    const { events, emit } = collect()
+    const result = await runStackedAction(
+      { workspaceDir: '/repo', actionId: 'a2', action: 'pull' },
+      emit,
+      fakeRun(seen, [{ stdout: 'Updating 1234abc..5678def\nFast-forward\n', code: 0 }]),
+    )
+    expect(result).toEqual({ ok: true })
+    expect(seen).toEqual([['pull', '--ff-only']])
+    expect(events.map((e) => e.kind)).toEqual([
+      'actionStarted',
+      'phaseStarted',
+      'output',
+      'phaseFinished',
+      'actionFinished',
+    ])
+  })
+
+  it('a DIVERGED branch (non-fast-forward) fails the pull phase with git’s reason — no merge attempted', async () => {
+    const seen: string[][] = []
+    const { emit } = collect()
+    const result = await runStackedAction(
+      { workspaceDir: '/repo', actionId: 'a2', action: 'pull' },
+      emit,
+      fakeRun(seen, [{ stderr: 'fatal: Not possible to fast-forward, aborting.', code: 128 }]),
+    )
+    expect(result).toEqual({ ok: false, phase: 'pull', error: 'fatal: Not possible to fast-forward, aborting.' })
+    expect(seen).toEqual([['pull', '--ff-only']])
+  })
+
+  it('a runner that REJECTS still degrades to {ok:false} + actionFailed (never throws)', async () => {
+    const { events, emit } = collect()
+    const result = await runStackedAction(
+      { workspaceDir: '/repo', actionId: 'a2', action: 'pull' },
+      emit,
+      () => Promise.reject(new Error('spawn EACCES')),
+    )
+    expect(result).toEqual({ ok: false, phase: 'pull', error: 'spawn EACCES' })
+    expect(events.at(-1)).toMatchObject({ kind: 'actionFailed', error: 'spawn EACCES' })
+  })
+})

--- a/src/main/git/stacked-action.ts
+++ b/src/main/git/stacked-action.ts
@@ -1,0 +1,116 @@
+import { defaultGitRun, errorMessage, failReason, type GitRun } from './run'
+import type {
+  GitActionPhase,
+  GitActionProgressEvent,
+  GitStackedActionArgs,
+  GitStackedActionResult,
+} from '../../shared/ipc'
+
+/**
+ * The stacked git-action engine (#234, PRD #233): runs one action as an ordered chain
+ * of phases over the injectable `GitRun` seam (like #86's `gitCommit`), streaming
+ * tagged progress events through `emit` and resolving with a typed result. Slice 1
+ * ships the single-phase actions — PUSH and PULL; #236 composes commit→push→PR chains
+ * onto the same engine, which is why the event grammar already speaks in phases.
+ * Event order per action: `actionStarted`, then per phase `phaseStarted` / optional
+ * `output` / `phaseFinished`, closed by exactly one of `actionFinished`|`actionFailed`.
+ * A failed phase STOPS the chain. Failure is SWALLOWED into the result — never throws.
+ */
+
+/** The progress sink — wired to a `webContents` broadcast in `index.ts`, a collector in tests. */
+export type GitActionEmit = (event: GitActionProgressEvent) => void
+
+export async function runStackedAction(
+  args: GitStackedActionArgs,
+  emit: GitActionEmit,
+  run: GitRun = defaultGitRun,
+): Promise<GitStackedActionResult> {
+  const chain = new ActionChain(args, emit, run)
+  emit({ workspaceDir: args.workspaceDir, actionId: args.actionId, kind: 'actionStarted', action: args.action })
+  try {
+    return args.action === 'pull' ? await chain.pull() : await chain.push()
+  } catch (err) {
+    // A truly unexpected throw (a runner that rejects) still degrades to a result —
+    // nothing crosses the IPC boundary as an exception (#86 style).
+    return chain.fail(args.action === 'pull' ? 'pull' : 'push', errorMessage(err))
+  }
+}
+
+/** One running action: the tag + emit + runner shared by its phases. */
+class ActionChain {
+  constructor(
+    private readonly args: GitStackedActionArgs,
+    private readonly emit: GitActionEmit,
+    private readonly run: GitRun,
+  ) {}
+
+  /** PULL: fast-forward ONLY — a diverged branch surfaces git's reason instead of the
+   *  app deciding a merge/rebase on the user's behalf (PRD #233). */
+  async pull(): Promise<GitStackedActionResult> {
+    this.phaseStarted('pull')
+    const pull = await this.run(['pull', '--ff-only'], this.args.workspaceDir)
+    if (pull.code !== 0) return this.fail('pull', failReason(pull))
+    return this.finishPhase('pull', pull)
+  }
+
+  /** PUSH: plain `git push` with an upstream; a FIRST push sets the upstream on the
+   *  primary remote so ahead/behind and the PR section's `hasUpstream` gate work on. */
+  async push(): Promise<GitStackedActionResult> {
+    const { workspaceDir } = this.args
+    this.phaseStarted('push')
+    const upstream = await this.run(
+      ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'],
+      workspaceDir,
+    )
+    let pushArgs = ['push']
+    if (upstream.code !== 0) {
+      // Detached HEAD has no branch to set an upstream for — fail with git's reason.
+      const branch = await this.run(['symbolic-ref', '--short', 'HEAD'], workspaceDir)
+      if (branch.code !== 0) return this.fail('push', failReason(branch))
+      const remotes = await this.run(['remote'], workspaceDir)
+      const names = remotes.stdout.split('\n').map((r) => r.trim()).filter(Boolean)
+      // Prefer `origin` when present, else the first configured remote.
+      const remote = names.includes('origin') ? 'origin' : names[0]
+      if (!remote) return this.fail('push', 'No remote configured — add one with `git remote add`.')
+      pushArgs = ['push', '-u', remote, branch.stdout.trim()]
+    }
+    const push = await this.run(pushArgs, workspaceDir)
+    if (push.code !== 0) return this.fail('push', failReason(push))
+    return this.finishPhase('push', push)
+  }
+
+  /** Fail the chain: emit `actionFailed` + resolve `{ok:false}` — later phases never start. */
+  fail(phase: GitActionPhase, error: string): GitStackedActionResult {
+    this.emitTagged({ kind: 'actionFailed', phase, error })
+    return { ok: false, phase, error }
+  }
+
+  private phaseStarted(phase: GitActionPhase): void {
+    this.emitTagged({ kind: 'phaseStarted', phase })
+  }
+
+  /** Close a successful phase: non-empty command output (hook chatter, fast-forward
+   *  summaries) as an `output` event — a FAILURE's text travels in `actionFailed.error`
+   *  instead, never both — then `phaseFinished` + (slice 1: single-phase) `actionFinished`. */
+  private finishPhase(
+    phase: GitActionPhase,
+    res: { stdout: string; stderr?: string },
+  ): GitStackedActionResult {
+    const text = `${res.stdout}\n${res.stderr ?? ''}`.trim()
+    if (text) this.emitTagged({ kind: 'output', phase, text })
+    this.emitTagged({ kind: 'phaseFinished', phase })
+    this.emitTagged({ kind: 'actionFinished' })
+    return { ok: true }
+  }
+
+  private emitTagged(
+    event:
+      | { kind: 'phaseStarted'; phase: GitActionPhase }
+      | { kind: 'output'; phase: GitActionPhase; text: string }
+      | { kind: 'phaseFinished'; phase: GitActionPhase }
+      | { kind: 'actionFinished' }
+      | { kind: 'actionFailed'; phase: GitActionPhase; error: string },
+  ): void {
+    this.emit({ workspaceDir: this.args.workspaceDir, actionId: this.args.actionId, ...event })
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,6 +6,7 @@ import {
   IPC,
   type CancelTurnArgs,
   type DeleteThreadResult,
+  type GitActionProgressEvent,
   type GitStatusEvent,
   type ListMetadataResult,
   type OpenThreadArgs,
@@ -636,7 +637,16 @@ function registerIpc(deps: MainDeps): void {
   // Feature registrars (conventions.md `registerIpc(deps)` DI): the git and files
   // handler groups are self-contained pass-throughs to their modules, registered
   // next to them.
-  registerGitIpc({ gitStatus })
+  registerGitIpc({
+    gitStatus,
+    // Stacked-action progress (#234) fans out to every window like `gitStatus` above;
+    // the renderer filters by workspaceDir + actionId.
+    emitGitActionProgress: (event: GitActionProgressEvent) => {
+      for (const win of BrowserWindow.getAllWindows()) {
+        if (!win.webContents.isDestroyed()) win.webContents.send(IPC.gitActionProgress, event)
+      }
+    },
+  })
   registerFilesIpc({ pool, cache: filesListCache })
   terminalManager = createTerminalManager()
   registerTerminalIpc({ pool, manager: terminalManager })

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -11,9 +11,12 @@ import {
   type GitBranchOpArgs,
   type GitCommitArgs,
   type GitCommitResult,
+  type GitActionProgressEvent,
   type GitDiffArgs,
   type GitDiffResult,
   type GitOpResult,
+  type GitStackedActionArgs,
+  type GitStackedActionResult,
   type GhCreatePrArgs,
   type GhCreateResult,
   type GhCurrentPrArgs,
@@ -123,6 +126,8 @@ const api = {
     ipcRenderer.invoke(IPC.gitCheckout, args),
   gitCreateBranch: (args: GitBranchOpArgs): Promise<GitOpResult> =>
     ipcRenderer.invoke(IPC.gitCreateBranch, args),
+  gitRunStackedAction: (args: GitStackedActionArgs): Promise<GitStackedActionResult> =>
+    ipcRenderer.invoke(IPC.gitRunStackedAction, args),
   ghCurrentPr: (args: GhCurrentPrArgs): Promise<GhPrResult> =>
     ipcRenderer.invoke(IPC.ghCurrentPr, args),
   ghCreatePr: (args: GhCreatePrArgs): Promise<GhCreateResult> =>
@@ -152,6 +157,7 @@ const api = {
   onThreadTitle: subscribe<ThreadTitleEvent>(IPC.threadTitle),
   onAgentEvicted: subscribe<AgentEvictedEvent>(IPC.agentEvicted),
   onGitStatus: subscribe<GitStatusEvent>(IPC.gitStatus),
+  onGitActionProgress: subscribe<GitActionProgressEvent>(IPC.gitActionProgress),
 }
 
 export type VibeMistroApi = typeof api

--- a/src/renderer/src/git/ChangesPanel.tsx
+++ b/src/renderer/src/git/ChangesPanel.tsx
@@ -3,9 +3,10 @@ import { Boxes, GitCommitHorizontal, Monitor, PanelRightClose, RefreshCw } from 
 import type { GitStatus } from '../../../shared/ipc'
 import { Badge, Button, IconButton, Textarea } from '../ui'
 import { getCommitDraft, setCommitDraft } from './commit-draft-store'
-import { buildChangesView, reconcileUnchecked } from './status-view'
+import { buildChangesView, buildSyncView, reconcileUnchecked } from './status-view'
 import { BranchMenu } from './BranchMenu'
 import { PrSection } from './PrSection'
+import { SyncSection } from './SyncSection'
 import { FileRow } from './FileRow'
 import { DiffWorkerProvider } from './DiffWorkerProvider'
 import { DiffView } from './DiffView'
@@ -222,7 +223,13 @@ export function ChangesPanel({
       />
 
       {view.files.length === 0 ? (
-        <p className="px-3 py-3 text-[13px] text-muted">No changes — working tree clean.</p>
+        <>
+          <p className="px-3 py-3 text-[13px] text-muted">No changes — working tree clean.</p>
+          {/* Clean-tree sync actions (#234): Push when ahead / upstream-less, Pull when
+              behind — driven by the pure `buildSyncView`. This un-dead-ends the PR
+              section's "Push your branch first" gate. */}
+          <SyncSection workspaceDir={workspaceDir} sync={buildSyncView(status)} busy={busy} />
+        </>
       ) : (
         <>
           <ul className="flex flex-col gap-0.5 py-1.5">

--- a/src/renderer/src/git/SyncSection.tsx
+++ b/src/renderer/src/git/SyncSection.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useRef, useState, type JSX } from 'react'
+import { ArrowDownToLine, ArrowUpFromLine } from 'lucide-react'
+import type { GitStackedActionKind } from '../../../shared/ipc'
+import { Button } from '../ui'
+import type { SyncView } from './status-view'
+
+/**
+ * The clean-tree sync actions (#234, PRD #233): Push / Pull driven by the pure
+ * `buildSyncView` derivation. Runs a stacked action via `gitRunStackedAction` with a
+ * renderer-minted `actionId`, and mirrors the streamed `gitActionProgress` events into
+ * an inline phase line while the invoke is in flight — the invoke's resolve is the
+ * final word (the stream is advisory UI, like the terminal's). Failure surfaces git's
+ * ACTUAL reason inline + recoverable (#86 style). Disabled while a turn streams
+ * (`busy`) or an action is already running — one stacked action at a time per panel.
+ */
+export function SyncSection({
+  workspaceDir,
+  sync,
+  busy,
+}: {
+  workspaceDir: string
+  sync: SyncView
+  busy: boolean
+}): JSX.Element | null {
+  // The in-flight action (null = idle). `progress` is the latest streamed line for it.
+  const [running, setRunning] = useState<GitStackedActionKind | null>(null)
+  const [progress, setProgress] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  // The current action's renderer-minted id — the filter key for streamed events.
+  const actionIdRef = useRef<string | null>(null)
+
+  // One subscription for the panel's lifetime; events are dropped unless they carry
+  // the CURRENT action's id (a stale action's stragglers can't repaint the line).
+  useEffect(() => {
+    return window.api.onGitActionProgress((event) => {
+      if (event.workspaceDir !== workspaceDir || event.actionId !== actionIdRef.current) return
+      if (event.kind === 'phaseStarted') setProgress(event.phase === 'push' ? 'Pushing…' : 'Pulling…')
+      else if (event.kind === 'output') setProgress(event.text.split('\n').at(-1) ?? null)
+    })
+  }, [workspaceDir])
+
+  if (!sync.showPush && !sync.showPull) return null
+
+  async function runAction(action: GitStackedActionKind): Promise<void> {
+    if (busy || running) return
+    const actionId = crypto.randomUUID()
+    actionIdRef.current = actionId
+    setRunning(action)
+    setProgress(null)
+    setError(null)
+    try {
+      const result = await window.api.gitRunStackedAction({ workspaceDir, actionId, action })
+      if (!result.ok) setError(result.error)
+    } finally {
+      // Always re-arm the buttons — even an unexpectedly rejecting IPC can't stick
+      // the panel on "Pushing…".
+      actionIdRef.current = null
+      setRunning(null)
+      setProgress(null)
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2 border-t border-border-muted px-3 py-2.5">
+      {sync.showPush && (
+        <Button
+          type="button"
+          size="sm"
+          className="w-full"
+          onClick={() => void runAction('push')}
+          disabled={busy || running !== null}
+        >
+          <ArrowUpFromLine className="size-4" aria-hidden />
+          {running === 'push'
+            ? (progress ?? 'Pushing…')
+            : sync.pushSetsUpstream
+              ? 'Publish branch'
+              : 'Push'}
+        </Button>
+      )}
+      {sync.showPull && (
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="w-full"
+          onClick={() => void runAction('pull')}
+          disabled={busy || running !== null}
+        >
+          <ArrowDownToLine className="size-4" aria-hidden />
+          {running === 'pull' ? (progress ?? 'Pulling…') : 'Pull'}
+        </Button>
+      )}
+      {error && (
+        <p className="text-[11px] text-bad" role="alert">
+          {error}
+        </p>
+      )}
+      {busy && <p className="text-[11px] text-muted">Agent is working…</p>}
+    </div>
+  )
+}

--- a/src/renderer/src/git/status-view.test.ts
+++ b/src/renderer/src/git/status-view.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { buildChangesView, fileGlyph, glyphClass, reconcileUnchecked } from './status-view'
+import { buildChangesView, buildSyncView, fileGlyph, glyphClass, reconcileUnchecked } from './status-view'
 import type { GitFile, GitStatus } from '../../../shared/ipc'
 
 function file(partial: Partial<GitFile> & { path: string }): GitFile {
@@ -66,6 +66,53 @@ describe('buildChangesView', () => {
     const view = buildChangesView({ ...status, branch: null, files: [] })
     expect(view.branch).toBe('HEAD')
     expect(view.detached).toBe(true)
+  })
+})
+
+describe('buildSyncView', () => {
+  const clean: GitStatus = {
+    isRepo: true,
+    branch: 'feat/x',
+    upstream: 'origin/feat/x',
+    ahead: 0,
+    behind: 0,
+    files: [],
+  }
+
+  it('clean + ahead: offers Push (upstream already set)', () => {
+    expect(buildSyncView({ ...clean, ahead: 2 })).toEqual({ showPush: true, showPull: false, pushSetsUpstream: false })
+  })
+
+  it('clean + behind: offers Pull', () => {
+    expect(buildSyncView({ ...clean, behind: 3 })).toEqual({ showPush: false, showPull: true, pushSetsUpstream: false })
+  })
+
+  it('diverged (ahead AND behind): offers both', () => {
+    const sync = buildSyncView({ ...clean, ahead: 1, behind: 1 })
+    expect(sync.showPush).toBe(true)
+    expect(sync.showPull).toBe(true)
+  })
+
+  it('clean branch with NO upstream: offers a first Push that will set the upstream', () => {
+    expect(buildSyncView({ ...clean, upstream: null })).toEqual({
+      showPush: true,
+      showPull: false,
+      pushSetsUpstream: true,
+    })
+  })
+
+  it('a DIRTY tree offers neither — the commit area owns the panel then (slice 1)', () => {
+    const dirty = { ...clean, ahead: 2, files: [file({ path: 'a.txt' })] }
+    expect(buildSyncView(dirty)).toEqual({ showPush: false, showPull: false, pushSetsUpstream: false })
+  })
+
+  it('detached HEAD and up-to-date trees offer neither', () => {
+    expect(buildSyncView({ ...clean, branch: null, upstream: null })).toEqual({
+      showPush: false,
+      showPull: false,
+      pushSetsUpstream: false,
+    })
+    expect(buildSyncView(clean)).toEqual({ showPush: false, showPull: false, pushSetsUpstream: false })
   })
 })
 

--- a/src/renderer/src/git/status-view.ts
+++ b/src/renderer/src/git/status-view.ts
@@ -73,6 +73,33 @@ export function reconcileUnchecked(unchecked: ReadonlySet<string>, paths: readon
   return changed ? next : (unchecked as Set<string>)
 }
 
+/** Whether the CLEAN-tree commit area offers Push / Pull (#234) — see `buildSyncView`. */
+export interface SyncView {
+  showPush: boolean
+  showPull: boolean
+  /** True when the push is a FIRST push (no upstream) that will set one — label it so. */
+  pushSetsUpstream: boolean
+}
+
+/**
+ * Derive the Push/Pull affordances from a repo `GitStatus` (#234, PRD #233). Slice-1
+ * scope: sync actions show only on a CLEAN tree (a dirty tree's commit area owns the
+ * panel; #236's quick action generalizes this). Push shows when the branch is ahead OR
+ * has no upstream yet (the "Push your branch first" dead-end this un-dead-ends); Pull
+ * when behind. Detached HEAD (branch null) offers neither — there is no branch to sync.
+ */
+export function buildSyncView(status: GitStatus): SyncView {
+  const clean = status.files.length === 0
+  const onBranch = status.branch !== null
+  if (!clean || !onBranch) return { showPush: false, showPull: false, pushSetsUpstream: false }
+  const pushSetsUpstream = status.upstream === null
+  return {
+    showPush: status.ahead > 0 || pushSetsUpstream,
+    showPull: status.behind > 0,
+    pushSetsUpstream,
+  }
+}
+
 /** Build the render-ready view from a repo `GitStatus` (assumes `isRepo:true`). */
 export function buildChangesView(status: GitStatus): ChangesView {
   const files: GitFileView[] = status.files

--- a/src/shared/ipc/git.ts
+++ b/src/shared/ipc/git.ts
@@ -33,6 +33,10 @@ export const gitChannels = {
   gitCheckout: 'git:checkout',
   /** Renderer -> main: CREATE + switch to a new branch on the active Workspace (#87) — see {@link GitBranchOpArgs}. */
   gitCreateBranch: 'git:create-branch',
+  /** Renderer -> main: run a STACKED git action (push/pull, #234) — see {@link GitStackedActionArgs}. */
+  gitRunStackedAction: 'git:run-stacked-action',
+  /** Main -> renderer: streamed progress for a running stacked action (#234) — see {@link GitActionProgressEvent}. */
+  gitActionProgress: 'git:action-progress',
 } as const
 
 /**
@@ -183,6 +187,52 @@ export type GitOpResult = { ok: true } | { ok: false; error: string }
 export interface GitBranchesArgs {
   workspaceDir: string
 }
+
+/**
+ * Which stacked git action to run (#234, PRD #233). Slice 1 ships the two single-phase
+ * actions — `push` / `pull`; the commit-composing chains (`commit_push`,
+ * `commit_push_pr`) arrive with the quick-action slice (#236) on the same engine.
+ */
+export type GitStackedActionKind = 'push' | 'pull'
+
+/** One phase of a stacked action (#234). Single-phase in slice 1; `commit`/`create_pr` join in #236. */
+export type GitActionPhase = 'push' | 'pull'
+
+/**
+ * Args for `gitRunStackedAction` (#234). `actionId` is CALLER-minted (the renderer
+ * generates it before invoking) so the caller can correlate `gitActionProgress` pushes
+ * with its own invocation — the invoke itself resolves with the final
+ * {@link GitStackedActionResult}; the stream is advisory UI.
+ */
+export interface GitStackedActionArgs {
+  workspaceDir: string
+  actionId: string
+  action: GitStackedActionKind
+}
+
+/**
+ * Main -> renderer streamed progress for a running stacked action (#234), tagged by
+ * `workspaceDir` + `actionId` (fans out to every window like `gitStatus`; the renderer
+ * filters). Ordered per action: `actionStarted`, then per phase `phaseStarted` /
+ * optional `output` (a finished command's non-empty stdout/stderr — hook output lives
+ * here) / `phaseFinished`, closed by exactly one of `actionFinished` | `actionFailed`.
+ * A failed phase STOPS the chain — later phases never start (#236 relies on this).
+ */
+export type GitActionProgressEvent = { workspaceDir: string; actionId: string } & (
+  | { kind: 'actionStarted'; action: GitStackedActionKind }
+  | { kind: 'phaseStarted'; phase: GitActionPhase }
+  | { kind: 'output'; phase: GitActionPhase; text: string }
+  | { kind: 'phaseFinished'; phase: GitActionPhase }
+  | { kind: 'actionFinished' }
+  | { kind: 'actionFailed'; phase: GitActionPhase; error: string }
+)
+
+/**
+ * The `gitRunStackedAction` reply (#234). `{ok:false}` names the phase that failed and
+ * carries git's ACTUAL reason (a rejected push, a non-fast-forward pull, a failed hook)
+ * — never a collapsed message (#86 style). Surfaced inline + recoverable.
+ */
+export type GitStackedActionResult = { ok: true } | { ok: false; phase: GitActionPhase; error: string }
 
 /**
  * Args for `gitCheckout` / `gitCreateBranch` (#87). For a CHECKOUT `name` is the branch's


### PR DESCRIPTION
Closes #234 (PRD #233, slice 1 of the git-review parity epic).

## What this does

The **stacked git-action engine**: a main-process phase sequencer over the established injectable `GitRun` seam, streaming tagged progress events over a new one-way `git:action-progress` channel (broadcast like `git:status`, tagged by Workspace dir + renderer-minted `actionId`), with the `git:run-stacked-action` invoke resolving the typed final result. Slice 1 ships the two single-phase actions; #236 composes commit→push→PR chains onto the same engine — the event grammar already speaks in phases.

- **Push**: plain `git push` with an upstream; a **first push sets the upstream** on the primary remote (prefer `origin`) — this un-dead-ends the PR section's "Push your branch first" gate. Detached HEAD and no-remote fail with git's actual reason.
- **Pull**: `git pull --ff-only` — a diverged branch surfaces git's reason inline instead of the app deciding a merge/rebase (PRD decision).
- **UI**: pure `buildSyncView` derives the clean-tree Push/Pull affordances ("Publish branch" label on a first push); `SyncSection` mirrors streamed phase progress inline, disabled while a turn streams. On success main re-reads status so ahead/behind + the PR gate reflect reality.

## Tests

- 8 fake-runner engine tests: command order, upstream-setup on first push, detached-HEAD/no-remote guards, rejected-push stderr surfacing + event closure, ff-only pull, diverged refusal, reject-degrade (never throws).
- 6 table-driven `buildSyncView` tests (ahead/behind/diverged/no-upstream/dirty/detached).
- Full gates green: lint, typecheck, build, `bun run test` (1154 tests / 90 files).
- **Verified against real git** (bare remote + two clones): first-push upstream setup, plain push, ff pull, diverged-pull refusal — all through the actual module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)