### PR TITLE
feat(git): revert changes — per file and all, behind a warning (#250)

### DIFF
--- a/src/main/git/commit.ts
+++ b/src/main/git/commit.ts
@@ -72,8 +72,10 @@ export async function gitCommit(
  * whose NEW path is in the selection, returns its `<orig>` so both halves get staged.
  * Best-effort: a non-zero status read returns `[]` (the commit proceeds without it,
  * degrading to the original add-the-new-only behaviour — never throws/blocks).
+ * Exported for `gitRevert` (#250), which needs the same origin lookup to restore a
+ * selected rename's source while cleaning its new name.
  */
-async function collectRenameOrigins(cwd: string, paths: string[], run: GitRun): Promise<string[]> {
+export async function collectRenameOrigins(cwd: string, paths: string[], run: GitRun): Promise<string[]> {
   const selected = new Set(paths)
   const res = await run(['-c', 'core.quotePath=false', 'status', '--porcelain=2'], cwd)
   if (res.code !== 0) return []

--- a/src/main/git/register-ipc.ts
+++ b/src/main/git/register-ipc.ts
@@ -11,6 +11,7 @@ import {
   type GitOpResult,
   type GitRangeDiffArgs,
   type GitRangeDiffResult,
+  type GitRevertArgs,
   type GhCreatePrArgs,
   type GhCreateResult,
   type GhCurrentPrArgs,
@@ -22,6 +23,7 @@ import {
 } from '../../shared/ipc'
 import { readGitFullDiff, readGitRangeDiff } from './diff'
 import { gitCommit } from './commit'
+import { gitRevert } from './revert'
 import { runStackedAction } from './stacked-action'
 import { gitBranches, gitCheckout, gitCreateBranch } from './branches'
 import { ghCreatePr, ghCurrentPr } from './github'
@@ -90,6 +92,17 @@ export function registerGitIpc(deps: {
     return settle(
       await gitCommit(args.workspaceDir, args.message, args.paths),
       `[vibe-mistro:git] commit failed (${args.workspaceDir})`,
+      args.workspaceDir,
+    )
+  })
+
+  ipcMain.handle(IPC.gitRevert, async (_event, args: GitRevertArgs): Promise<GitOpResult> => {
+    // REVERT working-tree changes (#250) — destructive; the renderer's warning dialog
+    // is the consent gate. A revert rewrites the working tree AND `.git` (index), so
+    // on success re-read status — the reverted rows drop off the panel.
+    return settle(
+      await gitRevert(args.workspaceDir, args.files, args.all),
+      `[vibe-mistro:git] revert failed (${args.workspaceDir})`,
       args.workspaceDir,
     )
   })

--- a/src/main/git/revert.test.ts
+++ b/src/main/git/revert.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest'
+import { gitRevert } from './revert'
+import type { GitRun } from './run'
+
+/**
+ * `gitRevert` is the DESTRUCTIVE git write (#250) — the testable seam is the exact
+ * COMMAND SEQUENCE per file bucket over a fake `GitRun` (no test shells real git):
+ * tracked-in-HEAD files restore, index-only adds unstage-then-clean, untracked files
+ * clean, renames restore their origin and clean the new name. The UI's warning dialog
+ * is the safety; this module just has to destroy EXACTLY the selection, nothing more.
+ */
+
+function fakeRun(
+  seen: string[][],
+  responses: { stdout?: string; stderr?: string; code: number }[] = [],
+): GitRun {
+  let i = 0
+  return (args) => {
+    seen.push(args)
+    const r = responses[i++] ?? { code: 0 }
+    return Promise.resolve({ stdout: r.stdout ?? '', stderr: r.stderr ?? '', code: r.code })
+  }
+}
+
+function file(path: string, status = '.M', untracked = false): { path: string; status: string; untracked: boolean } {
+  return { path, status, untracked }
+}
+
+describe('gitRevert: all', () => {
+  it('reverts EVERYTHING: hard reset then clean untracked (incl. directories)', async () => {
+    const seen: string[][] = []
+    const result = await gitRevert('/repo', [], true, fakeRun(seen))
+    expect(result).toEqual({ ok: true })
+    expect(seen).toEqual([
+      ['reset', '--hard', '-q'],
+      ['clean', '-fd', '-q'],
+    ])
+  })
+
+  it('a failing reset surfaces git’s reason and skips the clean', async () => {
+    const seen: string[][] = []
+    const result = await gitRevert('/repo', [], true, fakeRun(seen, [{ stderr: 'fatal: index lock', code: 128 }]))
+    expect(result).toEqual({ ok: false, error: 'fatal: index lock' })
+    expect(seen).toEqual([['reset', '--hard', '-q']])
+  })
+})
+
+describe('gitRevert: selection', () => {
+  it('a MODIFIED tracked file restores staged+worktree from HEAD in one command', async () => {
+    const seen: string[][] = []
+    const result = await gitRevert('/repo', [file('a.txt', 'MM')], false, fakeRun(seen))
+    expect(result).toEqual({ ok: true })
+    expect(seen).toEqual([
+      ['-c', 'core.quotePath=false', 'restore', '--source=HEAD', '--staged', '--worktree', '--', 'a.txt'],
+    ])
+  })
+
+  it('an UNTRACKED file is DELETED via clean (no restore possible)', async () => {
+    const seen: string[][] = []
+    const result = await gitRevert('/repo', [file('new.txt', '?', true)], false, fakeRun(seen))
+    expect(result).toEqual({ ok: true })
+    expect(seen).toEqual([['-c', 'core.quotePath=false', 'clean', '-f', '-q', '--', 'new.txt']])
+  })
+
+  it('an index-only ADD (not in HEAD) unstages then cleans — restore would fail on it', async () => {
+    const seen: string[][] = []
+    const result = await gitRevert('/repo', [file('added.txt', 'A.')], false, fakeRun(seen))
+    expect(result).toEqual({ ok: true })
+    expect(seen).toEqual([
+      ['reset', '-q', '--', 'added.txt'],
+      ['-c', 'core.quotePath=false', 'clean', '-f', '-q', '--', 'added.txt'],
+    ])
+  })
+
+  it('a staged RENAME restores its ORIGIN and cleans the new name', async () => {
+    const seen: string[][] = []
+    const porcelain = '2 R. N... 100644 100644 100644 111 222 R100 moved.txt\torig.txt\n'
+    const result = await gitRevert(
+      '/repo',
+      [file('moved.txt', 'R.')],
+      false,
+      fakeRun(seen, [{ stdout: porcelain, code: 0 }]),
+    )
+    expect(result).toEqual({ ok: true })
+    expect(seen).toEqual([
+      ['-c', 'core.quotePath=false', 'status', '--porcelain=2'], // origin scan (only when an R row is selected)
+      ['reset', '-q', '--', 'moved.txt'],
+      ['-c', 'core.quotePath=false', 'restore', '--source=HEAD', '--staged', '--worktree', '--', 'orig.txt'],
+      ['-c', 'core.quotePath=false', 'clean', '-f', '-q', '--', 'moved.txt'],
+    ])
+  })
+
+  it('a MIXED selection buckets correctly and only runs the commands it needs', async () => {
+    const seen: string[][] = []
+    const result = await gitRevert(
+      '/repo',
+      [file('mod.txt', '.M'), file('gone.txt', '.D'), file('new.txt', '?', true)],
+      false,
+      fakeRun(seen),
+    )
+    expect(result).toEqual({ ok: true })
+    expect(seen).toEqual([
+      ['-c', 'core.quotePath=false', 'restore', '--source=HEAD', '--staged', '--worktree', '--', 'mod.txt', 'gone.txt'],
+      ['-c', 'core.quotePath=false', 'clean', '-f', '-q', '--', 'new.txt'],
+    ])
+  })
+
+  it('a failing restore surfaces git’s reason and stops before the clean', async () => {
+    const result = await gitRevert(
+      '/repo',
+      [file('mod.txt', '.M'), file('new.txt', '?', true)],
+      false,
+      fakeRun([], [{ stderr: 'error: pathspec did not match', code: 1 }]),
+    )
+    expect(result).toEqual({ ok: false, error: 'error: pathspec did not match' })
+  })
+
+  it('an empty selection with all=false is a no-op {ok:true} — nothing runs', async () => {
+    const seen: string[][] = []
+    expect(await gitRevert('/repo', [], false, fakeRun(seen))).toEqual({ ok: true })
+    expect(seen).toEqual([])
+  })
+
+  it('never throws — a rejecting runner degrades to {ok:false}', async () => {
+    const result = await gitRevert('/repo', [file('a.txt')], false, () => Promise.reject(new Error('boom')))
+    expect(result).toEqual({ ok: false, error: 'boom' })
+  })
+})

--- a/src/main/git/revert.ts
+++ b/src/main/git/revert.ts
@@ -1,0 +1,77 @@
+import { defaultGitRun, errorMessage, failReason, type GitRun } from './run'
+import { collectRenameOrigins } from './commit'
+import type { GitOpResult } from '../../shared/ipc'
+
+/**
+ * REVERT working-tree changes (#250) — the app's one deliberately DESTRUCTIVE git
+ * write. Like every git module, it runs in main through the injectable `GitRun` seam
+ * and swallows failure into a typed result (never throws). The renderer's warning
+ * dialog is the consent gate; this module's job is to destroy EXACTLY the selection:
+ *
+ *  - ALL (`all: true`): `git reset --hard -q` (tracked: staged + worktree back to
+ *    HEAD) then `git clean -fd -q` (untracked files AND directories deleted).
+ *  - SELECTION: bucketed by the porcelain status the panel already holds —
+ *      · untracked (`?`)            → `clean -f -q --` (DELETED — nothing to restore)
+ *      · index-only add (X === 'A') → `reset -q --` (unstage) then `clean` — a
+ *        `restore --source=HEAD` would FAIL on a path HEAD doesn't have
+ *      · staged rename (X === 'R')  → unstage the NEW name, `restore` the ORIGIN
+ *        (via the same rename-origin scan as #86's commit), `clean` the new name
+ *      · everything else            → `restore --source=HEAD --staged --worktree --`
+ *    Steps run in that dependency order; the first failure stops the chain with
+ *    git's actual reason (#86 style). Paths are argv elements — spaces are safe.
+ */
+export async function gitRevert(
+  cwd: string,
+  files: { path: string; status: string; untracked: boolean }[],
+  all: boolean,
+  run: GitRun = defaultGitRun,
+): Promise<GitOpResult> {
+  try {
+    if (all) {
+      const reset = await run(['reset', '--hard', '-q'], cwd)
+      if (reset.code !== 0) return { ok: false, error: failReason(reset) }
+      const clean = await run(['clean', '-fd', '-q'], cwd)
+      if (clean.code !== 0) return { ok: false, error: failReason(clean) }
+      return { ok: true }
+    }
+    if (files.length === 0) return { ok: true }
+
+    const untracked = files.filter((f) => f.untracked).map((f) => f.path)
+    const added = files.filter((f) => !f.untracked && f.status[0] === 'A').map((f) => f.path)
+    const renamed = files.filter((f) => !f.untracked && f.status[0] === 'R').map((f) => f.path)
+    const restorable = files
+      .filter((f) => !f.untracked && f.status[0] !== 'A' && f.status[0] !== 'R')
+      .map((f) => f.path)
+
+    // A selected rename reverts as: origin restored, new name deleted. Scan for the
+    // origins BEFORE any reset decomposes the rename (same trick as gitCommit).
+    const renameOrigins = renamed.length > 0 ? await collectRenameOrigins(cwd, renamed, run) : []
+
+    // 1. Unstage what HEAD doesn't have (adds + rename new-names) so clean can take it.
+    const toUnstage = [...added, ...renamed]
+    if (toUnstage.length > 0) {
+      const reset = await run(['reset', '-q', '--', ...toUnstage], cwd)
+      if (reset.code !== 0) return { ok: false, error: failReason(reset) }
+    }
+
+    // 2. Restore tracked-in-HEAD paths (both halves) — including rename origins.
+    const toRestore = [...restorable, ...renameOrigins]
+    if (toRestore.length > 0) {
+      const restore = await run(
+        ['-c', 'core.quotePath=false', 'restore', '--source=HEAD', '--staged', '--worktree', '--', ...toRestore],
+        cwd,
+      )
+      if (restore.code !== 0) return { ok: false, error: failReason(restore) }
+    }
+
+    // 3. Delete what only exists in the working tree (untracked + now-unstaged paths).
+    const toClean = [...untracked, ...added, ...renamed]
+    if (toClean.length > 0) {
+      const clean = await run(['-c', 'core.quotePath=false', 'clean', '-f', '-q', '--', ...toClean], cwd)
+      if (clean.code !== 0) return { ok: false, error: failReason(clean) }
+    }
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, error: errorMessage(err) }
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -17,6 +17,7 @@ import {
   type GitOpResult,
   type GitRangeDiffArgs,
   type GitRangeDiffResult,
+  type GitRevertArgs,
   type GitStackedActionArgs,
   type GitStackedActionResult,
   type GhCreatePrArgs,
@@ -127,6 +128,7 @@ const api = {
   gitRangeDiff: (args: GitRangeDiffArgs): Promise<GitRangeDiffResult> =>
     ipcRenderer.invoke(IPC.gitRangeDiff, args),
   gitCommit: (args: GitCommitArgs): Promise<GitCommitResult> => ipcRenderer.invoke(IPC.gitCommit, args),
+  gitRevert: (args: GitRevertArgs): Promise<GitOpResult> => ipcRenderer.invoke(IPC.gitRevert, args),
   gitBranches: (args: GitBranchesArgs): Promise<GitBranchesResult> =>
     ipcRenderer.invoke(IPC.gitBranches, args),
   gitCheckout: (args: GitBranchOpArgs): Promise<GitOpResult> =>

--- a/src/renderer/src/git/ChangesPanel.tsx
+++ b/src/renderer/src/git/ChangesPanel.tsx
@@ -18,7 +18,7 @@ import {
 import { getCommitDraft, setCommitDraft } from './commit-draft-store'
 import { readDiffScope, writeDiffScope, type DiffScopeState } from './diff-scope-store'
 import { BranchDiffView } from './BranchDiffView'
-import { buildChangesView, reconcileUnchecked } from './status-view'
+import { buildChangesView, reconcileUnchecked, type GitFileView } from './status-view'
 import { autoCommitMessage, isDefaultBranch, suggestBranchName } from './commit-guard'
 import { deriveQuickAction, type QuickActionKind } from './quick-action'
 import { QuickActions } from './QuickActions'
@@ -128,6 +128,12 @@ export function ChangesPanel({
   }
   // The in-flight stacked action (#236): its kind, the streamed phase line, its error,
   // and the renderer-minted id the progress events are filtered by.
+  // The revert dialog (#250): which target awaits confirmation — one file or 'all'.
+  // DESTRUCTIVE, so nothing runs until the dialog's confirm; a failure stays in the
+  // dialog with git's reason.
+  const [revertTarget, setRevertTarget] = useState<GitFileView | 'all' | null>(null)
+  const [reverting, setReverting] = useState(false)
+  const [revertError, setRevertError] = useState<string | null>(null)
   const [acting, setActing] = useState<GitStackedActionKind | null>(null)
   const [actionProgress, setActionProgress] = useState<string | null>(null)
   const [actionError, setActionError] = useState<string | null>(null)
@@ -323,6 +329,32 @@ export function ChangesPanel({
     }
   }
 
+  /** Run the CONFIRMED revert (#250): the dialog is the consent gate; a failure stays
+   *  IN the dialog with git's actual reason, success closes it (the streamed status
+   *  refresh main triggers drops the reverted rows off the panel). */
+  async function doRevert(): Promise<void> {
+    if (!revertTarget) return
+    setReverting(true)
+    setRevertError(null)
+    try {
+      const result = await window.api.gitRevert(
+        revertTarget === 'all'
+          ? { workspaceDir, files: [], all: true }
+          : {
+              workspaceDir,
+              files: [
+                { path: revertTarget.path, status: revertTarget.status, untracked: revertTarget.untracked },
+              ],
+              all: false,
+            },
+      )
+      if (result.ok) setRevertTarget(null)
+      else setRevertError(result.error)
+    } finally {
+      setReverting(false)
+    }
+  }
+
   // DIFF mode (#235: ALL files in one scroll, the clicked row is just the scroll
   // target), gated on `isActive` so a backgrounded (mounted-hidden) Workspace left in
   // DIFF doesn't keep the `@pierre/diffs` worker pool alive while off-screen — and only
@@ -442,6 +474,14 @@ export function ChangesPanel({
                 })
               }
               onSelect={() => setSelectedPath(file.path)}
+              onRevert={
+                busy
+                  ? undefined
+                  : () => {
+                      setRevertError(null)
+                      setRevertTarget(file)
+                    }
+              }
             />
           ))}
         </ul>
@@ -479,8 +519,68 @@ export function ChangesPanel({
             error={actionError ?? commitError}
             onRun={(kind) => void runQuickAction(kind)}
           />
+          {view.files.length > 0 && (
+            // Revert-all (#250): a deliberately quiet affordance — destruction hides
+            // behind the dialog, not behind a prominent button.
+            <button
+              type="button"
+              onClick={() => {
+                setRevertError(null)
+                setRevertTarget('all')
+              }}
+              disabled={busy || reverting}
+              className="self-start text-[11px] text-muted transition-colors hover:text-bad disabled:opacity-50"
+            >
+              Revert all changes…
+            </button>
+          )}
         </div>
       )}
+
+      {/* Revert warning (#250): the ONE consent gate before the app's only destructive
+          git write. Names exactly what is destroyed — an untracked file is DELETED,
+          not restored — and that it cannot be undone. Esc/Cancel leaves the tree
+          untouched; a failed revert stays here with git's actual reason. */}
+      <Dialog open={revertTarget !== null} onOpenChange={(open) => !reverting && !open && setRevertTarget(null)}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              {revertTarget === 'all'
+                ? `Revert all ${view.fileCount} changed ${view.fileCount === 1 ? 'file' : 'files'}?`
+                : revertTarget?.untracked
+                  ? `Delete ${revertTarget.path}?`
+                  : `Revert changes to ${revertTarget?.path}?`}
+            </DialogTitle>
+            <DialogDescription>
+              {revertTarget === 'all'
+                ? 'Tracked files are restored to the last commit; untracked files are DELETED from disk.'
+                : revertTarget !== null && revertTarget.untracked
+                  ? 'This file is untracked — there is nothing to restore. It will be deleted from disk.'
+                  : 'Your changes to this file are discarded and it is restored to the last commit.'}{' '}
+              This cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          {revertError && (
+            <p className="text-[11px] text-bad" role="alert">
+              {revertError}
+            </p>
+          )}
+          <DialogFooter>
+            <DialogClose render={<Button variant="secondary" size="sm" disabled={reverting} />}>
+              Cancel
+            </DialogClose>
+            <Button variant="destructive" size="sm" disabled={reverting} onClick={() => void doRevert()}>
+              {reverting
+                ? 'Reverting…'
+                : revertTarget === 'all'
+                  ? 'Revert all'
+                  : revertTarget?.untracked
+                    ? 'Delete file'
+                    : 'Revert file'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Default-branch guard (#238, generalized by #236): interposed by
           `runQuickAction` on ANY commit-family action when HEAD is the repository's

--- a/src/renderer/src/git/FileRow.tsx
+++ b/src/renderer/src/git/FileRow.tsx
@@ -1,4 +1,5 @@
 import type { JSX } from 'react'
+import { Undo2 } from 'lucide-react'
 import { cn } from '../lib/utils'
 import { glyphClass, type GitFileView } from './status-view'
 
@@ -6,6 +7,8 @@ import { glyphClass, type GitFileView } from './status-view'
  * One changed-file row. A leading checkbox toggles the file's commit selection (#86)
  * WITHOUT opening the diff (it's a separate control, not nested in the row button);
  * clicking the rest of the row opens the file's working-tree diff (#85, DIFF mode).
+ * A trailing hover-revealed Revert affordance (#250) asks the panel to open its
+ * warning dialog for this file — the row itself never destroys anything.
  * The row insets from the panel edges (mx-2) so its rounded hover tint floats clear of
  * the border, matching the menu/list idiom.
  */
@@ -14,14 +17,17 @@ export function FileRow({
   checked,
   onToggle,
   onSelect,
+  onRevert,
 }: {
   file: GitFileView
   checked: boolean
   onToggle: () => void
   onSelect: () => void
+  /** Open the revert warning dialog for this file (#250); absent = affordance hidden. */
+  onRevert?: () => void
 }): JSX.Element {
   return (
-    <li className="mx-2 flex items-center gap-1 rounded-md transition-colors hover:bg-accent/10">
+    <li className="group mx-2 flex items-center gap-1 rounded-md transition-colors hover:bg-accent/10">
       <input
         type="checkbox"
         checked={checked}
@@ -54,6 +60,19 @@ export function FileRow({
           </span>
         )}
       </button>
+      {onRevert && (
+        <button
+          type="button"
+          onClick={onRevert}
+          aria-label={
+            file.untracked ? `Delete ${file.path} (untracked)` : `Revert changes to ${file.path}`
+          }
+          title={file.untracked ? 'Delete file (untracked)…' : 'Revert changes…'}
+          className="mr-1.5 inline-flex size-5 shrink-0 items-center justify-center rounded-sm text-muted opacity-0 transition-opacity group-hover:opacity-100 hover:text-bad focus-visible:opacity-100"
+        >
+          <Undo2 className="size-3.5" aria-hidden />
+        </button>
+      )}
     </li>
   )
 }

--- a/src/shared/ipc/git.ts
+++ b/src/shared/ipc/git.ts
@@ -29,6 +29,8 @@ export const gitChannels = {
   gitRangeDiff: 'git:range-diff',
   /** Renderer -> main: COMMIT working-tree changes from the Changes panel (#86) — see {@link GitCommitArgs}. */
   gitCommit: 'git:commit',
+  /** Renderer -> main: REVERT working-tree changes — DESTRUCTIVE, dialog-gated (#250) — see {@link GitRevertArgs}. */
+  gitRevert: 'git:revert',
   /** Renderer -> main: list the active Workspace's branches (#87) — see {@link GitBranchesArgs}. */
   gitBranches: 'git:branches',
   /** Renderer -> main: CHECK OUT a branch on the active Workspace (#87) — see {@link GitBranchOpArgs}. */
@@ -180,6 +182,21 @@ export interface GitCommitArgs {
   workspaceDir: string
   message: string
   paths: string[]
+}
+
+/**
+ * Args for `gitRevert` (#250) — the app's one deliberately DESTRUCTIVE git write,
+ * always behind the renderer's warning dialog. `all: true` reverts the WHOLE tree
+ * (tracked restored to HEAD, untracked files AND directories deleted); otherwise
+ * `files` is the exact selection — each entry carries its porcelain `status` +
+ * `untracked` flag so main buckets it correctly (an index-only add can't `restore`
+ * from HEAD; an untracked file is DELETED, not restored; a rename restores its origin
+ * and deletes the new name). On success main re-reads status so the rows drop off.
+ */
+export interface GitRevertArgs {
+  workspaceDir: string
+  files: { path: string; status: string; untracked: boolean }[]
+  all: boolean
 }
 
 /**


### PR DESCRIPTION
Closes #250 (follow-up to PRD #233 — revert was the one deliberately deferred write).

## What this does

**Revert in the Review Surface, always behind a warning.**

- **Per file**: hovering a changed-file row reveals a Revert affordance (labelled *Delete* for untracked files — there's nothing to restore).
- **All**: a quiet "Revert all changes…" button under the quick action.
- **One dialog gates both**: it names exactly what will be destroyed (tracked files restored to the last commit; untracked files **deleted from disk**) and states it cannot be undone. Cancel/Esc leaves the tree untouched; a failure stays in the dialog with git's actual reason. Disabled while a turn streams, like every git write.

**Main-process semantics** (`gitRevert`, injectable-runner seam): the selection is bucketed by the porcelain status the panel already holds —
| bucket | commands |
|---|---|
| untracked (`?`) | `clean -f -q --` |
| index-only add (`A.`) | `reset -q --` then `clean` (a `restore --source=HEAD` would fail on a path HEAD lacks) |
| staged rename (`R.`) | unstage the new name, `restore` the **origin** (the #86 rename-origin scan, now shared), `clean` the new name |
| everything else | `restore --source=HEAD --staged --worktree --` |
| **all** | `reset --hard -q` + `clean -fd -q` (untracked directories included) |

First failing step stops the chain with git's stderr; on success main re-reads status so the reverted rows drop off the panel.

## Tests

- 10 fake-runner tests pinning the exact command sequences per bucket, the mixed-selection case, failure mapping, empty-selection no-op, and reject-degrade.
- Full gates green: lint, typecheck, build, `bun run test` (**1270** tests / 100 files).
- **Verified against real git**: MM restore, untracked delete, staged-add unstage+delete, rename origin-restore + new-name delete, and revert-all wiping a dirty tree including an untracked directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)