### PR TITLE
feat(editors): slice 1 — editor detection + launch, header Open button (#252)

### DIFF
--- a/src/main/editors/detect.test.ts
+++ b/src/main/editors/detect.test.ts
@@ -1,0 +1,90 @@
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  candidateCommandPaths,
+  detectAvailableEditors,
+  resolveAvailableCommand,
+  resolveCommandPath,
+} from './detect'
+
+describe('candidateCommandPaths', () => {
+  it('joins the command onto every PATH dir (posix)', () => {
+    expect(candidateCommandPaths('code', '/usr/bin:/opt/bin', 'darwin')).toEqual([
+      '/usr/bin/code',
+      '/opt/bin/code',
+    ])
+  })
+
+  it('skips empty PATH segments', () => {
+    expect(candidateCommandPaths('code', '/usr/bin::', 'linux')).toEqual(['/usr/bin/code'])
+  })
+
+  it('fans out per PATHEXT extension on win32', () => {
+    const candidates = candidateCommandPaths('code', 'C:\\bin', 'win32', '.EXE;.CMD')
+    expect(candidates).toEqual([join('C:\\bin', 'code.EXE'), join('C:\\bin', 'code.CMD')])
+  })
+
+  it('returns nothing for an empty PATH', () => {
+    expect(candidateCommandPaths('code', '', 'darwin')).toEqual([])
+  })
+})
+
+describe('PATH probing against a real fixture dir', () => {
+  let binDir: string
+
+  async function installExecutable(name: string): Promise<void> {
+    const path = join(binDir, name)
+    await writeFile(path, '#!/bin/sh\nexit 0\n')
+    await chmod(path, 0o755)
+  }
+
+  beforeEach(async () => {
+    binDir = await mkdtemp(join(tmpdir(), 'vibe-mistro-editors-'))
+  })
+
+  afterEach(async () => {
+    await rm(binDir, { recursive: true, force: true })
+  })
+
+  it('resolveCommandPath resolves an executable to its absolute path, misses an absent one', async () => {
+    await installExecutable('zed')
+    const env = { PATH: binDir }
+    expect(await resolveCommandPath('zed', env, process.platform)).toBe(join(binDir, 'zed'))
+    expect(await resolveCommandPath('cursor', env, process.platform)).toBeNull()
+  })
+
+  it('a non-executable file does not count (posix)', async () => {
+    if (process.platform === 'win32') return // X_OK is a no-op on Windows
+    await writeFile(join(binDir, 'code'), 'not executable')
+    expect(await resolveCommandPath('code', { PATH: binDir }, process.platform)).toBeNull()
+  })
+
+  it('resolveAvailableCommand picks the FIRST available alias', async () => {
+    await installExecutable('zeditor')
+    const env = { PATH: binDir }
+    expect(await resolveAvailableCommand(['zed', 'zeditor'], env, process.platform)).toBe(
+      join(binDir, 'zeditor'),
+    )
+    expect(await resolveAvailableCommand(['nope', 'nada'], env, process.platform)).toBeNull()
+  })
+
+  it('detectAvailableEditors reports installed editors in table order', async () => {
+    // Install out of preference order — detection must still report table order.
+    await installExecutable('zed')
+    await installExecutable('cursor')
+    const detected = await detectAvailableEditors({ PATH: binDir }, 'darwin')
+    expect(detected).toEqual(['cursor', 'zed'])
+  })
+
+  it('detectAvailableEditors includes file-manager when the platform opener resolves', async () => {
+    await installExecutable('open')
+    const detected = await detectAvailableEditors({ PATH: binDir }, 'darwin')
+    expect(detected).toEqual(['file-manager'])
+  })
+
+  it('detectAvailableEditors is empty on an empty PATH', async () => {
+    expect(await detectAvailableEditors({ PATH: '' }, 'darwin')).toEqual([])
+  })
+})

