### PR TITLE
feat(skills): slice 1 — installed-skills browser in the sidebar (#259)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -69,6 +69,7 @@ import { GitStatusManager } from './git/status-stream'
 import { chokidarWatchFactory, realClock } from './git/runtime'
 import { registerGitIpc } from './git/register-ipc'
 import { registerFilesIpc } from './files/register-ipc'
+import { registerSkillsIpc } from './skills/register-ipc'
 import { registerEditorsIpc } from './editors/register-ipc'
 import { createTerminalManager, registerTerminalIpc } from './terminal/register-ipc'
 import { registerBrowserIpc } from './browser/register-ipc'
@@ -674,6 +675,7 @@ function registerIpc(deps: MainDeps): void {
     },
   })
   registerFilesIpc({ pool, cache: filesListCache })
+  registerSkillsIpc()
   registerEditorsIpc({ pool })
   terminalManager = createTerminalManager()
   registerTerminalIpc({ pool, manager: terminalManager })

--- a/src/main/skills/list-skills.test.ts
+++ b/src/main/skills/list-skills.test.ts
@@ -1,0 +1,95 @@
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { isListableSkillPath, listSkills } from './list-skills'
+import { skillSearchDirs } from './skill-dirs'
+
+async function writeSkill(root: string, dirName: string, frontmatter: string): Promise<string> {
+  const dir = join(root, dirName)
+  await mkdir(dir, { recursive: true })
+  const file = join(dir, 'SKILL.md')
+  await writeFile(file, `---\n${frontmatter}\n---\n\nBody.\n`)
+  return file
+}
+
+describe('skillSearchDirs', () => {
+  it('orders project .vibe → project .agents → $VIBE_HOME → ~/.agents, honoring VIBE_HOME', () => {
+    const dirs = skillSearchDirs('/ws', { VIBE_HOME: '/custom-vibe' }, '/home/u')
+    expect(dirs).toEqual([
+      { dir: join('/ws', '.vibe', 'skills'), scope: 'project' },
+      { dir: join('/ws', '.agents', 'skills'), scope: 'project' },
+      { dir: join('/custom-vibe', 'skills'), scope: 'global' },
+      { dir: join('/home/u', '.agents', 'skills'), scope: 'global' },
+    ])
+    // no Workspace → global only; VIBE_HOME default = ~/.vibe
+    expect(skillSearchDirs(null, {}, '/home/u')).toEqual([
+      { dir: join('/home/u', '.vibe', 'skills'), scope: 'global' },
+      { dir: join('/home/u', '.agents', 'skills'), scope: 'global' },
+    ])
+  })
+})
+
+describe('listSkills', () => {
+  it('scans immediate subdirs, derives scope, applies first-name-wins, sorts by name', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skills-test-'))
+    const project = join(root, 'ws', '.vibe', 'skills')
+    const globalVibe = join(root, 'home', '.vibe', 'skills')
+    await writeSkill(project, 'deploy', 'name: deploy\ndescription: Project deploy')
+    await writeSkill(globalVibe, 'deploy', 'name: deploy\ndescription: Global deploy (shadowed)')
+    await writeSkill(globalVibe, 'audit', 'name: audit\ndescription: Audit things')
+
+    const skills = await listSkills([
+      { dir: project, scope: 'project' },
+      { dir: globalVibe, scope: 'global' },
+    ])
+    expect(skills.map((s) => s.name)).toEqual(['audit', 'deploy']) // sorted
+    expect(skills.find((s) => s.name === 'deploy')).toMatchObject({
+      scope: 'project',
+      description: 'Project deploy', // project shadows global (first wins)
+      userInvocable: true,
+    })
+    expect(skills.find((s) => s.name === 'deploy')?.path).toBe(join(project, 'deploy', 'SKILL.md'))
+  })
+
+  it('skips reserved names, non-parsing skills, bare files, and missing dirs — never throws', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skills-test-'))
+    const dir = join(root, 'skills')
+    await writeSkill(dir, 'vibe', 'name: vibe\ndescription: reserved built-in')
+    await writeSkill(dir, 'help', 'name: help\ndescription: reserved command')
+    await writeSkill(dir, 'broken', 'no-frontmatter-fields: true')
+    await mkdir(join(dir, 'empty-dir'))
+    await writeFile(join(dir, 'stray-file.md'), 'not a skill dir')
+    await writeSkill(dir, 'keeper', 'name: keeper\ndescription: The one that loads\nuser-invocable: false')
+
+    const skills = await listSkills([
+      { dir, scope: 'global' },
+      { dir: join(root, 'does-not-exist'), scope: 'global' },
+    ])
+    expect(skills).toEqual([
+      {
+        name: 'keeper',
+        description: 'The one that loads',
+        scope: 'global',
+        path: join(dir, 'keeper', 'SKILL.md'),
+        userInvocable: false,
+      },
+    ])
+  })
+})
+
+describe('isListableSkillPath (the reveal gate)', () => {
+  const dirs = [{ dir: '/home/u/.vibe/skills', scope: 'global' as const }]
+
+  it('accepts only <search-dir>/<skill>/SKILL.md', () => {
+    expect(isListableSkillPath('/home/u/.vibe/skills/deploy/SKILL.md', dirs)).toBe(true)
+    expect(isListableSkillPath('/home/u/.vibe/skills/deploy/notes.md', dirs)).toBe(false)
+    expect(isListableSkillPath('/home/u/.vibe/skills/deploy/nested/SKILL.md', dirs)).toBe(false)
+    expect(isListableSkillPath('/home/u/.ssh/id_rsa', dirs)).toBe(false)
+  })
+
+  it('refuses traversal out of the search dirs', () => {
+    expect(isListableSkillPath('/home/u/.vibe/skills/../../.ssh/SKILL.md', dirs)).toBe(false)
+    expect(isListableSkillPath('/home/u/.vibe/skills-evil/x/SKILL.md', dirs)).toBe(false)
+  })
+})

