### PR TITLE
feat(composer): workspace-level skills cache — / autocomplete live on draft Threads and cold reopens (#241)

### DIFF
--- a/src/renderer/src/conversation/ColdThread.tsx
+++ b/src/renderer/src/conversation/ColdThread.tsx
@@ -5,6 +5,7 @@ import { UsageBar } from './items/UsageBar'
 import { initialConversationState, type ConversationState } from './reducer'
 import { replayTranscript, transcriptHasImages } from './replay'
 import { replayCache } from './replay-cache'
+import { getWorkspaceCommands } from './workspace-commands'
 
 /**
  * A reopened Thread rendered READ-ONLY from its persisted JSONL (ADR-0005, TB3
@@ -104,7 +105,15 @@ export function ColdThread({
         ) : (
           view.items.map((item) => (
             // Read-only reopened history: no live turn, so reasoning renders collapsed.
-            <Item key={item.id} item={item} streaming={false} onPermission={noPermission} />
+            // The retroactive skill chip (PR #213) matches against the Workspace-level
+            // commands cache (#241) — no agent runs here, so there is no session list.
+            <Item
+              key={item.id}
+              item={item}
+              streaming={false}
+              onPermission={noPermission}
+              availableCommands={getWorkspaceCommands(window.localStorage, thread.workspaceId)}
+            />
           ))
         )}
       </div>

--- a/src/renderer/src/conversation/Conversation.tsx
+++ b/src/renderer/src/conversation/Conversation.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useReducer, useRef, useState, type JSX } from 'react'
+import { useCallback, useEffect, useReducer, useRef, useState, useSyncExternalStore, type JSX } from 'react'
 import type {
   AuthMethod,
   ThreadAgentControls,
@@ -25,6 +25,11 @@ import { UsageBar } from './items/UsageBar'
 import { WorkingRow } from './items/WorkingRow'
 import { Composer } from './Composer'
 import { isSending, useFollowUpQueue } from './follow-up-queue'
+import {
+  foldCommandsEvent,
+  getWorkspaceCommands,
+  subscribeWorkspaceCommands,
+} from './workspace-commands'
 
 /** Process-local counter for unique echoed-prompt ids. */
 let promptSeq = 0
@@ -206,11 +211,16 @@ export function Conversation({
   useEffect(() => {
     return window.api.onAcpEvent((event) => {
       if (event.agentId !== thread.agentId) return
+      // Workspace-level commands cache (#241): fold an `available_commands_update`
+      // BEFORE Thread routing — the list is per-agent, not per-session, and it is not
+      // conversation content, so the reject-while-unbound rule below doesn't apply.
+      // This is what lets an UNBOUND draft's `/` autocomplete see the skills.
+      foldCommandsEvent(window.localStorage, thread.workspaceId, event.payload)
       if (!eventBelongsToThread(event.payload, boundRef.current)) return
       liveSeen.current = true
       dispatch({ type: 'acp-event', payload: event.payload })
     })
-  }, [thread.agentId])
+  }, [thread.agentId, thread.workspaceId])
 
   // The actual send of ONE message as a fresh `session/prompt` (#105). Owns the
   // whole turn lifecycle — echo dispatch, IPC, result handling, and (in `finally`)
@@ -361,6 +371,16 @@ export function Conversation({
   // reasoning auto-open to the live turn only (#115 review S1).
   const lastUserIndex = state.items.map((i) => i.kind).lastIndexOf('user')
 
+  // The `/` skill list with the Workspace-level fallback (#241): a bound Thread uses its
+  // own session's list; an unbound draft (or a just-warmed Thread whose update hasn't
+  // streamed yet) falls back to the Workspace cache — live this session or seeded from
+  // localStorage — so the FIRST prompt can already pick a skill.
+  const workspaceCommands = useSyncExternalStore(subscribeWorkspaceCommands, () =>
+    getWorkspaceCommands(window.localStorage, thread.workspaceId),
+  )
+  const availableCommands =
+    state.availableCommands.length > 0 ? state.availableCommands : workspaceCommands
+
   return (
     // Chip clicks (#116) open files through main; provided here (agentId closed over)
     // for the FileChips streamdown renders far below in the assistant markdown.
@@ -387,7 +407,7 @@ export function Conversation({
               // history's "Thinking" blocks (they belong to prior, settled turns).
               streaming={state.isProcessing && idx > lastUserIndex}
               onPermission={respondPermission}
-              availableCommands={state.availableCommands}
+              availableCommands={availableCommands}
             />
           ))}
           {/* Working indicator (#115): while a turn is in flight, a self-ticking
@@ -411,7 +431,7 @@ export function Conversation({
           boundSessionId={boundSessionId}
           isProcessing={state.isProcessing}
           isEmpty={state.items.length === 0}
-          availableCommands={state.availableCommands}
+          availableCommands={availableCommands}
           followUps={followUps}
           submitPrompt={submitPrompt}
           modes={modes}

--- a/src/renderer/src/conversation/workspace-commands.test.ts
+++ b/src/renderer/src/conversation/workspace-commands.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  commandsFromEvent,
+  foldCommandsEvent,
+  getWorkspaceCommands,
+  subscribeWorkspaceCommands,
+  WORKSPACE_COMMANDS_STORAGE_KEY,
+  type CommandsStorage,
+} from './workspace-commands'
+
+/** An in-memory CommandsStorage double. */
+function fakeStorage(seed: Record<string, string> = {}): CommandsStorage & { data: Record<string, string> } {
+  const data = { ...seed }
+  return {
+    data,
+    getItem: (key) => (key in data ? data[key] : null),
+    setItem: (key, value) => {
+      data[key] = value
+    },
+  }
+}
+
+/** A wire-shaped `available_commands_update` (acp-capture §4). */
+function commandsEvent(commands: unknown): unknown {
+  return {
+    method: 'session/update',
+    params: {
+      sessionId: 'sess-1',
+      update: { sessionUpdate: 'available_commands_update', availableCommands: commands },
+    },
+  }
+}
+
+describe('commandsFromEvent', () => {
+  it('extracts the commands list from an available_commands_update payload', () => {
+    const payload = commandsEvent([
+      { name: 'teach', description: 'Teach mode' },
+      { name: 'review' },
+    ])
+    expect(commandsFromEvent(payload)).toEqual([
+      { name: 'teach', description: 'Teach mode' },
+      { name: 'review', description: undefined },
+    ])
+  })
+
+  it('returns null for any other payload', () => {
+    expect(
+      commandsFromEvent({
+        method: 'session/update',
+        params: { sessionId: 's', update: { sessionUpdate: 'agent_message_chunk' } },
+      }),
+    ).toBeNull()
+    expect(commandsFromEvent({ method: 'exit' })).toBeNull()
+    expect(commandsFromEvent(null)).toBeNull()
+  })
+
+  it('drops malformed entries but keeps the well-formed rest', () => {
+    const payload = commandsEvent([{ name: 'ok' }, { description: 'no name' }, 'junk', null])
+    expect(commandsFromEvent(payload)).toEqual([{ name: 'ok', description: undefined }])
+  })
+})
+
+describe('foldCommandsEvent / getWorkspaceCommands', () => {
+  it('folds an update into the live cache and serves it back', () => {
+    const storage = fakeStorage()
+    foldCommandsEvent(storage, 'ws-live', commandsEvent([{ name: 'teach' }]))
+    expect(getWorkspaceCommands(storage, 'ws-live')).toEqual([{ name: 'teach', description: undefined }])
+  })
+
+  it('ignores non-command events entirely (no write, no notify)', () => {
+    const storage = fakeStorage()
+    const listener = vi.fn()
+    const off = subscribeWorkspaceCommands(listener)
+    foldCommandsEvent(storage, 'ws-noop', { method: 'exit' })
+    expect(getWorkspaceCommands(storage, 'ws-noop')).toEqual([])
+    expect(listener).not.toHaveBeenCalled()
+    off()
+  })
+
+  it('persists the folded list and seeds a fresh read from storage (cold reopen)', () => {
+    const storage = fakeStorage()
+    foldCommandsEvent(storage, 'ws-persist', commandsEvent([{ name: 'plan', description: 'Plan' }]))
+    // Simulate a restart: a NEW storage carrying the old blob, an unseen workspace key
+    // in the live cache is impossible to fake here, so use a distinct workspace id whose
+    // entry exists ONLY in storage.
+    const blob = storage.getItem(WORKSPACE_COMMANDS_STORAGE_KEY)!
+    const restarted = fakeStorage({ [WORKSPACE_COMMANDS_STORAGE_KEY]: blob.replace('ws-persist', 'ws-cold') })
+    expect(getWorkspaceCommands(restarted, 'ws-cold')).toEqual([{ name: 'plan', description: 'Plan' }])
+  })
+
+  it('returns a STABLE empty list and tolerates malformed storage', () => {
+    const storage = fakeStorage({ [WORKSPACE_COMMANDS_STORAGE_KEY]: '{not json' })
+    const first = getWorkspaceCommands(storage, 'ws-broken')
+    expect(first).toEqual([])
+    expect(getWorkspaceCommands(storage, 'ws-broken')).toBe(first) // useSyncExternalStore-stable
+  })
+
+  it('a later update replaces the list and notifies subscribers', () => {
+    const storage = fakeStorage()
+    foldCommandsEvent(storage, 'ws-replace', commandsEvent([{ name: 'old' }]))
+    const listener = vi.fn()
+    const off = subscribeWorkspaceCommands(listener)
+    foldCommandsEvent(storage, 'ws-replace', commandsEvent([{ name: 'new' }]))
+    expect(getWorkspaceCommands(storage, 'ws-replace')).toEqual([{ name: 'new', description: undefined }])
+    expect(listener).toHaveBeenCalled()
+    off()
+  })
+})

--- a/src/renderer/src/conversation/workspace-commands.ts
+++ b/src/renderer/src/conversation/workspace-commands.ts
@@ -1,0 +1,148 @@
+/**
+ * Workspace-level skills/commands cache (#241): the `/` autocomplete's data source for
+ * the Threads that have none of their own. `available_commands_update` is session-tagged
+ * and the event router rightly rejects session-tagged events for an UNBOUND draft
+ * (ADR-0011), so a draft's composer — and a cold, process-free reopen (ADR-0005) — sees
+ * an empty list until the first prompt binds. But the list is per-AGENT (per-Workspace),
+ * not per-session: every session of one `vibe-acp` process reports the same commands. So
+ * any mounted Conversation folds the update in here, keyed by the durable `workspaceId`,
+ * BEFORE Thread routing; drafts and cold Threads fall back to this cache.
+ *
+ * Pure module over an injected storage seam (the `composer-draft-store.ts` pattern):
+ * the live Map serves the session; localStorage carries the last-known list across
+ * restarts (renderer-only UI affordance data — not transcript, not IPC). Reads and
+ * writes swallow malformed blobs and storage exceptions.
+ */
+
+import type { AcpCommand } from './reducer'
+
+/** The single localStorage key holding the `workspaceId -> commands` map. */
+export const WORKSPACE_COMMANDS_STORAGE_KEY = 'vibe-mistro:workspace-commands:v1'
+
+/** The slice of the Web Storage API we depend on — `window.localStorage` satisfies it. */
+export interface CommandsStorage {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+}
+
+/** A stable frozen empty list, so repeat reads snapshot-compare equal (useSyncExternalStore). */
+const NO_COMMANDS: AcpCommand[] = []
+
+/** Live per-Workspace cache. Also memoizes storage-seeded reads for reference stability. */
+const commandsByWorkspace = new Map<string, AcpCommand[]>()
+
+type CommandsListener = () => void
+const listeners = new Set<CommandsListener>()
+
+/** Subscribe to any Workspace's commands changing; returns an unsubscribe. */
+export function subscribeWorkspaceCommands(listener: CommandsListener): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+/** Read + parse the persisted `workspaceId -> commands` map; never throws. */
+function readPersisted(storage: CommandsStorage | null | undefined): Record<string, unknown> {
+  if (!storage) return {}
+  let raw: string | null
+  try {
+    raw = storage.getItem(WORKSPACE_COMMANDS_STORAGE_KEY)
+  } catch {
+    return {}
+  }
+  if (!raw) return {}
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {}
+  } catch {
+    return {}
+  }
+}
+
+/** Defensively coerce one persisted workspace entry back into a commands list. */
+function coercePersistedCommands(raw: unknown): AcpCommand[] {
+  if (!Array.isArray(raw)) return NO_COMMANDS
+  const list = raw
+    .filter(
+      (c): c is { name: string; description?: unknown } =>
+        !!c && typeof c === 'object' && typeof (c as { name?: unknown }).name === 'string',
+    )
+    .map((c) => ({
+      name: c.name,
+      description: typeof c.description === 'string' ? c.description : undefined,
+    }))
+  return list.length > 0 ? list : NO_COMMANDS
+}
+
+/**
+ * Fold an `acp:event` payload into the Workspace cache: a no-op for anything but an
+ * `available_commands_update`; otherwise store live, persist best-effort, and notify.
+ * Call this BEFORE Thread routing — the commands list is not conversation content, so
+ * the reject-while-unbound rule's sibling-splicing hazard does not apply to it.
+ */
+export function foldCommandsEvent(
+  storage: CommandsStorage | null | undefined,
+  workspaceId: string,
+  payload: unknown,
+): void {
+  const commands = commandsFromEvent(payload)
+  if (!commands) return
+  commandsByWorkspace.set(workspaceId, commands)
+  if (storage) {
+    try {
+      const map = readPersisted(storage)
+      map[workspaceId] = commands
+      storage.setItem(WORKSPACE_COMMANDS_STORAGE_KEY, JSON.stringify(map))
+    } catch {
+      // Best-effort persistence — the live cache still serves this session.
+    }
+  }
+  for (const listener of listeners) listener()
+}
+
+/**
+ * The Workspace's last-known commands: the live cache when this session has seen an
+ * update, else a one-time seed from storage (memoized into the cache so repeat reads
+ * return the SAME reference — a `useSyncExternalStore` snapshot requirement). Empty
+ * when neither exists (e.g. a never-connected Workspace).
+ */
+export function getWorkspaceCommands(
+  storage: CommandsStorage | null | undefined,
+  workspaceId: string,
+): AcpCommand[] {
+  const live = commandsByWorkspace.get(workspaceId)
+  if (live) return live
+  const seeded = coercePersistedCommands(readPersisted(storage)[workspaceId])
+  commandsByWorkspace.set(workspaceId, seeded)
+  return seeded
+}
+
+/**
+ * Probe an `acp:event` payload for an `available_commands_update` (acp-capture §4) and
+ * return its parsed commands list, or null for any other payload. Mirrors the reducer's
+ * own defensive parse: entries without a string `name` are dropped.
+ */
+export function commandsFromEvent(payload: unknown): AcpCommand[] | null {
+  if (!payload || typeof payload !== 'object') return null
+  const message = payload as { method?: unknown; params?: unknown }
+  if (message.method !== 'session/update') return null
+  const update = (message.params as { update?: unknown } | undefined)?.update
+  if (!update || typeof update !== 'object') return null
+  if ((update as { sessionUpdate?: unknown }).sessionUpdate !== 'available_commands_update') {
+    return null
+  }
+  const list = (update as { availableCommands?: unknown }).availableCommands
+  if (!Array.isArray(list)) return null
+  return list
+    .filter(
+      (c): c is { name: string; description?: unknown } =>
+        !!c && typeof c === 'object' && typeof (c as { name?: unknown }).name === 'string',
+    )
+    .map((c) => ({
+      name: c.name,
+      description: typeof c.description === 'string' ? c.description : undefined,
+    }))
+}


### PR DESCRIPTION
Closes #241.

## What changed

- **New pure module `workspace-commands.ts`** (8 tests, TDD): probes `acp:event` payloads for `available_commands_update`, folds the list into a per-`workspaceId` cache, persists it to localStorage (injected-storage seam, defensive parse), and serves reference-stable snapshots for `useSyncExternalStore`.
- **`Conversation`** folds the update *before* Thread routing (the commands list is not conversation content, so ADR-0011's reject-while-unbound rule's splicing hazard doesn't apply), and both the composer and the message rows fall back to the Workspace cache whenever the Thread's own session list is empty.
- **`ColdThread`** read-only rows now pass the cached list to the retroactive skill chip (previously they passed nothing).

## Behavior

- New draft on a warm Workspace: `/` shows the full skill list before the first prompt; accepting stages the #229 skill chip.
- Cold reopen / fresh launch: `/` shows the last-known persisted list before any agent warms; refreshed by the next live update.
- Bound Threads: unchanged (their own session list wins).

## Gates

`bun run lint && bun run typecheck && bun run build && bun run test` — all green, **1166 tests** (+8).

## Test suggestions

1. Fresh draft on a connected Workspace → `/` immediately lists skills → pick one → chip → send → skill invokes.
2. Quit + relaunch → open the same Workspace → new draft *before* the agent finishes warming → `/` lists skills from the persisted cache.
3. A never-connected Workspace still shows an empty popover (nothing cached) — expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)