--- a/src/main/editors/detect.ts
+++ b/src/main/editors/detect.ts
@@ -1,0 +1,93 @@
+import { constants } from 'node:fs'
+import { access } from 'node:fs/promises'
+import { join } from 'node:path'
+import { EDITORS, fileManagerCommandForPlatform, type EditorId } from '../../shared/editors'
+
+/**
+ * Which-on-PATH editor detection (#252) — the t3code model: an editor is
+ * "installed" iff one of its CLI aliases resolves to an executable on the
+ * shell-env PATH. No macOS app-bundle scanning, no icon extraction. The PATH
+ * must be the RESOLVED shell env (`getShellEnv()`), not bare `process.env` —
+ * a Finder/Dock launch drops the rc-file PATH where `code`/`cursor` live.
+ */
+
+/**
+ * The absolute candidate paths a command may resolve to, one per PATH dir —
+ * pure so the PATH-splitting/PATHEXT logic is unit-testable without fs. On
+ * win32, each dir fans out per PATHEXT extension (a bare `code` on Windows is
+ * really `code.cmd`); elsewhere it's a straight dir join.
+ */
+export function candidateCommandPaths(
+  command: string,
+  pathVar: string,
+  platform: string,
+  pathExt?: string,
+): string[] {
+  // The delimiter follows the `platform` PARAMETER (not the host's `node:path`)
+  // so the win32 fan-out is exercisable from the posix-run test suite.
+  const dirs = pathVar.split(platform === 'win32' ? ';' : ':').filter(Boolean)
+  if (platform === 'win32') {
+    const exts = (pathExt ?? '.COM;.EXE;.BAT;.CMD').split(';').filter(Boolean)
+    return dirs.flatMap((dir) => exts.map((ext) => join(dir, command + ext)))
+  }
+  return dirs.map((dir) => join(dir, command))
+}
+
+async function isExecutable(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * The ABSOLUTE path `command` resolves to on `env`'s PATH, or null. Returning
+ * the resolved path (not the bare alias) lets the launcher spawn exactly the
+ * executable the probe found, instead of re-trusting `spawn`'s own PATH lookup
+ * against a custom env.
+ */
+export async function resolveCommandPath(
+  command: string,
+  env: NodeJS.ProcessEnv,
+  platform: string,
+): Promise<string | null> {
+  for (const candidate of candidateCommandPaths(command, env.PATH ?? '', platform, env.PATHEXT)) {
+    if (await isExecutable(candidate)) return candidate
+  }
+  return null
+}
+
+/** The resolved path of the FIRST of `commands` found on PATH, or null. */
+export async function resolveAvailableCommand(
+  commands: readonly string[],
+  env: NodeJS.ProcessEnv,
+  platform: string,
+): Promise<string | null> {
+  for (const command of commands) {
+    const resolved = await resolveCommandPath(command, env, platform)
+    if (resolved !== null) return resolved
+  }
+  return null
+}
+
+/**
+ * The installed subset of the curated `EDITORS` table, in table (= preference)
+ * order. The `file-manager` entry probes the platform opener instead of a fixed
+ * alias. Probes are fs `access` checks — cheap, but callers should still cache
+ * the result per session (the installed set doesn't change mid-run).
+ */
+export async function detectAvailableEditors(
+  env: NodeJS.ProcessEnv,
+  platform: string,
+): Promise<EditorId[]> {
+  const available: EditorId[] = []
+  for (const editor of EDITORS) {
+    const commands = editor.commands ?? [fileManagerCommandForPlatform(platform)]
+    if ((await resolveAvailableCommand(commands, env, platform)) !== null) {
+      available.push(editor.id)
+    }
+  }
+  return available
+}

--- a/src/main/editors/launch.test.ts
+++ b/src/main/editors/launch.test.ts
@@ -1,0 +1,100 @@
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { launchEditor } from './launch'
+
+const posixOnly = process.platform === 'win32' ? describe.skip : describe
+
+posixOnly('launchEditor', () => {
+  let binDir: string
+  let workspaceDir: string
+
+  /** A fake editor CLI that records its argv so the test can assert the launch. */
+  async function installRecordingEditor(name: string): Promise<string> {
+    const recordFile = join(binDir, `${name}.argv`)
+    const path = join(binDir, name)
+    await writeFile(path, `#!/bin/sh\necho "$@" > "${recordFile}"\n`)
+    await chmod(path, 0o755)
+    return recordFile
+  }
+
+  async function readRecordedArgv(recordFile: string): Promise<string> {
+    // The child is detached — poll briefly for its write instead of racing it.
+    for (let i = 0; i < 50; i++) {
+      try {
+        return (await readFile(recordFile, 'utf8')).trim()
+      } catch {
+        await sleep(20)
+      }
+    }
+    throw new Error(`fake editor never wrote ${recordFile}`)
+  }
+
+  beforeEach(async () => {
+    binDir = await mkdtemp(join(tmpdir(), 'vibe-mistro-launch-bin-'))
+    workspaceDir = await mkdtemp(join(tmpdir(), 'vibe-mistro-launch-ws-'))
+  })
+
+  afterEach(async () => {
+    await rm(binDir, { recursive: true, force: true })
+    await rm(workspaceDir, { recursive: true, force: true })
+  })
+
+  it('spawns the editor CLI with the Workspace dir', async () => {
+    const recordFile = await installRecordingEditor('zed')
+    const result = await launchEditor({
+      workspaceDir,
+      editorId: 'zed',
+      env: { PATH: binDir },
+      platform: process.platform,
+    })
+    expect(result).toEqual({ ok: true })
+    expect(await readRecordedArgv(recordFile)).toBe(workspaceDir)
+  })
+
+  it('falls through alias order to the installed CLI (zed -> zeditor)', async () => {
+    const recordFile = await installRecordingEditor('zeditor')
+    const result = await launchEditor({
+      workspaceDir,
+      editorId: 'zed',
+      env: { PATH: binDir },
+      platform: process.platform,
+    })
+    expect(result).toEqual({ ok: true })
+    expect(await readRecordedArgv(recordFile)).toBe(workspaceDir)
+  })
+
+  it('opens the file-manager entry via the platform opener', async () => {
+    const recordFile = await installRecordingEditor('xdg-open')
+    const result = await launchEditor({
+      workspaceDir,
+      editorId: 'file-manager',
+      env: { PATH: binDir },
+      platform: 'linux',
+    })
+    expect(result).toEqual({ ok: true })
+    expect(await readRecordedArgv(recordFile)).toBe(workspaceDir)
+  })
+
+  it('rejects an id outside the curated table', async () => {
+    const result = await launchEditor({
+      workspaceDir,
+      editorId: 'not-an-editor',
+      env: { PATH: binDir },
+      platform: process.platform,
+    })
+    expect(result).toEqual({ ok: false, reason: 'unknown-editor' })
+  })
+
+  it('reports command-not-found when no alias resolves on PATH', async () => {
+    const result = await launchEditor({
+      workspaceDir,
+      editorId: 'cursor',
+      env: { PATH: binDir },
+      platform: process.platform,
+    })
+    expect(result).toEqual({ ok: false, reason: 'command-not-found' })
+  })
+})

--- a/src/main/editors/launch.ts
+++ b/src/main/editors/launch.ts
@@ -1,0 +1,56 @@
+import { spawn } from 'node:child_process'
+import {
+  fileManagerCommandForPlatform,
+  findEditor,
+  resolveEditorArgs,
+} from '../../shared/editors'
+import type { EditorsOpenResult } from '../../shared/ipc'
+import { resolveAvailableCommand } from './detect'
+
+/**
+ * Launch a Workspace directory in a curated external editor (#252) — the t3code
+ * model: resolve the editor's first available CLI alias on the shell-env PATH,
+ * then spawn it DETACHED (stdio ignored, unref'd) so the editor outlives us and
+ * never blocks or chatters at the main process. The file-manager entry opens the
+ * directory via the platform opener (`open` / `explorer` / `xdg-open`) instead.
+ * Every failure is a typed result (the handler logs it) — never a throw, never
+ * a silent no-op.
+ */
+export async function launchEditor(opts: {
+  workspaceDir: string
+  editorId: string
+  env: NodeJS.ProcessEnv
+  platform: string
+}): Promise<EditorsOpenResult> {
+  const editor = findEditor(opts.editorId)
+  if (!editor) return { ok: false, reason: 'unknown-editor' }
+
+  const aliases = editor.commands ?? [fileManagerCommandForPlatform(opts.platform)]
+  const command = await resolveAvailableCommand(aliases, opts.env, opts.platform)
+  if (command === null) return { ok: false, reason: 'command-not-found' }
+
+  // The file manager takes the bare dir; a real editor goes through the
+  // launchStyle mapping (a no-op for a bare directory in slice 1, load-bearing
+  // once #254 passes file:line targets through this same path).
+  const args = editor.commands === null ? [opts.workspaceDir] : resolveEditorArgs(editor, opts.workspaceDir)
+  return spawnDetached(command, args, opts.env)
+}
+
+function spawnDetached(
+  command: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+): Promise<EditorsOpenResult> {
+  return new Promise((resolve) => {
+    try {
+      const child = spawn(command, args, { detached: true, stdio: 'ignore', env })
+      child.once('error', () => resolve({ ok: false, reason: 'spawn-failed' }))
+      child.once('spawn', () => {
+        child.unref()
+        resolve({ ok: true })
+      })
+    } catch {
+      resolve({ ok: false, reason: 'spawn-failed' })
+    }
+  })
+}

--- a/src/main/editors/register-ipc.ts
+++ b/src/main/editors/register-ipc.ts
@@ -1,0 +1,61 @@
+import { ipcMain } from 'electron'
+import {
+  IPC,
+  type EditorsListResult,
+  type EditorsOpenArgs,
+  type EditorsOpenResult,
+} from '../../shared/ipc'
+import type { AgentPool } from '../agent-pool'
+import { getShellEnv } from '../shell-env'
+import { detectAvailableEditors } from './detect'
+import { launchEditor } from './launch'
+
+/**
+ * The Open-in-IDE IPC handlers (#252, epic #178), registered beside the modules
+ * they pass through to. Launching a user-chosen local app on the Workspace dir is
+ * user-trusted (parity with reveal-in-Finder); commands come ONLY from the curated
+ * `EDITORS` table — no user-supplied command strings. The open target is the warm
+ * agent's OWN `workspaceDir` (`pool.get`, the `filesList`/`revealPath` model), never
+ * a renderer-supplied path. NEITHER handler is agent activity: no `pool.touch`, so
+ * listing or opening an editor never keeps a warm agent alive past its idle window.
+ */
+export function registerEditorsIpc(deps: { pool: AgentPool }): void {
+  // Session-lifetime detection cache: the installed-editor set doesn't change
+  // mid-run, so the first probe's promise is shared by every later call (also
+  // coalescing concurrent invokes). A probe FAILURE is not cached — the slot
+  // resets so a transient fs hiccup doesn't blank the menu for the whole session.
+  let detected: Promise<EditorsListResult> | null = null
+
+  ipcMain.handle(IPC.editorsList, (): Promise<EditorsListResult> => {
+    detected ??= detectAvailableEditors(getShellEnv(), process.platform).then(
+      (editors) => ({ editors }),
+      (err) => {
+        console.error(`[vibe-mistro:editors] detection failed: ${String(err)}`)
+        detected = null
+        return { editors: [] }
+      },
+    )
+    return detected
+  })
+
+  ipcMain.handle(
+    IPC.editorsOpen,
+    async (_event, args: EditorsOpenArgs): Promise<EditorsOpenResult> => {
+      const agent = deps.pool.get(args.agentId)
+      if (!agent) {
+        console.error(`[vibe-mistro:editors] open ${args.editorId}: unknown agent ${args.agentId}`)
+        return { ok: false, reason: 'unknown-agent' }
+      }
+      const result = await launchEditor({
+        workspaceDir: agent.workspaceDir,
+        editorId: args.editorId,
+        env: getShellEnv(),
+        platform: process.platform,
+      })
+      if (!result.ok) {
+        console.error(`[vibe-mistro:editors] open ${args.editorId} failed: ${result.reason}`)
+      }
+      return result
+    },
+  )
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -68,6 +68,7 @@ import { GitStatusManager } from './git/status-stream'
 import { chokidarWatchFactory, realClock } from './git/runtime'
 import { registerGitIpc } from './git/register-ipc'
 import { registerFilesIpc } from './files/register-ipc'
+import { registerEditorsIpc } from './editors/register-ipc'
 import { createTerminalManager, registerTerminalIpc } from './terminal/register-ipc'
 import { registerBrowserIpc } from './browser/register-ipc'
 import type { TerminalManager } from './terminal/terminal-manager'
@@ -653,6 +654,7 @@ function registerIpc(deps: MainDeps): void {
     },
   })
   registerFilesIpc({ pool, cache: filesListCache })
