### PR TITLE
feat(git): slice 3 — default-branch guard + heuristic auto commit message (#238)

### DIFF
--- a/src/renderer/src/git/ChangesPanel.tsx
+++ b/src/renderer/src/git/ChangesPanel.tsx
@@ -1,9 +1,23 @@
 import { useEffect, useState, type JSX } from 'react'
 import { Boxes, GitCommitHorizontal, Monitor, PanelRightClose, RefreshCw } from 'lucide-react'
 import type { GitStatus } from '../../../shared/ipc'
-import { Badge, Button, IconButton, Textarea } from '../ui'
+import {
+  Badge,
+  Button,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  IconButton,
+  Input,
+  Textarea,
+} from '../ui'
 import { getCommitDraft, setCommitDraft } from './commit-draft-store'
 import { buildChangesView, buildSyncView, reconcileUnchecked } from './status-view'
+import { autoCommitMessage, isDefaultBranch, suggestBranchName } from './commit-guard'
 import { BranchMenu } from './BranchMenu'
 import { PrSection } from './PrSection'
 import { SyncSection } from './SyncSection'
@@ -81,6 +95,12 @@ export function ChangesPanel({
   // manual refresh too (its own effect otherwise only fires on a branch change — a PR is a
   // network call we don't tie to every status tick).
   const [prRefreshKey, setPrRefreshKey] = useState(0)
+  // The default-branch guard dialog (#238): open flag, the escape hatch's editable
+  // branch name (prefilled from the effective message), its in-flight + error state.
+  const [guardOpen, setGuardOpen] = useState(false)
+  const [guardBranchName, setGuardBranchName] = useState('')
+  const [guardWorking, setGuardWorking] = useState(false)
+  const [guardError, setGuardError] = useState<string | null>(null)
 
   useEffect(() => {
     if (!isActive) return
@@ -137,15 +157,34 @@ export function ChangesPanel({
 
   // The selected files = everything not explicitly deselected (#86). These are the exact
   // paths handed to `gitCommit`; main stages precisely this selection then commits.
-  const selectedPaths = view.files.filter((f) => !unchecked.has(f.path)).map((f) => f.path)
-  const canCommit = message.trim().length > 0 && selectedPaths.length > 0 && !busy && !committing
+  const selectedFiles = view.files.filter((f) => !unchecked.has(f.path))
+  const selectedPaths = selectedFiles.map((f) => f.path)
+  // A BLANK message no longer blocks committing (#238): the heuristic message shows as
+  // the placeholder — what you see is exactly what a blank submit commits.
+  const generatedMessage = autoCommitMessage(selectedFiles)
+  const effectiveMessage = message.trim() || generatedMessage
+  const canCommit = effectiveMessage.length > 0 && selectedPaths.length > 0 && !busy && !committing
 
   async function commit(): Promise<void> {
     if (!canCommit) return
+    // Default-branch guard (#238): interpose BEFORE a commit that would land straight
+    // on the default branch. Strictly best-effort — a failed branches read (or an
+    // unresolved default) skips the guard rather than blocking the commit.
+    const branches = await window.api.gitBranches({ workspaceDir })
+    if (branches.ok && isDefaultBranch(status?.branch ?? null, branches.branches)) {
+      setGuardBranchName(suggestBranchName(effectiveMessage))
+      setGuardError(null)
+      setGuardOpen(true)
+      return
+    }
+    await doCommit()
+  }
+
+  async function doCommit(): Promise<void> {
     setCommitting(true)
     setCommitError(null)
     try {
-      const result = await window.api.gitCommit({ workspaceDir, message: message.trim(), paths: selectedPaths })
+      const result = await window.api.gitCommit({ workspaceDir, message: effectiveMessage, paths: selectedPaths })
       if (result.ok) {
         // The committed files drop off via the status refresh main triggers; clear the
         // message so the next commit starts fresh. The deselection set reconciles itself
@@ -159,6 +198,26 @@ export function ChangesPanel({
       // Always re-enable the button — even if the IPC unexpectedly rejects, it can't
       // stick on "Committing…".
       setCommitting(false)
+    }
+  }
+
+  /** The guard's escape hatch (#238): create + switch to the named branch, then run the
+   *  original commit on it. A create failure (name collision) stays IN the dialog. */
+  async function createBranchAndCommit(): Promise<void> {
+    const name = guardBranchName.trim()
+    if (!name) return
+    setGuardWorking(true)
+    setGuardError(null)
+    try {
+      const result = await window.api.gitCreateBranch({ workspaceDir, name })
+      if (!result.ok) {
+        setGuardError(result.error)
+        return
+      }
+      setGuardOpen(false)
+      await doCommit()
+    } finally {
+      setGuardWorking(false)
     }
   }
 
@@ -247,14 +306,15 @@ export function ChangesPanel({
             ))}
           </ul>
 
-          {/* Commit area (#86): message + "Commit N". Disabled on an empty message,
-              no selection, or `busy` (the v1 concurrency guard — no concurrent
-              user+agent commit). git's reason surfaces inline + recoverable. */}
+          {/* Commit area (#86, #238): message + "Commit N". A BLANK message commits
+              with the heuristic shown as the placeholder; disabled only with no
+              selection or `busy` (the v1 concurrency guard — no concurrent user+agent
+              commit). git's reason surfaces inline + recoverable. */}
           <div className="flex flex-col gap-2 border-t border-border-muted px-3 py-2.5">
             <Textarea
               value={message}
               onChange={(e) => setMessage(e.target.value)}
-              placeholder="Commit message"
+              placeholder={generatedMessage || 'Commit message'}
               rows={2}
               className="min-h-16 resize-y text-[13px]"
               // Ctrl/Cmd+Enter commits, matching the prompt composer's submit chord.
@@ -276,6 +336,62 @@ export function ChangesPanel({
               {committing ? 'Committing…' : `Commit ${selectedPaths.length}`}
             </Button>
           </div>
+
+          {/* Default-branch guard (#238): interposed by `commit()` when HEAD is the
+              repository's default branch — Abort / Continue on default / Create feature
+              branch (prefilled, editable) & continue. A create failure stays in the
+              dialog with git's reason; Continue behaves exactly like today's commit. */}
+          <Dialog open={guardOpen} onOpenChange={(open) => !guardWorking && setGuardOpen(open)}>
+            <DialogContent className="max-w-md">
+              <DialogHeader>
+                <DialogTitle>Commit on {view.branch}?</DialogTitle>
+                <DialogDescription>
+                  {view.branch} is this repository’s default branch. You can commit here, or move the
+                  commit onto a new feature branch.
+                </DialogDescription>
+              </DialogHeader>
+              <div className="flex flex-col gap-1.5">
+                <label htmlFor="guard-branch-name" className="text-[11px] font-medium text-muted">
+                  New branch name
+                </label>
+                <Input
+                  id="guard-branch-name"
+                  value={guardBranchName}
+                  onChange={(e) => setGuardBranchName(e.target.value)}
+                  disabled={guardWorking}
+                  className="text-[13px]"
+                />
+                {guardError && (
+                  <p className="text-[11px] text-bad" role="alert">
+                    {guardError}
+                  </p>
+                )}
+              </div>
+              <DialogFooter>
+                <DialogClose render={<Button variant="secondary" size="sm" disabled={guardWorking} />}>
+                  Cancel
+                </DialogClose>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={guardWorking}
+                  onClick={() => {
+                    setGuardOpen(false)
+                    void doCommit()
+                  }}
+                >
+                  Commit on {view.branch}
+                </Button>
+                <Button
+                  size="sm"
+                  disabled={guardWorking || guardBranchName.trim().length === 0}
+                  onClick={() => void createBranchAndCommit()}
+                >
+                  {guardWorking ? 'Creating…' : 'Create branch & commit'}
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
         </>
       )}
     </aside>

--- a/src/renderer/src/git/commit-guard.test.ts
+++ b/src/renderer/src/git/commit-guard.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { autoCommitMessage, isDefaultBranch, suggestBranchName } from './commit-guard'
+import type { GitBranch } from '../../../shared/ipc'
+
+/**
+ * Pure seams for slice 3 (#238, PRD #233): the heuristic auto commit message. The
+ * heuristic lives renderer-side (not main) because the SAME string must show as the
+ * textarea's placeholder BEFORE the commit — the renderer substitutes it for a blank
+ * message at submit, so what you see is exactly what gets committed.
+ */
+
+/** Minimal file shape: the view's sorted files (path + display glyph). */
+function f(path: string, glyph = 'M'): { path: string; glyph: string } {
+  return { path, glyph }
+}
+
+describe('autoCommitMessage', () => {
+  it('returns the empty string for no files (nothing to describe)', () => {
+    expect(autoCommitMessage([])).toBe('')
+  })
+
+  it('one modified file: "Update <basename>"', () => {
+    expect(autoCommitMessage([f('src/renderer/src/git/ChangesPanel.tsx')])).toBe('Update ChangesPanel.tsx')
+  })
+
+  it('maps each glyph family to its verb (untracked counts as Add)', () => {
+    expect(autoCommitMessage([f('a.txt', 'A')])).toBe('Add a.txt')
+    expect(autoCommitMessage([f('a.txt', 'U')])).toBe('Add a.txt')
+    expect(autoCommitMessage([f('a.txt', 'D')])).toBe('Delete a.txt')
+    expect(autoCommitMessage([f('a.txt', 'R')])).toBe('Rename a.txt')
+    expect(autoCommitMessage([f('a.txt', 'C')])).toBe('Update a.txt')
+  })
+
+  it('the DOMINANT verb wins and the headline is the first file of that verb', () => {
+    const files = [f('m.txt', 'M'), f('new1.txt', 'U'), f('new2.txt', 'A')]
+    // Add (U+A = 2) beats Update (1); headline = first Add-family file in view order.
+    expect(autoCommitMessage(files)).toBe('Add new1.txt and 2 more')
+  })
+
+  it('counts the OTHER files, singular/plural', () => {
+    expect(autoCommitMessage([f('a.txt'), f('b.txt')])).toBe('Update a.txt and 1 more')
+    expect(autoCommitMessage([f('a.txt'), f('b.txt'), f('c.txt')])).toBe('Update a.txt and 2 more')
+  })
+
+  it('a verb TIE falls back to Update-first ordering (stable, unsurprising)', () => {
+    // 1 M + 1 A: tie → Update wins, headline is the M file.
+    expect(autoCommitMessage([f('new.txt', 'A'), f('mod.txt', 'M')])).toBe('Update mod.txt and 1 more')
+  })
+})
+
+function branch(partial: Partial<GitBranch> & { name: string }): GitBranch {
+  return { isRemote: false, current: false, isDefault: false, ...partial }
+}
+
+describe('isDefaultBranch', () => {
+  const branches = [
+    branch({ name: 'main', isDefault: true }),
+    branch({ name: 'feat/x', current: true }),
+    branch({ name: 'origin/other', isRemote: true }),
+  ]
+
+  it('true only when the CURRENT branch name is the LOCAL default', () => {
+    expect(isDefaultBranch('main', branches)).toBe(true)
+    expect(isDefaultBranch('feat/x', branches)).toBe(false)
+  })
+
+  it('a REMOTE entry named like the branch does not count (local default only)', () => {
+    const remoteDefault = [branch({ name: 'origin/main', isRemote: true, isDefault: true })]
+    expect(isDefaultBranch('origin/main', remoteDefault)).toBe(false)
+  })
+
+  it('unresolved default (no isDefault anywhere) or a null branch → false (no guard)', () => {
+    expect(isDefaultBranch('main', [branch({ name: 'main' })])).toBe(false)
+    expect(isDefaultBranch(null, branches)).toBe(false)
+  })
+})
+
+describe('suggestBranchName', () => {
+  it('slugifies the message: lowercase, non-alphanumerics collapse to single dashes', () => {
+    expect(suggestBranchName('Update ChangesPanel.tsx and 2 more')).toBe('update-changespanel-tsx-and-2-more')
+  })
+
+  it('trims leading/trailing dashes and caps the length', () => {
+    expect(suggestBranchName('  !!Fix: the (thing)!!  ')).toBe('fix-the-thing')
+    expect(suggestBranchName('x'.repeat(100)).length).toBeLessThanOrEqual(40)
+  })
+
+  it('an empty/unusable message falls back to "changes"', () => {
+    expect(suggestBranchName('')).toBe('changes')
+    expect(suggestBranchName('!!!')).toBe('changes')
+  })
+})

--- a/src/renderer/src/git/commit-guard.ts
+++ b/src/renderer/src/git/commit-guard.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure seams for slice 3 (#238, PRD #233): the commit flow's guard rails — the
+ * heuristic auto commit message, the default-branch predicate, and the escape-hatch
+ * branch-name suggestion. All renderer-side pure functions (unit-tested DOM-free);
+ * `ChangesPanel` wires them to the dialog + textarea. The heuristic deliberately lives
+ * HERE, not main: the same string shows as the textarea's placeholder BEFORE the
+ * commit and is substituted for a blank message at submit — what you see is exactly
+ * what gets committed (no agent involvement, ADR-0002 thin-orchestrator).
+ */
+
+import type { GitBranch } from '../../../shared/ipc'
+
+/** The verb for a view glyph: Add (A/U), Delete (D), Rename (R), else Update. */
+const GLYPH_VERB: Record<string, string> = { A: 'Add', U: 'Add', D: 'Delete', R: 'Rename' }
+
+/** Verb precedence for ties — Update first (the unsurprising default), then by weight. */
+const VERB_ORDER = ['Update', 'Add', 'Delete', 'Rename']
+
+/**
+ * A deterministic commit message from the SELECTED files (the view's sorted order):
+ * dominant verb + the first matching file's basename + "and N more". Empty selection →
+ * empty string (the caller keeps its disabled state).
+ */
+export function autoCommitMessage(files: readonly { path: string; glyph: string }[]): string {
+  if (files.length === 0) return ''
+  const counts = new Map<string, number>()
+  for (const file of files) {
+    const verb = GLYPH_VERB[file.glyph] ?? 'Update'
+    counts.set(verb, (counts.get(verb) ?? 0) + 1)
+  }
+  let dominant = 'Update'
+  let best = -1
+  for (const verb of VERB_ORDER) {
+    const n = counts.get(verb) ?? 0
+    if (n > best) {
+      dominant = verb
+      best = n
+    }
+  }
+  const headline = files.find((file) => (GLYPH_VERB[file.glyph] ?? 'Update') === dominant) ?? files[0]
+  const basename = headline.path.split('/').at(-1) ?? headline.path
+  const others = files.length - 1
+  return others === 0 ? `${dominant} ${basename}` : `${dominant} ${basename} and ${others} more`
+}
+
+/**
+ * Whether the checked-out branch is the repository's LOCAL default (#238's guard
+ * predicate). Deliberately strict: an unresolved default (origin/HEAD unset — the
+ * branches module then flags nothing) or a detached HEAD (`branch` null) yields false,
+ * so the guard NEVER fires on uncertainty — a wrongly-shown dialog nags, a wrongly-
+ * skipped one just restores today's behavior.
+ */
+export function isDefaultBranch(branch: string | null, branches: readonly GitBranch[]): boolean {
+  if (branch === null) return false
+  return branches.some((b) => b.isDefault && !b.isRemote && b.name === branch)
+}
+
+/**
+ * The escape hatch's prefilled branch name (#238): the commit message slugified —
+ * lowercase, runs of non-alphanumerics collapse to one dash, trimmed, capped at 40
+ * chars (branch names want to stay short). An unusable message falls back to
+ * `changes` so the input is never prefilled empty.
+ */
+export function suggestBranchName(message: string): string {
+  const slug = message
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40)
+    .replace(/-+$/, '')
+  return slug || 'changes'
+}


### PR DESCRIPTION
Closes #238 (PRD #233, slice 3 of the git-review parity epic).

## What this does

Two guard rails for the Review Surface's commit flow:

**Default-branch guard.** Clicking Commit while on the repository's default branch now interposes a dialog: **Cancel** / **Commit on `main`** / **Create branch & commit**. The escape hatch prefills an editable branch name (a slug of the effective commit message), creates it via the existing create-branch path, and runs the original commit on it; a create failure (e.g. name collision) stays in the dialog with git's actual reason. The predicate (`isDefaultBranch`) is deliberately strict — an unresolved default (origin/HEAD unset), a detached HEAD, or a failed branches read **skips the guard** rather than blocking the commit: a wrongly-skipped guard just restores today's behavior, a wrongly-shown one nags.

**Heuristic auto commit message.** A blank message no longer disables Commit. `autoCommitMessage` (dominant status verb + headline file basename + "and N more", e.g. `Update ChangesPanel.tsx and 2 more`) shows as the textarea **placeholder** and is substituted at submit — what you see is exactly what gets committed. A typed message always wins. It's renderer-side (a small deviation from the PRD's "main-side" wording) precisely so the preview and the committed string are one value; no agent turn is spent on message prose (ADR-0002).

**Slice-order note:** #238 was speced behind #236 (quick action). Landing first, both features wrap today's plain `commit()` seam; #236 will layer the commit→push→PR chains onto the same interposition point.

## Tests

- 12 pure tests for the three seams: `autoCommitMessage` (verb mapping, dominant-verb + headline selection, singular/plural counts, tie fallback), `isDefaultBranch` (local-default only, remote exclusion, unresolved/detached → no guard), `suggestBranchName` (slugging, trimming, cap, fallback).
- Full gates green: lint, typecheck, build, `bun run test` (1196 tests / 94 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)