--- a/src/main/skills/list-skills.ts
+++ b/src/main/skills/list-skills.ts
@@ -1,0 +1,62 @@
+import { readdir, readFile } from 'node:fs/promises'
+import { join, resolve, sep } from 'node:path'
+import type { SkillInfo } from '../../shared/ipc'
+import { parseSkillFrontmatter } from './parse-skill'
+import { RESERVED_SKILL_NAMES, type SkillDir } from './skill-dirs'
+
+/**
+ * Scan the skill search dirs and parse each skill (#259) — mirroring Vibe's
+ * `_discover_skills`: IMMEDIATE subdirectories only (no recursion), one
+ * `SKILL.md` per skill dir, first NAME wins across the precedence order,
+ * reserved names dropped. Everything is best-effort: a missing search dir is
+ * the normal fresh-install case, an unreadable/unparseable `SKILL.md` skips
+ * that one skill — a scan never throws.
+ */
+export async function listSkills(dirs: SkillDir[]): Promise<SkillInfo[]> {
+  const byName = new Map<string, SkillInfo>()
+  for (const { dir, scope } of dirs) {
+    let children: Array<{ name: string; isDirectory(): boolean }>
+    try {
+      children = await readdir(dir, { withFileTypes: true })
+    } catch {
+      continue // absent dir — a fresh install has none of them
+    }
+    for (const child of children) {
+      if (!child.isDirectory()) continue
+      const skillFile = join(dir, child.name, 'SKILL.md')
+      let content: string
+      try {
+        content = await readFile(skillFile, 'utf8')
+      } catch {
+        continue // a dir without SKILL.md isn't a skill
+      }
+      const parsed = parseSkillFrontmatter(content)
+      if (!parsed) continue
+      if (RESERVED_SKILL_NAMES.has(parsed.name)) continue
+      if (byName.has(parsed.name)) continue // first occurrence wins (Vibe parity)
+      byName.set(parsed.name, {
+        name: parsed.name,
+        description: parsed.description,
+        scope,
+        path: skillFile,
+        userInvocable: parsed.userInvocable,
+      })
+    }
+  }
+  return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name))
+}
+
+/**
+ * Whether `path` points at a `SKILL.md` directly under one of the search dirs —
+ * the reveal gate: the renderer can only reveal what a scan could have listed.
+ * Pure string containment on RESOLVED paths (reveal itself never opens/executes).
+ */
+export function isListableSkillPath(path: string, dirs: SkillDir[]): boolean {
+  const resolved = resolve(path)
+  return dirs.some(({ dir }) => {
+    const root = resolve(dir) + sep
+    if (!resolved.startsWith(root)) return false
+    const rest = resolved.slice(root.length).split(sep)
+    return rest.length === 2 && rest[1] === 'SKILL.md'
+  })
+}

