### PR TITLE
feat(git): slice 6 — review comments to composer chips (re-landed on main) (#239)

### DIFF
--- a/src/renderer/src/conversation/Composer.tsx
+++ b/src/renderer/src/conversation/Composer.tsx
@@ -8,7 +8,7 @@ import {
   type JSX,
   type KeyboardEvent,
 } from 'react'
-import { ArrowUp, File, Mic, MousePointerClick, Plus, Sparkles, Square, X } from 'lucide-react'
+import { ArrowUp, File, Mic, MessageSquareText, MousePointerClick, Plus, Sparkles, Square, X } from 'lucide-react'
 import type {
   FileEntry,
   ThreadConfigAxis,
@@ -27,6 +27,7 @@ import {
   subscribeComposerInsert,
   subscribeComposerInsertElement,
   subscribeComposerInsertImage,
+  subscribeComposerInsertReviewComment,
   subscribeComposerInsertText,
 } from './composer-insert'
 import { ACCEPTED_IMAGE_TYPES, isAcceptedImageType, parseDataUrl } from './image-attach'
@@ -41,9 +42,18 @@ import { nextQueueId, type FollowUpQueue } from './follow-up-queue'
 import { useComposerAutocomplete, CompletionPopover } from './use-composer-autocomplete'
 import { createCommandSource, createPathSource } from './composer-sources'
 
-/** Process-local counters for unique pending-image / element-chip ids (not Math.random/Date). */
+/** Process-local counters for unique pending-image / element / review-chip ids (not Math.random/Date). */
 let imageSeq = 0
 let elementSeq = 0
+let reviewSeq = 0
+
+/** A review chip's compact line-range suffix, e.g. `:10-12` / `:7` — empty when unlocated. */
+function reviewRange(context: { startLine: number | null; endLine: number | null }): string {
+  if (context.startLine === null || context.endLine === null) return ''
+  return context.startLine === context.endLine
+    ? `:${context.startLine}`
+    : `:${context.startLine}-${context.endLine}`
+}
 
 /** A pending-context chip's visible label, per kind. */
 function chipLabel(context: PendingContext): string {
@@ -54,6 +64,8 @@ function chipLabel(context: PendingContext): string {
       return context.path
     case 'element':
       return context.selector ?? `<${context.tagName}>`
+    case 'review':
+      return `${context.filePath}${reviewRange(context)}`
   }
 }
 
@@ -73,6 +85,8 @@ function chipTitle(context: PendingContext): string | undefined {
       ]
         .filter((line) => line.length > 0)
         .join('\n')
+    case 'review':
+      return [`${context.filePath}${reviewRange(context)}`, context.note, '', context.excerpt].join('\n')
   }
 }
 
@@ -251,6 +265,17 @@ export function Composer({
     })
   }, [threadId])
 
+  // Stage a Review Surface diff comment (#239): file + located line range + note +
+  // verbatim diff excerpt arrive through the module-level channel keyed by threadId;
+  // each comment is its own removable chip, several accumulate into one prompt and
+  // flatten into a trailing <review_comments> block at send.
+  useEffect(() => {
+    return subscribeComposerInsertReviewComment(threadId, (comment) => {
+      setPendingContexts((prev) => addContext(prev, { kind: 'review', id: `rc:${reviewSeq++}`, ...comment }))
+      inputRef.current?.focus()
+    })
+  }, [threadId])
+
   // Read a pasted/picked image blob to a data URL (DOM: FileReader lives here, not
   // in the pure module), split it into bare base64 + mime via `parseDataUrl`, and
   // stage it. Non-accepted types are skipped up front so we don't read junk.
@@ -417,6 +442,8 @@ export function Composer({
                     <Sparkles className="size-3 shrink-0" aria-hidden />
                   ) : context.kind === 'file' ? (
                     <File className="size-3 shrink-0" aria-hidden />
+                  ) : context.kind === 'review' ? (
+                    <MessageSquareText className="size-3 shrink-0" aria-hidden />
                   ) : (
                     <MousePointerClick className="size-3 shrink-0" aria-hidden />
                   )}

--- a/src/renderer/src/conversation/composer-insert.ts
+++ b/src/renderer/src/conversation/composer-insert.ts
@@ -42,10 +42,55 @@ type ElementListener = (payload: ComposerInsertElement) => void
 
 type ImageListener = (image: ComposerInsertImage) => void
 
+/**
+ * A Review Surface diff comment to stage in a Thread's composer (#239): the file, the
+ * located new-file line range (null when the selection couldn't be mapped), the user's
+ * note, and the verbatim +/-/space diff excerpt. The composer mints the chip id.
+ */
+export interface ComposerInsertReviewComment {
+  filePath: string
+  startLine: number | null
+  endLine: number | null
+  note: string
+  excerpt: string
+}
+
+type ReviewCommentListener = (payload: ComposerInsertReviewComment) => void
+
 const listenersByThread = new Map<string, Set<InsertListener>>()
 const textListenersByThread = new Map<string, Set<InsertListener>>()
 const imageListenersByThread = new Map<string, Set<ImageListener>>()
 const elementListenersByThread = new Map<string, Set<ElementListener>>()
