### PR TITLE
feat(account): live plan tier in the account chip via console whoami

### DIFF
--- a/docs/adr/0003-auth-delegated-to-vibe.md
+++ b/docs/adr/0003-auth-delegated-to-vibe.md
@@ -33,3 +33,24 @@ This is the auth-specific application of ADR-0002's thin-orchestrator stance: ag
   shapes in `docs/acp-capture.md` §8 and re-verify on Vibe upgrades.
 - BYOK (a `MISTRAL_API_KEY` env var or `~/.vibe/.env`) authenticates without our sign-in flow; we treat
   any `authenticated: true` from `auth/status` as signed in regardless of `authState`.
+
+## Amendment (2026-07-03): read-only credential access for plan display
+
+The sidebar account chip and Settings Account section show the account's **plan tier** (e.g. "Pro").
+Vibe cannot supply it over ACP — its sign-in ends with a bare `MISTRAL_API_KEY` and `_auth/status`
+reports only `{authenticated, authState, signOutAvailable}`; the plan lives behind Mistral's console
+`GET /api/vibe/whoami`, which Vibe's own TUI calls directly with the key as a Bearer token. There is
+no email/name/user-id anywhere in Vibe's surfaces — plan is the ceiling of account identity.
+
+So main (`src/main/auth/whoami.ts`, the `auth:account-whoami` IPC) **reads** the key exactly where
+Vibe keeps it — resolved shell env → `$VIBE_HOME/.env` → OS keychain (`ai.mistral.vibe`), the same
+active-credential precedence as Vibe's `assess_auth_state` — and makes that one whoami request.
+
+Boundaries that keep the original decision intact:
+
+- **Read-only, transient.** The key is never persisted, logged, or sent over IPC/to the renderer;
+  only the parsed `{planType, planName}` crosses the bridge. Vibe still owns storage and rotation.
+- **Display-only.** Failures (no key, rejected key, network) are typed results the UI silently
+  degrades on — never an auth gate. Sign-in/out remain exclusively Vibe's ACP methods.
+- The whoami endpoint is unversioned console surface; treat it like the `_auth/*` extensions —
+  pinned against Vibe's `http_whoami_gateway.py` and re-verified on Vibe upgrades.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,6 +20,9 @@ export default tseslint.config(
       'coverage/**',
       '**/*.gen.*',
       '*.tsbuildinfo',
+      // Agent worktrees are full repo copies — linting them double-reports and
+      // confuses the typed parser with multiple candidate tsconfig roots.
+      '.claude/worktrees/**',
     ],
   },
 