--- a/src/main/skills/parse-skill.test.ts
+++ b/src/main/skills/parse-skill.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import { parseSkillFrontmatter } from './parse-skill'
+
+function skillMd(frontmatter: string, body = 'Do the thing.'): string {
+  return `---\n${frontmatter}\n---\n\n${body}\n`
+}
+
+describe('parseSkillFrontmatter', () => {
+  it('parses the required fields with the user-invocable default (true)', () => {
+    expect(parseSkillFrontmatter(skillMd('name: review-pr\ndescription: Review a PR'))).toEqual({
+      name: 'review-pr',
+      description: 'Review a PR',
+      userInvocable: true,
+    })
+  })
+
+  it('honors quotes, hyphenated keys, comments, and an explicit user-invocable: false', () => {
+    const content = skillMd(
+      `# a comment\nname: "deploy"\ndescription: 'Ship it safely'\nuser-invocable: false\nlicense: MIT`,
+    )
+    expect(parseSkillFrontmatter(content)).toEqual({
+      name: 'deploy',
+      description: 'Ship it safely',
+      userInvocable: false,
+    })
+  })
+
+  it('ignores nested structures (metadata dicts) without breaking scalar fields', () => {
+    const content = skillMd('name: x1\ndescription: has metadata\nmetadata:\n  type: user\n  extra: 1')
+    expect(parseSkillFrontmatter(content)).toMatchObject({ name: 'x1', description: 'has metadata' })
+  })
+
+  it('folds block-scalar descriptions (>- / |) — the shape real skills use', () => {
+    const folded = skillMd('name: caveman\ndescription: >-\n  Ultra-compressed mode.\n  Cuts tokens.\nuser-invocable: true')
+    expect(parseSkillFrontmatter(folded)).toMatchObject({
+      description: 'Ultra-compressed mode. Cuts tokens.',
+    })
+    const literal = skillMd('name: lit\ndescription: |\n  Line one.\n  Line two.')
+    expect(parseSkillFrontmatter(literal)).toMatchObject({ description: 'Line one. Line two.' })
+  })
+
+  it('joins plain-scalar continuation lines (multi-line description without a block marker)', () => {
+    const content = skillMd(
+      'name: clerk\ndescription: Clerk authentication router. Use when user asks\n  about Clerk CLI operations,\n  or setting up Clerk.',
+    )
+    expect(parseSkillFrontmatter(content)).toMatchObject({
+      description: 'Clerk authentication router. Use when user asks about Clerk CLI operations, or setting up Clerk.',
+    })
+    // continuation must not leak into the NEXT field
+    const twoFields = skillMd('name: x2\ndescription: first\n  continued\nuser-invocable: false')
+    expect(parseSkillFrontmatter(twoFields)).toEqual({
+      name: 'x2',
+      description: 'first continued',
+      userInvocable: false,
+    })
+  })
+
+  it("rejects files that don't start with a fence, lack a closing fence, or miss required fields", () => {
+    expect(parseSkillFrontmatter('name: x\ndescription: y')).toBeNull()
+    expect(parseSkillFrontmatter('---\nname: x\ndescription: y')).toBeNull()
+    expect(parseSkillFrontmatter(skillMd('name: solo'))).toBeNull() // no description
+    expect(parseSkillFrontmatter(skillMd('description: no name'))).toBeNull()
+  })
+
+  it("rejects names outside Vibe's shape (lowercase alnum + hyphens, ≤64)", () => {
+    expect(parseSkillFrontmatter(skillMd('name: Bad Name\ndescription: d'))).toBeNull()
+    expect(parseSkillFrontmatter(skillMd('name: -lead\ndescription: d'))).toBeNull()
+    expect(parseSkillFrontmatter(skillMd(`name: ${'a'.repeat(65)}\ndescription: d`))).toBeNull()
+    expect(parseSkillFrontmatter(skillMd('name: ok-2\ndescription: d'))).not.toBeNull()
+  })
+})

--- a/src/main/skills/parse-skill.ts
+++ b/src/main/skills/parse-skill.ts
@@ -1,0 +1,78 @@
+/**
+ * Minimal `SKILL.md` frontmatter parsing (#259) — deliberately NOT a YAML
+ * dependency: the three fields the browser needs (`name`, `description`,
+ * `user-invocable`) are plain scalars, and Vibe's own contract (mistral-vibe
+ * `parser.py:15-39` + `SkillMetadata`) is what we mirror: the file must BEGIN
+ * with a `---` fence, frontmatter runs to the next `---` line, `name` and
+ * `description` are required, `user-invocable` defaults to true. A file that
+ * doesn't parse is skipped by the scanner (Vibe skips it too), never a throw.
+ */
+
+export interface SkillFrontmatter {
+  name: string
+  description: string
+  userInvocable: boolean
+}
+
+/** Vibe's skill-name shape (`SkillMetadata.name`): lowercase alnum + hyphens, 1–64. */
+const NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+
+/** Strip one layer of matching single/double quotes. */
+function unquote(value: string): string {
+  if (
+    value.length >= 2 &&
+    ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'")))
+  ) {
+    return value.slice(1, -1)
+  }
+  return value
+}
+
+/** Parse a `SKILL.md`'s frontmatter, or null when it isn't a loadable skill. */
+export function parseSkillFrontmatter(content: string): SkillFrontmatter | null {
+  const lines = content.split(/\r?\n/)
+  if (lines[0]?.trim() !== '---') return null
+  const closing = lines.findIndex((line, i) => i > 0 && line.trim() === '---')
+  if (closing === -1) return null
+
+  // Real-world descriptions are frequently MULTI-LINE — YAML block scalars
+  // (`description: >-` + indented lines) or plain scalars continued on indented
+  // lines — so each top-level key consumes its following INDENTED lines:
+  // block/plain values fold them in (joined with spaces — display-fidelity is
+  // all we need); an EMPTY value (a nested dict like `metadata:`) skips them.
+  const fields = new Map<string, string>()
+  let i = 1
+  while (i < closing) {
+    const line = lines[i] as string
+    i += 1
+    if (!line.trim() || line.trim().startsWith('#') || /^\s/.test(line)) continue
+    const colon = line.indexOf(':')
+    if (colon <= 0) continue
+    const key = line.slice(0, colon).trim().toLowerCase()
+    const rawValue = line.slice(colon + 1).trim()
+
+    const continuation: string[] = []
+    while (i < closing) {
+      const next = lines[i] as string
+      if (next.trim() !== '' && !/^\s/.test(next)) break // next top-level key
+      i += 1
+      if (next.trim()) continuation.push(next.trim())
+    }
+
+    if (rawValue === '') continue // nested block (e.g. `metadata:`) — not a scalar field
+    const isBlockScalar = /^[>|][+-]?$/.test(rawValue)
+    const value = isBlockScalar
+      ? continuation.join(' ')
+      : [unquote(rawValue), ...continuation].join(' ')
+    fields.set(key, value)
+  }
+
+  const name = fields.get('name') ?? ''
+  const description = fields.get('description') ?? ''
+  if (!NAME_PATTERN.test(name) || name.length > 64) return null
+  if (!description) return null
+  // Vibe's default is true; only an explicit false-y scalar turns it off.
+  const invocableRaw = fields.get('user-invocable')?.toLowerCase()
+  const userInvocable = !(invocableRaw === 'false' || invocableRaw === 'no' || invocableRaw === 'off')
+  return { name, description, userInvocable }
+}

