### PR TITLE
feat(git): slice 5 — Branch-changes diff scope with base-ref picker (#237)

### DIFF
--- a/src/main/git/diff.test.ts
+++ b/src/main/git/diff.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { createHash } from 'node:crypto'
-import { finalizeDiff, readGitDiff, readGitFullDiff } from './diff'
+import { finalizeDiff, readGitDiff, readGitFullDiff, readGitRangeDiff } from './diff'
 import type { GitRun } from './run'
 
 /**
@@ -224,5 +224,89 @@ describe('readGitFullDiff', () => {
     )
     expect(res.files[0]).toEqual({ path: 'bad.txt', patch: '', diffHash: '', truncated: false })
     expect(res.files[1].patch).toBe(trackedPatch)
+  })
+})
+
+describe('readGitRangeDiff', () => {
+  /** A scripted runner: responses consumed in call order, args recorded. */
+  function fakeRun(
+    seen: string[][],
+    responses: { stdout?: string; stderr?: string; code: number }[] = [],
+  ): GitRun {
+    let i = 0
+    return (args) => {
+      seen.push(args)
+      const r = responses[i++] ?? { code: 0 }
+      return Promise.resolve({ stdout: r.stdout ?? '', stderr: r.stderr ?? '', code: r.code })
+    }
+  }
+
+  it('explicit base: enumerates `base...HEAD` names (NUL-separated) then reads each file, per-file cap/hash', async () => {
+    const seen: string[][] = []
+    const res = await readGitRangeDiff(
+      '/repo',
+      'main',
+      false,
+      fakeRun(seen, [
+        { stdout: 'a.txt\0dir/b.txt\0', code: 0 }, // name enumeration
+        { stdout: trackedPatch, code: 0 }, // a.txt
+        { stdout: untrackedPatch, code: 0 }, // dir/b.txt
+      ]),
+    )
+    expect(res).toMatchObject({ ok: true, baseRef: 'main' })
+    if (!res.ok) throw new Error('unreachable')
+    expect(res.files.map((f) => f.path)).toEqual(['a.txt', 'dir/b.txt'])
+    expect(res.files[0].patch).toBe(trackedPatch)
+    expect(res.files[0].diffHash).toBe(createHash('sha256').update(trackedPatch).digest('hex'))
+    // Enumeration + each per-file read use the three-dot range form.
+    expect(seen[0]).toContain('main...HEAD')
+    expect(seen[0]).toContain('--name-only')
+    expect(seen[1].slice(-3)).toEqual(['main...HEAD', '--', 'a.txt'])
+  })
+
+  it('AUTOMATIC base (undefined): resolves origin/HEAD first and diffs against it', async () => {
+    const seen: string[][] = []
+    const res = await readGitRangeDiff(
+      '/repo',
+      undefined,
+      false,
+      fakeRun(seen, [
+        { stdout: 'origin/main\n', code: 0 }, // symbolic-ref origin/HEAD
+        { stdout: 'a.txt\0', code: 0 },
+        { stdout: trackedPatch, code: 0 },
+      ]),
+    )
+    expect(res).toMatchObject({ ok: true, baseRef: 'origin/main' })
+    expect(seen[0]).toEqual(['symbolic-ref', '--quiet', '--short', 'refs/remotes/origin/HEAD'])
+    expect(seen[1]).toContain('origin/main...HEAD')
+  })
+
+  it('AUTOMATIC base with NO resolvable default → {ok:false} with an actionable reason', async () => {
+    const res = await readGitRangeDiff('/repo', undefined, false, fakeRun([], [{ stdout: '', code: 1 }]))
+    expect(res.ok).toBe(false)
+    if (res.ok) throw new Error('unreachable')
+    expect(res.error).toContain('default branch')
+  })
+
+  it('an UNKNOWN base surfaces git’s reason as {ok:false} (the renderer wraps it in friendly copy)', async () => {
+    const res = await readGitRangeDiff(
+      '/repo',
+      'nope',
+      false,
+      fakeRun([], [{ stderr: "fatal: bad revision 'nope...HEAD'", code: 128 }]),
+    )
+    expect(res).toEqual({ ok: false, error: "fatal: bad revision 'nope...HEAD'" })
+  })
+
+  it('empty range (no names) → ok with zero files; -w passes through everywhere', async () => {
+    const seen: string[][] = []
+    const res = await readGitRangeDiff('/repo', 'main', true, fakeRun(seen, [{ stdout: '', code: 0 }]))
+    expect(res).toEqual({ ok: true, baseRef: 'main', files: [] })
+    expect(seen[0]).toContain('-w')
+  })
+
+  it('never throws — a rejecting runner degrades to {ok:false}', async () => {
+    const res = await readGitRangeDiff('/repo', 'main', false, () => Promise.reject(new Error('boom')))
+    expect(res).toEqual({ ok: false, error: 'boom' })
   })
 })

--- a/src/main/git/diff.ts
+++ b/src/main/git/diff.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
-import { defaultGitRun, type GitRun } from './run'
-import type { GitDiffResult, GitFullDiffResult } from '../../shared/ipc'
+import { defaultGitRun, errorMessage, failReason, type GitRun } from './run'
+import type { GitDiffResult, GitFullDiffResult, GitRangeDiffResult } from '../../shared/ipc'
 
 /**
  * Read a single changed path's WORKING-TREE unified diff (#85, ADR-0008). Like #84's
@@ -103,4 +103,52 @@ export async function readGitFullDiff(
     }),
   )
   return { files: entries }
+}
+
+/**
+ * Read a BRANCH-RANGE diff — `<base>...HEAD`, what this branch adds relative to where
+ * it forked (#237, PRD #233). `baseRef` undefined means AUTOMATIC: resolve the
+ * repository's default branch from `origin/HEAD` (same source as #87's default-branch
+ * flag). Shape mirrors `readGitFullDiff`: enumerate the range's paths, then one
+ * per-file read (concurrent), each entry individually capped + hashed. Unlike the
+ * working-tree reads, a bad RANGE is a meaningful, user-actionable state — an unknown
+ * base or an unresolvable default returns `{ok:false, error}` (git's actual reason)
+ * instead of degrading to an empty diff the renderer can't explain. A failed PER-FILE
+ * read still degrades to that file's empty entry. Never throws.
+ */
+export async function readGitRangeDiff(
+  cwd: string,
+  baseRef: string | undefined,
+  ignoreWhitespace = false,
+  run: GitRun = defaultGitRun,
+): Promise<GitRangeDiffResult> {
+  try {
+    const ws = ignoreWhitespace ? ['-w'] : []
+    let base = baseRef
+    if (base === undefined) {
+      // Automatic: the default branch via origin/HEAD (kept fresh by #84's fetch loop).
+      const head = await run(['symbolic-ref', '--quiet', '--short', 'refs/remotes/origin/HEAD'], cwd)
+      if (head.code !== 0 || !head.stdout.trim()) {
+        return { ok: false, error: 'Could not resolve the default branch — pick a base ref explicitly.' }
+      }
+      base = head.stdout.trim()
+    }
+    const range = `${base}...HEAD`
+    // `-z` NUL-separation so non-ASCII / space-y paths round-trip unmangled.
+    const names = await run(
+      ['-c', 'core.quotePath=false', 'diff', '--no-color', ...ws, '-z', '--name-only', range],
+      cwd,
+    )
+    if (names.code !== 0) return { ok: false, error: failReason(names) }
+    const paths = names.stdout.split('\0').filter(Boolean)
+    const files = await Promise.all(
+      paths.map(async (path) => {
+        const res = await run(['-c', 'core.quotePath=false', 'diff', '--no-color', ...ws, range, '--', path], cwd)
+        return { path, ...finalizeDiff(res.code === 0 ? res.stdout : '') }
+      }),
+    )
+    return { ok: true, baseRef: base, files }
+  } catch (err) {
+    return { ok: false, error: errorMessage(err) }
+  }
 }