+const reviewListenersByThread = new Map<string, Set<ReviewCommentListener>>()
+
+/** Subscribe a Thread's composer to review-comment payloads (#239); returns an unsubscribe. */
+export function subscribeComposerInsertReviewComment(
+  threadId: string,
+  listener: ReviewCommentListener,
+): () => void {
+  let set = reviewListenersByThread.get(threadId)
+  if (!set) {
+    set = new Set()
+    reviewListenersByThread.set(threadId, set)
+  }
+  set.add(listener)
+  return () => {
+    const current = reviewListenersByThread.get(threadId)
+    if (!current) return
+    current.delete(listener)
+    if (current.size === 0) reviewListenersByThread.delete(threadId)
+  }
+}
+
+/** Deliver a Review Surface diff comment to the Thread's composer; a no-op if none is mounted. */
+export function emitComposerInsertReviewComment(
+  threadId: string,
+  payload: ComposerInsertReviewComment,
+): void {
+  const set = reviewListenersByThread.get(threadId)
+  if (!set) return
+  for (const listener of set) listener(payload)
+}
 
 /**
  * Subscribe a Thread's composer to STANDALONE image insert requests (#226 page

--- a/src/renderer/src/conversation/items/message-rows.tsx
+++ b/src/renderer/src/conversation/items/message-rows.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type JSX } from 'react'
-import { Check, Copy, File, MousePointerClick, RotateCcw, Sparkles, ThumbsDown, ThumbsUp } from 'lucide-react'
+import { Check, Copy, File, MessageSquareText, MousePointerClick, RotateCcw, Sparkles, ThumbsDown, ThumbsUp } from 'lucide-react'
 import { IconButton } from '../../ui/icon-button'
 import { Response } from '../Response'
 import { matchInvokedCommand } from '../command-autocomplete'
@@ -18,7 +18,7 @@ export function UserRow({
   // `<attached_files>` / `<element_context>` marker blocks; strip them back into chips at
   // RENDER time so the bubble shows the clean prose — live and on JSONL replay, which
   // ride the same text. User-typed inline `@path` mentions pass through untouched.
-  const { cleanText, files, elements } = extractPromptContexts(item.text)
+  const { cleanText, files, elements, reviews } = extractPromptContexts(item.text)
   // Skill/command chip: vibe-acp invokes a skill when the prompt opens with a
   // known `/name`, but gives NO wire-level acknowledgment — so we surface the
   // match ourselves. Matched at RENDER time against the CURRENT list (not stamped
@@ -29,7 +29,7 @@ export function UserRow({
   // instead of spanning the pane. Echoed attachments (#100) re-home into the bubble.
   return (
     <div className="flex flex-col items-end gap-1.5">
-      {(command || files.length > 0 || elements.length > 0) && (
+      {(command || files.length > 0 || elements.length > 0 || reviews.length > 0) && (
         <div className="flex max-w-[80%] flex-wrap justify-end gap-1.5">
           {command && (
             <span
@@ -62,6 +62,26 @@ export function UserRow({
             >
               <MousePointerClick className="size-3 shrink-0" aria-hidden />
               <span className="truncate">{element.selector ?? `<${element.tagName}>`}</span>
+            </span>
+          ))}
+          {reviews.map((review) => (
+            // Review-comment chips (#239): the sent-turn mirror of the composer's
+            // staged comments — path + line range, note + excerpt in the tooltip.
+            <span
+              key={review.id}
+              data-review-chip
+              title={[review.note, '', review.excerpt].join('\n')}
+              className="inline-flex max-w-full items-center gap-1 rounded-md border border-[var(--accent-tint-border)] bg-[var(--accent-tint)] px-1.5 py-0.5 font-mono text-xs leading-none text-accent-text"
+            >
+              <MessageSquareText className="size-3 shrink-0" aria-hidden />
+              <span className="truncate">
+                {review.filePath}
+                {review.startLine !== null && review.endLine !== null
+                  ? review.startLine === review.endLine
+                    ? `:${review.startLine}`
+                    : `:${review.startLine}-${review.endLine}`
+                  : ''}
+              </span>
             </span>
           ))}
         </div>

--- a/src/renderer/src/conversation/pending-contexts.test.ts
+++ b/src/renderer/src/conversation/pending-contexts.test.ts
@@ -110,6 +110,7 @@ describe('extractPromptContexts — display mirror for the full payload', () => 
     expect(extractPromptContexts(wire)).toEqual({
       cleanText: '/teach style this',
       files: [reducerFile],
+      reviews: [],
       elements: [
         {
           kind: 'element',
@@ -146,6 +147,7 @@ describe('extractPromptContexts — display mirror for the full payload', () => 
       cleanText: 'just prose with @src/typed.ts',
       files: [],
       elements: [],
+      reviews: [],
     })
   })
 })
@@ -172,5 +174,80 @@ describe('removeContext', () => {
     const staged = addContext([], teach)
     expect(removeContext(staged, contextKey(teach))).toEqual([])
     expect(removeContext(staged, contextKey(review))).toEqual(staged)
+  })
+})
+
+describe('review-comment chips (#239)', () => {
+  const comment1 = {
+    kind: 'review',
+    id: 'rc:1',
+    filePath: 'src/git/diff.ts',
+    startLine: 10,
+    endLine: 12,
+    note: 'this cap looks wrong',
+    excerpt: ' const CAP = 120\n-const OLD = 1\n+const NEW = 2',
+  } as const
+
+  const comment2 = {
+    kind: 'review',
+    id: 'rc:2',
+    filePath: 'src/other.ts',
+    startLine: 3,
+    endLine: 3,
+    note: 'rename this',
+    excerpt: '+const x = 1',
+  } as const
+
+  it('accumulates comments (each id its own chip) and removes by key', () => {
+    const staged = addContext(addContext([], comment1), comment2)
+    expect(staged).toEqual([comment1, comment2])
+    expect(removeContext(staged, contextKey(comment1))).toEqual([comment2])
+  })
+
+  it('serializes as a trailing <review_comments> block: path + line range + note + fenced diff excerpt', () => {
+    const wire = serializeForSend('please address these', [comment1])
+    expect(wire).toBe(
+      'please address these\n\n' +
+        '<review_comments>\n' +
+        'Review comment on src/git/diff.ts (lines 10-12)\n' +
+        'note: this cap looks wrong\n' +
+        '```diff\n' +
+        ' const CAP = 120\n-const OLD = 1\n+const NEW = 2\n' +
+        '```\n' +
+        '</review_comments>',
+    )
+  })
+
+  it('several comments across files ride ONE block in staged order', () => {
+    const wire = serializeForSend('', [comment1, comment2])
+    expect(wire).toContain('Review comment on src/git/diff.ts (lines 10-12)')
+    expect(wire).toContain('Review comment on src/other.ts (line 3)')
+    expect(wire.indexOf('src/git/diff.ts')).toBeLessThan(wire.indexOf('src/other.ts'))
+  })
+
+  it('round-trips through the display mirror: prose recovered, comments recovered', () => {
+    const wire = serializeForSend('please address these', [comment1, comment2])
+    const extracted = extractPromptContexts(wire)
+    expect(extracted.cleanText).toBe('please address these')
+    expect(extracted.reviews.map((r) => ({ path: r.filePath, note: r.note, excerpt: r.excerpt }))).toEqual([
+      { path: 'src/git/diff.ts', note: 'this cap looks wrong', excerpt: ' const CAP = 120\n-const OLD = 1\n+const NEW = 2' },
+      { path: 'src/other.ts', note: 'rename this', excerpt: '+const x = 1' },
+    ])
+    expect(extracted.reviews[0]).toMatchObject({ startLine: 10, endLine: 12 })
+  })
+
+  it('coexists with the other chip kinds — reviews serialize LAST and extract first', () => {
+    const wire = serializeForSend('style this', [reducerFile, button, comment1])
+    const extracted = extractPromptContexts(wire)
+    expect(extracted.cleanText).toBe('style this')
+    expect(extracted.files).toEqual([reducerFile])
+    expect(extracted.elements.length).toBe(1)
+    expect(extracted.reviews.length).toBe(1)
+  })
+
+  it('hand-typed text mentioning <review_comments> mid-prose passes through untouched', () => {
+    const text = 'what does <review_comments> mean here?\nnothing.'
+    expect(extractPromptContexts(text).cleanText).toBe(text)
+    expect(extractPromptContexts(text).reviews).toEqual([])
   })
 })

--- a/src/renderer/src/conversation/pending-contexts.ts
+++ b/src/renderer/src/conversation/pending-contexts.ts
@@ -35,8 +35,26 @@ export interface ElementContext {
   imageId: string | null
 }
 
+/**
+ * A Review Surface diff comment staged as a chip (#239, PRD #233): the user selected
+ * lines in a diff and wrote a note. `excerpt` is the selected diff lines VERBATIM
+ * (with their +/-/space prefixes) so the agent sees exactly which code the note points
+ * at; `startLine`/`endLine` are new-file line numbers (null when the selection
+ * couldn't be located — the excerpt still pins the code). `id` is composer-minted —
+ * each comment is its own chip, several accumulate into one prompt.
+ */
+export interface ReviewCommentContext {
+  kind: 'review'
+  id: string
+  filePath: string
+  startLine: number | null
+  endLine: number | null
+  note: string
+  excerpt: string
+}
+
 /** A context chip staged in the composer awaiting send. */