--- a/src/main/auth/whoami.test.ts
+++ b/src/main/auth/whoami.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest'
+import type { AccountWhoamiResult } from '../../shared/ipc'
+import {
+  getAccountWhoami,
+  MISTRAL_API_KEY,
+  parseDotenvValue,
+  parseWhoamiPayload,
+  resolveMistralApiKey,
+  WHOAMI_URL,
+  type WhoamiDeps,
+} from './whoami'
+
+describe('parseDotenvValue', () => {
+  it('reads a bare assignment', () => {
+    expect(parseDotenvValue('MISTRAL_API_KEY=abc123\n', MISTRAL_API_KEY)).toBe('abc123')
+  })
+
+  it('strips single and double quotes (python-dotenv set_key writes quoted)', () => {
+    expect(parseDotenvValue("MISTRAL_API_KEY='abc123'", MISTRAL_API_KEY)).toBe('abc123')
+    expect(parseDotenvValue('MISTRAL_API_KEY="abc123"', MISTRAL_API_KEY)).toBe('abc123')
+  })
+
+  it('handles export prefix, surrounding whitespace, and other keys', () => {
+    const content = '# creds\nexport OTHER=x\n  export MISTRAL_API_KEY = abc123  \n'
+    expect(parseDotenvValue(content, MISTRAL_API_KEY)).toBe('abc123')
+  })
+
+  it('ignores comments and takes the LAST assignment (dotenv semantics)', () => {
+    const content = '# MISTRAL_API_KEY=commented\nMISTRAL_API_KEY=first\nMISTRAL_API_KEY=second\n'
+    expect(parseDotenvValue(content, MISTRAL_API_KEY)).toBe('second')
+  })
+
+  it('returns null for a missing key or an empty value', () => {
+    expect(parseDotenvValue('OTHER=x\n', MISTRAL_API_KEY)).toBeNull()
+    expect(parseDotenvValue('MISTRAL_API_KEY=\n', MISTRAL_API_KEY)).toBeNull()
+    expect(parseDotenvValue('MISTRAL_API_KEY=""\n', MISTRAL_API_KEY)).toBeNull()
+  })
+
+  it('does not match keys that merely start with the wanted name', () => {
+    expect(parseDotenvValue('MISTRAL_API_KEY_OLD=x\n', MISTRAL_API_KEY)).toBeNull()
+  })
+})
+
+describe('parseWhoamiPayload', () => {
+  it('parses the documented shape', () => {
+    expect(
+      parseWhoamiPayload({ plan_type: 'CHAT', plan_name: 'INDIVIDUAL', prompt_switching_to_pro_plan: false }),
+    ).toEqual({ planType: 'CHAT', planName: 'INDIVIDUAL' })
+  })
+
+  it('normalises case/whitespace and degrades unknown plan types to UNKNOWN (Vibe parity)', () => {
+    expect(parseWhoamiPayload({ plan_type: ' chat ', plan_name: ' Free ' })).toEqual({
+      planType: 'CHAT',
+      planName: 'Free',
+    })
+    expect(parseWhoamiPayload({ plan_type: 'SOMETHING_NEW', plan_name: 'X' })).toEqual({
+      planType: 'UNKNOWN',
+      planName: 'X',
+    })
+  })
+
+  it('rejects payloads where plan_type/plan_name are not both strings', () => {
+    expect(parseWhoamiPayload({ plan_type: 'CHAT' })).toBeNull()
+    expect(parseWhoamiPayload({ plan_type: 1, plan_name: 'x' })).toBeNull()
+    expect(parseWhoamiPayload(null)).toBeNull()
+    expect(parseWhoamiPayload('nope')).toBeNull()
+  })
+})
+
+function deps(overrides: Partial<WhoamiDeps>): WhoamiDeps {
+  return {
+    env: {},
+    readEnvFile: async () => null,
+    readKeyring: async () => null,
+    fetchFn: async () => {
+      throw new Error('fetch not expected')
+    },
+    ...overrides,
+  }
+}
+
+describe('resolveMistralApiKey', () => {
+  it('prefers process env over dotenv over keyring (Vibe active-credential order)', async () => {
+    const all = deps({
+      env: { MISTRAL_API_KEY: 'from-env' },
+      readEnvFile: async () => 'MISTRAL_API_KEY=from-dotenv',
+      readKeyring: async () => 'from-keyring',
+    })
+    expect(await resolveMistralApiKey(all)).toBe('from-env')
+    expect(await resolveMistralApiKey({ ...all, env: {} })).toBe('from-dotenv')
+    expect(await resolveMistralApiKey({ ...all, env: {}, readEnvFile: async () => null })).toBe(
+      'from-keyring',
+    )
+  })
+
+  it('treats an empty env value as absent', async () => {
+    const d = deps({ env: { MISTRAL_API_KEY: '' }, readKeyring: async () => 'from-keyring' })
+    expect(await resolveMistralApiKey(d)).toBe('from-keyring')
+  })
+
+  it('returns null when signed out of every store', async () => {
+    expect(await resolveMistralApiKey(deps({}))).toBeNull()
+  })
+})
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), { status })
+}
+
+describe('getAccountWhoami', () => {
+  it('returns no-key without touching the network when nothing is stored', async () => {
+    const result = await getAccountWhoami(deps({}))
+    expect(result).toEqual<AccountWhoamiResult>({
+      ok: false,
+      reason: 'no-key',
+      error: 'No Mistral API key found.',
+    })
+  })
+
+  it('sends the resolved key as a Bearer token to the whoami URL and parses the plan', async () => {
+    let seenUrl: string | undefined
+    let seenAuth: string | null | undefined
+    const result = await getAccountWhoami(
+      deps({
+        env: { MISTRAL_API_KEY: 'sk-test' },
+        fetchFn: async (url, init) => {
+          seenUrl = String(url)
+          seenAuth = new Headers(init?.headers).get('Authorization')
+          return jsonResponse(200, { plan_type: 'CHAT', plan_name: 'INDIVIDUAL' })
+        },
+      }),
+    )
+    expect(seenUrl).toBe(WHOAMI_URL)
+    expect(seenAuth).toBe('Bearer sk-test')
+    expect(result).toEqual({ ok: true, plan: { planType: 'CHAT', planName: 'INDIVIDUAL' } })
+  })
+
+  it('classifies 401/403 as unauthorized (Vibe gateway parity)', async () => {
+    for (const status of [401, 403]) {
+      const result = await getAccountWhoami(
+        deps({
+          env: { MISTRAL_API_KEY: 'sk-test' },
+          fetchFn: async () => jsonResponse(status, {}),
+        }),
+      )
+      expect(result).toMatchObject({ ok: false, reason: 'unauthorized' })
+    }
+  })
+
+  it('classifies other failures as error: bad status, network throw, non-JSON, bad shape', async () => {
+    const cases: Array<WhoamiDeps['fetchFn']> = [
+      async () => jsonResponse(500, {}),
+      async () => {
+        throw new Error('offline')
+      },
+      async () => new Response('<html>', { status: 200 }),
+      async () => jsonResponse(200, { plan_type: 'CHAT' }),
+    ]
+    for (const fetchFn of cases) {
+      const result = await getAccountWhoami(deps({ env: { MISTRAL_API_KEY: 'sk-test' }, fetchFn }))
+      expect(result).toMatchObject({ ok: false, reason: 'error' })
+    }
+  })
+})

