### PR TITLE
feat(search): slice 2 — transcript prose search with snippets & hit counts (#174)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -41,7 +41,8 @@ import {
 import { detectVibe } from './vibe-detect'
 import { getShellEnv } from './shell-env'
 import { getAccountWhoami, readKeychainApiKey, readVibeEnvFile } from './auth/whoami'
-import { searchThreads } from './search/search-threads'
+import { searchThreads, tokenizeQuery } from './search/search-threads'
+import { proseEntries, type ProseEntry } from './search/transcript-prose'
 import { groupThreadsByWorkspace, MetadataStore } from './persistence/metadata-store'
 import {
   acpEventEntry,
@@ -1099,12 +1100,38 @@ function registerIpc(deps: MainDeps): void {
     return groupThreadsByWorkspace(deps.store.snapshot())
   })
 
-  ipcMain.handle(IPC.searchQuery, (_event, args: SearchQueryArgs): SearchQueryResult => {
-    // The Search palette's ranked hits (#174 slice 1): a pure scan over the same
-    // cold metadata snapshot listMetadata serves — no agent, no transcript I/O yet
-    // (slice 2 widens the corpus to transcript prose behind this same channel).
-    return searchThreads(groupThreadsByWorkspace(deps.store.snapshot()), args.query, args.limit)
-  })
+  ipcMain.handle(
+    IPC.searchQuery,
+    async (_event, args: SearchQueryArgs): Promise<SearchQueryResult> => {
+      // The Search palette's ranked hits (#174): a pure scan over the same cold
+      // metadata snapshot listMetadata serves — no agent involved. A NON-empty
+      // query also scans transcript prose (slice 2): read every Thread's JSONL
+      // through the TranscriptStore seam (its only reader, ADR-0005) and extract
+      // the conversation proper; scan-on-query per the epic decision (no index
+      // until measured slow). Best-effort per thread — a failed read degrades
+      // that thread to title-only matching, never the query.
+      const snapshot = groupThreadsByWorkspace(deps.store.snapshot())
+      let prose: Map<string, ProseEntry[]> | undefined
+      if (deps.transcript && tokenizeQuery(args.query).length > 0) {
+        const store = deps.transcript
+        const threads = snapshot.flatMap((ws) => ws.threads)
+        const loaded = await Promise.all(
+          threads.map(async (thread) => {
+            try {
+              return [thread.id, proseEntries(await store.read(thread.id))] as const
+            } catch (err) {
+              console.error(
+                `[vibe-mistro:search] transcript read failed (${thread.id}): ${String(err)}`,
+              )
+              return [thread.id, [] as ProseEntry[]] as const
+            }
+          }),
+        )
+        prose = new Map(loaded)
+      }
+      return searchThreads(snapshot, args.query, args.limit, prose)
+    },
+  )
 
   ipcMain.handle(IPC.readTranscript, (_event, threadId: string): Promise<ReadTranscriptResult> => {
     // The process-free reopen source (ADR-0005, TB3): hand the renderer the

--- a/src/main/search/search-threads.test.ts
+++ b/src/main/search/search-threads.test.ts
@@ -113,6 +113,44 @@ describe('searchThreads', () => {
     expect(hit).toMatchObject({ archived: true, workspaceName: 'vibe-mistro', workspaceId: 'ws-a' })
   })
 
+  it('matches transcript prose (slice 2): strong entries carry snippet/hitCount/entryIndex', () => {
+    const prose = new Map([
+      ['t-miss', [{ index: 3, text: 'we should use the warm pool here' }, { index: 7, text: 'warm pool again' }]],
+    ])
+    const hits = searchThreads(ws, 'warm pool', 20, prose)
+    const hit = hits.find((h) => h.threadId === 't-miss')
+    expect(hit).toMatchObject({ hitCount: 2, entryIndex: 3 })
+    expect(hit?.snippet).toContain('warm pool here')
+  })
+
+  it('ranks strong prose matches above scattered matches within tier 0, by hit count', () => {
+    const prose = new Map([
+      ['t-miss', [{ index: 0, text: 'warm pool' }]], // strong body match, low recency (50)
+    ])
+    const ids = searchThreads(ws, 'warm pool', 20, prose).map((h) => h.threadId)
+    // t-scattered (tier 0, no strong entries, recency 40) loses to the strong body hit
+    expect(ids.indexOf('t-miss')).toBeLessThan(ids.indexOf('t-scattered'))
+    // but any whole-query TITLE tier still outranks a body-only match
+    expect(ids.indexOf('t-contains')).toBeLessThan(ids.indexOf('t-miss'))
+  })
+
+  it('matches tokens scattered ACROSS messages (no snippet — no single strong entry)', () => {
+    const prose = new Map([
+      ['t-miss', [{ index: 1, text: 'the pool is here' }, { index: 2, text: 'keep it warm' }]],
+    ])
+    const hit = searchThreads(ws, 'warm pool', 20, prose).find((h) => h.threadId === 't-miss')
+    expect(hit).toBeDefined()
+    expect(hit?.snippet).toBeUndefined()
+    expect(hit?.hitCount).toBeUndefined()
+  })
+
+  it('folds accents in prose and ignores prose entirely at rest', () => {
+    const prose = new Map([['t-miss', [{ index: 0, text: 'le café était chaud' }]]])
+    expect(searchThreads(ws, 'cafe chaud', 20, prose).map((h) => h.threadId)).toEqual(['t-miss'])
+    const resting = searchThreads(ws, '', 20, prose)
+    expect(resting.every((h) => h.snippet === undefined)).toBe(true)
+  })
+
   it('caps at the limit (default 20) and tolerates limit 0', () => {
     const many = snapshot({
       id: 'ws-many',

--- a/src/main/search/search-threads.ts
+++ b/src/main/search/search-threads.ts
@@ -1,4 +1,5 @@
 import type { ListMetadataResult, SearchHit } from '../../shared/ipc'
+import { buildSnippet, type ProseEntry } from './transcript-prose'
 
 /**
  * Pure Thread search over the cold metadata snapshot (#174 slice 1) — the module
@@ -51,27 +52,50 @@ export function titleTier(foldedTitle: string, foldedQuery: string): number {
   return 0
 }
 
-/** Rank Threads against a query over the cold metadata snapshot. Pure. */
+/**
+ * Rank Threads against a query. Pure — transcript I/O happens in the handler,
+ * which passes each Thread's extracted prose via `proseByThread` (slice 2;
+ * absent/missing threads search by title + Workspace name alone, so a transcript
+ * read failure degrades a thread's rank, never the query).
+ *
+ * A prose entry containing ALL tokens is a "strong" message match: it seeds the
+ * row's snippet, `entryIndex`, and `hitCount`, and ranks the thread within its
+ * title tier. Tokens may also match SCATTERED across the title, Workspace name,
+ * and different messages — the thread still hits, just without a snippet.
+ */
 export function searchThreads(
   workspaces: ListMetadataResult,
   query: string,
   limit: number = DEFAULT_SEARCH_LIMIT,
+  proseByThread?: ReadonlyMap<string, ProseEntry[]>,
 ): SearchHit[] {
   const tokens = tokenizeQuery(query)
   const resting = tokens.length === 0
   // Collapse inner whitespace so the tier comparison sees one canonical phrase.
   const foldedQuery = tokens.join(' ')
 
-  const scored: Array<{ hit: SearchHit; tier: number }> = []
+  const scored: Array<{ hit: SearchHit; tier: number; hits: number }> = []
   for (const workspace of workspaces) {
     const foldedWorkspace = foldSearchText(workspace.displayName)
     for (const thread of workspace.threads) {
       const archived = thread.archived === true
       if (resting && archived) continue // switcher context — archived stays out
       const foldedTitle = foldSearchText(thread.title ?? '')
+      const prose = proseByThread?.get(thread.id) ?? []
+      let strong: { entry: ProseEntry; count: number } | null = null
       if (!resting) {
-        const haystack = `${foldedTitle}\n${foldedWorkspace}`
-        if (!tokens.every((token) => haystack.includes(token))) continue
+        const foldedProse = prose.map((entry) => foldSearchText(entry.text))
+        for (let i = 0; i < prose.length; i += 1) {
+          const folded = foldedProse[i] as string
+          if (!tokens.every((token) => folded.includes(token))) continue
+          // Count every strong entry; the FIRST one seeds snippet + entryIndex.
+          if (strong) strong.count += 1
+          else strong = { entry: prose[i] as ProseEntry, count: 1 }
+        }
+        if (!strong) {
+          const haystack = `${foldedTitle}\n${foldedWorkspace}\n${foldedProse.join('\n')}`
+          if (!tokens.every((token) => haystack.includes(token))) continue
+        }
       }
       scored.push({
         hit: {
@@ -81,12 +105,22 @@ export function searchThreads(
           title: thread.title,
           archived,
           lastActiveAt: thread.lastActiveAt,
+          ...(strong
+            ? {
+                snippet: buildSnippet(strong.entry.text, tokens),
+                hitCount: strong.count,
+                entryIndex: strong.entry.index,
+              }
+            : {}),
         },
         tier: resting ? 0 : titleTier(foldedTitle, foldedQuery),
+        hits: strong?.count ?? 0,
       })
     }
   }
 
-  scored.sort((a, b) => b.tier - a.tier || b.hit.lastActiveAt - a.hit.lastActiveAt)
+  scored.sort(
+    (a, b) => b.tier - a.tier || b.hits - a.hits || b.hit.lastActiveAt - a.hit.lastActiveAt,
+  )
   return scored.slice(0, Math.max(0, limit)).map((entry) => entry.hit)
 }

--- a/src/main/search/transcript-prose.test.ts
+++ b/src/main/search/transcript-prose.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import type { TranscriptEntry } from '../../shared/ipc'
+import { buildSnippet, extractProse, proseEntries } from './transcript-prose'
+
+/** An `acp-event` transcript entry wrapping one `session/update`. */
+function acpEvent(update: unknown): TranscriptEntry {
+  return { t: 'acp-event', payload: { method: 'session/update', params: { update } } }
+}
+
+function agentChunk(text: string): TranscriptEntry {
+  return acpEvent({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text }, messageId: 'm1' })
+}
+
+describe('extractProse', () => {
+  it('extracts user prompts and agent message chunks (the conversation proper)', () => {
+    expect(extractProse({ t: 'user-prompt', id: 'p1', text: 'fix the pool' })).toBe('fix the pool')
+    expect(extractProse(agentChunk('use execFileAsync here'))).toBe('use execFileAsync here')
+  })
+
+  it('ignores reasoning, tool payloads, and non-conversation entries (CONTEXT.md Search)', () => {
+    expect(
+      extractProse(acpEvent({ sessionUpdate: 'agent_thought_chunk', content: { type: 'text', text: 'hmm' } })),
+    ).toBeNull()
+    expect(
+      extractProse(acpEvent({ sessionUpdate: 'tool_call', toolCallId: 'tc1', rawInput: { cmd: 'grep secret' } })),
+    ).toBeNull()
+    expect(extractProse({ t: 'turn-complete' })).toBeNull()
+    expect(extractProse({ t: 'agent-rebound' })).toBeNull()
+  })
+
+  it('tolerates malformed payloads and empty text', () => {
+    expect(extractProse({ t: 'acp-event', payload: null })).toBeNull()
+    expect(extractProse({ t: 'acp-event', payload: { method: 'other' } })).toBeNull()
+    expect(extractProse(acpEvent({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 42 } }))).toBeNull()
+    expect(extractProse(agentChunk(''))).toBeNull()
+    expect(extractProse({ t: 'user-prompt', id: 'p', text: '' })).toBeNull()
+  })
+})
+
+describe('proseEntries', () => {
+  it('keeps transcript line indexes (the jump pointer) and drops non-prose lines', () => {
+    const entries: TranscriptEntry[] = [
+      { t: 'user-prompt', id: 'p1', text: 'hello' },
+      acpEvent({ sessionUpdate: 'agent_thought_chunk', content: { type: 'text', text: 'thinking' } }),
+      agentChunk('answer'),
+      { t: 'turn-complete' },
+    ]
+    expect(proseEntries(entries)).toEqual([
+      { index: 0, text: 'hello' },
+      { index: 2, text: 'answer' },
+    ])
+  })
+})
+
+describe('buildSnippet', () => {
+  it('windows around the first matched token with ellipses and collapsed whitespace', () => {
+    const text = `${'x'.repeat(100)} the warm\n\npool  answer ${'y'.repeat(100)}`
+    const snippet = buildSnippet(text, ['pool'])
+    expect(snippet.startsWith('…')).toBe(true)
+    expect(snippet.endsWith('…')).toBe(true)
+    expect(snippet).toContain('warm pool answer')
+    expect(snippet.length).toBeLessThanOrEqual(92) // 90 + both ellipses
+  })
+
+  it('keeps short texts whole (no ellipses) and falls back to the start on no positional match', () => {
+    expect(buildSnippet('short answer', ['answer'])).toBe('short answer')
+    // Accent mismatch: folded token not found by toLowerCase search → entry start.
+    expect(buildSnippet('Réviser le café', ['cafe'])).toBe('Réviser le café')
+  })
+})

--- a/src/main/search/transcript-prose.ts
+++ b/src/main/search/transcript-prose.ts
@@ -1,0 +1,76 @@
+import type { TranscriptEntry } from '../../shared/ipc'
+
+/**
+ * Prose extraction for Search slice 2 (#174): pull the CONVERSATION PROPER out
+ * of a Thread's transcript — the user's prompts and the agent's replies, and
+ * nothing else (CONTEXT.md "Search"). Reasoning (`agent_thought_chunk`) and tool
+ * payloads (`tool_call*` rawInput/rawOutput) are deliberately not searchable:
+ * they poison ranking (every grep the agent ran would hit) and aren't "what was
+ * said". Shapes verified against docs/acp-capture.md §4:
+ * `agent_message_chunk` = `{content:{type:"text",text}, messageId}`.
+ */
+
+/** One searchable prose piece: its transcript line index (the slice-3 jump
+ * pointer) + the raw text. */
+export interface ProseEntry {
+  /** Index of the source line in the Thread's transcript (replay order). */
+  index: number
+  text: string
+}
+
+/** Extract an entry's searchable prose, or null when the entry carries none. */
+export function extractProse(entry: TranscriptEntry): string | null {
+  if (entry.t === 'user-prompt') return entry.text || null
+  if (entry.t !== 'acp-event') return null
+  const message = entry.payload as { method?: unknown; params?: unknown } | null
+  if (!message || message.method !== 'session/update') return null
+  const update = (message.params as { update?: unknown } | undefined)?.update as
+    | { sessionUpdate?: unknown; content?: unknown }
+    | undefined
+  if (!update || update.sessionUpdate !== 'agent_message_chunk') return null
+  const content = update.content as { type?: unknown; text?: unknown } | undefined
+  if (content?.type !== 'text' || typeof content.text !== 'string') return null
+  return content.text || null
+}
+
+/**
+ * A transcript's prose pieces, indexed by transcript line. Adjacent
+ * agent_message_chunk deltas are NOT merged — each chunk is one entry; token-AND
+ * matching happens per-entry, and the first strong entry seeds the snippet.
+ */
+export function proseEntries(entries: TranscriptEntry[]): ProseEntry[] {
+  const prose: ProseEntry[] = []
+  for (let index = 0; index < entries.length; index += 1) {
+    const entry = entries[index]
+    if (!entry) continue
+    const text = extractProse(entry)
+    if (text) prose.push({ index, text })
+  }
+  return prose
+}
+
+/** Max snippet length (one palette row line). */
+const SNIPPET_MAX = 90
+/** Context kept before the first matched token. */
+const SNIPPET_LEAD = 20
+
+/**
+ * One display line around the first occurrence of any token: whitespace
+ * collapsed, windowed to ~{@link SNIPPET_MAX} chars, ellipsized at cut edges.
+ * Position finding is case-folded only (not accent-folded) — an accent-mismatch
+ * falls back to the entry's start, which still shows the right message.
+ */
+export function buildSnippet(text: string, tokens: readonly string[]): string {
+  const collapsed = text.replace(/\s+/g, ' ').trim()
+  const lowered = collapsed.toLowerCase()
+  let matchAt = -1
+  for (const token of tokens) {
+    const at = lowered.indexOf(token)
+    if (at !== -1 && (matchAt === -1 || at < matchAt)) matchAt = at
+  }
+  const start = matchAt === -1 ? 0 : Math.max(0, matchAt - SNIPPET_LEAD)
+  const end = Math.min(collapsed.length, start + SNIPPET_MAX)
+  const head = start > 0 ? '…' : ''
+  const tail = end < collapsed.length ? '…' : ''
+  return `${head}${collapsed.slice(start, end).trim()}${tail}`
+}

--- a/src/renderer/src/search/SearchPalette.tsx
+++ b/src/renderer/src/search/SearchPalette.tsx
@@ -102,10 +102,16 @@ export function SearchPalette({
                         </Badge>
                       )}
                     </span>
-                    <span className="truncate text-[11px] text-faint">{hit.workspaceName}</span>
+                    <span className="truncate text-[11px] text-faint">
+                      {hit.workspaceName}
+                      {hit.snippet && <span className="text-muted"> · {hit.snippet}</span>}
+                    </span>
                   </span>
-                  <span className="shrink-0 text-[11px] tabular-nums text-faint">
-                    {formatRelativeTime(hit.lastActiveAt, Date.now())}
+                  <span className="flex shrink-0 flex-col items-end text-[11px] tabular-nums text-faint">
+                    <span>{formatRelativeTime(hit.lastActiveAt, Date.now())}</span>
+                    {typeof hit.hitCount === 'number' && hit.hitCount > 1 && (
+                      <span>{hit.hitCount} matches</span>
+                    )}
                   </span>
                 </CommandItem>
               )}

--- a/src/shared/ipc/search.ts
+++ b/src/shared/ipc/search.ts
@@ -20,8 +20,9 @@ export interface SearchQueryArgs {
 
 /**
  * One ranked Search hit. A hit is a THREAD, never an individual message
- * (CONTEXT.md "Search") — slice 2 enriches rows with `snippet`/`hitCount`/
- * `entryIndex` additively; slice 1 carries the metadata-only fields.
+ * (CONTEXT.md "Search"). The three optional fields are present iff at least one
+ * transcript prose entry contains ALL query tokens (a "strong" message match,
+ * slice 2) — a title/Workspace-only match carries just the metadata fields.
  */
 export interface SearchHit {
   threadId: string
@@ -34,6 +35,12 @@ export interface SearchHit {
   archived: boolean
   /** Epoch-ms recency — the ranking tiebreak and the row's relative timestamp. */
   lastActiveAt: number
+  /** One display line from the best-matching message (whitespace-collapsed, windowed). */
+  snippet?: string
+  /** How many prose entries contain all tokens — the within-tier rank signal. */
+  hitCount?: number
+  /** Transcript line index of the best match — the slice-3 jump-to-message pointer. */
+  entryIndex?: number
 }
 
 /** The `search:query` reply: ranked hits, best first, capped at the limit. */


### PR DESCRIPTION
## What

Slice 2 of the Search epic (#174): Search now finds Threads by **what was said** — the user's prompts and the agent's replies — behind the same `search:query` channel and UI slice 1 shipped. Rows gain a one-line snippet and an "N matches" count.

## How

- **`src/main/search/transcript-prose.ts`** (new, 9 tests) — pure extractor over the two prose entry kinds: `user-prompt.text` and `agent_message_chunk` `content.text` (shape verified against `docs/acp-capture.md` §4). Reasoning (`agent_thought_chunk`) and tool payloads (`rawInput`/`rawOutput`) are deliberately NOT searchable per the epic decision — every grep the agent ran would otherwise hit. Includes the windowed snippet builder.
- **Ranking** (`search-threads.ts`, +4 tests) — a prose entry containing ALL tokens is a *strong* match: seeds `snippet`, `hitCount` (within-tier rank), and `entryIndex` (the slice-3 jump-to-message pointer). Tokens may still match scattered across title/Workspace/messages (thread hits, no snippet). Order: title tiers > hit count > recency.
- **Handler** — reads transcripts through the `TranscriptStore` seam (its only reader, ADR-0005), scan-on-query, only for non-empty queries; per-thread read failures degrade to title-only matching, never fail the query. Resting recents unchanged (no transcript I/O).
- **`SearchHit`** — additive optional fields only; slice-1 renderer shape untouched.

## Verification

- Gates: lint, typecheck, build, test — 1323 tests green (13 new).
- End-to-end via the Playwright Electron harness with seeded JSONL transcripts: `keychain whoami` returns the thread with snippet "…can we read the keychain to call whoami for the plan tier?" + "2 matches"; a second thread whose *reasoning and tool payload* contain the same tokens correctly does **not** match; case folding (`macOS` ← `macos`) confirmed; Enter opens the Thread with the replayed transcript visible.

Refs #174 (slice 2 of 3 — remaining: jump-to-message, explicitly droppable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)