+  registerEditorsIpc({ pool })
   terminalManager = createTerminalManager()
   registerTerminalIpc({ pool, manager: terminalManager })
   registerBrowserIpc()

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -25,6 +25,9 @@ import {
   type GhCurrentPrArgs,
   type GhPrResult,
   type RevealPathArgs,
+  type EditorsListResult,
+  type EditorsOpenArgs,
+  type EditorsOpenResult,
   type FilesListArgs,
   type FilesListResult,
   type FilesReadArgs,
@@ -149,6 +152,9 @@ const api = {
   filesList: (args: FilesListArgs): Promise<FilesListResult> => ipcRenderer.invoke(IPC.filesList, args),
   filesRead: (args: FilesReadArgs): Promise<FilesReadResult> => ipcRenderer.invoke(IPC.filesRead, args),
   openExternal: (args: OpenExternalArgs): Promise<void> => ipcRenderer.invoke(IPC.openExternal, args),
+  editorsList: (): Promise<EditorsListResult> => ipcRenderer.invoke(IPC.editorsList),
+  editorsOpen: (args: EditorsOpenArgs): Promise<EditorsOpenResult> =>
+    ipcRenderer.invoke(IPC.editorsOpen, args),
   discoverDevServers: (): Promise<DiscoverDevServersResult> =>
     ipcRenderer.invoke(IPC.discoverDevServers),
   terminalOpen: (args: TerminalOpenArgs): Promise<TerminalOpenResult> =>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -32,6 +32,7 @@ import { replayCache, wireReplayCacheInvalidation } from './conversation/replay-
 import { setWorkspaceControls, workspaceControlsKey } from './connection/workspace-controls-store'
 import { ArrowLeft, ArrowRight, Maximize2, PanelLeft, PanelRight, Terminal } from 'lucide-react'
 import { IconButton } from './ui/icon-button'
+import { OpenInEditorButton } from './editors/OpenInEditorButton'
 import { SearchPalette } from './search/SearchPalette'
 import { Shell, type WorkspaceFlags } from './shell/Shell'
 import { firstRunState } from './shell/first-run'
@@ -719,6 +720,11 @@ export function App(): JSX.Element {
             header affordance — toggles the ACTIVE Workspace's panel visibility via the
             store); Terminal/Expand stay placeholders (#future). */}
         <div className="flex items-center gap-0.5 [-webkit-app-region:no-drag]">
+          {/* Open the ACTIVE Workspace's dir in the first detected external editor
+              (#252, epic #178) — grows into the OpenInPicker split button in #253. */}
+          <OpenInEditorButton
+            agentId={selected.status === 'connected' ? selected.thread.agentId : null}
+          />
           <IconButton
             size="icon-sm"
             aria-label={activePanel.isOpen ? 'Close side panel' : 'Open side panel'}

--- a/src/renderer/src/editors/OpenInEditorButton.tsx
+++ b/src/renderer/src/editors/OpenInEditorButton.tsx
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useRef, useState, type JSX } from 'react'
+import { SquareArrowOutUpRight } from 'lucide-react'
+import type { EditorId } from '../../../shared/editors'
+import { IconButton } from '../ui/icon-button'
+import { firstAvailableEditor, openFailureMessage } from './open-in-editor'
+
+/**
+ * The window-header Open-in-editor affordance (#252, epic #178): one click opens
+ * the ACTIVE Workspace's directory in the first detected external editor. Slice 1
+ * of the t3code OpenInPicker — #253 grows this into the split button (preferred-
+ * editor icon + dropdown that switches the stored preference).
+ *
+ * Detection (`editorsList`) is fetched once on mount — main caches the probe for
+ * the whole session, so remounts are cheap. A launch failure (typed, never a
+ * silent no-op) surfaces as a transient status line beside the button.
+ */
+export function OpenInEditorButton({
+  agentId,
+}: {
+  /** The ACTIVE Workspace's agent, or null when nothing connected is selected. */
+  agentId: string | null
+}): JSX.Element {
+  const [available, setAvailable] = useState<readonly EditorId[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const clearTimer = useRef<number | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    void window.api.editorsList().then((result) => {
+      if (!cancelled) setAvailable(result.editors)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(
+    () => () => {
+      if (clearTimer.current !== null) window.clearTimeout(clearTimer.current)
+    },
+    [],
+  )
+
+  const editor = firstAvailableEditor(available)
+
+  const open = useCallback(async () => {
+    if (!agentId || !editor) return
+    const result = await window.api.editorsOpen({ agentId, editorId: editor.id })
+    if (!result.ok) {
+      setError(openFailureMessage(result.reason, editor.label))
+      if (clearTimer.current !== null) window.clearTimeout(clearTimer.current)
+      clearTimer.current = window.setTimeout(() => setError(null), 5000)
+    }
+  }, [agentId, editor])
+
+  const label = editor ? `Open in ${editor.label}` : 'No installed editors found'
+  return (
+    <div className="flex items-center gap-1.5">
+      {error && (
+        <span role="status" className="text-xs text-bad">
+          {error}
+        </span>
+      )}
+      <IconButton
+        size="icon-sm"
+        aria-label={label}
+        title={label}
+        disabled={!agentId || !editor}
+        onClick={() => void open()}
+      >
+        <SquareArrowOutUpRight className="size-4" aria-hidden />
+      </IconButton>
+    </div>
+  )
+}

--- a/src/renderer/src/editors/open-in-editor.test.ts
+++ b/src/renderer/src/editors/open-in-editor.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { firstAvailableEditor, openFailureMessage } from './open-in-editor'
+
+describe('firstAvailableEditor', () => {
+  it('picks the first available editor in TABLE order, not wire order', () => {
+    expect(firstAvailableEditor(['zed', 'cursor'])).toEqual({ id: 'cursor', label: 'Cursor' })
+  })
+
+  it('falls through to a lone detected editor', () => {
+    expect(firstAvailableEditor(['file-manager'])).toEqual({
+      id: 'file-manager',
+      label: 'File Manager',
+    })
+  })
+
+  it('returns null when nothing is detected', () => {
+    expect(firstAvailableEditor([])).toBeNull()
+  })
+})
+
+describe('openFailureMessage', () => {
+  it('names the editor in CLI/launch failures', () => {
+    expect(openFailureMessage('command-not-found', 'Zed')).toBe('Zed CLI not found on PATH')
+    expect(openFailureMessage('spawn-failed', 'Zed')).toBe("Couldn't launch Zed")
+  })
+
+  it('covers the agent/editor identity failures', () => {
+    expect(openFailureMessage('unknown-agent', 'Zed')).toBe('Workspace agent is not connected')
+    expect(openFailureMessage('unknown-editor', 'Zed')).toBe('Unknown editor')
+  })
+})

--- a/src/renderer/src/editors/open-in-editor.ts
+++ b/src/renderer/src/editors/open-in-editor.ts
@@ -1,0 +1,42 @@
+import { EDITORS, type EditorId } from '../../../shared/editors'
+import type { EditorsOpenResult } from '../../../shared/ipc'
+
+/**
+ * Pure logic behind the header's Open-in-editor affordance (#252): choose which
+ * detected editor the button opens, and word a launch failure for the header's
+ * transient status text. Slice 2 (#253) replaces `firstAvailableEditor` with the
+ * stored-preference resolution (stored-if-still-available, else this same
+ * table-order fallback) — keep the fallback semantics here when it lands.
+ */
+
+export interface EditorChoice {
+  id: EditorId
+  label: string
+}
+
+/**
+ * The editor slice 1's button opens: the FIRST available one in `EDITORS` table
+ * (= preference) order. Re-derived against the table rather than trusting the
+ * wire's ordering, so a reordered or hand-crafted list can't change the pick.
+ */
+export function firstAvailableEditor(available: readonly EditorId[]): EditorChoice | null {
+  const set = new Set(available)
+  const editor = EDITORS.find((e) => set.has(e.id))
+  return editor ? { id: editor.id, label: editor.label } : null
+}
+
+type OpenFailureReason = Extract<EditorsOpenResult, { ok: false }>['reason']
+
+/** A short human line for each typed `editorsOpen` failure (never a silent no-op). */
+export function openFailureMessage(reason: OpenFailureReason, editorLabel: string): string {
+  switch (reason) {
+    case 'command-not-found':
+      return `${editorLabel} CLI not found on PATH`
+    case 'spawn-failed':
+      return `Couldn't launch ${editorLabel}`
+    case 'unknown-agent':
+      return 'Workspace agent is not connected'
+    case 'unknown-editor':
+      return 'Unknown editor'
+  }
+}

--- a/src/shared/editors.test.ts
+++ b/src/shared/editors.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import {
+  EDITORS,
+  findEditor,
+  fileManagerCommandForPlatform,
+  parseTargetPosition,
+  resolveEditorArgs,
+  type EditorDefinition,
+} from './editors'
+
+describe('EDITORS table', () => {
+  it('has unique ids', () => {
+    const ids = EDITORS.map((e) => e.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('only the file-manager entry has null commands', () => {
+    for (const editor of EDITORS) {
+      if (editor.id === 'file-manager') expect(editor.commands).toBeNull()
+      else expect(editor.commands?.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('findEditor resolves a known id and rejects an unknown one', () => {
+    expect(findEditor('zed')?.label).toBe('Zed')
+    expect(findEditor('emacs-brain-implant')).toBeNull()
+  })
+})
+
+describe('parseTargetPosition', () => {
+  it('splits path:line', () => {
+    expect(parseTargetPosition('/a/b.ts:12')).toEqual({ path: '/a/b.ts', line: '12', column: null })
+  })
+
+  it('splits path:line:col', () => {
+    expect(parseTargetPosition('/a/b.ts:12:4')).toEqual({ path: '/a/b.ts', line: '12', column: '4' })
+  })
+
+  it('returns null for a bare path', () => {
+    expect(parseTargetPosition('/a/b.ts')).toBeNull()
+  })
+
+  it('returns null for a Windows drive path with no position', () => {
+    expect(parseTargetPosition('C:\\proj\\x.ts')).toBeNull()
+  })
+
+  it('keeps a drive prefix inside the path when a position follows', () => {
+    expect(parseTargetPosition('C:\\proj\\x.ts:3')).toEqual({
+      path: 'C:\\proj\\x.ts',
+      line: '3',
+      column: null,
+    })
+  })
+})
+
+describe('resolveEditorArgs', () => {
+  const goto: EditorDefinition = { id: 'x', label: 'X', commands: ['x'], launchStyle: 'goto' }
+  const lineColumn: EditorDefinition = {
+    id: 'y',
+    label: 'Y',
+    commands: ['y'],
+    launchStyle: 'line-column',
+  }
+  const directPath: EditorDefinition = {
+    id: 'z',
+    label: 'Z',
+    commands: ['z'],
+    launchStyle: 'direct-path',
+  }
+
+  it('passes a bare directory through untouched for every style', () => {
+    expect(resolveEditorArgs(goto, '/proj')).toEqual(['/proj'])
+    expect(resolveEditorArgs(lineColumn, '/proj')).toEqual(['/proj'])
+    expect(resolveEditorArgs(directPath, '/proj')).toEqual(['/proj'])
+  })
+
+  it('goto style forwards the positioned target via --goto', () => {
+    expect(resolveEditorArgs(goto, '/a/b.ts:12:4')).toEqual(['--goto', '/a/b.ts:12:4'])
+  })
+
+  it('line-column style splits the position into flags', () => {
+    expect(resolveEditorArgs(lineColumn, '/a/b.ts:12:4')).toEqual([
+      '--line',
+      '12',
+      '--column',
+      '4',
+      '/a/b.ts',
+    ])
+    expect(resolveEditorArgs(lineColumn, '/a/b.ts:12')).toEqual(['--line', '12', '/a/b.ts'])
+  })
+
+  it('direct-path style strips the position down to the path', () => {
+    expect(resolveEditorArgs(directPath, '/a/b.ts:12:4')).toEqual(['/a/b.ts'])
+  })
+
+  it('prepends baseArgs', () => {
+    const withBase: EditorDefinition = { ...goto, baseArgs: ['ide'] }
+    expect(resolveEditorArgs(withBase, '/proj')).toEqual(['ide', '/proj'])
+  })
+})
+
+describe('fileManagerCommandForPlatform', () => {
+  it('maps the three platforms', () => {
+    expect(fileManagerCommandForPlatform('darwin')).toBe('open')
+    expect(fileManagerCommandForPlatform('win32')).toBe('explorer')
+    expect(fileManagerCommandForPlatform('linux')).toBe('xdg-open')
+  })
+})

--- a/src/shared/editors.ts
+++ b/src/shared/editors.ts
@@ -1,0 +1,128 @@
+/**
+ * The curated external-editor table for Open in IDE (#252, epic #178), ported from
+ * t3code's contract shape: ONE static list drives detection (main probes each
+ * `commands` alias on the shell-env PATH), launch-arg building (`launchStyle`),
+ * and the renderer's labels — the renderer never re-declares ids or labels.
+ * Node/DOM-free (like `shared/ipc`) so both tsconfig projects can consume it.
+ */
+
+/**
+ * How an editor's CLI takes a file target with a position (t3code): `goto` is the
+ * VS Code family's `--goto path:line:col`; `line-column` is the JetBrains launchers'
+ * `--line N [--column M] path`; `direct-path` editors (Zed, the file manager) take
+ * the bare path. Slice 1 (#252) only ever passes a bare directory — the mapping is
+ * exercised by the open-file-at-line slice (#254) — but it ships (and is tested) here
+ * so the table is complete from the start.
+ */
+export type EditorLaunchStyle = 'direct-path' | 'goto' | 'line-column'
+
+export interface EditorDefinition {
+  readonly id: string
+  readonly label: string
+  /**
+   * CLI aliases probed IN ORDER on the shell-env PATH (e.g. Zed installs `zed` or
+   * `zeditor` depending on channel). `null` marks the platform file manager, whose
+   * command is per-platform (`open` / `explorer` / `xdg-open`), not a fixed alias.
+   */
+  readonly commands: readonly string[] | null
+  /** Args prepended before the target (e.g. a subcommand), rarely needed. */
+  readonly baseArgs?: readonly string[]
+  readonly launchStyle: EditorLaunchStyle
+}
+
+/**
+ * Table order is PREFERENCE order: detection reports available editors in this
+ * order, and slice 1's header button opens the first available one (slice 2's
+ * stored preference falls back to the same order).
+ */
+export const EDITORS = [
+  { id: 'cursor', label: 'Cursor', commands: ['cursor'], launchStyle: 'goto' },
+  { id: 'vscode', label: 'VS Code', commands: ['code'], launchStyle: 'goto' },
+  {
+    id: 'vscode-insiders',
+    label: 'VS Code Insiders',
+    commands: ['code-insiders'],
+    launchStyle: 'goto',
+  },
+  { id: 'vscodium', label: 'VSCodium', commands: ['codium'], launchStyle: 'goto' },
+  { id: 'windsurf', label: 'Windsurf', commands: ['windsurf'], launchStyle: 'goto' },
+  { id: 'zed', label: 'Zed', commands: ['zed', 'zeditor'], launchStyle: 'direct-path' },
+  { id: 'antigravity', label: 'Antigravity', commands: ['agy'], launchStyle: 'goto' },
+  { id: 'idea', label: 'IntelliJ IDEA', commands: ['idea'], launchStyle: 'line-column' },
+  { id: 'pycharm', label: 'PyCharm', commands: ['pycharm'], launchStyle: 'line-column' },
+  { id: 'webstorm', label: 'WebStorm', commands: ['webstorm'], launchStyle: 'line-column' },
+  { id: 'phpstorm', label: 'PhpStorm', commands: ['phpstorm'], launchStyle: 'line-column' },
+  { id: 'goland', label: 'GoLand', commands: ['goland'], launchStyle: 'line-column' },
+  { id: 'clion', label: 'CLion', commands: ['clion'], launchStyle: 'line-column' },
+  { id: 'rider', label: 'Rider', commands: ['rider'], launchStyle: 'line-column' },
+  { id: 'rubymine', label: 'RubyMine', commands: ['rubymine'], launchStyle: 'line-column' },
+  { id: 'rustrover', label: 'RustRover', commands: ['rustrover'], launchStyle: 'line-column' },
+  { id: 'datagrip', label: 'DataGrip', commands: ['datagrip'], launchStyle: 'line-column' },
+  { id: 'file-manager', label: 'File Manager', commands: null, launchStyle: 'direct-path' },
+] as const satisfies ReadonlyArray<EditorDefinition>
+
+/** The closed id union the IPC contract speaks — literal ids extracted from the table. */
+export type EditorId = (typeof EDITORS)[number]['id']
+
+export function findEditor(id: string): (typeof EDITORS)[number] | null {
+  return EDITORS.find((editor) => editor.id === id) ?? null
+}
+
+/** A `path:line[:col]` target split for per-`launchStyle` arg building. */
+export interface TargetPosition {
+  path: string
+  line: string
+  column: string | null
+}
+
+const TARGET_WITH_POSITION_PATTERN = /^(.*?):(\d+)(?::(\d+))?$/
+
+/**
+ * Split a `path:line[:col]` target. A bare path (no trailing `:digits`) returns
+ * null — including Windows drive prefixes (`C:\x` — the segment after the first
+ * `:` isn't digits) and paths whose colon-suffix isn't a position.
+ */
+export function parseTargetPosition(target: string): TargetPosition | null {
+  const match = TARGET_WITH_POSITION_PATTERN.exec(target)
+  if (!match?.[1] || !match[2]) return null
+  return { path: match[1], line: match[2], column: match[3] ?? null }
+}
+
+/**
+ * Build the CLI args (after the command) that open `target` in `editor`, per its
+ * `launchStyle`. `target` may carry a `:line[:col]` suffix; a bare path passes
+ * through untouched for every style. Not meaningful for the file-manager entry
+ * (`commands: null`) — its launch is the platform opener with the bare path.
+ */
+export function resolveEditorArgs(editor: EditorDefinition, target: string): string[] {
+  const position = parseTargetPosition(target)
+  const base = editor.baseArgs ? [...editor.baseArgs] : []
+  switch (editor.launchStyle) {
+    case 'direct-path':
+      return [...base, position?.path ?? target]
+    case 'goto':
+      return position ? [...base, '--goto', target] : [...base, target]
+    case 'line-column':
+      return position
+        ? [
+            ...base,
+            '--line',
+            position.line,
+            ...(position.column ? ['--column', position.column] : []),
+            position.path,
+          ]
+        : [...base, target]
+  }
+}
+
+/** The platform opener backing the `file-manager` entry (t3code's mapping). */
+export function fileManagerCommandForPlatform(platform: string): string {
+  switch (platform) {
+    case 'darwin':
+      return 'open'
+    case 'win32':
+      return 'explorer'
+    default:
+      return 'xdg-open'
+  }
+}

--- a/src/shared/ipc/editors.ts
+++ b/src/shared/ipc/editors.ts
@@ -1,0 +1,50 @@
+/**
+ * Editors domain of the shared IPC contract (#252, epic #178): detect the external
+ * editors installed on this machine and open a Workspace directory in one. The
+ * id vocabulary + labels live in the curated `shared/editors` table — this module
+ * only owns the wire shapes. Keep free of Node/DOM imports.
+ */
+import type { EditorId } from '../editors'
+
+/** The editors channel entries, merged into the single `IPC` const in `./index`. */
+export const editorsChannels = {
+  /** Renderer -> main: LIST the installed editors (which-on-PATH probe) — see {@link EditorsListResult}. */
+  editorsList: 'editors:list',
+  /** Renderer -> main: OPEN a Workspace dir in an installed editor — see {@link EditorsOpenArgs}. */
+  editorsOpen: 'editors:open',
+} as const
+
+/**
+ * The `editorsList` reply: ids from the curated table whose CLI resolves on the
+ * shell-env PATH, in table (= preference) order. Detected ONCE per app session and
+ * cached in main — the installed set doesn't change mid-session, and re-probing
+ * every alias on every render would be pure waste. Best-effort: a probe failure
+ * degrades to an empty list (logged), never a throw.
+ */
+export interface EditorsListResult {
+  editors: EditorId[]
+}
+
+/**
+ * Args for `editorsOpen`: open the Workspace directory in one detected editor.
+ * Addressed by `agentId` — main resolves the directory from the warm agent's OWN
+ * `workspaceDir` (`pool.get`), NOT a renderer-supplied path (the `filesList`/
+ * `revealPath` model). `editorId` must come from the curated table; launching is a
+ * detached spawn of a curated CLI on the Workspace dir — user-trusted (parity with
+ * reveal-in-Finder), no user-supplied command strings. NOT agent activity: no
+ * `pool.touch`, so opening your editor never keeps a warm agent alive.
+ */
+export interface EditorsOpenArgs {
+  agentId: string
+  editorId: EditorId
+}
+
+/**
+ * The `editorsOpen` reply — a typed result, never a silent no-op: `unknown-agent`
+ * (stale/evicted `agentId`), `unknown-editor` (id not in the table), `command-not-found`
+ * (no CLI alias resolves on the shell-env PATH anymore), `spawn-failed` (the launch
+ * itself errored). Every failure is also logged in main; the renderer surfaces it.
+ */
+export type EditorsOpenResult =
+  | { ok: true }
+  | { ok: false; reason: 'unknown-agent' | 'unknown-editor' | 'command-not-found' | 'spawn-failed' }

--- a/src/shared/ipc/index.ts
+++ b/src/shared/ipc/index.ts
@@ -15,6 +15,7 @@ import { authChannels } from './auth'
 import { gitChannels } from './git'
 import { ghChannels } from './gh'
 import { filesChannels } from './files'
+import { editorsChannels } from './editors'
 import { terminalChannels } from './terminal'
 import { browserChannels } from './browser'
 import { searchChannels } from './search'
@@ -31,6 +32,7 @@ export const IPC = {
   ...gitChannels,
   ...ghChannels,
   ...filesChannels,
+  ...editorsChannels,
   ...terminalChannels,
   ...browserChannels,
   ...searchChannels,
@@ -42,6 +44,7 @@ export * from './auth'
 export * from './git'
 export * from './gh'
 export * from './files'
+export * from './editors'
 export * from './terminal'
 export * from './browser'
 export * from './search'


### PR DESCRIPTION
Closes #252 (epic #178, slice 1 of 3 — next: #253 OpenInPicker split button, #254 open-file-at-line).

## What

The Open-in-IDE tracer bullet, ported from t3code's shape (findings comment on #178):

- **`src/shared/editors.ts`** — ONE curated `EDITORS` table (`id`, `label`, CLI `commands` aliases, `launchStyle`) drives detection, launch args, and renderer labels. The `launchStyle` mapping (`goto` / `line-column` / `direct-path`, incl. `file:line:col` parsing) ships fully tested now; #254 consumes it for open-file-at-line.
- **`editors:list`** — which-on-PATH detection against the resolved shell-env PATH (`getShellEnv()`, so Finder/Dock launches still see `code`/`cursor`), cached for the session (failures are NOT cached), returned in table = preference order.
- **`editors:open`** — addressed by `agentId`; the dir is the warm agent's OWN `workspaceDir` (the `filesList`/`revealPath` model, never a renderer-supplied path). Detached, unref'd spawn of the probe-resolved absolute path. Typed failure union (`unknown-agent` / `unknown-editor` / `command-not-found` / `spawn-failed`) — logged in main AND surfaced in the renderer, never a silent no-op.
- **Header button** — opens the ACTIVE Workspace in the first detected editor; disabled with a hint when nothing is detected / nothing connected; launch failures show a transient status line beside it. Grows into the split-button picker in #253.
- **file-manager entry** — resolves to the platform opener (`open` / `explorer` / `xdg-open`).

## Security posture

Deliberate, per the epic: launching a user-chosen local app on the Workspace dir is user-trusted (parity with reveal-in-Finder). Commands come ONLY from the curated table — no user-supplied command strings reach a spawn.

## Tests

34 new tests (table invariants, position parsing, per-style arg mapping, PATH candidate fan-out incl. the win32 PATHEXT branch, real-fs detection fixtures, detached-launch behavior via a recording fake CLI, renderer pick/message helpers). All four gates pass: lint, typecheck, build, test (1323 tests / 107 files).

Note: this branch shares a working tree with in-flight search slice-2 work; the commit is surgically scoped to the editors files only (verified hunk-by-hunk on the shared `main/index.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)