--- a/src/main/auth/whoami.ts
+++ b/src/main/auth/whoami.ts
@@ -1,0 +1,188 @@
+import { execFile } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import type { AccountPlan, AccountWhoamiResult } from '../../shared/ipc'
+
+/**
+ * Fetch the signed-in account's PLAN from Mistral's console whoami endpoint
+ * (ADR-0003 amendment). Vibe stores no identity — its sign-in ends with a bare
+ * `MISTRAL_API_KEY` and the console `whoami` reports only the plan tier — so we
+ * READ that key exactly where Vibe keeps it and make the same call Vibe's TUI
+ * makes (vibe/cli/plan_offer/adapters/http_whoami_gateway.py). The key is used
+ * for the one request and NEVER persisted, surfaced over IPC, or logged.
+ *
+ * Key-resolution order mirrors Vibe's ACTIVE-credential precedence
+ * (vibe/setup/auth/auth_state.py `assess_auth_state`): process env, then the
+ * `$VIBE_HOME/.env` dotenv, then the OS keyring — Vibe loads the dotenv into
+ * its process env and reads env before keyring, so a dotenv entry outranks a
+ * keyring one. Our "process env" is the resolved login-shell env we also spawn
+ * `vibe-acp` with, so the agent and this lookup agree on the credential.
+ */
+
+/** The env key Vibe persists its Mistral credential under (all three stores). */
+export const MISTRAL_API_KEY = 'MISTRAL_API_KEY'
+
+/** Vibe's whoami endpoint (console base + WHOAMI_PATH, http_whoami_gateway.py). */
+export const WHOAMI_URL = 'https://console.mistral.ai/api/vibe/whoami'
+
+/** Keychain service names Vibe writes (vibe/core/utils/keyring.py; legacy first app). */
+const KEYRING_SERVICES = ['ai.mistral.vibe', 'vibe'] as const
+
+const execFileAsync = promisify(execFile)
+
+/**
+ * Extract `key`'s value from dotenv-file content (Vibe's `~/.vibe/.env`
+ * fallback store, written by python-dotenv's `set_key`). Handles the shapes
+ * that writer produces plus hand-edits: optional `export `, single/double
+ * quotes, surrounding whitespace, `#` comment lines. Last assignment wins,
+ * matching dotenv semantics.
+ */
+export function parseDotenvValue(content: string, key: string): string | null {
+  let value: string | null = null
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) continue
+    const unexported = line.startsWith('export ') ? line.slice('export '.length).trimStart() : line
+    const eq = unexported.indexOf('=')
+    if (eq <= 0 || unexported.slice(0, eq).trim() !== key) continue
+    let raw = unexported.slice(eq + 1).trim()
+    if (
+      raw.length >= 2 &&
+      ((raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'")))
+    ) {
+      raw = raw.slice(1, -1)
+    }
+    value = raw
+  }
+  return value ? value : null
+}
+
+/**
+ * Parse the whoami response body into an `AccountPlan`. Mirrors Vibe's
+ * `WhoAmIResponse.from_payload`: both `plan_type` and `plan_name` must be
+ * strings (else the payload is invalid → null), and an unrecognised
+ * `plan_type` degrades to `UNKNOWN` rather than failing.
+ */
+export function parseWhoamiPayload(payload: unknown): AccountPlan | null {
+  const planType = (payload as { plan_type?: unknown } | null)?.plan_type
+  const planName = (payload as { plan_name?: unknown } | null)?.plan_name
+  if (typeof planType !== 'string' || typeof planName !== 'string') return null
+  const normalized = planType.trim().toUpperCase()
+  const known: readonly AccountPlan['planType'][] = [
+    'API',
+    'CHAT',
+    'MISTRAL_CODE',
+    'UNKNOWN',
+    'UNAUTHORIZED',
+  ]
+  return {
+    planType: known.includes(normalized as AccountPlan['planType'])
+      ? (normalized as AccountPlan['planType'])
+      : 'UNKNOWN',
+    planName: planName.trim(),
+  }
+}
+
+/** The IO seams `getAccountWhoami` composes — injectable for tests. */
+export interface WhoamiDeps {
+  /** The resolved shell env (the same one `vibe-acp` is spawned with). */
+  env: NodeJS.ProcessEnv
+  /** Read the dotenv-store content, or null when absent/unreadable. */
+  readEnvFile: () => Promise<string | null>
+  /** Read the keychain-stored key, or null when absent/unsupported. */
+  readKeyring: () => Promise<string | null>
+  /** The fetch to hit the whoami endpoint with. */
+  fetchFn: typeof fetch
+}
+
+/**
+ * Resolve the Mistral API key the way Vibe would pick its active credential:
+ * process env → `$VIBE_HOME/.env` → OS keyring. Returns null when signed out
+ * everywhere.
+ */
+export async function resolveMistralApiKey(
+  deps: Pick<WhoamiDeps, 'env' | 'readEnvFile' | 'readKeyring'>,
+): Promise<string | null> {
+  const fromEnv = deps.env[MISTRAL_API_KEY]
+  if (fromEnv) return fromEnv
+  const envFile = await deps.readEnvFile()
+  const fromDotenv = envFile === null ? null : parseDotenvValue(envFile, MISTRAL_API_KEY)
+  if (fromDotenv) return fromDotenv
+  return deps.readKeyring()
+}
+
+/** Read Vibe's dotenv store at `$VIBE_HOME/.env` (default `~/.vibe/.env`). */
+export async function readVibeEnvFile(env: NodeJS.ProcessEnv): Promise<string | null> {
+  const vibeHome = env.VIBE_HOME || join(homedir(), '.vibe')
+  try {
+    return await readFile(join(vibeHome, '.env'), 'utf8')
+  } catch {
+    return null // absent file = signed out of this store, not an error
+  }
+}
+
+/**
+ * Read the key from the OS keychain the way Vibe stores it. macOS only for
+ * now (`security find-generic-password`, the same binary Vibe's python-keyring
+ * shells out to); other platforms return null — the env/dotenv stores still
+ * work there. Tries the current service name, then the legacy one.
+ */
+export async function readKeychainApiKey(): Promise<string | null> {
+  if (process.platform !== 'darwin') return null
+  for (const service of KEYRING_SERVICES) {
+    try {
+      const { stdout } = await execFileAsync('/usr/bin/security', [
+        'find-generic-password',
+        '-s',
+        service,
+        '-a',
+        MISTRAL_API_KEY,
+        '-w',
+      ])
+      const key = stdout.trim()
+      if (key) return key
+    } catch {
+      // exit 44 = item not found — fall through to the next service name
+    }
+  }
+  return null
+}
+
+/**
+ * The composed lookup behind the `auth:account-whoami` IPC: resolve the key,
+ * hit the whoami endpoint, classify. Every failure is a typed, recoverable
+ * result — the account chip degrades to its static label, never an error state
+ * that blocks the app.
+ */
+export async function getAccountWhoami(deps: WhoamiDeps): Promise<AccountWhoamiResult> {
+  const key = await resolveMistralApiKey(deps)
+  if (!key) return { ok: false, reason: 'no-key', error: 'No Mistral API key found.' }
+
+  let response: Response
+  try {
+    response = await deps.fetchFn(WHOAMI_URL, {
+      headers: { Authorization: `Bearer ${key}` },
+    })
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err)
+    return { ok: false, reason: 'error', error }
+  }
+  if (response.status === 401 || response.status === 403) {
+    return { ok: false, reason: 'unauthorized', error: 'The stored API key was rejected.' }
+  }
+  if (!response.ok) {
+    return { ok: false, reason: 'error', error: `Unexpected status ${response.status}.` }
+  }
+
+  let payload: unknown
+  try {
+    payload = await response.json()
+  } catch {
+    return { ok: false, reason: 'error', error: 'Whoami response was not JSON.' }
+  }
+  const plan = parseWhoamiPayload(payload)
+  if (!plan) return { ok: false, reason: 'error', error: 'Whoami response shape was invalid.' }
+  return { ok: true, plan }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -17,6 +17,7 @@ import {
   type RespondPermissionArgs,
   type SendPromptArgs,
   type SendPromptResult,
+  type AccountWhoamiResult,
   type CheckAuthStatusArgs,
   type CheckAuthStatusResult,
   type SetThreadConfigArgs,
@@ -37,6 +38,7 @@ import {
 } from '../shared/ipc'
 import { detectVibe } from './vibe-detect'
 import { getShellEnv } from './shell-env'
+import { getAccountWhoami, readKeychainApiKey, readVibeEnvFile } from './auth/whoami'
 import { groupThreadsByWorkspace, MetadataStore } from './persistence/metadata-store'
 import {
   acpEventEntry,
@@ -886,6 +888,24 @@ function registerIpc(deps: MainDeps): void {
       }
     },
   )
