### PR TITLE
feat(search): slice 1 — ⌘K Search palette with ranked title search (#174)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,6 +34,20 @@ agent blocks until the user picks a Permission option (allow once / reject once 
 pending queue and answered by request id.
 _Avoid_: approval, confirmation, prompt (reserve "prompt" for the user's message to the agent).
 
+**Search**:
+Finding past conversations by what was said — matches Thread titles and the conversation proper
+(the user's prompts and the agent's replies), across all Workspaces. Never matches the agent's
+reasoning or tool input/output (diffs, terminal dumps, file reads), never searches files (the
+Files browser owns file finding, per Workspace), and never touches Vibe-owned context/history.
+A Search result is a **Thread** (evidenced by its best-matching text), never an individual message.
+_Avoid_: file search, global search (it is conversation-history search only).
+
+**Search palette**:
+The modal command window where Search happens — opened from the sidebar's Search item or ⌘K,
+floating above the whole shell (it is cross-Workspace, so it belongs to no Workspace's side panel).
+_Avoid_: Surface (reserved for side-panel tabs), command palette (a possible future superset that
+would add actions; the Search palette is search-only).
+
 ## Side panel
 
 **Surface**:

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,6 +15,8 @@ import {
   type TranscriptImageRef,
   type RemoveWorkspaceResult,
   type RespondPermissionArgs,
+  type SearchQueryArgs,
+  type SearchQueryResult,
   type SendPromptArgs,
   type SendPromptResult,
   type AccountWhoamiResult,
@@ -39,6 +41,7 @@ import {
 import { detectVibe } from './vibe-detect'
 import { getShellEnv } from './shell-env'
 import { getAccountWhoami, readKeychainApiKey, readVibeEnvFile } from './auth/whoami'
+import { searchThreads } from './search/search-threads'
 import { groupThreadsByWorkspace, MetadataStore } from './persistence/metadata-store'
 import {
   acpEventEntry,
@@ -1092,6 +1095,13 @@ function registerIpc(deps: MainDeps): void {
     // The cold launch list (ADR-0005): persisted Workspaces + Threads from
     // metadata alone — no agent spawned, no transcript loaded.
     return groupThreadsByWorkspace(deps.store.snapshot())
+  })
+
+  ipcMain.handle(IPC.searchQuery, (_event, args: SearchQueryArgs): SearchQueryResult => {
+    // The Search palette's ranked hits (#174 slice 1): a pure scan over the same
+    // cold metadata snapshot listMetadata serves — no agent, no transcript I/O yet
+    // (slice 2 widens the corpus to transcript prose behind this same channel).
+    return searchThreads(groupThreadsByWorkspace(deps.store.snapshot()), args.query, args.limit)
   })
 
   ipcMain.handle(IPC.readTranscript, (_event, threadId: string): Promise<ReadTranscriptResult> => {

--- a/src/main/search/search-threads.test.ts
+++ b/src/main/search/search-threads.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+import type { ListMetadataResult, ThreadMeta } from '../../shared/ipc'
+import {
+  DEFAULT_SEARCH_LIMIT,
+  foldSearchText,
+  searchThreads,
+  titleTier,
+  tokenizeQuery,
+} from './search-threads'
+
+function thread(overrides: Partial<ThreadMeta> & { id: string }): ThreadMeta {
+  return {
+    workspaceId: 'ws-1',
+    sessionId: null,
+    title: null,
+    createdAt: 1,
+    lastActiveAt: 1,
+    ...overrides,
+  }
+}
+
+function snapshot(
+  ...workspaces: Array<{ id: string; name: string; threads: ThreadMeta[] }>
+): ListMetadataResult {
+  return workspaces.map((ws) => ({
+    id: ws.id,
+    dir: `/tmp/${ws.id}`,
+    displayName: ws.name,
+    lastOpenedAt: 1,
+    threads: ws.threads.map((t) => ({ ...t, workspaceId: ws.id })),
+  }))
+}
+
+describe('foldSearchText / tokenizeQuery', () => {
+  it('folds case and diacritics', () => {
+    expect(foldSearchText('RéVisEr le Café')).toBe('reviser le cafe')
+  })
+
+  it('tokenizes on whitespace, dropping empties', () => {
+    expect(tokenizeQuery('  Warm   Pool ')).toEqual(['warm', 'pool'])
+    expect(tokenizeQuery('   ')).toEqual([])
+    expect(tokenizeQuery('')).toEqual([])
+  })
+})
+
+describe('titleTier', () => {
+  it('tiers exact > prefix > contains > none (t3code parity)', () => {
+    expect(titleTier('warm pool', 'warm pool')).toBe(3)
+    expect(titleTier('warm pool eviction', 'warm pool')).toBe(2)
+    expect(titleTier('the warm pool fix', 'warm pool')).toBe(1)
+    expect(titleTier('cold storage', 'warm pool')).toBe(0)
+    expect(titleTier('', 'warm')).toBe(0)
+  })
+})
+
+describe('searchThreads', () => {
+  const ws = snapshot(
+    {
+      id: 'ws-a',
+      name: 'vibe-mistro',
+      threads: [
+        thread({ id: 't-exact', title: 'Warm pool', lastActiveAt: 10 }),
+        thread({ id: 't-prefix', title: 'Warm pool eviction bug', lastActiveAt: 20 }),
+        thread({ id: 't-contains', title: 'Fix the warm pool sweep', lastActiveAt: 30 }),
+        thread({ id: 't-scattered', title: 'Pool heater went warm', lastActiveAt: 40 }),
+        thread({ id: 't-miss', title: 'Composer chips', lastActiveAt: 50 }),
+        thread({ id: 't-archived', title: 'Warm pool archive notes', lastActiveAt: 60, archived: true }),
+        thread({ id: 't-untitled', title: null, lastActiveAt: 70 }),
+      ],
+    },
+    {
+      id: 'ws-b',
+      name: 'Café Warm',
+      threads: [thread({ id: 't-ws-assist', title: 'Pool ideas', lastActiveAt: 5 })],
+    },
+  )
+
+  it('requires every token (AND), matching across title + workspace name', () => {
+    const hits = searchThreads(ws, 'warm pool')
+    const ids = hits.map((h) => h.threadId)
+    expect(ids).toContain('t-scattered') // both tokens in title, not contiguous
+    expect(ids).toContain('t-ws-assist') // "pool" from title + "warm" from workspace name
+    expect(ids).not.toContain('t-miss')
+    expect(ids).not.toContain('t-untitled')
+  })
+
+  it('ranks title tiers exact > prefix > contains > scattered/assisted, recency within a tier', () => {
+    const ids = searchThreads(ws, 'warm pool').map((h) => h.threadId)
+    expect(ids.indexOf('t-exact')).toBeLessThan(ids.indexOf('t-prefix'))
+    expect(ids.indexOf('t-prefix')).toBeLessThan(ids.indexOf('t-contains'))
+    expect(ids.indexOf('t-contains')).toBeLessThan(ids.indexOf('t-scattered'))
+    // tier-0 pair: scattered (lastActiveAt 40) beats workspace-assisted (5) on recency
+    expect(ids.indexOf('t-scattered')).toBeLessThan(ids.indexOf('t-ws-assist'))
+    // archived is INCLUDED under a query, tiered like any other (contains → above tier 0)
+    expect(ids).toContain('t-archived')
+  })
+
+  it('folds case and accents between query and haystack', () => {
+    expect(searchThreads(ws, 'WARM POOL').map((h) => h.threadId)).toContain('t-exact')
+    // "café" workspace matches the unaccented query token
+    expect(searchThreads(ws, 'cafe pool').map((h) => h.threadId)).toEqual(['t-ws-assist'])
+  })
+
+  it('resting state (empty query): recency order, archived EXCLUDED, untitled included', () => {
+    const ids = searchThreads(ws, '').map((h) => h.threadId)
+    expect(ids[0]).toBe('t-untitled') // lastActiveAt 70
+    expect(ids).not.toContain('t-archived')
+    expect(ids).toContain('t-miss')
+  })
+
+  it('marks archived hits and carries workspace fields for the row', () => {
+    const hit = searchThreads(ws, 'archive').find((h) => h.threadId === 't-archived')
+    expect(hit).toMatchObject({ archived: true, workspaceName: 'vibe-mistro', workspaceId: 'ws-a' })
+  })
+
+  it('caps at the limit (default 20) and tolerates limit 0', () => {
+    const many = snapshot({
+      id: 'ws-many',
+      name: 'many',
+      threads: Array.from({ length: 30 }, (_, i) =>
+        thread({ id: `t-${i}`, title: `match ${i}`, lastActiveAt: i }),
+      ),
+    })
+    expect(searchThreads(many, 'match')).toHaveLength(DEFAULT_SEARCH_LIMIT)
+    expect(searchThreads(many, 'match', 3)).toHaveLength(3)
+    expect(searchThreads(many, 'match', 0)).toHaveLength(0)
+  })
+})

--- a/src/main/search/search-threads.ts
+++ b/src/main/search/search-threads.ts
@@ -1,0 +1,92 @@
+import type { ListMetadataResult, SearchHit } from '../../shared/ipc'
+
+/**
+ * Pure Thread search over the cold metadata snapshot (#174 slice 1) — the module
+ * behind the `search:query` IPC. Slice 2 widens the corpus to transcript prose;
+ * the contract and this ranking stay put.
+ *
+ * Semantics (all decided in #174):
+ * - Matching is TOKEN-AND: every whitespace-separated query token must appear as
+ *   a case-insensitive, accent-insensitive substring of the Thread's searchable
+ *   text (title + Workspace name). A single-token query is t3code's normalized
+ *   `includes`; no fuzzy (wrong tool for prose).
+ * - Ranking mirrors t3code's title tiers — exact > prefix > contains — extended
+ *   with a workspace-assisted floor (tokens matched, but not all in the title);
+ *   recency breaks ties.
+ * - An EMPTY query is the palette's resting state: recent Threads, ARCHIVED
+ *   EXCLUDED (a switcher context, not a search). A non-empty query includes
+ *   archived Threads — archived is exactly what scrolling can't find.
+ */
+
+/** Ranked-hit cap (top-N); the palette never pages. */
+export const DEFAULT_SEARCH_LIMIT = 20
+
+/**
+ * Fold text for matching: lowercase + strip diacritics (NFD, drop combining
+ * marks) so `reviser` matches `réviser`. Applied to query and haystack alike.
+ */
+export function foldSearchText(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+}
+
+/** Split a query into folded tokens; `[]` means "resting state" (match all). */
+export function tokenizeQuery(query: string): string[] {
+  return foldSearchText(query).split(/\s+/).filter(Boolean)
+}
+
+/**
+ * t3code's title tiers (`rankSearchFieldMatch`), on pre-folded inputs: the whole
+ * normalized query against the title — exact (3) > prefix (2) > contains (1) >
+ * no whole-query title match (0). Tier 0 hits still matched token-wise (scattered
+ * tokens and/or Workspace-name assists) and rank below any whole-query title hit.
+ */
+export function titleTier(foldedTitle: string, foldedQuery: string): number {
+  if (!foldedTitle || !foldedQuery) return 0
+  if (foldedTitle === foldedQuery) return 3
+  if (foldedTitle.startsWith(foldedQuery)) return 2
+  if (foldedTitle.includes(foldedQuery)) return 1
+  return 0
+}
+
+/** Rank Threads against a query over the cold metadata snapshot. Pure. */
+export function searchThreads(
+  workspaces: ListMetadataResult,
+  query: string,
+  limit: number = DEFAULT_SEARCH_LIMIT,
+): SearchHit[] {
+  const tokens = tokenizeQuery(query)
+  const resting = tokens.length === 0
+  // Collapse inner whitespace so the tier comparison sees one canonical phrase.
+  const foldedQuery = tokens.join(' ')
+
+  const scored: Array<{ hit: SearchHit; tier: number }> = []
+  for (const workspace of workspaces) {
+    const foldedWorkspace = foldSearchText(workspace.displayName)
+    for (const thread of workspace.threads) {
+      const archived = thread.archived === true
+      if (resting && archived) continue // switcher context — archived stays out
+      const foldedTitle = foldSearchText(thread.title ?? '')
+      if (!resting) {
+        const haystack = `${foldedTitle}\n${foldedWorkspace}`
+        if (!tokens.every((token) => haystack.includes(token))) continue
+      }
+      scored.push({
+        hit: {
+          threadId: thread.id,
+          workspaceId: workspace.id,
+          workspaceName: workspace.displayName,
+          title: thread.title,
+          archived,
+          lastActiveAt: thread.lastActiveAt,
+        },
+        tier: resting ? 0 : titleTier(foldedTitle, foldedQuery),
+      })
+    }
+  }
+
+  scored.sort((a, b) => b.tier - a.tier || b.hit.lastActiveAt - a.hit.lastActiveAt)
+  return scored.slice(0, Math.max(0, limit)).map((entry) => entry.hit)
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -46,6 +46,8 @@ import {
   type RemoveWorkspaceResult,
   type RespondPermissionArgs,
   type OpenThreadArgs,
+  type SearchQueryArgs,
+  type SearchQueryResult,
   type SendPromptArgs,
   type SendPromptResult,
   type AccountWhoamiResult,
@@ -119,6 +121,8 @@ const api = {
     ipcRenderer.invoke(IPC.readTranscript, threadId),
   readThreadAttachments: (threadId: string): Promise<ReadThreadAttachmentsResult> =>
     ipcRenderer.invoke(IPC.readThreadAttachments, threadId),
+  searchQuery: (args: SearchQueryArgs): Promise<SearchQueryResult> =>
+    ipcRenderer.invoke(IPC.searchQuery, args),
   gitSubscribeStatus: (args: GitStatusSubscriptionArgs): Promise<void> =>
     ipcRenderer.invoke(IPC.gitSubscribeStatus, args),
   gitUnsubscribeStatus: (args: GitStatusSubscriptionArgs): Promise<void> =>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -32,6 +32,7 @@ import { replayCache, wireReplayCacheInvalidation } from './conversation/replay-
 import { setWorkspaceControls, workspaceControlsKey } from './connection/workspace-controls-store'
 import { ArrowLeft, ArrowRight, Maximize2, PanelLeft, PanelRight, Terminal } from 'lucide-react'
 import { IconButton } from './ui/icon-button'
+import { SearchPalette } from './search/SearchPalette'
 import { Shell, type WorkspaceFlags } from './shell/Shell'
 import { firstRunState } from './shell/first-run'
 import { installBannerMessage } from './shell/install-banner'
@@ -89,6 +90,19 @@ export function App(): JSX.Element {
       return next
     })
   }
+  // The Search palette (#174): renderer-only open flag; ⌘K toggles it from
+  // anywhere (window-level, so it works with the composer focused).
+  const [searchOpen, setSearchOpen] = useState(false)
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent): void {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+        event.preventDefault()
+        setSearchOpen((prev) => !prev)
+      }
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [])
   // Navigation (decision 2): WHICH Workspace/Thread the user is looking at —
   // lifted here so the connect flow (Open project, Continue, sign-in) can drive it.
   const [nav, navDispatch] = useReducer(navReducer, initialNavState)
@@ -748,6 +762,13 @@ export function App(): JSX.Element {
           renameThread: actions.renameThread,
         }}
         onOpenSettings={() => navDispatch({ type: 'open-settings' })}
+        onOpenSearch={() => setSearchOpen(true)}
+      />
+
+      <SearchPalette
+        open={searchOpen}
+        onOpenChange={setSearchOpen}
+        onSelectThread={selectThreadInWorkspace}
       />
     </div>
   )

--- a/src/renderer/src/search/SearchPalette.tsx
+++ b/src/renderer/src/search/SearchPalette.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useRef, useState, type JSX } from 'react'
+import { MessageSquare } from 'lucide-react'
+import type { SearchHit } from '../../../shared/ipc'
+import { formatRelativeTime } from '../shell/relative-time'
+import { Badge } from '../ui/badge'
+import {
+  Command,
+  CommandCollection,
+  CommandDialog,
+  CommandDialogPopup,
+  CommandEmpty,
+  CommandFooter,
+  CommandInput,
+  CommandList,
+  CommandItem,
+} from '../ui/command'
+
+/** Debounce for non-empty queries; the resting (empty) query fires immediately. */
+const QUERY_DEBOUNCE_MS = 120
+
+/**
+ * The Search palette (#174, CONTEXT.md "Search palette"): the ⌘K / sidebar-Search
+ * modal for finding past conversations. UI-only — matching and ranking live in
+ * main behind `search:query`; this component debounces keystrokes, drops stale
+ * replies (invoke can't cancel, so a sequence stamp keeps a slow older response
+ * from clobbering a newer one), and renders ranked Thread rows. An empty query
+ * shows the resting recents, so the palette doubles as a quick Thread switcher.
+ * Selecting a row closes the palette and opens the Thread via App's existing
+ * cross-Workspace select (cold auto-continue included).
+ */
+export function SearchPalette({
+  open,
+  onOpenChange,
+  onSelectThread,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSelectThread: (workspaceId: string, threadId: string) => void
+}): JSX.Element {
+  const [query, setQuery] = useState('')
+  const [hits, setHits] = useState<SearchHit[]>([])
+  // Monotonic stamp for stale-drop: only the LATEST issued query may apply.
+  const seq = useRef(0)
+
+  // Clear on close so a reopen starts at the resting recents, not a stale query.
+  useEffect(() => {
+    if (!open) setQuery('')
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    const stamp = ++seq.current
+    const run = (): void => {
+      void window.api.searchQuery({ query }).then((results) => {
+        if (seq.current === stamp) setHits(results)
+      })
+    }
+    if (query.trim() === '') {
+      run() // resting state: no debounce, the palette fills the instant it opens
+      return
+    }
+    const timer = setTimeout(run, QUERY_DEBOUNCE_MS)
+    return () => clearTimeout(timer)
+  }, [open, query])
+
+  function selectHit(hit: SearchHit): void {
+    onOpenChange(false)
+    onSelectThread(hit.workspaceId, hit.threadId)
+  }
+
+  return (
+    <CommandDialog open={open} onOpenChange={onOpenChange}>
+      <CommandDialogPopup>
+        <Command
+          aria-label="Search threads"
+          items={hits}
+          itemToStringValue={(hit: SearchHit) => hit.title ?? 'Untitled'}
+          value={query}
+          onValueChange={setQuery}
+        >
+          <CommandInput placeholder="Search threads…" />
+          <CommandList>
+            <CommandEmpty>
+              {query.trim() === '' ? 'No threads yet.' : 'No matching threads.'}
+            </CommandEmpty>
+            <CommandCollection>
+              {(hit: SearchHit) => (
+                <CommandItem
+                  key={hit.threadId}
+                  value={hit}
+                  // Keep focus in the input (t3code pattern): select on click only.
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={() => selectHit(hit)}
+                >
+                  <MessageSquare className="size-4 shrink-0 text-muted" aria-hidden />
+                  <span className="flex min-w-0 flex-1 flex-col">
+                    <span className="flex min-w-0 items-center gap-1.5">
+                      <span className="truncate text-text-strong">{hit.title ?? 'Untitled'}</span>
+                      {hit.archived && (
+                        <Badge variant="outline" className="shrink-0 px-1.5 py-0 text-[10px]">
+                          Archived
+                        </Badge>
+                      )}
+                    </span>
+                    <span className="truncate text-[11px] text-faint">{hit.workspaceName}</span>
+                  </span>
+                  <span className="shrink-0 text-[11px] tabular-nums text-faint">
+                    {formatRelativeTime(hit.lastActiveAt, Date.now())}
+                  </span>
+                </CommandItem>
+              )}
+            </CommandCollection>
+          </CommandList>
+          <CommandFooter>
+            <span>↑↓ Navigate</span>
+            <span>↵ Open</span>
+            <span>Esc Close</span>
+          </CommandFooter>
+        </Command>
+      </CommandDialogPopup>
+    </CommandDialog>
+  )
+}

--- a/src/renderer/src/shell/Shell.tsx
+++ b/src/renderer/src/shell/Shell.tsx
@@ -49,6 +49,7 @@ export function Shell({
   onNewThread,
   actions,
   onOpenSettings,
+  onOpenSearch,
 }: {
   /** Whether the left sidebar is collapsed (#127) — animate its width to 0 (still mounted). */
   collapsed: boolean
@@ -74,6 +75,8 @@ export function Shell({
   actions: ThreadRowActions
   /** Open the routed Settings page (#130) — from the account chip's menu. */
   onOpenSettings: () => void
+  /** Open the Search palette (#174) — from the primary nav's Search row (or ⌘K). */
+  onOpenSearch: () => void
 }): JSX.Element {
   // The sidebar's EXPANDED width (#drag-to-resize): renderer-only UI state, seeded from
   // localStorage (clamped) and persisted on drag-release. `dragging` disables the
@@ -148,7 +151,7 @@ export function Shell({
         <div className="flex h-full flex-none flex-col gap-3 p-3" style={{ width }}>
           <div className="flex flex-none flex-col gap-3">
             <SidebarHeader />
-            <PrimaryNav busy={opening} onNewThread={onNewThread} />
+            <PrimaryNav busy={opening} onNewThread={onNewThread} onOpenSearch={onOpenSearch} />
           </div>
           <div className="min-h-0 flex-1 overflow-y-auto">
             <WorkspaceNav
@@ -214,15 +217,17 @@ function SidebarHeader(): JSX.Element {
  * `--accent-fill`). It's ALWAYS actionable now — `onNewThread` (App's `startNewChat`)
  * targets the selected/most-recent project (connect-if-needed) or opens the picker when
  * there are none — so it's only disabled while a connect is in flight (`busy`). Below it,
- * Search / Scheduled / Plugins are net-new features (ADR-0010) shown as disabled "Soon"
- * rows until their own epics land, so they read as intentional rather than broken.
+ * Search opens the Search palette (#174; also ⌘K); Scheduled / Plugins are still
+ * net-new features (ADR-0010) shown as disabled "Soon" rows until their epics land.
  */
 function PrimaryNav({
   busy,
   onNewThread,
+  onOpenSearch,
 }: {
   busy: boolean
   onNewThread: () => void
+  onOpenSearch: () => void
 }): JSX.Element {
   return (
     <nav className="flex flex-col gap-0.5">
@@ -235,7 +240,11 @@ function PrimaryNav({
         <SquarePen className="size-[18px]" aria-hidden />
         New chat
       </button>
-      <PlaceholderNav icon={<Search className="size-[18px]" aria-hidden />}>Search</PlaceholderNav>
+      <NavItem onClick={onOpenSearch}>
+        <Search className="size-[18px]" aria-hidden />
+        <span className="flex-1">Search</span>
+        <span className="text-[11px] font-medium text-faint">⌘K</span>
+      </NavItem>
       <PlaceholderNav icon={<Clock className="size-[18px]" aria-hidden />}>Scheduled</PlaceholderNav>
       <PlaceholderNav icon={<Atom className="size-[18px]" aria-hidden />}>Plugins</PlaceholderNav>
     </nav>

--- a/src/renderer/src/ui/command.tsx
+++ b/src/renderer/src/ui/command.tsx
@@ -1,0 +1,153 @@
+import type { ComponentProps, JSX, ReactNode } from 'react'
+import { Autocomplete as BaseAutocomplete } from '@base-ui/react/autocomplete'
+import { Dialog as BaseDialog } from '@base-ui/react/dialog'
+import { Search } from 'lucide-react'
+import { cn } from '../lib/utils'
+
+/**
+ * Command-window primitives (#174): a top-anchored modal shell + a Base UI
+ * Autocomplete in external-filtering mode — the t3code `ui/command.tsx` pattern
+ * (Base UI Dialog + Autocomplete, NOT cmdk) ported onto our tokens. The Search
+ * palette composes these today; a future general command palette reuses them.
+ *
+ * Filtering/ranking is the CALLER's job (`mode="none"`): pass ranked `items` and
+ * render rows via `CommandCollection`'s render prop — the primitives contribute
+ * keyboard highlight/selection (↑↓ + Enter → item click) and the chrome.
+ */
+
+export const CommandDialog = BaseDialog.Root
+
+/**
+ * The palette's modal chrome: dimming backdrop + a top-anchored panel (10vh down,
+ * not centred — palettes hang from the top so the list can grow without jumping).
+ */
+export function CommandDialogPopup({
+  className,
+  children,
+  ...props
+}: ComponentProps<typeof BaseDialog.Popup>): JSX.Element {
+  return (
+    <BaseDialog.Portal>
+      <BaseDialog.Backdrop
+        data-slot="command-dialog-backdrop"
+        className="fixed inset-0 z-50 bg-black/30"
+      />
+      <div className="pointer-events-none fixed inset-0 z-50 flex flex-col items-center px-4 py-[10vh]">
+        <BaseDialog.Popup
+          data-slot="command-dialog-popup"
+          className={cn(
+            'pointer-events-auto flex max-h-[min(28rem,70vh)] w-full max-w-xl flex-col overflow-hidden rounded-2xl border border-border bg-panel text-text shadow-lg outline-none',
+            className,
+          )}
+          {...props}
+        >
+          {children}
+        </BaseDialog.Popup>
+      </div>
+    </BaseDialog.Portal>
+  )
+}
+
+/** The Autocomplete root, pinned to command-window behavior (inline, always open,
+ * external filtering, keyboard highlight that survives pointer leave). Typed on
+ * Base UI's FLAT-list overload — ranked results are one list, never grouped. */
+export function Command<ItemValue>({
+  ...props
+}: Omit<BaseAutocomplete.Root.Props<ItemValue>, 'items'> & {
+  items?: readonly ItemValue[] | undefined
+}): JSX.Element {
+  return (
+    <BaseAutocomplete.Root
+      inline
+      open
+      mode="none"
+      autoHighlight="always"
+      keepHighlight
+      {...props}
+    />
+  )
+}
+
+/** The query input row: a search glyph + a borderless input under the panel's top edge. */
+export function CommandInput({
+  className,
+  ...props
+}: ComponentProps<typeof BaseAutocomplete.Input>): JSX.Element {
+  return (
+    <div className="flex items-center gap-2.5 border-b border-border px-3.5 py-3">
+      <Search className="size-4 shrink-0 text-muted" aria-hidden />
+      <BaseAutocomplete.Input
+        data-slot="command-input"
+        className={cn(
+          'w-full bg-transparent text-[14px] text-text outline-none placeholder:text-faint',
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  )
+}
+
+/** The scrolling results region. */
+export function CommandList({
+  className,
+  ...props
+}: ComponentProps<typeof BaseAutocomplete.List>): JSX.Element {
+  return (
+    <BaseAutocomplete.List
+      data-slot="command-list"
+      className={cn('min-h-0 flex-1 overflow-y-auto not-empty:p-1.5', className)}
+      {...props}
+    />
+  )
+}
+
+/** Render-prop bridge over the root's `items` — one call per ranked item. */
+export function CommandCollection(
+  props: ComponentProps<typeof BaseAutocomplete.Collection>,
+): JSX.Element {
+  return <BaseAutocomplete.Collection data-slot="command-collection" {...props} />
+}
+
+/** The no-results state (renders only when the list is empty). */
+export function CommandEmpty({
+  className,
+  ...props
+}: ComponentProps<typeof BaseAutocomplete.Empty>): JSX.Element {
+  return (
+    <BaseAutocomplete.Empty
+      data-slot="command-empty"
+      className={cn('not-empty:py-10 text-center text-[13px] text-muted', className)}
+      {...props}
+    />
+  )
+}
+
+/** One selectable row: flat flex, accent wash on keyboard/pointer highlight. */
+export function CommandItem({
+  className,
+  ...props
+}: ComponentProps<typeof BaseAutocomplete.Item>): JSX.Element {
+  return (
+    <BaseAutocomplete.Item
+      data-slot="command-item"
+      className={cn(
+        'flex cursor-pointer select-none items-center gap-2.5 rounded-[9px] px-2.5 py-2 text-[13px] outline-none data-[highlighted]:bg-accent/10',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+/** The bottom hint strip (keyboard legend). */
+export function CommandFooter({ children }: { children: ReactNode }): JSX.Element {
+  return (
+    <div
+      data-slot="command-footer"
+      className="flex items-center gap-3 border-t border-border px-3.5 py-2 text-[11px] text-faint"
+    >
+      {children}
+    </div>
+  )
+}

--- a/src/shared/ipc/index.ts
+++ b/src/shared/ipc/index.ts
@@ -17,6 +17,7 @@ import { ghChannels } from './gh'
 import { filesChannels } from './files'
 import { terminalChannels } from './terminal'
 import { browserChannels } from './browser'
+import { searchChannels } from './search'
 
 /**
  * The one typed channel map. ONE exported object — the channel names are the wire
@@ -32,6 +33,7 @@ export const IPC = {
   ...filesChannels,
   ...terminalChannels,
   ...browserChannels,
+  ...searchChannels,
 } as const
 
 export * from './core'
@@ -42,3 +44,4 @@ export * from './gh'
 export * from './files'
 export * from './terminal'
 export * from './browser'
+export * from './search'

--- a/src/shared/ipc/search.ts
+++ b/src/shared/ipc/search.ts
@@ -1,0 +1,40 @@
+/**
+ * Search domain of the shared IPC contract (#174): the Search palette's one query
+ * channel + payload types. Search is main-owned from slice 1 (even though titles
+ * alone could be filtered renderer-side) so the seam never migrates when transcript
+ * prose search lands — the renderer sends a query, main returns ranked hits.
+ * Keep this file free of Node/DOM imports so both sides can consume it.
+ */
+
+/** The search channel entries, merged into the single `IPC` const in `./index`. */
+export const searchChannels = {
+  /** Rank Threads against a query; an EMPTY query returns the resting recents. */
+  searchQuery: 'search:query',
+} as const
+
+/** A Search query. `limit` caps the ranked hits (default `DEFAULT_SEARCH_LIMIT`). */
+export interface SearchQueryArgs {
+  query: string
+  limit?: number
+}
+
+/**
+ * One ranked Search hit. A hit is a THREAD, never an individual message
+ * (CONTEXT.md "Search") — slice 2 enriches rows with `snippet`/`hitCount`/
+ * `entryIndex` additively; slice 1 carries the metadata-only fields.
+ */
+export interface SearchHit {
+  threadId: string
+  workspaceId: string
+  /** The Workspace's display name — shown on every row (flat list, no grouping). */
+  workspaceName: string
+  /** The Thread title (`null` = never titled; the renderer shows "Untitled"). */
+  title: string | null
+  /** Archived Threads are searchable but badged (and hidden from resting recents). */
+  archived: boolean
+  /** Epoch-ms recency — the ranking tiebreak and the row's relative timestamp. */
+  lastActiveAt: number
+}
+
+/** The `search:query` reply: ranked hits, best first, capped at the limit. */
+export type SearchQueryResult = SearchHit[]


### PR DESCRIPTION
## What

Slice 1 of the Search epic (#174, decisions in the issue body): the sidebar's "Soon" Search placeholder becomes the **Search palette** — a ⌘K command window that finds Threads across all Workspaces, with resting recents doubling as a quick switcher.

## How

- **`ui/command.tsx`** — reusable command-window primitives: Base UI Dialog (top-anchored popup) + Base UI Autocomplete in external-filtering mode (`mode="none"`), the t3code `ui/command.tsx` pattern ported onto our tokens. A future general command palette composes these.
- **`search:query` IPC** (`src/shared/ipc/search.ts`) — main-owned from slice 1 so the seam never moves when transcript prose search lands (slice 2 just widens the corpus behind the same channel).
- **`src/main/search/search-threads.ts`** (9 tests) — pure ranked scan over the cold metadata snapshot: token-AND matching, case + accent folding (NFD), t3code title tiers (exact > prefix > contains > scattered/workspace-assisted), recency tiebreak, top-20. Empty query = resting recents, archived excluded; typed query includes archived.
- **`SearchPalette`** — 120 ms debounce, sequence-stamp stale-drop, rows with Workspace name + Archived badge + relative time; selection closes and opens the Thread via the existing cross-Workspace select (cold auto-continue included).
- **Shell/App wiring** — enabled Search nav row (with ⌘K hint), window-level ⌘K toggle.
- **CONTEXT.md** — the grill session's glossary terms (Search, Search palette) ride along.

## Verification

- Gates: lint, typecheck, build, test — 1279 tests green.
- End-to-end via the repo's Playwright Electron harness on a seeded two-Workspace profile: resting recents in recency order (archived hidden), `warm pool` returns exact → prefix → contains(Archived-badged), `reviser cafe` hits the accented "Réviser le café menu" via workspace-name token assist, Esc/⌘K close/reopen, Enter opens the Thread (fake-agent connected).

Refs #174 (slice 1 of 3 — next: transcript prose search).

🤖 Generated with [Claude Code](https://claude.com/claude-code)