--- a/src/main/git/register-ipc.ts
+++ b/src/main/git/register-ipc.ts
@@ -9,6 +9,8 @@ import {
   type GitFullDiffArgs,
   type GitFullDiffResult,
   type GitOpResult,
+  type GitRangeDiffArgs,
+  type GitRangeDiffResult,
   type GhCreatePrArgs,
   type GhCreateResult,
   type GhCurrentPrArgs,
@@ -18,7 +20,7 @@ import {
   type GitStackedActionResult,
   type GitStatusSubscriptionArgs,
 } from '../../shared/ipc'
-import { readGitFullDiff } from './diff'
+import { readGitFullDiff, readGitRangeDiff } from './diff'
 import { gitCommit } from './commit'
 import { runStackedAction } from './stacked-action'
 import { gitBranches, gitCheckout, gitCreateBranch } from './branches'
@@ -73,6 +75,13 @@ export function registerGitIpc(deps: {
     // view (#235). Per-file failure swallows into that file's empty entry inside
     // `readGitFullDiff` (#85 style); the invoke itself never rejects.
     return readGitFullDiff(args.workspaceDir, args.files, args.ignoreWhitespace ?? false)
+  })
+
+  ipcMain.handle(IPC.gitRangeDiff, (_event, args: GitRangeDiffArgs): Promise<GitRangeDiffResult> => {
+    // Read a branch-range diff (`base...HEAD`) for the Branch-changes scope (#237).
+    // A bad range (unknown base / unresolvable default) resolves {ok:false, error} —
+    // meaningful, user-actionable — but the invoke itself never rejects.
+    return readGitRangeDiff(args.workspaceDir, args.baseRef, args.ignoreWhitespace ?? false)
   })
 
   ipcMain.handle(IPC.gitCommit, async (_event, args: GitCommitArgs): Promise<GitCommitResult> => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -15,6 +15,8 @@ import {
   type GitFullDiffArgs,
   type GitFullDiffResult,
   type GitOpResult,
+  type GitRangeDiffArgs,
+  type GitRangeDiffResult,
   type GitStackedActionArgs,
   type GitStackedActionResult,
   type GhCreatePrArgs,
@@ -122,6 +124,8 @@ const api = {
     ipcRenderer.invoke(IPC.gitUnsubscribeStatus, args),
   gitFullDiff: (args: GitFullDiffArgs): Promise<GitFullDiffResult> =>
     ipcRenderer.invoke(IPC.gitFullDiff, args),
+  gitRangeDiff: (args: GitRangeDiffArgs): Promise<GitRangeDiffResult> =>
+    ipcRenderer.invoke(IPC.gitRangeDiff, args),
   gitCommit: (args: GitCommitArgs): Promise<GitCommitResult> => ipcRenderer.invoke(IPC.gitCommit, args),
   gitBranches: (args: GitBranchesArgs): Promise<GitBranchesResult> =>
     ipcRenderer.invoke(IPC.gitBranches, args),

--- a/src/renderer/src/git/AllFilesDiffView.tsx
+++ b/src/renderer/src/git/AllFilesDiffView.tsx
@@ -1,11 +1,10 @@
-import { memo, useEffect, useMemo, useRef, useState, type JSX } from 'react'
-import { ArrowLeft, ChevronDown, ChevronRight } from 'lucide-react'
-import { PatchDiff } from '@pierre/diffs/react'
-import type { GitFileDiff, GitFullDiffResult } from '../../../shared/ipc'
-import { cn } from '../lib/utils'
+import { useEffect, useRef, useState, type JSX } from 'react'
+import { ArrowLeft } from 'lucide-react'
+import type { GitFullDiffResult } from '../../../shared/ipc'
 import { Button } from '../ui'
 import { readDiffPrefs, writeDiffPrefs, type DiffPrefs } from './diff-prefs-store'
-import { diffRequestKey, glyphClass, type GitFileView } from './status-view'
+import { diffRequestKey, type GitFileView } from './status-view'
+import { DiffFileSection, DiffToggles } from './diff-view-chrome'
 
 /**
  * The ALL-FILES working-tree diff view (#235, PRD #233) — every changed file as a
@@ -18,7 +17,8 @@ import { diffRequestKey, glyphClass, type GitFileView } from './status-view'
  * Refetches when the changed set / churn changes (`diffRequestKey` over the LIVE
  * files — the streamed status is the trigger, like the old per-file churn dep) and on
  * the whitespace toggle (a fresh `-w` read). Stacked/Split and word WRAP are pure
- * relayout — no re-fetch. All three toggles persist via `diff-prefs-store`.
+ * relayout — no re-fetch. All three toggles persist via `diff-prefs-store`; the
+ * section + toggle chrome is shared with #237's `BranchDiffView` (`diff-view-chrome`).
  */
 export function AllFilesDiffView({
   workspaceDir,
@@ -105,49 +105,17 @@ export function AllFilesDiffView({
         </span>
       </div>
 
-      <div className="flex items-center gap-2 border-b border-border-muted px-3 py-2 text-[13px]">
-        <div className="flex overflow-hidden rounded-md border border-border">
-          <ToggleButton active={prefs.diffStyle === 'unified'} onClick={() => updatePrefs({ diffStyle: 'unified' })}>
-            Stacked
-          </ToggleButton>
-          <ToggleButton active={prefs.diffStyle === 'split'} onClick={() => updatePrefs({ diffStyle: 'split' })}>
-            Split
-          </ToggleButton>
-        </div>
-        <button
-          type="button"
-          onClick={() => updatePrefs({ wrap: !prefs.wrap })}
-          aria-pressed={prefs.wrap}
-          title={prefs.wrap ? 'Scroll long lines' : 'Wrap long lines'}
-          className={cn(
-            'shrink-0 rounded-md border border-border px-2.5 py-1 transition-colors',
-            prefs.wrap ? 'bg-accent/10 text-accent-text' : 'text-muted hover:text-accent-text',
-          )}
-        >
-          Wrap
-        </button>
-        <button
-          type="button"
-          onClick={() => updatePrefs({ ignoreWhitespace: !prefs.ignoreWhitespace })}
-          aria-pressed={prefs.ignoreWhitespace}
-          title={prefs.ignoreWhitespace ? 'Show whitespace changes' : 'Hide whitespace changes'}
-          className={cn(
-            'ml-auto shrink-0 rounded-md border border-border px-2.5 py-1 transition-colors',
-            prefs.ignoreWhitespace ? 'bg-accent/10 text-accent-text' : 'text-muted hover:text-accent-text',
-          )}
-        >
-          Ignore whitespace
-        </button>
-      </div>
+      <DiffToggles prefs={prefs} onChange={updatePrefs} />
 
       <div className="min-h-0 flex-1 overflow-auto">
         {loading && !result ? (
           <p className="px-3 py-3 text-[13px] text-muted">Loading diff…</p>
         ) : (
           files.map((file) => (
-            <FileSection
+            <DiffFileSection
               key={file.path}
-              file={file}
+              path={file.path}
+              meta={{ glyph: file.glyph, insertions: file.insertions, deletions: file.deletions }}
               entry={entryByPath.get(file.path)}
               collapsed={collapsed.has(file.path)}
               onToggle={() =>
@@ -170,125 +138,5 @@ export function AllFilesDiffView({
         )}
       </div>
     </div>
-  )
-}
-
-/**
- * One file's collapsible section: a STICKY header (glyph + path + churn + truncated
- * marker + collapse chevron) over its own `PatchDiff`. Memoized so a sibling section's
- * collapse or an unchanged refetch (same `diffHash`) doesn't re-render this one —
- * per-file memoization is the whole point of per-file hashes.
- */
-const FileSection = memo(
-  function FileSection({
-    file,
-    entry,
-    collapsed,
-    onToggle,
-    refFn,
-    diffStyle,
-    wrap,
-    ignoreWhitespace,
-  }: {
-    file: GitFileView
-    entry: GitFileDiff | undefined
-    collapsed: boolean
-    onToggle: () => void
-    refFn: (el: HTMLElement | null) => void
-    diffStyle: 'unified' | 'split'
-    wrap: boolean
-    ignoreWhitespace: boolean
-  }): JSX.Element {
-    const patch = entry?.patch ?? ''
-    const diffHash = entry?.diffHash ?? ''
-    const rendered = useMemo(() => {
-      if (!patch) return null
-      return (
-        <PatchDiff
-          patch={patch}
-          options={{
-            diffStyle,
-            theme: 'pierre-light',
-            themeType: 'light',
-            overflow: wrap ? 'wrap' : 'scroll',
-          }}
-        />
-      )
-      // diffHash is a 1:1 proxy for `patch`; depend on it (not the long string).
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [diffHash, diffStyle, wrap])
-
-    return (
-      <section ref={refFn} className="border-b border-border-muted">
-        <button
-          type="button"
-          onClick={onToggle}
-          aria-expanded={!collapsed}
-          className="sticky top-0 z-10 flex w-full items-center gap-1.5 border-b border-border-muted bg-background px-3 py-1.5 text-left"
-        >
-          {collapsed ? (
-            <ChevronRight className="size-3.5 shrink-0 text-muted" aria-hidden />
-          ) : (
-            <ChevronDown className="size-3.5 shrink-0 text-muted" aria-hidden />
-          )}
-          <span className={cn('w-3 shrink-0 text-center text-[11px] font-semibold', glyphClass(file.glyph))}>
-            {file.glyph}
-          </span>
-          <span className="min-w-0 flex-1 truncate text-[13px] text-text" dir="rtl" title={file.path}>
-            {file.path}
-          </span>
-          {entry?.truncated && (
-            <span className="shrink-0 text-[11px] text-muted" title="Diff truncated — file too large">
-              truncated
-            </span>
-          )}
-          <span className="shrink-0 text-[11px] tabular-nums">
-            {file.insertions > 0 && <span className="text-ok">+{file.insertions}</span>}{' '}
-            {file.deletions > 0 && <span className="text-bad">−{file.deletions}</span>}
-          </span>
-        </button>
-        {!collapsed &&
-          (rendered ?? (
-            <p className="px-3 py-2 text-[13px] text-muted">
-              No changes to show{ignoreWhitespace ? ' (whitespace-only changes hidden).' : '.'}
-            </p>
-          ))}
-      </section>
-    )
-  },
-  (prev, next) =>
-    prev.entry?.diffHash === next.entry?.diffHash &&
-    prev.entry?.truncated === next.entry?.truncated &&
-    prev.collapsed === next.collapsed &&
-    prev.diffStyle === next.diffStyle &&
-    prev.wrap === next.wrap &&
-    prev.ignoreWhitespace === next.ignoreWhitespace &&
-    prev.file.insertions === next.file.insertions &&
-    prev.file.deletions === next.file.deletions &&
-    prev.file.glyph === next.file.glyph,
-)
-
-/** A segmented-control button (Stacked / Split) — rounded via its container's clip. */
-function ToggleButton({
-  active,
-  onClick,
-  children,
-}: {
-  active: boolean
-  onClick: () => void
-  children: React.ReactNode
-}): JSX.Element {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-pressed={active}
-      className={cn(
-        'px-2.5 py-1 transition-colors',
-        active ? 'bg-accent/10 text-accent-text' : 'text-muted hover:text-accent-text',
-      )}
-    >
-      {children}
-    </button>
   )
 }

--- a/src/renderer/src/git/BranchDiffView.tsx
+++ b/src/renderer/src/git/BranchDiffView.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useState, type JSX } from 'react'
+import { ArrowRight, Check } from 'lucide-react'
+import type { GitBranch, GitRangeDiffResult } from '../../../shared/ipc'
+import { Input, Menu, MenuContent, MenuItem, MenuSeparator, MenuTrigger } from '../ui'
+import { readDiffPrefs, writeDiffPrefs, type DiffPrefs } from './diff-prefs-store'
+import { buildBaseRefChoices, filterRefChoices } from './branch-scope'
+import { DiffFileSection, DiffToggles } from './diff-view-chrome'
+
+/**
+ * The BRANCH-CHANGES scope (#237, PRD #233): `base...HEAD` — what this branch adds
+ * relative to where it forked — as the same collapsible per-file sections as #235's
+ * working-tree view (shared `diff-view-chrome`). Review keeps working after commits
+ * land. Refreshes ON DEMAND — base change, whitespace toggle, the panel's manual
+ * refresh (`refreshKey`) — never from the fs watcher (a range over commits doesn't
+ * move when the working tree does). The `head → base` row opens a searchable base-ref
+ * picker over the #87 branches list; "Automatic" (baseRef null) lets main resolve the
+ * default branch, and the resolved name renders back so Automatic is never opaque.
+ * Detached HEAD and unknown-base states surface as friendly inline copy — the raw git
+ * reason stays in the title attribute.
+ */
+export function BranchDiffView({
+  workspaceDir,
+  currentBranch,
+  baseRef,
+  onBaseRefChange,
+  refreshKey,
+}: {
+  workspaceDir: string
+  /** The checked-out branch, or null when detached (no range to show). */
+  currentBranch: string | null
+  /** The persisted base choice — null = Automatic (main resolves the default). */
+  baseRef: string | null
+  onBaseRefChange: (baseRef: string | null) => void
+  /** Bumped by the panel's manual refresh — the on-demand re-read trigger. */
+  refreshKey: number
+}): JSX.Element {
+  const [prefs, setPrefs] = useState<DiffPrefs>(() => readDiffPrefs(window.localStorage))
+  const [result, setResult] = useState<GitRangeDiffResult | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set())
+  const [choices, setChoices] = useState<GitBranch[]>([])
+  const [query, setQuery] = useState('')
+
+  function updatePrefs(patch: Partial<DiffPrefs>): void {
+    setPrefs((prev) => {
+      const next = { ...prev, ...patch }
+      writeDiffPrefs(window.localStorage, next)
+      return next
+    })
+  }
+
+  useEffect(() => {
+    if (currentBranch === null) return // detached: nothing to fetch, friendly copy below
+    let cancelled = false
+    setLoading(true)
+    void window.api
+      .gitRangeDiff({ workspaceDir, baseRef: baseRef ?? undefined, ignoreWhitespace: prefs.ignoreWhitespace })
+      .then((res) => {
+        if (cancelled) return
+        setResult(res)
+        setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [workspaceDir, currentBranch, baseRef, prefs.ignoreWhitespace, refreshKey])
+
+  // The picker's choices load once per Workspace/branch (the dropdown also refreshes
+  // them on open, like BranchMenu) — a local read, not a network call.
+  useEffect(() => {
+    let cancelled = false
+    void window.api.gitBranches({ workspaceDir }).then((res) => {
+      if (!cancelled && res.ok) setChoices(res.branches)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [workspaceDir, currentBranch])
+
+  if (currentBranch === null) {
+    return (
+      <p className="px-3 py-3 text-[13px] text-muted">
+        Branch changes needs a checked-out branch — HEAD is currently detached.
+      </p>
+    )
+  }
+
+  const filtered = filterRefChoices(buildBaseRefChoices(choices, currentBranch), query)
+  const resolvedBase = result?.ok ? result.baseRef : null
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* The compare row: head → base picker. */}
+      <div className="flex items-center gap-1.5 border-b border-border-muted px-3 py-2 text-[13px]">
+        <span className="min-w-0 shrink truncate font-medium text-text" title={currentBranch}>
+          {currentBranch}
+        </span>
+        <ArrowRight className="size-3.5 shrink-0 text-muted" aria-hidden />
+        <Menu>
+          <MenuTrigger
+            render={
+              <button
+                type="button"
+                className="min-w-0 flex-1 truncate rounded-md border border-border px-2 py-1 text-left text-[13px] text-text transition-colors hover:bg-accent/10"
+                title="Choose the base ref to compare against"
+              />
+            }
+          >
+            {baseRef ?? `Automatic${resolvedBase ? ` (${resolvedBase})` : ''}`}
+          </MenuTrigger>
+          <MenuContent align="start" className="max-h-80 min-w-52 overflow-y-auto">
+            <div className="px-2 py-1.5">
+              <Input
+                autoFocus
+                aria-label="Filter refs"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Filter refs…"
+                className="h-7 text-[12px]"
+              />
+            </div>
+            <MenuItem onClick={() => onBaseRefChange(null)}>
+              <span className="min-w-0 flex-1 truncate">Automatic (default branch)</span>
+              {baseRef === null && <Check className="size-3.5 shrink-0 text-accent-text" aria-hidden />}
+            </MenuItem>
+            <MenuSeparator />
+            {filtered.map((b) => (
+              <MenuItem key={b.name} onClick={() => onBaseRefChange(b.name)}>
+                <span className="min-w-0 flex-1 truncate">{b.name}</span>
+                {b.isRemote && <span className="shrink-0 text-[10px] text-faint">remote</span>}
+                {baseRef === b.name && <Check className="size-3.5 shrink-0 text-accent-text" aria-hidden />}
+              </MenuItem>
+            ))}
+            {filtered.length === 0 && <p className="px-2 py-1.5 text-[12px] text-muted">No matching refs.</p>}
+          </MenuContent>
+        </Menu>
+      </div>
+
+      <DiffToggles prefs={prefs} onChange={updatePrefs} />
+
+      <div className="min-h-0 flex-1 overflow-auto">
+        {loading && !result ? (
+          <p className="px-3 py-3 text-[13px] text-muted">Loading branch diff…</p>
+        ) : result && !result.ok ? (
+          // Friendly copy, raw git reason preserved in the tooltip (never a crash).
+          <p className="px-3 py-3 text-[13px] text-muted" title={result.error} role="alert">
+            Can’t compare against {baseRef ?? 'the default branch'} — pick another base ref.
+          </p>
+        ) : result && result.files.length === 0 ? (
+          <p className="px-3 py-3 text-[13px] text-muted">
+            No changes against {result.baseRef}
+            {prefs.ignoreWhitespace ? ' (whitespace-only changes hidden)' : ''}.
+          </p>
+        ) : (
+          (result?.ok ? result.files : []).map((file) => (
+            <DiffFileSection
+              key={file.path}
+              path={file.path}
+              entry={file}
+              collapsed={collapsed.has(file.path)}
+              onToggle={() =>
+                setCollapsed((prev) => {
+                  const next = new Set(prev)
+                  if (next.has(file.path)) next.delete(file.path)
+                  else next.add(file.path)
+                  return next
+                })
+              }
+              diffStyle={prefs.diffStyle}
+              wrap={prefs.wrap}
+              ignoreWhitespace={prefs.ignoreWhitespace}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/git/ChangesPanel.tsx
+++ b/src/renderer/src/git/ChangesPanel.tsx
@@ -16,6 +16,8 @@ import {
   Textarea,
 } from '../ui'
 import { getCommitDraft, setCommitDraft } from './commit-draft-store'
+import { readDiffScope, writeDiffScope, type DiffScopeState } from './diff-scope-store'
+import { BranchDiffView } from './BranchDiffView'
 import { buildChangesView, reconcileUnchecked } from './status-view'
 import { autoCommitMessage, isDefaultBranch, suggestBranchName } from './commit-guard'
 import { deriveQuickAction, type QuickActionKind } from './quick-action'
@@ -108,6 +110,19 @@ export function ChangesPanel({
   // The current branch's PR, reported up by PrSection (#236) — feeds the quick-action
   // derivation (an OPEN PR flips the dirty-tree primary to "Commit & push").
   const [pr, setPr] = useState<GhPr | null>(null)
+  // The diff scope (#237): Working tree (live, the #84 stream) vs Branch changes
+  // (`base...HEAD`, on demand). Persisted per Workspace so reopening the panel
+  // restores the review context.
+  const [diffScope, setDiffScope] = useState<DiffScopeState>(() =>
+    readDiffScope(window.localStorage, workspaceDir),
+  )
+  function updateDiffScope(patch: Partial<DiffScopeState>): void {
+    setDiffScope((prev) => {
+      const next = { ...prev, ...patch }
+      writeDiffScope(window.localStorage, workspaceDir, next)
+      return next
+    })
+  }
   // The in-flight stacked action (#236): its kind, the streamed phase line, its error,
   // and the renderer-minted id the progress events are filtered by.
   const [acting, setActing] = useState<GitStackedActionKind | null>(null)
@@ -362,7 +377,49 @@ export function ChangesPanel({
         onPrChange={setPr}
       />
 
-      {view.files.length === 0 ? (
+      {/* Diff scope (#237): Working tree (live) vs Branch changes (`base...HEAD`, on
+          demand) — persisted per Workspace. Branch scope swaps the list + commit area
+          for the read-only range view; review keeps working after commits land. */}
+      <div className="flex items-center border-b border-border-muted px-3 py-2 text-[13px]">
+        <div className="flex overflow-hidden rounded-md border border-border">
+          <button
+            type="button"
+            aria-pressed={diffScope.scope === 'working'}
+            onClick={() => updateDiffScope({ scope: 'working' })}
+            className={
+              diffScope.scope === 'working'
+                ? 'bg-accent/10 px-2.5 py-1 text-accent-text'
+                : 'px-2.5 py-1 text-muted transition-colors hover:text-accent-text'
+            }
+          >
+            Working tree
+          </button>
+          <button
+            type="button"
+            aria-pressed={diffScope.scope === 'branch'}
+            onClick={() => updateDiffScope({ scope: 'branch' })}
+            className={
+              diffScope.scope === 'branch'
+                ? 'bg-accent/10 px-2.5 py-1 text-accent-text'
+                : 'px-2.5 py-1 text-muted transition-colors hover:text-accent-text'
+            }
+          >
+            Branch changes
+          </button>
+        </div>
+      </div>
+
+      {diffScope.scope === 'branch' ? (
+        <DiffWorkerProvider>
+          <BranchDiffView
+            workspaceDir={workspaceDir}
+            currentBranch={status.branch}
+            baseRef={diffScope.baseRef}
+            onBaseRefChange={(baseRef) => updateDiffScope({ baseRef })}
+            refreshKey={prRefreshKey}
+          />
+        </DiffWorkerProvider>
+      ) : view.files.length === 0 ? (
         <p className="px-3 py-3 text-[13px] text-muted">No changes — working tree clean.</p>
       ) : (
         <ul className="flex flex-col gap-0.5 py-1.5">
@@ -390,7 +447,7 @@ export function ChangesPanel({
           quick-action control (primary follows repo state: Commit, push & PR / Commit &
           push / Push / Pull / View PR; the rest in the attached menu). Disabled while a
           turn streams (`busy`) or an action runs. git's reason surfaces inline. */}
-      {(view.files.length > 0 || quickAction.primary !== null) && (
+      {diffScope.scope === 'working' && (view.files.length > 0 || quickAction.primary !== null) && (
         <div className="flex flex-col gap-2 border-t border-border-muted px-3 py-2.5">
           {view.files.length > 0 && (
             <Textarea

--- a/src/renderer/src/git/branch-scope.test.ts
+++ b/src/renderer/src/git/branch-scope.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { buildBaseRefChoices, filterRefChoices } from './branch-scope'
+import type { GitBranch } from '../../../shared/ipc'
+
+/** Pure seams for the Branch-changes scope's base-ref picker (#237). */
+
+function branch(partial: Partial<GitBranch> & { name: string }): GitBranch {
+  return { isRemote: false, current: false, isDefault: false, ...partial }
+}
+
+describe('buildBaseRefChoices', () => {
+  const branches = [
+    branch({ name: 'zeta' }),
+    branch({ name: 'feat/x', current: true }),
+    branch({ name: 'main', isDefault: true }),
+    branch({ name: 'origin/alpha', isRemote: true }),
+    branch({ name: 'alpha' }),
+  ]
+
+  it('excludes the CURRENT branch (comparing a branch against itself is empty)', () => {
+    const names = buildBaseRefChoices(branches, 'feat/x').map((b) => b.name)
+    expect(names).not.toContain('feat/x')
+  })
+
+  it('orders: default first, then locals alphabetical, then remotes', () => {
+    expect(buildBaseRefChoices(branches, 'feat/x').map((b) => b.name)).toEqual([
+      'main',
+      'alpha',
+      'zeta',
+      'origin/alpha',
+    ])
+  })
+
+  it('a null current branch (detached) excludes nothing', () => {
+    expect(buildBaseRefChoices(branches, null).map((b) => b.name)).toContain('feat/x')
+  })
+})
+
+describe('filterRefChoices', () => {
+  const choices = [branch({ name: 'main' }), branch({ name: 'feat/alpha' }), branch({ name: 'origin/alpha' })]
+
+  it('case-insensitive substring match; empty query returns all', () => {
+    expect(filterRefChoices(choices, 'ALPHA').map((b) => b.name)).toEqual(['feat/alpha', 'origin/alpha'])
+    expect(filterRefChoices(choices, '')).toEqual(choices)
+  })
+})

--- a/src/renderer/src/git/branch-scope.ts
+++ b/src/renderer/src/git/branch-scope.ts
@@ -1,0 +1,22 @@
+import type { GitBranch } from '../../../shared/ipc'
+
+/**
+ * Pure seams for the Branch-changes scope's base-ref picker (#237, PRD #233). The
+ * picker offers the #87 branches list minus the CURRENT branch (a branch diffed
+ * against itself is empty), ordered default-first (the overwhelmingly common base),
+ * then locals, then remotes — with a simple case-insensitive substring filter
+ * (client-side: the list is already fetched and deduped by the branches read).
+ */
+
+export function buildBaseRefChoices(branches: readonly GitBranch[], currentBranch: string | null): GitBranch[] {
+  const rank = (b: GitBranch): number => (b.isDefault ? 0 : b.isRemote ? 2 : 1)
+  return branches
+    .filter((b) => b.name !== currentBranch)
+    .sort((a, b) => rank(a) - rank(b) || a.name.localeCompare(b.name))
+}
+
+export function filterRefChoices(choices: readonly GitBranch[], query: string): GitBranch[] {
+  const q = query.trim().toLowerCase()
+  if (!q) return [...choices]
+  return choices.filter((b) => b.name.toLowerCase().includes(q))
+}

--- a/src/renderer/src/git/diff-scope-store.test.ts
+++ b/src/renderer/src/git/diff-scope-store.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { DIFF_SCOPE_STORAGE_KEY, readDiffScope, writeDiffScope } from './diff-scope-store'
+
+/**
+ * The Review Surface's persisted diff scope (#237): Working tree vs Branch changes +
+ * the chosen base ref, PER WORKSPACE (unlike the global diff prefs — which branch you
+ * review against is workspace state). Injected-storage seam, DOM-free tests.
+ */
+
+function fakeStorage(seed: Record<string, string> = {}): {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+} {
+  const map = new Map(Object.entries(seed))
+  return { getItem: (k) => map.get(k) ?? null, setItem: (k, v) => void map.set(k, v) }
+}
+
+describe('readDiffScope', () => {
+  it('defaults to the working tree with an Automatic base', () => {
+    expect(readDiffScope(fakeStorage(), '/ws')).toEqual({ scope: 'working', baseRef: null })
+  })
+
+  it('round-trips per Workspace — another Workspace keeps its own entry', () => {
+    const storage = fakeStorage()
+    writeDiffScope(storage, '/a', { scope: 'branch', baseRef: 'origin/main' })
+    writeDiffScope(storage, '/b', { scope: 'working', baseRef: null })
+    expect(readDiffScope(storage, '/a')).toEqual({ scope: 'branch', baseRef: 'origin/main' })
+    expect(readDiffScope(storage, '/b')).toEqual({ scope: 'working', baseRef: null })
+  })
+
+  it('coerces garbage (bad JSON / wrong shapes) to the default', () => {
+    expect(readDiffScope(fakeStorage({ [DIFF_SCOPE_STORAGE_KEY]: 'nope' }), '/ws')).toEqual({
+      scope: 'working',
+      baseRef: null,
+    })
+    expect(
+      readDiffScope(fakeStorage({ [DIFF_SCOPE_STORAGE_KEY]: '{"/ws":{"scope":"upside-down","baseRef":7}}' }), '/ws'),
+    ).toEqual({ scope: 'working', baseRef: null })
+  })
+
+  it('is throw-tolerant on both read and write', () => {
+    const throwing = {
+      getItem: (): string | null => {
+        throw new Error('quota')
+      },
+      setItem: (): void => {
+        throw new Error('quota')
+      },
+    }
+    expect(readDiffScope(throwing, '/ws')).toEqual({ scope: 'working', baseRef: null })
+    expect(() => writeDiffScope(throwing, '/ws', { scope: 'branch', baseRef: null })).not.toThrow()
+  })
+})

--- a/src/renderer/src/git/diff-scope-store.ts
+++ b/src/renderer/src/git/diff-scope-store.ts
@@ -1,0 +1,59 @@
+/**
+ * The Review Surface's persisted diff scope (#237, PRD #233): Working tree vs Branch
+ * changes + the chosen base ref, PER WORKSPACE — which branch you review against is
+ * workspace state, unlike the global rendering prefs in `diff-prefs-store`. Same
+ * injected-storage seam (throw-tolerant, renderer-only localStorage boundary).
+ * `baseRef: null` means Automatic — main resolves the default branch.
+ */
+
+export type DiffScope = 'working' | 'branch'
+
+export interface DiffScopeState {
+  scope: DiffScope
+  baseRef: string | null
+}
+
+export const DIFF_SCOPE_STORAGE_KEY = 'vibe-mistro:diff-scope:v1'
+
+/** The slice of the Web Storage API we depend on — `window.localStorage` satisfies it. */
+export interface ScopeStorage {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+}
+
+const DEFAULT: DiffScopeState = { scope: 'working', baseRef: null }
+
+function coerce(entry: unknown): DiffScopeState {
+  if (typeof entry !== 'object' || entry === null) return { ...DEFAULT }
+  const e = entry as Record<string, unknown>
+  return {
+    scope: e.scope === 'branch' ? 'branch' : 'working',
+    baseRef: typeof e.baseRef === 'string' && e.baseRef ? e.baseRef : null,
+  }
+}
+
+function readMap(storage: ScopeStorage): Record<string, unknown> {
+  try {
+    const raw = storage.getItem(DIFF_SCOPE_STORAGE_KEY)
+    const parsed: unknown = raw ? JSON.parse(raw) : null
+    return typeof parsed === 'object' && parsed !== null ? (parsed as Record<string, unknown>) : {}
+  } catch {
+    return {}
+  }
+}
+
+/** Read one Workspace's scope; anything unreadable coerces to the working-tree default. */
+export function readDiffScope(storage: ScopeStorage, workspaceDir: string): DiffScopeState {
+  return coerce(readMap(storage)[workspaceDir])
+}
+
+/** Persist one Workspace's scope, best-effort (a throwing storage is silently ignored). */
+export function writeDiffScope(storage: ScopeStorage, workspaceDir: string, state: DiffScopeState): void {
+  try {
+    const map = readMap(storage)
+    map[workspaceDir] = state
+    storage.setItem(DIFF_SCOPE_STORAGE_KEY, JSON.stringify(map))
+  } catch {
+    // Best-effort: losing a scope preference is not worth surfacing.
+  }
+}

--- a/src/renderer/src/git/diff-view-chrome.tsx
+++ b/src/renderer/src/git/diff-view-chrome.tsx
@@ -1,0 +1,190 @@
+import { memo, useMemo, type JSX } from 'react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import { PatchDiff } from '@pierre/diffs/react'
+import type { GitFileDiff } from '../../../shared/ipc'
+import { cn } from '../lib/utils'
+import { glyphClass } from './status-view'
+import type { DiffPrefs } from './diff-prefs-store'
+
+/**
+ * Shared chrome for the multi-file diff views (#235/#237): the per-file collapsible
+ * section and the rendering-prefs toggle row, used by both the working-tree
+ * `AllFilesDiffView` and the branch-range `BranchDiffView`. Extracted (not duplicated)
+ * because the two views must FEEL like one surface — same sticky headers, same
+ * toggles, same truncation marker — differing only in where their entries come from.
+ */
+
+/**
+ * One file's collapsible section: a STICKY header (optional status glyph + path +
+ * churn + truncated marker + collapse chevron) over its own `PatchDiff`. Memoized so a
+ * sibling section's collapse or an unchanged refetch (same `diffHash`) doesn't
+ * re-render this one — per-file memoization is the whole point of per-file hashes.
+ * `meta` (glyph + churn) comes from the streamed status in the working-tree view and
+ * is ABSENT in the branch-range view (a range entry has no porcelain status).
+ */
+export const DiffFileSection = memo(
+  function DiffFileSection({
+    path,
+    meta,
+    entry,
+    collapsed,
+    onToggle,
+    refFn,
+    diffStyle,
+    wrap,
+    ignoreWhitespace,
+  }: {
+    path: string
+    meta?: { glyph: string; insertions: number; deletions: number }
+    entry: GitFileDiff | undefined
+    collapsed: boolean
+    onToggle: () => void
+    refFn?: (el: HTMLElement | null) => void
+    diffStyle: 'unified' | 'split'
+    wrap: boolean
+    ignoreWhitespace: boolean
+  }): JSX.Element {
+    const patch = entry?.patch ?? ''
+    const diffHash = entry?.diffHash ?? ''
+    const rendered = useMemo(() => {
+      if (!patch) return null
+      return (
+        <PatchDiff
+          patch={patch}
+          options={{
+            diffStyle,
+            theme: 'pierre-light',
+            themeType: 'light',
+            overflow: wrap ? 'wrap' : 'scroll',
+          }}
+        />
+      )
+      // diffHash is a 1:1 proxy for `patch`; depend on it (not the long string).
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [diffHash, diffStyle, wrap])
+
+    return (
+      <section ref={refFn} className="border-b border-border-muted">
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-expanded={!collapsed}
+          className="sticky top-0 z-10 flex w-full items-center gap-1.5 border-b border-border-muted bg-background px-3 py-1.5 text-left"
+        >
+          {collapsed ? (
+            <ChevronRight className="size-3.5 shrink-0 text-muted" aria-hidden />
+          ) : (
+            <ChevronDown className="size-3.5 shrink-0 text-muted" aria-hidden />
+          )}
+          {meta && (
+            <span className={cn('w-3 shrink-0 text-center text-[11px] font-semibold', glyphClass(meta.glyph))}>
+              {meta.glyph}
+            </span>
+          )}
+          <span className="min-w-0 flex-1 truncate text-[13px] text-text" dir="rtl" title={path}>
+            {path}
+          </span>
+          {entry?.truncated && (
+            <span className="shrink-0 text-[11px] text-muted" title="Diff truncated — file too large">
+              truncated
+            </span>
+          )}
+          {meta && (
+            <span className="shrink-0 text-[11px] tabular-nums">
+              {meta.insertions > 0 && <span className="text-ok">+{meta.insertions}</span>}{' '}
+              {meta.deletions > 0 && <span className="text-bad">−{meta.deletions}</span>}
+            </span>
+          )}
+        </button>
+        {!collapsed &&
+          (rendered ?? (
+            <p className="px-3 py-2 text-[13px] text-muted">
+              No changes to show{ignoreWhitespace ? ' (whitespace-only changes hidden).' : '.'}
+            </p>
+          ))}
+      </section>
+    )
+  },
+  (prev, next) =>
+    prev.path === next.path &&
+    prev.entry?.diffHash === next.entry?.diffHash &&
+    prev.entry?.truncated === next.entry?.truncated &&
+    prev.collapsed === next.collapsed &&
+    prev.diffStyle === next.diffStyle &&
+    prev.wrap === next.wrap &&
+    prev.ignoreWhitespace === next.ignoreWhitespace &&
+    prev.meta?.insertions === next.meta?.insertions &&
+    prev.meta?.deletions === next.meta?.deletions &&
+    prev.meta?.glyph === next.meta?.glyph,
+)
+
+/** The rendering-prefs row shared by both views: Stacked/Split + Wrap + Ignore whitespace. */
+export function DiffToggles({
+  prefs,
+  onChange,
+}: {
+  prefs: DiffPrefs
+  onChange: (patch: Partial<DiffPrefs>) => void
+}): JSX.Element {
+  return (
+    <div className="flex items-center gap-2 border-b border-border-muted px-3 py-2 text-[13px]">
+      <div className="flex overflow-hidden rounded-md border border-border">
+        <ToggleButton active={prefs.diffStyle === 'unified'} onClick={() => onChange({ diffStyle: 'unified' })}>
+          Stacked
+        </ToggleButton>
+        <ToggleButton active={prefs.diffStyle === 'split'} onClick={() => onChange({ diffStyle: 'split' })}>
+          Split
+        </ToggleButton>
+      </div>
+      <button
+        type="button"
+        onClick={() => onChange({ wrap: !prefs.wrap })}
+        aria-pressed={prefs.wrap}
+        title={prefs.wrap ? 'Scroll long lines' : 'Wrap long lines'}
+        className={cn(
+          'shrink-0 rounded-md border border-border px-2.5 py-1 transition-colors',
+          prefs.wrap ? 'bg-accent/10 text-accent-text' : 'text-muted hover:text-accent-text',
+        )}
+      >
+        Wrap
+      </button>
+      <button
+        type="button"
+        onClick={() => onChange({ ignoreWhitespace: !prefs.ignoreWhitespace })}
+        aria-pressed={prefs.ignoreWhitespace}
+        title={prefs.ignoreWhitespace ? 'Show whitespace changes' : 'Hide whitespace changes'}
+        className={cn(
+          'ml-auto shrink-0 rounded-md border border-border px-2.5 py-1 transition-colors',
+          prefs.ignoreWhitespace ? 'bg-accent/10 text-accent-text' : 'text-muted hover:text-accent-text',
+        )}
+      >
+        Ignore whitespace
+      </button>
+    </div>
+  )
+}
+
+/** A segmented-control button (Stacked / Split) — rounded via its container's clip. */
+function ToggleButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean
+  onClick: () => void
+  children: React.ReactNode
+}): JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={cn(
+        'px-2.5 py-1 transition-colors',
+        active ? 'bg-accent/10 text-accent-text' : 'text-muted hover:text-accent-text',
+      )}
+    >
+      {children}
+    </button>
+  )
+}

--- a/src/shared/ipc/git.ts
+++ b/src/shared/ipc/git.ts
@@ -25,6 +25,8 @@ export const gitChannels = {
   gitStatus: 'git:status',
   /** Renderer -> main: read the FULL working-tree diff — one entry per changed path (#235) — see {@link GitFullDiffArgs}. */
   gitFullDiff: 'git:full-diff',
+  /** Renderer -> main: read a BRANCH-RANGE diff (`base...HEAD`, #237) — see {@link GitRangeDiffArgs}. */
+  gitRangeDiff: 'git:range-diff',
   /** Renderer -> main: COMMIT working-tree changes from the Changes panel (#86) — see {@link GitCommitArgs}. */
   gitCommit: 'git:commit',
   /** Renderer -> main: list the active Workspace's branches (#87) — see {@link GitBranchesArgs}. */
@@ -138,6 +140,31 @@ export interface GitFileDiff extends GitDiffResult {
 export interface GitFullDiffResult {
   files: GitFileDiff[]
 }
+
+/**
+ * Args for `gitRangeDiff` (#237, PRD #233): read the branch's diff against a base —
+ * `<baseRef>...HEAD`, what the branch adds relative to where it forked. `baseRef`
+ * OMITTED means Automatic: main resolves the repository's default branch from
+ * origin/HEAD. `ignoreWhitespace` re-reads with `-w` (same rationale as the
+ * working-tree reads). Read-only; not agent activity.
+ */
+export interface GitRangeDiffArgs {
+  workspaceDir: string
+  baseRef?: string
+  ignoreWhitespace?: boolean
+}
+
+/**
+ * The `gitRangeDiff` reply (#237). `{ok:true}` carries the RESOLVED base (so
+ * "Automatic" shows what it compared against) + per-file entries, individually
+ * capped + hashed like {@link GitFullDiffResult}. Unlike the working-tree reads, a
+ * bad RANGE is a meaningful state — an unknown base, an unresolvable default, a
+ * detached HEAD — so it surfaces as `{ok:false, error}` (git's actual reason; the
+ * renderer wraps it in friendly copy) instead of degrading to an empty diff.
+ */
+export type GitRangeDiffResult =
+  | { ok: true; baseRef: string; files: GitFileDiff[] }
+  | { ok: false; error: string }
 
 /**
  * Args for `gitCommit` (#86, ADR-0008 — the first git WRITE): commit working-tree


### PR DESCRIPTION
Closes #237 (PRD #233, slice 5 of the git-review parity epic).

**Stacked on #245** (slice 2) because both rework `ChangesPanel` — this PR's base is the slice-2 branch and it auto-retargets to `main` when #245 merges. Review/merge #245 first.

## What this does

A **diff scope** for the Review Surface: *Working tree* (today's live view) vs *Branch changes* (`base...HEAD` — what the branch adds relative to where it forked), so review keeps working after commits land instead of going blank.

- **Main**: `readGitRangeDiff` mirrors the all-files shape — enumerate the range's paths (`-z`), one per-file read, each entry individually capped + hashed. Omitted base = **Automatic**: main resolves the default branch from `origin/HEAD` and returns the resolved name so "Automatic" is never opaque. A bad range (unknown base, unresolvable default) returns `{ok:false, error}` — meaningful and user-actionable — rather than degrading to an empty diff. New `git:range-diff` invoke.
- **Renderer**: a scope segmented control under the PR section, **persisted per Workspace** (`diff-scope-store`) — which branch you review against is workspace state, unlike the global rendering prefs. Branch scope renders `BranchDiffView`: a `head → base` row with a **searchable base-ref picker** (default-first ordering, current branch excluded, remotes tagged), the same collapsible per-file sections, and the shared Stacked/Split/Wrap/Ignore-whitespace toggles. Detached HEAD and unknown-base states show friendly copy with the raw git reason in the tooltip.
- **Refresh discipline**: working-tree scope stays live from the status stream; branch scope refreshes **on demand only** (scope switch, base change, whitespace toggle, the panel's manual refresh) — a range over commits doesn't move when the working tree does.
- The per-file section + toggle chrome is extracted to `diff-view-chrome.tsx` and shared by both scopes, so they read as one surface.

## Tests

- 6 `readGitRangeDiff` fake-runner tests: range command forms, Automatic resolution, unresolvable-default and unknown-base errors, `-w` pass-through, reject-degrade.
- 4 `diff-scope-store` tests (per-Workspace round-trip, garbage coercion, throw-tolerance) + 4 pure picker tests (`buildBaseRefChoices` ordering/exclusion, filter).
- Full gates green: lint, typecheck, build, `bun run test` (**1228** tests / 97 files).
- **Verified against real git**: explicit + Automatic bases, three-dot semantics excluding post-fork main-side commits, non-ASCII path with spaces, unknown-base error surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)