--- a/src/main/skills/register-ipc.ts
+++ b/src/main/skills/register-ipc.ts
@@ -1,0 +1,36 @@
+import { ipcMain, shell } from 'electron'
+import { homedir } from 'node:os'
+import {
+  IPC,
+  type SkillsListArgs,
+  type SkillsListResult,
+  type SkillsRevealArgs,
+} from '../../shared/ipc'
+import { getShellEnv } from '../shell-env'
+import { isListableSkillPath, listSkills } from './list-skills'
+import { skillSearchDirs } from './skill-dirs'
+
+/**
+ * The Skills-browser IPC handlers (#259), registered beside their modules
+ * (the git/files registrar pattern). No agent involved — skills are Vibe-owned
+ * on-disk config main scans itself, so the browser works with zero warm agents.
+ * The shell env supplies `VIBE_HOME` (same resolution the spawned agent sees).
+ * NOT agent activity: no pool, no touch — listing skills never keeps anything alive.
+ */
+export function registerSkillsIpc(): void {
+  ipcMain.handle(IPC.skillsList, (_event, args: SkillsListArgs): Promise<SkillsListResult> => {
+    return listSkills(skillSearchDirs(args.workspaceDir, getShellEnv(), homedir()))
+  })
+
+  ipcMain.handle(IPC.skillsReveal, (_event, args: SkillsRevealArgs): void => {
+    // Reveal-only (never open/execute — no Launch Services), and gated: the path
+    // must be a SKILL.md directly under a CURRENT search dir, i.e. something a
+    // scan could have listed. An out-of-tree path is refused + logged.
+    const dirs = skillSearchDirs(args.workspaceDir, getShellEnv(), homedir())
+    if (!isListableSkillPath(args.path, dirs)) {
+      console.error(`[vibe-mistro:skills] reveal refused (outside skill dirs): ${args.path}`)
+      return
+    }
+    shell.showItemInFolder(args.path)
+  })
+}