-export type PendingContext = SkillContext | FileContext | ElementContext
+export type PendingContext = SkillContext | FileContext | ElementContext | ReviewCommentContext
 
 /** The stable identity of a chip — the React key, the remove handle, and the dedupe key. */
 export function contextKey(context: PendingContext): string {
@@ -47,6 +65,8 @@ export function contextKey(context: PendingContext): string {
       return `file:${context.path}`
     case 'element':
       return `element:${context.id}`
+    case 'review':
+      return `review:${context.id}`
   }
 }
 
@@ -84,6 +104,63 @@ const ATTACHED_FILES_CLOSE = '</attached_files>'
  *  prose the agent reads naturally (the former #224 draft-text annotation, relocated). */
 const ELEMENT_CONTEXT_OPEN = '<element_context>'
 const ELEMENT_CONTEXT_CLOSE = '</element_context>'
+
+/** The marker element fencing review comments in the wire text (#239). */
+const REVIEW_COMMENTS_OPEN = '<review_comments>'
+const REVIEW_COMMENTS_CLOSE = '</review_comments>'
+
+/** One review comment's lines inside the block (#239): a head line naming the file +
+ *  line range, a single-line `note:` (whitespace-normalized, like element text), then
+ *  the selected diff lines verbatim inside a ```diff fence. Line-parseable — the
+ *  extraction inverse is {@link parseReviewEntries}. */
+function formatReviewEntry(comment: ReviewCommentContext): string[] {
+  const range =
+    comment.startLine !== null && comment.endLine !== null
+      ? comment.startLine === comment.endLine
+        ? ` (line ${comment.startLine})`
+        : ` (lines ${comment.startLine}-${comment.endLine})`
+      : ''
+  return [
+    `Review comment on ${comment.filePath}${range}`,
+    `note: ${comment.note.replace(/\s+/g, ' ').trim()}`,
+    '```diff',
+    ...comment.excerpt.split('\n'),
+    '```',
+  ]
+}
+
+/** Parse a `<review_comments>` block's inner lines back into comments (#239) — a
+ *  line-by-line state machine (NOT a head-line split: excerpt lines inside the ```diff
+ *  fences may contain anything, including our own head shape). Null on any shape we
+ *  didn't write, so hand-typed text is never mangled. */
+function parseReviewEntries(lines: string[]): ReviewCommentContext[] | null {
+  const comments: ReviewCommentContext[] = []
+  let i = 0
+  while (i < lines.length) {
+    if (lines[i].trim().length === 0) {
+      i++
+      continue
+    }
+    const head = /^Review comment on (.+?)(?: \((?:line (\d+)|lines (\d+)-(\d+))\))?$/.exec(lines[i])
+    if (!head) return null
+    const note = lines[i + 1]
+    if (note === undefined || !note.startsWith('note: ') || lines[i + 2] !== '```diff') return null
+    const close = lines.indexOf('```', i + 3)
+    if (close === -1) return null
+    const single = head[2] ? Number(head[2]) : null
+    comments.push({
+      kind: 'review',
+      id: `rc-extract:${comments.length}`,
+      filePath: head[1],
+      startLine: single ?? (head[3] ? Number(head[3]) : null),
+      endLine: single ?? (head[4] ? Number(head[4]) : null),
+      note: note.slice('note: '.length),
+      excerpt: lines.slice(i + 3, close).join('\n'),
+    })
+    i = close + 1
+  }
+  return comments.length > 0 ? comments : null
+}
 
 /** One element's lines inside the block — `Picked element <tag>` (the entry delimiter),
  *  optional `selector:`/`text:` lines (text whitespace-normalized so entries stay line-
@@ -148,6 +225,7 @@ export interface ExtractedPromptContexts {
   cleanText: string
   files: FileContext[]
   elements: ElementContext[]
+  reviews: ReviewCommentContext[]
 }
 
 /**
@@ -161,6 +239,23 @@ export interface ExtractedPromptContexts {
 export function extractPromptContexts(text: string): ExtractedPromptContexts {
   let working = text
   let elements: ElementContext[] = []
+  let reviews: ReviewCommentContext[] = []
+  // Reviews serialize LAST (#239), so they strip FIRST.
+  const reviewTrimmed = working.trimEnd()
+  if (reviewTrimmed.endsWith(REVIEW_COMMENTS_CLOSE)) {
+    const open = reviewTrimmed.lastIndexOf(REVIEW_COMMENTS_OPEN)
+    if (open !== -1) {
+      const inner = reviewTrimmed.slice(
+        open + REVIEW_COMMENTS_OPEN.length,
+        reviewTrimmed.length - REVIEW_COMMENTS_CLOSE.length,
+      )
+      const parsed = parseReviewEntries(inner.split('\n'))
+      if (parsed) {
+        reviews = parsed
+        working = reviewTrimmed.slice(0, open).replace(/\n+$/, '')
+      }
+    }
+  }
   const trimmed = working.trimEnd()
   if (trimmed.endsWith(ELEMENT_CONTEXT_CLOSE)) {
     const open = trimmed.lastIndexOf(ELEMENT_CONTEXT_OPEN)
@@ -181,7 +276,7 @@ export function extractPromptContexts(text: string): ExtractedPromptContexts {
     }
   }
   const { cleanText, files } = extractAttachedFiles(working)
-  return { cleanText, files, elements }
+  return { cleanText, files, elements, reviews }
 }
 
 /**
@@ -205,6 +300,12 @@ export function serializeForSend(text: string, contexts: readonly PendingContext
   if (elements.length > 0) {
     parts.push(
       [ELEMENT_CONTEXT_OPEN, ...elements.flatMap(formatElementEntry), ELEMENT_CONTEXT_CLOSE].join('\n'),
+    )
+  }
+  const reviews = contexts.filter((c) => c.kind === 'review')
+  if (reviews.length > 0) {
+    parts.push(
+      [REVIEW_COMMENTS_OPEN, ...reviews.flatMap(formatReviewEntry), REVIEW_COMMENTS_CLOSE].join('\n'),
     )
   }
   return parts.filter((p) => p.length > 0).join('\n\n')

--- a/src/renderer/src/git/AllFilesDiffView.tsx
+++ b/src/renderer/src/git/AllFilesDiffView.tsx
@@ -5,6 +5,7 @@ import { Button } from '../ui'
 import { readDiffPrefs, writeDiffPrefs, type DiffPrefs } from './diff-prefs-store'
 import { diffRequestKey, type GitFileView } from './status-view'
 import { DiffFileSection, DiffToggles } from './diff-view-chrome'
+import { ReviewSelectionLayer } from './ReviewSelectionLayer'
 
 /**
  * The ALL-FILES working-tree diff view (#235, PRD #233) — every changed file as a
@@ -25,6 +26,7 @@ export function AllFilesDiffView({
   files,
   initialPath,
   onBack,
+  activeThreadId,
 }: {
   workspaceDir: string
   /** The LIVE sorted view files — sections follow this order and churn drives refetch. */
@@ -32,6 +34,8 @@ export function AllFilesDiffView({
   /** The section to scroll to on open (the clicked row), if any. */
   initialPath: string | null
   onBack: () => void
+  /** The active Thread for review comments (#239) — null renders the layer inert. */
+  activeThreadId: string | null
 }): JSX.Element {
   const [prefs, setPrefs] = useState<DiffPrefs>(() => readDiffPrefs(window.localStorage))
   const [result, setResult] = useState<GitFullDiffResult | null>(null)
@@ -107,7 +111,9 @@ export function AllFilesDiffView({
 
       <DiffToggles prefs={prefs} onChange={updatePrefs} />
 
-      <div className="min-h-0 flex-1 overflow-auto">
+      {/* Review comments (#239): select lines in any section → floating Comment →
+          note editor → a pending-context chip in the active Thread's composer. */}
+      <ReviewSelectionLayer threadId={activeThreadId} getPatch={(path) => entryByPath.get(path)?.patch}>
         {loading && !result ? (
           <p className="px-3 py-3 text-[13px] text-muted">Loading diff…</p>
         ) : (
@@ -136,7 +142,7 @@ export function AllFilesDiffView({
             />
           ))
         )}
-      </div>
+      </ReviewSelectionLayer>
     </div>
   )
 }

--- a/src/renderer/src/git/BranchDiffView.tsx
+++ b/src/renderer/src/git/BranchDiffView.tsx
@@ -5,6 +5,7 @@ import { Input, Menu, MenuContent, MenuItem, MenuSeparator, MenuTrigger } from '
 import { readDiffPrefs, writeDiffPrefs, type DiffPrefs } from './diff-prefs-store'
 import { buildBaseRefChoices, filterRefChoices } from './branch-scope'
 import { DiffFileSection, DiffToggles } from './diff-view-chrome'
+import { ReviewSelectionLayer } from './ReviewSelectionLayer'
 
 /**
  * The BRANCH-CHANGES scope (#237, PRD #233): `base...HEAD` — what this branch adds
@@ -24,6 +25,7 @@ export function BranchDiffView({
   baseRef,
   onBaseRefChange,
   refreshKey,
+  activeThreadId,
 }: {
   workspaceDir: string
   /** The checked-out branch, or null when detached (no range to show). */
@@ -33,6 +35,8 @@ export function BranchDiffView({
   onBaseRefChange: (baseRef: string | null) => void
   /** Bumped by the panel's manual refresh — the on-demand re-read trigger. */
   refreshKey: number
+  /** The active Thread for review comments (#239) — null renders the layer inert. */
+  activeThreadId: string | null
 }): JSX.Element {
   const [prefs, setPrefs] = useState<DiffPrefs>(() => readDiffPrefs(window.localStorage))
   const [result, setResult] = useState<GitRangeDiffResult | null>(null)
@@ -138,7 +142,11 @@ export function BranchDiffView({
 
       <DiffToggles prefs={prefs} onChange={updatePrefs} />
 
-      <div className="min-h-0 flex-1 overflow-auto">
+      {/* Review comments work in BOTH scopes (#239): whatever the diff shows is quotable. */}
+      <ReviewSelectionLayer
+        threadId={activeThreadId}
+        getPatch={(path) => (result?.ok ? result.files.find((f) => f.path === path)?.patch : undefined)}
+      >
         {loading && !result ? (
           <p className="px-3 py-3 text-[13px] text-muted">Loading branch diff…</p>
         ) : result && !result.ok ? (
@@ -172,7 +180,7 @@ export function BranchDiffView({
             />
           ))
         )}
-      </div>
+      </ReviewSelectionLayer>
     </div>
   )
 }

--- a/src/renderer/src/git/ChangesPanel.tsx
+++ b/src/renderer/src/git/ChangesPanel.tsx
@@ -66,9 +66,12 @@ export function ChangesPanel({
   isActive,
   busy,
   onCollapse,
+  activeThreadId,
 }: {
   workspaceDir: string
   isActive: boolean
+  /** The active Thread — the review-comment chips' destination (#239); null = inert. */
+  activeThreadId: string | null
   /**
    * Whether this Workspace has a streaming turn (#86 concurrency guard). The agent can
    * run `git commit` itself as a tool-call mid-turn, so the v1 guard simply DISABLES the
@@ -335,6 +338,7 @@ export function ChangesPanel({
             files={view.files}
             initialPath={selectedPath}
             onBack={() => setSelectedPath(null)}
+            activeThreadId={activeThreadId}
           />
         </DiffWorkerProvider>
       </aside>
@@ -417,6 +421,7 @@ export function ChangesPanel({
             baseRef={diffScope.baseRef}
             onBaseRefChange={(baseRef) => updateDiffScope({ baseRef })}
             refreshKey={prRefreshKey}
+            activeThreadId={activeThreadId}
           />
         </DiffWorkerProvider>
       ) : view.files.length === 0 ? (

--- a/src/renderer/src/git/ReviewSelectionLayer.tsx
+++ b/src/renderer/src/git/ReviewSelectionLayer.tsx
@@ -1,0 +1,145 @@
+import { useRef, useState, type JSX, type ReactNode } from 'react'
+import { MessageSquareText } from 'lucide-react'
+import { Button, Textarea } from '../ui'
+import { emitComposerInsertReviewComment } from '../conversation/composer-insert'
+import { locateExcerptInPatch } from './review-comment'
+
+/**
+ * The review-comment selection layer (#239, PRD #233): wraps a multi-file diff view
+ * and turns a NATIVE text selection inside any file section into a comment. On
+ * mouseup over a `[data-diff-path]` section a floating "Comment" affordance appears
+ * by the selection; clicking it opens an inline note editor (Cmd/Ctrl+Enter submits,
+ * Esc cancels). Submit locates the selection in that file's raw patch
+ * (`locateExcerptInPatch` — verbatim +/-/space excerpt + new-file line range;
+ * unlocatable selections fall back to the selected text with no range) and emits it
+ * to the ACTIVE Thread's composer through the module-level channel, where it stages
+ * as a pending-context chip. Renderer-only — no IPC, no main-process involvement.
+ * With no active Thread (`threadId` null) the layer is inert chrome.
+ */
+export function ReviewSelectionLayer({
+  threadId,
+  getPatch,
+  children,
+}: {
+  threadId: string | null
+  /** The raw patch for a section's path — the locator's ground truth. */
+  getPatch: (path: string) => string | undefined
+  children: ReactNode
+}): JSX.Element {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  // The captured selection: which file, the selected text, and where to float the UI.
+  const [pending, setPending] = useState<{ path: string; text: string; top: number; left: number } | null>(null)
+  const [editing, setEditing] = useState(false)
+  const [note, setNote] = useState('')
+
+  function handleMouseUp(): void {
+    if (editing || threadId === null) return
+    const selection = window.getSelection()
+    const container = containerRef.current
+    if (!selection || selection.isCollapsed || !container) {
+      setPending(null)
+      return
+    }
+    const text = selection.toString()
+    if (text.trim().length === 0) {
+      setPending(null)
+      return
+    }
+    // The selection must live inside ONE of our file sections.
+    const anchor = selection.anchorNode
+    const element = anchor instanceof Element ? anchor : anchor?.parentElement
+    const section = element?.closest('[data-diff-path]')
+    if (!section || !container.contains(section)) {
+      setPending(null)
+      return
+    }
+    const path = section.getAttribute('data-diff-path')
+    if (!path) return
+    const rect = selection.getRangeAt(0).getBoundingClientRect()
+    const containerRect = container.getBoundingClientRect()
+    setPending({
+      path,
+      text,
+      // Float just below the selection, clamped into the container.
+      top: Math.max(0, rect.bottom - containerRect.top + container.scrollTop + 4),
+      left: Math.max(8, Math.min(rect.left - containerRect.left, containerRect.width - 200)),
+    })
+  }
+
+  function submit(): void {
+    if (!pending || threadId === null) return
+    const trimmed = note.trim()
+    if (trimmed.length === 0) return
+    const located = locateExcerptInPatch(getPatch(pending.path) ?? '', pending.text)
+    emitComposerInsertReviewComment(threadId, {
+      filePath: pending.path,
+      startLine: located?.startLine ?? null,
+      endLine: located?.endLine ?? null,
+      note: trimmed,
+      // Unlocatable (e.g. a selection across collapsed chrome): the selected text
+      // still pins the code, just without line numbers.
+      excerpt: located?.excerpt ?? pending.text.trim(),
+    })
+    cancel()
+  }
+
+  function cancel(): void {
+    setPending(null)
+    setEditing(false)
+    setNote('')
+  }
+
+  return (
+    <div ref={containerRef} className="relative min-h-0 flex-1 overflow-auto" onMouseUp={handleMouseUp}>
+      {children}
+      {pending && (
+        <div
+          className="absolute z-20 rounded-md border border-border bg-surface shadow-md"
+          style={{ top: pending.top, left: pending.left }}
+        >
+          {!editing ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              onClick={() => setEditing(true)}
+              className="text-accent-text"
+            >
+              <MessageSquareText className="size-3.5" aria-hidden />
+              Comment
+            </Button>
+          ) : (
+            <div className="flex w-64 flex-col gap-1.5 p-2">
+              <Textarea
+                autoFocus
+                aria-label={`Review comment on ${pending.path}`}
+                value={note}
+                onChange={(e) => setNote(e.target.value)}
+                placeholder="Comment on this code…"
+                rows={2}
+                className="min-h-14 resize-y text-[13px]"
+                onKeyDown={(e) => {
+                  if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+                    e.preventDefault()
+                    submit()
+                  } else if (e.key === 'Escape') {
+                    e.preventDefault()
+                    cancel()
+                  }
+                }}
+              />
+              <div className="flex items-center justify-end gap-1.5">
+                <Button type="button" variant="ghost" size="xs" onClick={cancel} className="text-muted">
+                  Cancel
+                </Button>
+                <Button type="button" size="xs" onClick={submit} disabled={note.trim().length === 0}>
+                  Add to chat
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/git/diff-view-chrome.tsx
+++ b/src/renderer/src/git/diff-view-chrome.tsx
@@ -64,7 +64,7 @@ export const DiffFileSection = memo(
     }, [diffHash, diffStyle, wrap])
 
     return (
-      <section ref={refFn} className="border-b border-border-muted">
+      <section ref={refFn} data-diff-path={path} className="border-b border-border-muted">
         <button
           type="button"
           onClick={onToggle}

--- a/src/renderer/src/git/review-comment.test.ts
+++ b/src/renderer/src/git/review-comment.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { locateExcerptInPatch } from './review-comment'
+
+/**
+ * The excerpt locator (#239): map the user's NATIVE text selection over a rendered
+ * diff back to the patch's own lines — the verbatim +/-/space excerpt and the
+ * new-file line range. Pure over the raw unified patch; the selection may carry
+ * rendering artifacts (gutter line numbers, blank rows), which normalization drops.
+ */
+
+const patch = `diff --git a/src/x.ts b/src/x.ts
+index 111..222 100644
+--- a/src/x.ts
++++ b/src/x.ts
+@@ -1,4 +1,5 @@
+ const a = 1
+-const b = 2
++const b = 20
++const c = 3
+ const d = 4
+@@ -10,3 +11,3 @@
+ function f() {
+-  return b
++  return b + c
+ }
+`
+
+describe('locateExcerptInPatch', () => {
+  it('locates a contiguous selection and returns the prefixed excerpt + new-file range', () => {
+    const found = locateExcerptInPatch(patch, 'const b = 20\nconst c = 3\nconst d = 4')
+    expect(found).toEqual({
+      excerpt: '+const b = 20\n+const c = 3\n const d = 4',
+      startLine: 2,
+      endLine: 4,
+    })
+  })
+
+  it('drops rendering artifacts: gutter numbers and blank lines in the selection', () => {
+    const found = locateExcerptInPatch(patch, '2\n\nconst b = 20\n3\nconst c = 3\n')
+    expect(found).toMatchObject({ startLine: 2, endLine: 3 })
+  })
+
+  it('numbers lines correctly inside a LATER hunk', () => {
+    const found = locateExcerptInPatch(patch, 'return b + c\n}')
+    expect(found).toEqual({ excerpt: '+  return b + c\n }', startLine: 12, endLine: 13 })
+  })
+
+  it('a selection spanning a DELETED line keeps it in the excerpt', () => {
+    const found = locateExcerptInPatch(patch, 'const a = 1\nconst b = 2\nconst b = 20')
+    expect(found?.excerpt).toBe(' const a = 1\n-const b = 2\n+const b = 20')
+    expect(found).toMatchObject({ startLine: 1, endLine: 2 })
+  })
+
+  it('returns null when the selection matches nothing contiguous', () => {
+    expect(locateExcerptInPatch(patch, 'const a = 1\nconst d = 4')).toBeNull()
+    expect(locateExcerptInPatch(patch, 'not in the patch at all')).toBeNull()
+    expect(locateExcerptInPatch(patch, '')).toBeNull()
+  })
+})

--- a/src/renderer/src/git/review-comment.ts
+++ b/src/renderer/src/git/review-comment.ts
@@ -1,0 +1,85 @@
+/**
+ * The excerpt locator (#239, PRD #233): map the user's NATIVE text selection over a
+ * rendered diff back to the patch's own lines. The renderer can't ask `@pierre/diffs`
+ * which lines were selected, but it HAS the raw patch — so we normalize the selected
+ * text (dropping gutter line numbers and blank rows the DOM selection picks up) and
+ * find the matching contiguous run of patch body lines. The result carries the
+ * VERBATIM +/-/space excerpt (what the agent sees) and the new-file line range
+ * (deleted lines anchor to the position their deletion applies to). Pure, DOM-free.
+ */
+
+export interface LocatedExcerpt {
+  /** The matched patch lines verbatim, +/-/space prefixes intact. */
+  excerpt: string
+  startLine: number
+  endLine: number
+}
+
+interface BodyLine {
+  raw: string
+  content: string
+  /** New-file line number ('+' and context lines), null for deletions. */
+  newLine: number | null
+  /** The new-file position this line anchors to — for a deletion, where it applied. */
+  anchor: number
+  hunk: number
+}
+
+/** Parse the patch's hunk bodies into content-addressable lines with new-file numbers. */
+function parseBodyLines(patch: string): BodyLine[] {
+  const body: BodyLine[] = []
+  let newCounter = 0
+  let hunk = -1
+  let inHunk = false
+  for (const raw of patch.split('\n')) {
+    const header = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(raw)
+    if (header) {
+      newCounter = Number(header[1])
+      hunk++
+      inHunk = true
+      continue
+    }
+    if (!inHunk) continue
+    if (raw.startsWith('+')) {
+      body.push({ raw, content: raw.slice(1).trim(), newLine: newCounter, anchor: newCounter, hunk })
+      newCounter++
+    } else if (raw.startsWith('-')) {
+      body.push({ raw, content: raw.slice(1).trim(), newLine: null, anchor: newCounter, hunk })
+    } else if (raw.startsWith(' ')) {
+      body.push({ raw, content: raw.slice(1).trim(), newLine: newCounter, anchor: newCounter, hunk })
+      newCounter++
+    }
+    // Anything else (`\ No newline at end of file`, a stray header) is skipped.
+  }
+  return body
+}
+
+export function locateExcerptInPatch(patch: string, selectedText: string): LocatedExcerpt | null {
+  // Normalize the selection: trim lines, drop blanks and pure-number gutter artifacts.
+  const wanted = selectedText
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !/^\d+$/.test(line))
+  if (wanted.length === 0) return null
+
+  const body = parseBodyLines(patch)
+  for (let i = 0; i + wanted.length <= body.length; i++) {
+    let matched = true
+    for (let j = 0; j < wanted.length; j++) {
+      // Contiguous in the SAME hunk — a selection can't meaningfully span the gap
+      // between hunks (the rendered views separate them).
+      if (body[i + j].content !== wanted[j] || body[i + j].hunk !== body[i].hunk) {
+        matched = false
+        break
+      }
+    }
+    if (!matched) continue
+    const run = body.slice(i, i + wanted.length)
+    return {
+      excerpt: run.map((l) => l.raw).join('\n'),
+      startLine: run[0].newLine ?? run[0].anchor,
+      endLine: run[run.length - 1].newLine ?? run[run.length - 1].anchor,
+    }
+  }
+  return null
+}

--- a/src/renderer/src/side-panel/SurfacePanel.tsx
+++ b/src/renderer/src/side-panel/SurfacePanel.tsx
@@ -319,6 +319,7 @@ function PanelBody({
                 isActive={isActive}
                 busy={busy}
                 onCollapse={() => closeWorkspaceSurface(workspaceId, 'review')}
+                activeThreadId={activeThreadId}
               />
             )}
             {active?.kind === 'files' && (


### PR DESCRIPTION
Re-lands #248 onto `main`. Closes #239 (PRD #233, final slice of the git-review parity epic).

**Why this PR exists**: #248 was a stacked PR based on the slice-5 branch; merging it landed slice 6 on `worktree-git-review-slice5-branch-scope` instead of `main` (GitHub doesn't retarget an already-merged PR). This is the same squashed commit cherry-picked onto current `main` — content identical to what you already reviewed and merged in #248; all four gates re-verified here (lint, typecheck, build, 1260 tests).

See #248 for the full description: line selection → inline note editor → `ReviewCommentContext` chips → `<review_comments>` wire block with the verbatim diff excerpt, pure `locateExcerptInPatch`, `ReviewSelectionLayer` over both diff scopes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)