### PR TITLE
feat(search): slice 3 — jump-to-message from a Search hit (#174)

### DIFF
--- a/src/main/search/search-threads.test.ts
+++ b/src/main/search/search-threads.test.ts
@@ -115,17 +115,17 @@ describe('searchThreads', () => {
 
   it('matches transcript prose (slice 2): strong entries carry snippet/hitCount/entryIndex', () => {
     const prose = new Map([
-      ['t-miss', [{ index: 3, text: 'we should use the warm pool here' }, { index: 7, text: 'warm pool again' }]],
+      ['t-miss', [{ index: 3, itemId: 'item-3', text: 'we should use the warm pool here' }, { index: 7, itemId: 'item-7', text: 'warm pool again' }]],
     ])
     const hits = searchThreads(ws, 'warm pool', 20, prose)
     const hit = hits.find((h) => h.threadId === 't-miss')
-    expect(hit).toMatchObject({ hitCount: 2, entryIndex: 3 })
+    expect(hit).toMatchObject({ hitCount: 2, entryIndex: 3, jumpItemId: 'item-3' })
     expect(hit?.snippet).toContain('warm pool here')
   })
 
   it('ranks strong prose matches above scattered matches within tier 0, by hit count', () => {
     const prose = new Map([
-      ['t-miss', [{ index: 0, text: 'warm pool' }]], // strong body match, low recency (50)
+      ['t-miss', [{ index: 0, itemId: 'item-0', text: 'warm pool' }]], // strong body match, low recency (50)
     ])
     const ids = searchThreads(ws, 'warm pool', 20, prose).map((h) => h.threadId)
     // t-scattered (tier 0, no strong entries, recency 40) loses to the strong body hit
@@ -136,7 +136,7 @@ describe('searchThreads', () => {
 
   it('matches tokens scattered ACROSS messages (no snippet — no single strong entry)', () => {
     const prose = new Map([
-      ['t-miss', [{ index: 1, text: 'the pool is here' }, { index: 2, text: 'keep it warm' }]],
+      ['t-miss', [{ index: 1, itemId: 'item-1', text: 'the pool is here' }, { index: 2, itemId: 'item-2', text: 'keep it warm' }]],
     ])
     const hit = searchThreads(ws, 'warm pool', 20, prose).find((h) => h.threadId === 't-miss')
     expect(hit).toBeDefined()
@@ -145,7 +145,7 @@ describe('searchThreads', () => {
   })
 
   it('folds accents in prose and ignores prose entirely at rest', () => {
-    const prose = new Map([['t-miss', [{ index: 0, text: 'le café était chaud' }]]])
+    const prose = new Map([['t-miss', [{ index: 0, itemId: 'item-0', text: 'le café était chaud' }]]])
     expect(searchThreads(ws, 'cafe chaud', 20, prose).map((h) => h.threadId)).toEqual(['t-miss'])
     const resting = searchThreads(ws, '', 20, prose)
     expect(resting.every((h) => h.snippet === undefined)).toBe(true)

--- a/src/main/search/search-threads.ts
+++ b/src/main/search/search-threads.ts
@@ -110,6 +110,7 @@ export function searchThreads(
                 snippet: buildSnippet(strong.entry.text, tokens),
                 hitCount: strong.count,
                 entryIndex: strong.entry.index,
+                ...(strong.entry.itemId ? { jumpItemId: strong.entry.itemId } : {}),
               }
             : {}),
         },

--- a/src/main/search/transcript-prose.test.ts
+++ b/src/main/search/transcript-prose.test.ts
@@ -12,9 +12,21 @@ function agentChunk(text: string): TranscriptEntry {
 }
 
 describe('extractProse', () => {
-  it('extracts user prompts and agent message chunks (the conversation proper)', () => {
-    expect(extractProse({ t: 'user-prompt', id: 'p1', text: 'fix the pool' })).toBe('fix the pool')
-    expect(extractProse(agentChunk('use execFileAsync here'))).toBe('use execFileAsync here')
+  it('extracts user prompts and agent message chunks with their reducer item ids', () => {
+    expect(extractProse({ t: 'user-prompt', id: 'p1', text: 'fix the pool' })).toEqual({
+      text: 'fix the pool',
+      itemId: 'p1',
+    })
+    expect(extractProse(agentChunk('use execFileAsync here'))).toEqual({
+      text: 'use execFileAsync here',
+      itemId: 'assistant:m1',
+    })
+  })
+
+  it('degrades to itemId null (searchable, not jumpable) when the id is missing', () => {
+    expect(
+      extractProse(acpEvent({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'hi' } })),
+    ).toEqual({ text: 'hi', itemId: null })
   })
 
   it('ignores reasoning, tool payloads, and non-conversation entries (CONTEXT.md Search)', () => {
@@ -46,8 +58,8 @@ describe('proseEntries', () => {
       { t: 'turn-complete' },
     ]
     expect(proseEntries(entries)).toEqual([
-      { index: 0, text: 'hello' },
-      { index: 2, text: 'answer' },
+      { index: 0, text: 'hello', itemId: 'p1' },
+      { index: 2, text: 'answer', itemId: 'assistant:m1' },
     ])
   })
 })

--- a/src/main/search/transcript-prose.ts
+++ b/src/main/search/transcript-prose.ts
@@ -10,27 +10,38 @@ import type { TranscriptEntry } from '../../shared/ipc'
  * `agent_message_chunk` = `{content:{type:"text",text}, messageId}`.
  */
 
-/** One searchable prose piece: its transcript line index (the slice-3 jump
- * pointer) + the raw text. */
+/** One searchable prose piece: its transcript line index + the CONVERSATION ITEM
+ * id the replay reducer will mint for it (the jump-to-message anchor) + raw text. */
 export interface ProseEntry {
   /** Index of the source line in the Thread's transcript (replay order). */
   index: number
+  /**
+   * The reducer's item id for this entry — `user-prompt` replays as a user item
+   * with the prompt's own id; an `agent_message_chunk` folds into the assistant
+   * item keyed `assistant:${messageId}` (reducer.ts `appendChunk`). Null when
+   * the id can't be derived (e.g. a chunk with no messageId) — still searchable,
+   * just not jumpable.
+   */
+  itemId: string | null
   text: string
 }
 
-/** Extract an entry's searchable prose, or null when the entry carries none. */
-export function extractProse(entry: TranscriptEntry): string | null {
-  if (entry.t === 'user-prompt') return entry.text || null
+/** Extract an entry's searchable prose + jump anchor, or null when it carries none. */
+export function extractProse(entry: TranscriptEntry): { text: string; itemId: string | null } | null {
+  if (entry.t === 'user-prompt') {
+    return entry.text ? { text: entry.text, itemId: entry.id || null } : null
+  }
   if (entry.t !== 'acp-event') return null
   const message = entry.payload as { method?: unknown; params?: unknown } | null
   if (!message || message.method !== 'session/update') return null
   const update = (message.params as { update?: unknown } | undefined)?.update as
-    | { sessionUpdate?: unknown; content?: unknown }
+    | { sessionUpdate?: unknown; content?: unknown; messageId?: unknown }
     | undefined
   if (!update || update.sessionUpdate !== 'agent_message_chunk') return null
   const content = update.content as { type?: unknown; text?: unknown } | undefined
-  if (content?.type !== 'text' || typeof content.text !== 'string') return null
-  return content.text || null
+  if (content?.type !== 'text' || typeof content.text !== 'string' || !content.text) return null
+  const itemId = typeof update.messageId === 'string' ? `assistant:${update.messageId}` : null
+  return { text: content.text, itemId }
 }
 
 /**
@@ -43,8 +54,8 @@ export function proseEntries(entries: TranscriptEntry[]): ProseEntry[] {
   for (let index = 0; index < entries.length; index += 1) {
     const entry = entries[index]
     if (!entry) continue
-    const text = extractProse(entry)
-    if (text) prose.push({ index, text })
+    const extracted = extractProse(entry)
+    if (extracted) prose.push({ index, ...extracted })
   }
   return prose
 }

--- a/src/renderer/src/conversation/ColdThread.tsx
+++ b/src/renderer/src/conversation/ColdThread.tsx
@@ -5,6 +5,7 @@ import { UsageBar } from './items/UsageBar'
 import { initialConversationState, type ConversationState } from './reducer'
 import { replayTranscript, transcriptHasImages } from './replay'
 import { replayCache } from './replay-cache'
+import { useJumpToItem } from './use-jump-to-item'
 import { getWorkspaceCommands } from './workspace-commands'
 
 /**
@@ -80,8 +81,12 @@ export function ColdThread({
   const view = state ?? initialConversationState
   const title = view.title ?? thread.title ?? 'Untitled thread'
 
+  // Land a Search jump (#174 slice 3) once the replay has rendered its items.
+  const convRef = useRef<HTMLDivElement | null>(null)
+  useJumpToItem(thread.id, state !== null && view.items.length > 0, convRef)
+
   return (
-    <div className="conv conv--cold">
+    <div className="conv conv--cold" ref={convRef}>
       <div className="conv__head">
         <button className="btn btn--ghost" onClick={onClose}>
           ← Back
@@ -107,13 +112,15 @@ export function ColdThread({
             // Read-only reopened history: no live turn, so reasoning renders collapsed.
             // The retroactive skill chip (PR #213) matches against the Workspace-level
             // commands cache (#241) — no agent runs here, so there is no session list.
-            <Item
-              key={item.id}
-              item={item}
-              streaming={false}
-              onPermission={noPermission}
-              availableCommands={getWorkspaceCommands(window.localStorage, thread.workspaceId)}
-            />
+            // The data-item-id wrapper is the Search jump anchor (#174 slice 3).
+            <div key={item.id} data-item-id={item.id} className="rounded-lg">
+              <Item
+                item={item}
+                streaming={false}
+                onPermission={noPermission}
+                availableCommands={getWorkspaceCommands(window.localStorage, thread.workspaceId)}
+              />
+            </div>
           ))
         )}
       </div>

--- a/src/renderer/src/conversation/Conversation.tsx
+++ b/src/renderer/src/conversation/Conversation.tsx
@@ -19,6 +19,8 @@ import {
 import { eventBelongsToThread } from './event-routing'
 import { replayTranscript, transcriptHasImages } from './replay'
 import { replayCache } from './replay-cache'
+import { peekPendingJump } from '../search/jump-store'
+import { useJumpToItem } from './use-jump-to-item'
 import { MessageScroller } from './MessageScroller'
 import { Item } from './items/Item'
 import { UsageBar } from './items/UsageBar'
@@ -381,11 +383,18 @@ export function Conversation({
   const availableCommands =
     state.availableCommands.length > 0 ? state.availableCommands : workspaceCommands
 
+  // Land a Search jump (#174 slice 3) once this Thread's items are rendered.
+  // `hadJumpPending` is captured at MOUNT so the scroller's initial bottom-pin
+  // is suppressed for exactly the open that carries a jump (state can't flip later).
+  const convRef = useRef<HTMLDivElement | null>(null)
+  const [hadJumpPending] = useState(() => peekPendingJump(thread.threadId) !== null)
+  useJumpToItem(thread.threadId, state.items.length > 0, convRef)
+
   return (
     // Chip clicks (#116) open files through main; provided here (agentId closed over)
     // for the FileChips streamdown renders far below in the assistant markdown.
     <FileOpenProvider value={openFile}>
-      <div className="conv">
+      <div className="conv" ref={convRef}>
         <div className="conv__head">
           <span className="dot dot--ok" aria-hidden />
           <span className="conv__title">{title}</span>
@@ -394,21 +403,23 @@ export function Conversation({
 
         <UsageBar state={state} />
 
-        <MessageScroller>
+        <MessageScroller pinInitial={!hadJumpPending}>
           {state.items.length === 0 && (
             <p className="hint">Send a prompt to start the conversation.</p>
           )}
           {state.items.map((item, idx) => (
-            <Item
-              key={item.id}
-              item={item}
-              // Auto-open reasoning only for the CURRENT turn — items AFTER the last
-              // user message — so sending a new prompt doesn't re-expand the whole
-              // history's "Thinking" blocks (they belong to prior, settled turns).
-              streaming={state.isProcessing && idx > lastUserIndex}
-              onPermission={respondPermission}
-              availableCommands={availableCommands}
-            />
+            // The data-item-id wrapper is the Search jump anchor (#174 slice 3).
+            <div key={item.id} data-item-id={item.id} className="rounded-lg">
+              <Item
+                item={item}
+                // Auto-open reasoning only for the CURRENT turn — items AFTER the last
+                // user message — so sending a new prompt doesn't re-expand the whole
+                // history's "Thinking" blocks (they belong to prior, settled turns).
+                streaming={state.isProcessing && idx > lastUserIndex}
+                onPermission={respondPermission}
+                availableCommands={availableCommands}
+              />
+            </div>
           ))}
           {/* Working indicator (#115): while a turn is in flight, a self-ticking
               "Working for …" row after the transcript. It mounts when the turn opens

--- a/src/renderer/src/conversation/MessageScroller.tsx
+++ b/src/renderer/src/conversation/MessageScroller.tsx
@@ -16,12 +16,19 @@ import { cn } from '../lib/utils'
 export function MessageScroller({
   children,
   className,
+  pinInitial = true,
 }: {
   children: ReactNode
   className?: string
+  /**
+   * Whether mount scrolls to the newest message (the default). A Search jump
+   * (#174 slice 3) passes false so the initial bottom-pin doesn't race — and
+   * win against — the jump's scroll-to-item.
+   */
+  pinInitial?: boolean
 }): JSX.Element {
   const { scrollRef, contentRef, isAtBottom, scrollToBottom } = useStickToBottom({
-    initial: 'instant',
+    initial: pinInitial ? 'instant' : false,
     resize: 'smooth',
   })
   return (

--- a/src/renderer/src/conversation/use-jump-to-item.ts
+++ b/src/renderer/src/conversation/use-jump-to-item.ts
@@ -1,0 +1,61 @@
+import { useEffect, type RefObject } from 'react'
+import { consumePendingJump, peekPendingJump } from '../search/jump-store'
+
+/** Paint-timing retries: `ready` handles data timing; these bridge layout only. */
+const JUMP_RETRIES = 5
+const JUMP_RETRY_MS = 80
+
+/**
+ * Land a Search jump (#174 slice 3): when this Thread has a pending jump target,
+ * scroll its conversation item into view (centered) and flash it once. Scoped to
+ * `container` — several conversation views stay keep-mounted (hidden) at once,
+ * so a document-wide query could hit the wrong one. Runs when `ready` flips
+ * (items rendered); a missing item (transcript drifted) consumes the target and
+ * gives up quietly — the Thread just opens at the bottom, per the epic's
+ * "droppable" stance. The instant scroll also releases MessageScroller's
+ * stick-to-bottom pin, exactly as a user scroll would.
+ */
+export function useJumpToItem(
+  threadId: string,
+  ready: boolean,
+  container: RefObject<HTMLElement | null>,
+): void {
+  useEffect(() => {
+    if (!ready || peekPendingJump(threadId) === null) return
+    let cancelled = false
+    let tries = 0
+    const attempt = (): void => {
+      if (cancelled) return
+      const itemId = peekPendingJump(threadId)
+      if (itemId === null) return
+      const el = container.current?.querySelector(`[data-item-id="${CSS.escape(itemId)}"]`)
+      if (el instanceof HTMLElement) {
+        consumePendingJump(threadId)
+        el.scrollIntoView({ block: 'center' })
+        // Re-assert once after late layout shifts (code highlight, images) —
+        // content growing above the target would otherwise push it off-screen.
+        setTimeout(() => {
+          if (!cancelled) el.scrollIntoView({ block: 'center' })
+        }, 300)
+        // A brief accent wash so the eye lands on the matched message — Web
+        // Animations API, so no stylesheet coupling; cleans itself up on finish.
+        el.animate(
+          [
+            { backgroundColor: 'color-mix(in srgb, var(--accent) 18%, transparent)' },
+            { backgroundColor: 'transparent' },
+          ],
+          { duration: 1600, easing: 'ease-out' },
+        )
+      } else if (tries < JUMP_RETRIES) {
+        tries += 1
+        setTimeout(attempt, JUMP_RETRY_MS)
+      } else {
+        consumePendingJump(threadId) // item not in this replay — open-at-bottom
+      }
+    }
+    requestAnimationFrame(attempt)
+    return () => {
+      cancelled = true
+    }
+  }, [threadId, ready, container])
+}

--- a/src/renderer/src/search/SearchPalette.tsx
+++ b/src/renderer/src/search/SearchPalette.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, type JSX } from 'react'
 import { MessageSquare } from 'lucide-react'
 import type { SearchHit } from '../../../shared/ipc'
 import { formatRelativeTime } from '../shell/relative-time'
+import { setPendingJump } from './jump-store'
 import { Badge } from '../ui/badge'
 import {
   Command,
@@ -64,6 +65,9 @@ export function SearchPalette({
   }, [open, query])
 
   function selectHit(hit: SearchHit): void {
+    // Record the jump target BEFORE navigating (#174 slice 3): the conversation
+    // view that renders this Thread consumes it and scrolls to the matched item.
+    if (hit.jumpItemId) setPendingJump(hit.threadId, hit.jumpItemId)
     onOpenChange(false)
     onSelectThread(hit.workspaceId, hit.threadId)
   }

--- a/src/renderer/src/search/jump-store.test.ts
+++ b/src/renderer/src/search/jump-store.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { consumePendingJump, peekPendingJump, setPendingJump } from './jump-store'
+
+describe('jump-store', () => {
+  it('is single-shot per Thread and keyed by threadId', () => {
+    setPendingJump('t1', 'assistant:m1')
+    setPendingJump('t2', 'p9')
+    expect(peekPendingJump('t1')).toBe('assistant:m1') // peek does not consume
+    expect(peekPendingJump('t1')).toBe('assistant:m1')
+    expect(consumePendingJump('t1')).toBe('assistant:m1')
+    expect(consumePendingJump('t1')).toBeNull() // consumed exactly once
+    expect(peekPendingJump('t1')).toBeNull()
+    expect(consumePendingJump('t2')).toBe('p9') // other Threads unaffected
+  })
+
+  it('overwrites a prior target for the same Thread and misses cleanly', () => {
+    setPendingJump('t3', 'old')
+    setPendingJump('t3', 'new')
+    expect(consumePendingJump('t3')).toBe('new')
+    expect(peekPendingJump('never-set')).toBeNull()
+    expect(consumePendingJump('never-set')).toBeNull()
+  })
+})

--- a/src/renderer/src/search/jump-store.ts
+++ b/src/renderer/src/search/jump-store.ts
@@ -1,0 +1,28 @@
+/**
+ * The pending jump-to-message handoff (#174 slice 3): the Search palette records
+ * WHERE a selected hit should land (`threadId` → conversation item id), and the
+ * conversation view that next renders that Thread consumes it once and scrolls.
+ * A module-level single-shot store — renderer-only, transient by design (a
+ * relaunch or a normal sidebar open should never inherit an old jump), which is
+ * why this is not localStorage. Keying by Thread makes a stale jump harmless:
+ * opening a DIFFERENT Thread never consumes another Thread's target.
+ */
+
+const pending = new Map<string, string>()
+
+/** Record where the next open of `threadId` should land. Overwrites any prior target. */
+export function setPendingJump(threadId: string, itemId: string): void {
+  pending.set(threadId, itemId)
+}
+
+/** Read the pending target without consuming it (the retry loop peeks first). */
+export function peekPendingJump(threadId: string): string | null {
+  return pending.get(threadId) ?? null
+}
+
+/** Consume the pending target — the jump fires (or gives up) exactly once. */
+export function consumePendingJump(threadId: string): string | null {
+  const itemId = pending.get(threadId) ?? null
+  pending.delete(threadId)
+  return itemId
+}

--- a/src/shared/ipc/search.ts
+++ b/src/shared/ipc/search.ts
@@ -41,6 +41,12 @@ export interface SearchHit {
   hitCount?: number
   /** Transcript line index of the best match — the slice-3 jump-to-message pointer. */
   entryIndex?: number
+  /**
+   * The conversation ITEM id the best match replays into (user item id or
+   * `assistant:${messageId}`) — the jump-to-message scroll anchor. Absent when
+   * the id can't be derived; the row then opens at the bottom like any hit.
+   */
+  jumpItemId?: string
 }
 
 /** The `search:query` reply: ranked hits, best first, capped at the limit. */


### PR DESCRIPTION
## What

The final slice of the Search epic: selecting a Search hit opens the Thread **scrolled to the matched message** (centered, with a brief accent flash) instead of at the bottom. Closes #174.

## How

- **Main** — the strong entry's *reducer item id* (user prompt id / `assistant:${messageId}`, mirroring `reducer.ts` `appendChunk`) is derived at scan time and rides on `SearchHit.jumpItemId`; underivable ids simply omit it and the row opens at the bottom — the epic's "droppable" stance, per hit.
- **Handoff** — `search/jump-store.ts` (tested): a renderer-only, single-shot, Thread-keyed store. The palette records the target before navigating; no prop-threading through App.
- **Landing** — `useJumpToItem` in both conversation views (live `Conversation` + cold replay `ColdThread`): container-scoped lookup (several views stay keep-mounted hidden), `data-item-id` wrapper anchors, short paint-timing retries, a one-shot re-assert against late layout shifts, Web-Animations flash (no stylesheet coupling), quiet give-up when the transcript drifted.
- **The race that actually happened** — `use-stick-to-bottom`'s initial pin beat the jump and yanked the view back to the bottom (caught live in verification). `MessageScroller` gains `pinInitial`; a mount that carries a pending jump suppresses the initial pin only for that open.

## Verification

- Gates: lint, typecheck, build, test — 1326 tests green (3 new).
- Playwright harness, 60-message seeded thread: `zanzibar flag` → Enter lands the matched prompt centered near the TOP (`scrollTop 93/3739`, scroll-to-bottom pill visible). Control probe: a normal sidebar open of the same thread still pins to bottom (`atBottom: true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)