+
+  ipcMain.handle(IPC.accountWhoami, async (): Promise<AccountWhoamiResult> => {
+    // Plan display for the account chip (ADR-0003 amendment): read the key from
+    // Vibe's stores and ask console whoami for the plan tier. No agent involved —
+    // the credential is global, not per-Workspace. Best-effort: every failure is
+    // a typed result the renderer degrades on, but log it (log, don't swallow).
+    const env = getShellEnv()
+    const result = await getAccountWhoami({
+      env,
+      readEnvFile: () => readVibeEnvFile(env),
+      readKeyring: readKeychainApiKey,
+      fetchFn: fetch,
+    })
+    if (!result.ok && result.reason !== 'no-key') {
+      console.error(`[vibe-mistro:auth] account whoami failed (${result.reason}): ${result.error}`)
+    }
+    return result
+  })
 
   ipcMain.handle(IPC.stopAgent, (_event, agentId: string) => {
     // Explicit close: the pool stops the child and drops it; the Workspace

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -45,6 +45,7 @@ import {
   type OpenThreadArgs,
   type SendPromptArgs,
   type SendPromptResult,
+  type AccountWhoamiResult,
   type CheckAuthStatusArgs,
   type CheckAuthStatusResult,
   type SetThreadConfigArgs,
@@ -95,6 +96,7 @@ const api = {
   signOut: (args: SignOutArgs): Promise<SignOutResult> => ipcRenderer.invoke(IPC.signOut, args),
   checkAuthStatus: (args: CheckAuthStatusArgs): Promise<CheckAuthStatusResult> =>
     ipcRenderer.invoke(IPC.checkAuthStatus, args),
+  accountWhoami: (): Promise<AccountWhoamiResult> => ipcRenderer.invoke(IPC.accountWhoami),
   stopAgent: (agentId: string): Promise<void> => ipcRenderer.invoke(IPC.stopAgent, agentId),
   setActiveAgent: (agentId: string | null): Promise<void> =>
     ipcRenderer.invoke(IPC.setActiveAgent, agentId),

--- a/src/renderer/src/auth/plan-label.test.ts
+++ b/src/renderer/src/auth/plan-label.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { planLabel } from './plan-label'
+
+describe('planLabel', () => {
+  it('maps chat plans (Vibe plan_title parity)', () => {
+    expect(planLabel({ planType: 'CHAT', planName: 'FREE' })).toBe('Free')
+    expect(planLabel({ planType: 'CHAT', planName: 'INDIVIDUAL' })).toBe('Pro')
+    expect(planLabel({ planType: 'CHAT', planName: 'EDU' })).toBe('Pro')
+    expect(planLabel({ planType: 'CHAT', planName: 'TEAM' })).toBe('Pro')
+    expect(planLabel({ planType: 'CHAT', planName: 'SOMETHING_ELSE' })).toBeNull()
+  })
+
+  it('is case-insensitive on plan names', () => {
+    expect(planLabel({ planType: 'CHAT', planName: 'individual' })).toBe('Pro')
+  })
+
+  it('maps API plans: FREE substring is free, anything else is Scale', () => {
+    expect(planLabel({ planType: 'API', planName: 'FREE_TIER' })).toBe('Free')
+    expect(planLabel({ planType: 'API', planName: 'STANDARD' })).toBe('Scale plan')
+  })
+
+  it('maps Mistral Code single-letter plan names', () => {
+    expect(planLabel({ planType: 'MISTRAL_CODE', planName: 'F' })).toBe('Mistral Code Free')
+    expect(planLabel({ planType: 'MISTRAL_CODE', planName: 'E' })).toBe('Mistral Code Enterprise')
+    expect(planLabel({ planType: 'MISTRAL_CODE', planName: 'X' })).toBeNull()
+  })
+
+  it('returns null for unknown/unauthorized tiers and a missing plan', () => {
+    expect(planLabel({ planType: 'UNKNOWN', planName: 'FREE' })).toBeNull()
+    expect(planLabel({ planType: 'UNAUTHORIZED', planName: '' })).toBeNull()
+    expect(planLabel(null)).toBeNull()
+  })
+})

--- a/src/renderer/src/auth/plan-label.ts
+++ b/src/renderer/src/auth/plan-label.ts
@@ -1,0 +1,28 @@
+import type { AccountPlan } from '../../../shared/ipc'
+
+/**
+ * Derive the display label for the account's plan tier — a chip-friendly port
+ * of Vibe's `plan_title` (vibe/cli/plan_offer/decide_plan_offer.py) minus its
+ * `[Subscription]`/`[API]` prefixes. The plan-name matching mirrors Vibe's
+ * `PlanInfo` predicates exactly (CHAT names are exact matches, API "free" is a
+ * substring test, MISTRAL_CODE uses single-letter names). Returns null when
+ * the tier is unknown — callers fall back to their static label.
+ */
+export function planLabel(plan: AccountPlan | null): string | null {
+  if (!plan) return null
+  const name = plan.planName.toUpperCase()
+  switch (plan.planType) {
+    case 'CHAT':
+      if (name === 'FREE') return 'Free'
+      if (name === 'INDIVIDUAL' || name === 'EDU' || name === 'TEAM') return 'Pro'
+      return null
+    case 'API':
+      return name.includes('FREE') ? 'Free' : 'Scale plan'
+    case 'MISTRAL_CODE':
+      if (name === 'F') return 'Mistral Code Free'
+      if (name === 'E') return 'Mistral Code Enterprise'
+      return null
+    default:
+      return null
+  }
+}

--- a/src/renderer/src/auth/use-account-plan.ts
+++ b/src/renderer/src/auth/use-account-plan.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react'
+import type { AccountPlan } from '../../../shared/ipc'
+
+/**
+ * Fetch the signed-in account's plan tier once per mount (best-effort). Null
+ * while loading, on any failure, or when no key is stored — callers render
+ * their static fallback, never an error state; the network round-trip fills
+ * the tier in when it lands. The sidebar chip mounts once per app launch and
+ * the Settings page remounts per open, so each surface refreshes on its own
+ * natural cadence without a shared cache.
+ */
+export function useAccountPlan(): AccountPlan | null {
+  const [plan, setPlan] = useState<AccountPlan | null>(null)
+  useEffect(() => {
+    let cancelled = false
+    void window.api.accountWhoami().then((result) => {
+      if (!cancelled && result.ok) setPlan(result.plan)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+  return plan
+}

--- a/src/renderer/src/settings/SettingsView.tsx
+++ b/src/renderer/src/settings/SettingsView.tsx
@@ -2,6 +2,8 @@ import { useReducer, type JSX } from 'react'
 import { ArrowLeft } from 'lucide-react'
 import type { AuthMethod, VibeDetectResult } from '../../../shared/ipc'
 import { authReducer, selectAuthView, signedInAuthViewState } from '../auth/auth-view'
+import { planLabel } from '../auth/plan-label'
+import { useAccountPlan } from '../auth/use-account-plan'
 import { Button } from '../ui/button'
 import { IconButton } from '../ui/icon-button'
 import { Environment } from './Environment'
@@ -84,6 +86,9 @@ function AccountSettings({
     signedInAuthViewState(account?.authMethods ?? [], account?.signOutAvailable ?? false),
   )
   const view = selectAuthView(state)
+  // The plan tier from console whoami (ADR-0003 amendment) — the ceiling of what
+  // Vibe exposes about the account (no email/name exists). Best-effort: null hides it.
+  const plan = planLabel(useAccountPlan())
 
   async function signOut(): Promise<void> {
     if (!account) return
@@ -116,6 +121,7 @@ function AccountSettings({
         {view.kind === 'signed-in' && view.identity && (
           <span className="text-muted">{view.identity}</span>
         )}
+        {!signingOut && plan && <span className="text-muted">{plan}</span>}
         <span className="flex-1" />
         {view.kind === 'signed-in' && view.signOutAvailable && (
           <Button variant="outline" size="sm" onClick={() => void signOut()}>

--- a/src/renderer/src/shell/Shell.tsx
+++ b/src/renderer/src/shell/Shell.tsx
@@ -11,6 +11,8 @@ import {
   setSidebarWidth,
 } from './sidebar-width-store'
 import { cn } from '../lib/utils'
+import { planLabel } from '../auth/plan-label'
+import { useAccountPlan } from '../auth/use-account-plan'
 import { Menu, MenuContent, MenuItem, MenuTrigger } from '../ui/menu'
 import { NavItem } from '../ui/nav-item'
 import { Logo } from './logo'
@@ -257,17 +259,20 @@ function PlaceholderNav({ icon, children }: { icon: JSX.Element; children: React
 
 /**
  * The account chip pinned to the sidebar's bottom — a gradient avatar + a name + a
- * tier, now the TRIGGER of an account dropdown (#130). The chip's chrome stays a
- * STATIC placeholder (#future): Vibe exposes no account identity (see ADR-0003 / the
- * Settings Account section), so the avatar/name/tier are fixed strings, not live data. The menu
- * holds a real "Settings" item (→ the routed Settings page that now hosts the env/CLI
- * status the sidebar gear used to toggle) plus room for future account actions.
+ * tier, the TRIGGER of an account dropdown (#130). The tier line is LIVE: the plan
+ * from console whoami (ADR-0003 amendment), rendered as "Mistral Vibe · <plan>" when
+ * known. The name stays a static placeholder — plan is the CEILING of account
+ * identity Vibe exposes (no email/name anywhere in its surfaces), so a real name
+ * can never render here. The menu holds a real "Settings" item (→ the routed
+ * Settings page that now hosts the env/CLI status the sidebar gear used to toggle)
+ * plus room for future account actions.
  */
 function AccountChip({ onOpenSettings }: { onOpenSettings: () => void }): JSX.Element {
+  const plan = planLabel(useAccountPlan())
   return (
     <Menu>
       <MenuTrigger className="flex items-center gap-2.5 rounded-[9px] px-2 py-2 text-left outline-none transition-colors hover:bg-accent/10 focus-visible:bg-accent/10 data-[popup-open]:bg-accent/10">
-        {/* placeholder — account identity + tier (#future); no live account API exists yet. */}
+        {/* static avatar/name — Vibe exposes no identity to fill them with (ADR-0003). */}
         <span
           aria-hidden
           className="flex size-8 shrink-0 items-center justify-center rounded-md text-sm font-semibold text-white"
@@ -277,7 +282,9 @@ function AccountChip({ onOpenSettings }: { onOpenSettings: () => void }): JSX.El
         </span>
         <span className="flex min-w-0 flex-1 flex-col">
           <span className="truncate text-[14px] font-semibold text-text-strong">Your account</span>
-          <span className="truncate text-[12px] text-faint">Mistral Vibe</span>
+          <span className="truncate text-[12px] text-faint">
+            {plan ? `Mistral Vibe · ${plan}` : 'Mistral Vibe'}
+          </span>
         </span>
         <ChevronDown className="size-4 shrink-0 text-muted" aria-hidden />
       </MenuTrigger>
@@ -286,8 +293,7 @@ function AccountChip({ onOpenSettings }: { onOpenSettings: () => void }): JSX.El
           <Settings className="size-3.5" aria-hidden />
           Settings
         </MenuItem>
-        {/* room for future account actions (profile, sign-out, tier) — #future;
-            no live account API exists yet (ADR-0003). */}
+        {/* room for future account actions (sign-out shortcut, plan upgrade) — #future. */}
       </MenuContent>
     </Menu>
   )

--- a/src/shared/ipc/auth.ts
+++ b/src/shared/ipc/auth.ts
@@ -12,6 +12,8 @@ export const authChannels = {
   signOut: 'auth:sign-out',
   /** Re-query an agent's `_auth/status` without re-running sign-in (#79). */
   checkAuthStatus: 'auth:check-status',
+  /** Fetch the signed-in account's plan from Mistral's console whoami endpoint. */
+  accountWhoami: 'auth:account-whoami',
 } as const
 
 /**
@@ -90,3 +92,25 @@ export interface CheckAuthStatusArgs {
 export type CheckAuthStatusResult =
   | { ok: true; authState: AuthState; signOutAvailable: boolean }
   | { ok: false; error: string }
+
+/**
+ * The plan tier Vibe's console `whoami` endpoint reports for the stored API key
+ * (ADR-0003 amendment). This is the CEILING of account identity Vibe exposes —
+ * there is no email/name/user-id anywhere in its surfaces, only the plan.
+ * `planType` mirrors Vibe's `WhoAmIPlanType`; `planName` is the raw server
+ * string (e.g. `FREE`, `INDIVIDUAL`) — the renderer derives display labels.
+ */
+export interface AccountPlan {
+  planType: 'API' | 'CHAT' | 'MISTRAL_CODE' | 'UNKNOWN' | 'UNAUTHORIZED'
+  planName: string
+}
+
+/**
+ * Result of an account-plan fetch. All failures are non-fatal display gaps, but
+ * the renderer distinguishes them: `no-key` = nothing stored (signed out
+ * everywhere), `unauthorized` = a stored key the server rejected, `error` =
+ * network/parse trouble (key state unknown).
+ */
+export type AccountWhoamiResult =
+  | { ok: true; plan: AccountPlan }
+  | { ok: false; reason: 'no-key' | 'unauthorized' | 'error'; error: string }


### PR DESCRIPTION
## What

The sidebar account chip and Settings > Account now show the signed-in account's **plan tier** ("Mistral Vibe · Free" / "· Pro" / …), fetched from Mistral console's `GET /api/vibe/whoami` — the ceiling of account identity Vibe exposes (no email/name/user-id exists anywhere in its surfaces; verified against the mistral-vibe source).

## How

- **`auth:account-whoami` IPC** (`src/shared/ipc/auth.ts`): returns `{planType, planName}` or a typed failure (`no-key` / `unauthorized` / `error`) the UI silently degrades on.
- **Main** (`src/main/auth/whoami.ts`, 16 tests): resolves `MISTRAL_API_KEY` with Vibe's own active-credential precedence — resolved shell env → `$VIBE_HOME/.env` → macOS keychain (`ai.mistral.vibe`, legacy `vibe`) — and makes the same Bearer request Vibe's TUI makes (`http_whoami_gateway.py` parity: 401/403 → unauthorized, unknown plan types degrade to `UNKNOWN`). The key is read-only + transient: never persisted, logged, or sent to the renderer.
- **Renderer**: `plan-label.ts` (5 tests) ports Vibe's `plan_title` predicates to chip labels (`Free`, `Pro`, `Scale plan`, `Mistral Code Free/Enterprise`); `use-account-plan.ts` fetches once per mount. Chip subtitle + Settings Account row render it; static fallback when unknown.
- **ADR-0003 amendment**: documents the read-only credential-access boundary — sign-in/out remain exclusively Vibe's ACP methods.
- **eslint**: ignore `.claude/worktrees/**` — `eslint .` was failing on the nested worktree copies (multiple candidate tsconfig roots), pre-existing.

## Verification

- All four gates pass: lint, typecheck, build, test (1225 tests, 21 new).
- End-to-end against real stores on this machine: key resolved from the keychain, live endpoint returned `{"planType":"CHAT","planName":"FREE"}` → chip reads "Mistral Vibe · Free".

Known limitation: the chip fetches once per app launch (Settings once per open), so a mid-session sign-in/out won't refresh the tier until relaunch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)