--- a/src/main/skills/skill-dirs.ts
+++ b/src/main/skills/skill-dirs.ts
@@ -1,0 +1,51 @@
+import { join } from 'node:path'
+
+/**
+ * The skill search directories, in Vibe's exact precedence order (#259; verified
+ * against mistral-vibe `SkillManager._compute_search_paths` + `find_local_config_dirs`):
+ * project `.vibe/skills` → project `.agents/skills` → `$VIBE_HOME/skills`
+ * (default `~/.vibe/skills`) → `~/.agents/skills`. First occurrence of a skill
+ * NAME wins across this order, so project skills shadow global ones.
+ *
+ * Out of scope for v1 (issue #259): `config.toml` `skill_paths` extras and the
+ * enabled/disabled filters; Vibe's trusted-folder gate on project dirs (we are a
+ * read-only browser of what's on disk, not an executor).
+ */
+
+export interface SkillDir {
+  dir: string
+  scope: 'project' | 'global'
+}
+
+/** Names Vibe reserves — an on-disk skill with one of these is never loaded.
+ * (`vibe` = the code-only built-in skill; the rest are ACP built-in commands.) */
+export const RESERVED_SKILL_NAMES: ReadonlySet<string> = new Set([
+  'vibe',
+  'help',
+  'compact',
+  'reload',
+  'log',
+  'mcp',
+  'teleport',
+  'proxy-setup',
+  'leanstall',
+  'unleanstall',
+  'data-retention',
+])
+
+/** Assemble the search dirs for a Workspace. Pure — env + home are injected. */
+export function skillSearchDirs(
+  workspaceDir: string | null,
+  env: NodeJS.ProcessEnv,
+  home: string,
+): SkillDir[] {
+  const vibeHome = env.VIBE_HOME || join(home, '.vibe')
+  const dirs: SkillDir[] = []
+  if (workspaceDir) {
+    dirs.push({ dir: join(workspaceDir, '.vibe', 'skills'), scope: 'project' })
+    dirs.push({ dir: join(workspaceDir, '.agents', 'skills'), scope: 'project' })
+  }
+  dirs.push({ dir: join(vibeHome, 'skills'), scope: 'global' })
+  dirs.push({ dir: join(home, '.agents', 'skills'), scope: 'global' })
+  return dirs
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -52,6 +52,9 @@ import {
   type OpenThreadArgs,
   type SearchQueryArgs,
   type SearchQueryResult,
+  type SkillsListArgs,
+  type SkillsListResult,
+  type SkillsRevealArgs,
   type SendPromptArgs,
   type SendPromptResult,
   type AccountWhoamiResult,
@@ -127,6 +130,10 @@ const api = {
     ipcRenderer.invoke(IPC.readThreadAttachments, threadId),
   searchQuery: (args: SearchQueryArgs): Promise<SearchQueryResult> =>
     ipcRenderer.invoke(IPC.searchQuery, args),
+  skillsList: (args: SkillsListArgs): Promise<SkillsListResult> =>
+    ipcRenderer.invoke(IPC.skillsList, args),
+  skillsReveal: (args: SkillsRevealArgs): Promise<void> =>
+    ipcRenderer.invoke(IPC.skillsReveal, args),
   gitSubscribeStatus: (args: GitStatusSubscriptionArgs): Promise<void> =>
     ipcRenderer.invoke(IPC.gitSubscribeStatus, args),
   gitUnsubscribeStatus: (args: GitStatusSubscriptionArgs): Promise<void> =>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -34,6 +34,7 @@ import { ArrowLeft, ArrowRight, Maximize2, PanelLeft, PanelRight, Terminal } fro
 import { IconButton } from './ui/icon-button'
 import { OpenInEditorButton } from './editors/OpenInEditorButton'
 import { SearchPalette } from './search/SearchPalette'
+import { SkillsView } from './skills/SkillsView'
 import { Shell, type WorkspaceFlags } from './shell/Shell'
 import { Logo } from './shell/logo'
 import { firstRunState } from './shell/first-run'
@@ -596,12 +597,16 @@ export function App(): JSX.Element {
   // so each NON-connected view re-adds the old p-6 breathing room via a wrapper here;
   // the connected view spends it inside its chat column (ConnectedWorkspace) instead.
   const inSettings = nav.view === 'settings'
+  // The Skills browser (#259): a sibling routed outlet view, same keep-mounted
+  // contract as Settings — connected Workspaces hide (not unmount) beneath it.
+  const inSkills = nav.view === 'skills'
+  const overlayView = inSettings || inSkills
   // Persistent missing-CLI banner (visibility is the pure `installBannerMessage`):
   // spans the shell under the window chrome so a selected Workspace / open Thread
   // still surfaces the missing toolchain; suppressed where the fuller guidance is
   // already on screen (the needs-install first-run outlet, Settings' Environment).
   const emptyOutletVisible =
-    !inSettings && selected.status === 'idle' && !findSelectedThread(recents, nav)
+    !overlayView && selected.status === 'idle' && !findSelectedThread(recents, nav)
   const installBanner = installBannerMessage({
     detect,
     inSettings,
@@ -615,8 +620,8 @@ export function App(): JSX.Element {
         return (
           // h-full: complete the height chain from <main> down to `.conv` (100%)
           // so the transcript scrolls internally and the Composer stays pinned.
-          <div key={wid} className="h-full" hidden={inSettings || wid !== selectedWs}>
-            {renderConnected(conn.thread, !inSettings && wid === selectedWs, wsFlags[wid]?.streaming ?? false)}
+          <div key={wid} className="h-full" hidden={overlayView || wid !== selectedWs}>
+            {renderConnected(conn.thread, !overlayView && wid === selectedWs, wsFlags[wid]?.streaming ?? false)}
           </div>
         )
       })}
@@ -652,6 +657,17 @@ export function App(): JSX.Element {
             navDispatch({ type: 'close-settings' })
           }}
         />
+        </div>
+      ) : inSkills ? (
+        <div className="p-6">
+          <SkillsView
+            // The selected Workspace's dir feeds the PROJECT skill dirs; null =
+            // global skills only (nothing selected). Cold metadata is enough —
+            // no agent/connection is involved in listing skills (#259).
+            workspaceDir={recents.find((w) => w.id === selectedWs)?.dir ?? null}
+            workspaceName={recents.find((w) => w.id === selectedWs)?.displayName ?? null}
+            onClose={() => navDispatch({ type: 'close-skills' })}
+          />
         </div>
       ) : selected.status === 'connected' ? null : ( // connected: rendered (visible) in the keep-mounted map above
         // h-full so a cold Thread's `.conv` (height: 100%) keeps its internal scroll.
@@ -788,6 +804,7 @@ export function App(): JSX.Element {
         }}
         onOpenSettings={() => navDispatch({ type: 'open-settings' })}
         onOpenSearch={() => setSearchOpen(true)}
+        onOpenSkills={() => navDispatch({ type: 'open-skills' })}
       />
 
       <SearchPalette

--- a/src/renderer/src/shell/Shell.tsx
+++ b/src/renderer/src/shell/Shell.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type JSX, type PointerEvent, type ReactNode } from 'react'
-import { ChevronDown, Search, Settings, SquarePen } from 'lucide-react'
+import { ChevronDown, Search, Settings, Sparkles, SquarePen } from 'lucide-react'
 import type { ListMetadataResult } from '../../../shared/ipc'
 import type { NavState } from './nav-reducer'
 import type { UnifiedThreadRow } from './unified-threads'
@@ -49,6 +49,7 @@ export function Shell({
   actions,
   onOpenSettings,
   onOpenSearch,
+  onOpenSkills,
 }: {
   /** Whether the left sidebar is collapsed (#127) — animate its width to 0 (still mounted). */
   collapsed: boolean
@@ -76,6 +77,8 @@ export function Shell({
   onOpenSettings: () => void
   /** Open the Search palette (#174) — from the primary nav's Search row (or ⌘K). */
   onOpenSearch: () => void
+  /** Open the Skills browser (#259) — from the primary nav's Skills row. */
+  onOpenSkills: () => void
 }): JSX.Element {
   // The sidebar's EXPANDED width (#drag-to-resize): renderer-only UI state, seeded from
   // localStorage (clamped) and persisted on drag-release. `dragging` disables the
@@ -150,7 +153,12 @@ export function Shell({
             resized width (not shrinking) so content slides under the clip on collapse. */}
         <div className="flex h-full flex-none flex-col gap-3 p-3" style={{ width }}>
           <div className="flex flex-none flex-col gap-3">
-            <PrimaryNav busy={opening} onNewThread={onNewThread} onOpenSearch={onOpenSearch} />
+            <PrimaryNav
+              busy={opening}
+              onNewThread={onNewThread}
+              onOpenSearch={onOpenSearch}
+              onOpenSkills={onOpenSkills}
+            />
           </div>
           <div className="min-h-0 flex-1 overflow-y-auto">
             <WorkspaceNav
@@ -206,18 +214,21 @@ export function Shell({
  * `--accent-fill`). It's ALWAYS actionable now — `onNewThread` (App's `startNewChat`)
  * targets the selected/most-recent project (connect-if-needed) or opens the picker when
  * there are none — so it's only disabled while a connect is in flight (`busy`). Below it,
- * Search opens the Search palette (#174; also ⌘K). The old Scheduled / Plugins "Soon"
- * placeholders are HIDDEN for v1 (user call, 2026-07-03): their epics (#175 / #176)
- * stay parked, and unbuilt rows shouldn't greet first-version users.
+ * Search opens the Search palette (#174; also ⌘K); Skills opens the Skills browser
+ * (#259, the slot Plugins vacated). The old Scheduled / Plugins "Soon" placeholders
+ * are HIDDEN for v1 (user call, 2026-07-03): their epics (#175 / #176) stay parked
+ * as backlog, and unbuilt rows shouldn't greet first-version users.
  */
 function PrimaryNav({
   busy,
   onNewThread,
   onOpenSearch,
+  onOpenSkills,
 }: {
   busy: boolean
   onNewThread: () => void
   onOpenSearch: () => void
+  onOpenSkills: () => void
 }): JSX.Element {
   return (
     <nav className="flex flex-col gap-0.5">
@@ -234,6 +245,10 @@ function PrimaryNav({
         <Search className="size-[18px]" aria-hidden />
         <span className="flex-1">Search</span>
         <span className="text-[11px] font-medium text-faint">⌘K</span>
+      </NavItem>
+      <NavItem onClick={onOpenSkills}>
+        <Sparkles className="size-[18px]" aria-hidden />
+        <span className="flex-1">Skills</span>
       </NavItem>
     </nav>
   )

--- a/src/renderer/src/shell/nav-reducer.test.ts
+++ b/src/renderer/src/shell/nav-reducer.test.ts
@@ -86,6 +86,27 @@ describe('navReducer', () => {
       expect(next).not.toBe(start) // not a no-op here: it must exit Settings
     })
   })
+
+  describe('Skills view (#259)', () => {
+    it('open-skills / close-skills mirror the Settings contract, preserving the selection', () => {
+      const start: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 't1', view: 'conversation' }
+      const open = navReducer(start, { type: 'open-skills' })
+      expect(open).toEqual({ selectedWorkspaceId: 'w1', selectedThreadId: 't1', view: 'skills' })
+      expect(navReducer(open, { type: 'open-skills' })).toBe(open) // referential no-op
+      expect(navReducer(open, { type: 'close-skills' })).toEqual(start)
+    })
+
+    it('selecting a Thread while in Skills leaves Skills (resets view)', () => {
+      const start: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: null, view: 'skills' }
+      const next = navReducer(start, { type: 'select-thread', workspaceId: 'w1', threadId: 't2' })
+      expect(next).toEqual({ selectedWorkspaceId: 'w1', selectedThreadId: 't2', view: 'conversation' })
+    })
+
+    it('open-settings from Skills swaps views directly', () => {
+      const start: NavState = { selectedWorkspaceId: null, selectedThreadId: null, view: 'skills' }
+      expect(navReducer(start, { type: 'open-settings' }).view).toBe('settings')
+    })
+  })
 })
 
 describe('findSelectedThread (cold-outlet derivation)', () => {

--- a/src/renderer/src/shell/nav-reducer.ts
+++ b/src/renderer/src/shell/nav-reducer.ts
@@ -15,12 +15,12 @@ export interface NavState {
   selectedThreadId: string | null
   /**
    * WHICH top-level outlet view is showing (#130). `'settings'` swaps the outlet for
-   * the on-demand Settings page (env/CLI status + future settings), leaving the
-   * Workspace/Thread selection intact so closing it returns to the same conversation.
-   * Any `select-workspace` / `select-thread` (picking a project or thread from the
-   * sidebar) resets it to `'conversation'` — navigating leaves Settings.
+   * the on-demand Settings page (env/CLI status + future settings); `'skills'` for
+   * the Skills browser (#259) — both leave the Workspace/Thread selection intact so
+   * closing returns to the same conversation. Any `select-workspace` / `select-thread`
+   * (picking a project or thread from the sidebar) resets it to `'conversation'`.
    */
-  view: 'conversation' | 'settings'
+  view: 'conversation' | 'settings' | 'skills'
 }
 
 export type NavAction =
@@ -28,6 +28,8 @@ export type NavAction =
   | { type: 'select-thread'; workspaceId: string; threadId: string }
   | { type: 'open-settings' }
   | { type: 'close-settings' }
+  | { type: 'open-skills' }
+  | { type: 'close-skills' }
   | { type: 'clear' }
 
 export const initialNavState: NavState = {
@@ -56,7 +58,11 @@ export function navReducer(state: NavState, action: NavAction): NavState {
       // Swap the outlet for the Settings page, PRESERVING the current selection.
       // Referential no-op when already in Settings (uniform with select-workspace).
       return state.view === 'settings' ? state : { ...state, view: 'settings' }
+    case 'open-skills':
+      // Swap the outlet for the Skills browser (#259) — same contract as Settings.
+      return state.view === 'skills' ? state : { ...state, view: 'skills' }
     case 'close-settings':
+    case 'close-skills':
       // Return to the conversation view, PRESERVING the current selection.
       return state.view === 'conversation' ? state : { ...state, view: 'conversation' }
     case 'clear':

--- a/src/renderer/src/skills/SkillsView.tsx
+++ b/src/renderer/src/skills/SkillsView.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState, type JSX } from 'react'
+import { ArrowLeft, FolderSearch, Sparkles } from 'lucide-react'
+import type { SkillInfo } from '../../../shared/ipc'
+import { Badge } from '../ui/badge'
+import { Button } from '../ui/button'
+import { IconButton } from '../ui/icon-button'
+
+/**
+ * The Skills browser (#259): a routed outlet view (the Settings pattern) listing
+ * the installed Vibe skills for the selected Workspace + global — scanned and
+ * parsed by MAIN from the on-disk `SKILL.md` dirs, no agent involved, so it
+ * works process-free. Scan-on-open: mounting (and switching Workspace) re-lists;
+ * there is no filesystem watching (#259 out of scope). Rows carry a scope badge
+ * (project shadows global, Vibe's first-name-wins) and a "not invocable" badge
+ * for `user-invocable: false` skills the `/` menu would hide — the browser shows
+ * the on-disk truth. Reveal goes through the gated `skills:reveal` IPC.
+ */
+export function SkillsView({
+  workspaceDir,
+  workspaceName,
+  onClose,
+}: {
+  /** The selected Workspace's directory (project skills), or null = global only. */
+  workspaceDir: string | null
+  /** Display name for the project-scope hint (null when no Workspace is selected). */
+  workspaceName: string | null
+  onClose: () => void
+}): JSX.Element {
+  // null = scanning; [] = scanned, nothing installed.
+  const [skills, setSkills] = useState<SkillInfo[] | null>(null)
+
+  useEffect(() => {
+    let active = true
+    setSkills(null)
+    void window.api.skillsList({ workspaceDir }).then((result) => {
+      if (active) setSkills(result)
+    })
+    return () => {
+      active = false
+    }
+  }, [workspaceDir])
+
+  return (
+    <div className="mx-auto flex w-full max-w-[560px] flex-col gap-5">
+      <div className="flex items-center gap-2">
+        <IconButton aria-label="Back" title="Back" onClick={onClose}>
+          <ArrowLeft className="size-4" aria-hidden />
+        </IconButton>
+        <h1 className="text-[19px] font-semibold tracking-tight text-text-strong">Skills</h1>
+      </div>
+      <p className="text-[13px] text-muted">
+        The agent skills installed on this machine — invoked with <code>/name</code> in the
+        composer. Project skills{workspaceName ? ` (${workspaceName})` : ''} shadow global ones
+        of the same name.
+      </p>
+
+      {skills === null ? (
+        <div className="rounded-[9px] border border-border p-3 text-[13px] text-muted">
+          Scanning skill folders…
+        </div>
+      ) : skills.length === 0 ? (
+        <div className="flex flex-col gap-2 rounded-[9px] border border-border p-4 text-[13px] text-muted">
+          <span className="flex items-center gap-2 font-semibold text-text-strong">
+            <Sparkles className="size-4" aria-hidden />
+            No skills installed
+          </span>
+          <span>
+            Create one at <code>~/.vibe/skills/&lt;name&gt;/SKILL.md</code> (global) or{' '}
+            <code>.vibe/skills/&lt;name&gt;/SKILL.md</code> inside a project — a Markdown file
+            with <code>name</code> and <code>description</code> frontmatter. Vibe picks it up on
+            its next session (or <code>/reload</code>).
+          </span>
+        </div>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {skills.map((skill) => (
+            <li
+              key={skill.name}
+              className="flex items-start gap-3 rounded-[9px] border border-border p-3"
+            >
+              <Sparkles className="mt-0.5 size-4 shrink-0 text-muted" aria-hidden />
+              <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                <span className="flex min-w-0 items-center gap-1.5">
+                  <span className="truncate text-[13px] font-semibold text-text-strong">
+                    /{skill.name}
+                  </span>
+                  <Badge
+                    variant={skill.scope === 'project' ? 'accent' : 'outline'}
+                    className="shrink-0 px-1.5 py-0 text-[10px]"
+                  >
+                    {skill.scope === 'project' ? 'Project' : 'Global'}
+                  </Badge>
+                  {!skill.userInvocable && (
+                    <Badge variant="outline" className="shrink-0 px-1.5 py-0 text-[10px] text-muted">
+                      not invocable
+                    </Badge>
+                  )}
+                </span>
+                <span className="text-[13px] text-muted">{skill.description}</span>
+                <span className="truncate text-[11px] text-faint">{skill.path}</span>
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                className="shrink-0"
+                title="Reveal SKILL.md in the file manager"
+                onClick={() => void window.api.skillsReveal({ workspaceDir, path: skill.path })}
+              >
+                <FolderSearch className="size-3.5" aria-hidden />
+                Reveal
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/shared/ipc/index.ts
+++ b/src/shared/ipc/index.ts
@@ -19,6 +19,7 @@ import { editorsChannels } from './editors'
 import { terminalChannels } from './terminal'
 import { browserChannels } from './browser'
 import { searchChannels } from './search'
+import { skillsChannels } from './skills'
 
 /**
  * The one typed channel map. ONE exported object — the channel names are the wire
@@ -36,6 +37,7 @@ export const IPC = {
   ...terminalChannels,
   ...browserChannels,
   ...searchChannels,
+  ...skillsChannels,
 } as const
 
 export * from './core'
@@ -48,3 +50,4 @@ export * from './editors'
 export * from './terminal'
 export * from './browser'
 export * from './search'
+export * from './skills'

--- a/src/shared/ipc/skills.ts
+++ b/src/shared/ipc/skills.ts
@@ -1,0 +1,49 @@
+/**
+ * Skills domain of the shared IPC contract (#259): the Skills browser's channels
+ * + payload types. Skills are Vibe-owned ON-DISK config (`SKILL.md` directories);
+ * main scans and parses them itself — no agent involved, so the browser works
+ * with zero warm agents (process-free, like the cold Thread list). Keep this
+ * file free of Node/DOM imports so both sides can consume it.
+ */
+
+/** The skills channel entries, merged into the single `IPC` const in `./index`. */
+export const skillsChannels = {
+  /** Scan + parse the installed skills for a Workspace (project + global dirs). */
+  skillsList: 'skills:list',
+  /** Reveal a LISTED skill's SKILL.md in the OS file manager (validated in main). */
+  skillsReveal: 'skills:reveal',
+} as const
+
+/** List installed skills. `workspaceDir` = the selected Workspace (null = global only). */
+export interface SkillsListArgs {
+  workspaceDir: string | null
+}
+
+/**
+ * One installed skill, as parsed from its `SKILL.md`. `scope` is derived from
+ * WHICH directory the skill was found in (Vibe itself doesn't record it):
+ * `project` = `<workspace>/.vibe/skills` or `<workspace>/.agents/skills`,
+ * `global` = `$VIBE_HOME/skills` or `~/.agents/skills`.
+ */
+export interface SkillInfo {
+  name: string
+  description: string
+  scope: 'project' | 'global'
+  /** Absolute path to the skill's `SKILL.md` (the reveal/open target). */
+  path: string
+  /** Vibe's `user-invocable` frontmatter (default true) — false = never in the `/` menu. */
+  userInvocable: boolean
+}
+
+/** The `skills:list` reply: merged first-name-wins, sorted by name. */
+export type SkillsListResult = SkillInfo[]
+
+/**
+ * Reveal a skill's `SKILL.md`. Main re-derives the search dirs from
+ * `workspaceDir` and refuses a `path` outside them — the renderer can only
+ * reveal what a scan could have listed, never an arbitrary path.
+ */
+export interface SkillsRevealArgs {
+  workspaceDir: string | null
+  path: string
+}


### PR DESCRIPTION
## What

Slice 1 of the Skills epic (#259): a **Skills** sidebar item (the slot Plugins vacated) opens a routed view listing every Vibe skill installed on the machine — project + global — with scope badges and Reveal-in-Finder. Entirely agent-free: main scans the on-disk `SKILL.md` dirs itself, so the browser works with zero warm agents.

## How

- **Scanner** (`src/main/skills/`, 12 tests) — mirrors Vibe's discovery exactly (verified against mistral-vibe's `SkillManager`): project `.vibe/skills` → project `.agents/skills` → `$VIBE_HOME/skills` → `~/.agents/skills`; immediate subdirs only; first name wins (project shadows global); reserved names dropped; scope derived from source dir.
- **Frontmatter parser** — minimal by design (no yaml dep) but handles what real skills use: quoted scalars, block scalars (`>-` / `|`), plain-scalar continuation lines, nested `metadata:` dicts skipped. The block-scalar support was earned in verification: the first live run rendered a folded description as a literal `>`.
- **`skills:list` / `skills:reveal` IPC** — the reveal is gated (`isListableSkillPath`): only a `SKILL.md` directly under a *current* search dir is revealable — the renderer can't reveal arbitrary paths; reveal-only, never opens/executes.
- **Nav** — new `'skills'` view in the pure nav-reducer (Settings contract: preserves selection, any sidebar navigation exits it; 3 new tests); connected Workspaces stay mounted-but-hidden beneath it.

## Verification

- Gates: lint, typecheck, build, test — 1356 tests green (15 new).
- Playwright harness with seeded `VIBE_HOME` + project skills: project `deploy` **shadows** the global one; `.agents/skills` project dir listed; `not invocable` badge on `user-invocable: false`; reserved `help` suppressed; Back returns to the conversation. Bonus: the run listed the machine's real `~/.agents/skills` correctly (caveman, clerk, diagnose, …).

Refs #259 (slice 2 = in-app SKILL.md preview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)