### PR TITLE
feat(composer): long-paste chip compression + copy-button feedback + copy-only actions bar

### DIFF
--- a/src/renderer/src/conversation/Composer.tsx
+++ b/src/renderer/src/conversation/Composer.tsx
@@ -8,7 +8,7 @@ import {
   type JSX,
   type KeyboardEvent,
 } from 'react'
-import { ArrowUp, File, Mic, MessageSquareText, MousePointerClick, Plus, Sparkles, Square, X } from 'lucide-react'
+import { ArrowUp, Clipboard, File, Mic, MessageSquareText, MousePointerClick, Plus, Sparkles, Square, X } from 'lucide-react'
 import type {
   FileEntry,
   ThreadConfigAxis,
@@ -34,6 +34,8 @@ import { ACCEPTED_IMAGE_TYPES, isAcceptedImageType, parseDataUrl } from './image
 import {
   addContext,
   contextKey,
+  isLongPaste,
+  pastedLabel,
   removeContext,
   serializeForSend,
   type PendingContext,
@@ -42,10 +44,11 @@ import { nextQueueId, type FollowUpQueue } from './follow-up-queue'
 import { useComposerAutocomplete, CompletionPopover } from './use-composer-autocomplete'
 import { createCommandSource, createPathSource } from './composer-sources'
 
-/** Process-local counters for unique pending-image / element / review-chip ids (not Math.random/Date). */
+/** Process-local counters for unique pending-image / element / review / paste-chip ids (not Math.random/Date). */
 let imageSeq = 0
 let elementSeq = 0
 let reviewSeq = 0
+let pasteSeq = 0
 
 /** A review chip's compact line-range suffix, e.g. `:10-12` / `:7` — empty when unlocated. */
 function reviewRange(context: { startLine: number | null; endLine: number | null }): string {
@@ -66,8 +69,13 @@ function chipLabel(context: PendingContext): string {
       return context.selector ?? `<${context.tagName}>`
     case 'review':
       return `${context.filePath}${reviewRange(context)}`
+    case 'pasted':
+      return pastedLabel(context)
   }
 }
+
+/** A pasted chip's hover preview — the head of the text, capped so the tooltip stays sane. */
+const PASTE_TITLE_PREVIEW_CHARS = 400
 
 /** A pending-context chip's hover detail (`title`), per kind. */
 function chipTitle(context: PendingContext): string | undefined {
@@ -87,6 +95,10 @@ function chipTitle(context: PendingContext): string | undefined {
         .join('\n')
     case 'review':
       return [`${context.filePath}${reviewRange(context)}`, context.note, '', context.excerpt].join('\n')
+    case 'pasted':
+      return context.text.length > PASTE_TITLE_PREVIEW_CHARS
+        ? `${context.text.slice(0, PASTE_TITLE_PREVIEW_CHARS)}…`
+        : context.text
   }
 }
 
@@ -294,8 +306,11 @@ export function Composer({
     reader.readAsDataURL(file)
   }
 
-  // Clipboard paste (#100): stage any pasted image files. `preventDefault` fires
-  // ONLY when at least one image was handled, so a normal text paste is untouched.
+  // Clipboard paste (#100): stage any pasted image files. A LONG text paste stages as a
+  // pending-context chip instead of splicing into the draft (t3code's inline-token
+  // treatment, via our ADR-0017 chips) — the composer stays compact and the full text
+  // rides a trailing <pasted_text> block at send. `preventDefault` fires ONLY when we
+  // handled the paste ourselves, so a normal short text paste is untouched.
   function onPaste(e: ClipboardEvent<HTMLTextAreaElement>): void {
     let handled = false
     for (const item of e.clipboardData.items) {
@@ -304,6 +319,14 @@ export function Composer({
       if (!file) continue
       addFile(file, file.name || 'pasted-image')
       handled = true
+    }
+    if (!handled) {
+      // CRLF-normalized so line counts and the wire block are stable across sources.
+      const text = e.clipboardData.getData('text/plain').replace(/\r\n/g, '\n')
+      if (isLongPaste(text)) {
+        setPendingContexts((prev) => addContext(prev, { kind: 'pasted', id: `paste:${pasteSeq++}`, text }))
+        handled = true
+      }
     }
     if (handled) e.preventDefault()
   }
@@ -444,6 +467,8 @@ export function Composer({
                     <File className="size-3 shrink-0" aria-hidden />
                   ) : context.kind === 'review' ? (
                     <MessageSquareText className="size-3 shrink-0" aria-hidden />
+                  ) : context.kind === 'pasted' ? (
+                    <Clipboard className="size-3 shrink-0" aria-hidden />
                   ) : (
                     <MousePointerClick className="size-3 shrink-0" aria-hidden />
                   )}
@@ -583,7 +608,11 @@ export function Composer({
             <button
               type="button"
               onClick={() => void send()}
-              disabled={draft.trim().length === 0 && pendingImages.length === 0}
+              // A staged chip alone is sendable — it serializes to wire text (a bare
+              // /skill, @path block, or pasted_text block) even with an empty draft.
+              disabled={
+                draft.trim().length === 0 && pendingImages.length === 0 && pendingContexts.length === 0
+              }
               aria-label={followUps.sending ? 'Queue message' : 'Send message'}
               title={followUps.sending ? 'Queue' : 'Send'}
               className="inline-flex size-9 shrink-0 items-center justify-center rounded-full text-white shadow-[0_1px_2px_var(--accent-shadow)] outline-none transition-opacity [background:var(--accent-grad-action)] hover:opacity-90 disabled:cursor-default disabled:opacity-40 @max-[560px]:size-8"

--- a/src/renderer/src/conversation/items/message-rows.tsx
+++ b/src/renderer/src/conversation/items/message-rows.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useRef, useState, type JSX } from 'react'
-import { Check, Copy, File, MessageSquareText, MousePointerClick, RotateCcw, Sparkles, ThumbsDown, ThumbsUp } from 'lucide-react'
+import { Check, Clipboard, Copy, File, MessageSquareText, MousePointerClick, Sparkles } from 'lucide-react'
 import { IconButton } from '../../ui/icon-button'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../../ui/tooltip'
 import { Response } from '../Response'
 import { matchInvokedCommand } from '../command-autocomplete'
-import { extractPromptContexts } from '../pending-contexts'
+import { extractPromptContexts, pastedLabel } from '../pending-contexts'
 import type { AcpCommand, AssistantItem, UserItem } from '../reducer'
 
 export function UserRow({
@@ -18,7 +19,7 @@ export function UserRow({
   // `<attached_files>` / `<element_context>` marker blocks; strip them back into chips at
   // RENDER time so the bubble shows the clean prose — live and on JSONL replay, which
   // ride the same text. User-typed inline `@path` mentions pass through untouched.
-  const { cleanText, files, elements, reviews } = extractPromptContexts(item.text)
+  const { cleanText, files, elements, reviews, pasted } = extractPromptContexts(item.text)
   // Skill/command chip: vibe-acp invokes a skill when the prompt opens with a
   // known `/name`, but gives NO wire-level acknowledgment — so we surface the
   // match ourselves. Matched at RENDER time against the CURRENT list (not stamped
@@ -29,7 +30,7 @@ export function UserRow({
   // instead of spanning the pane. Echoed attachments (#100) re-home into the bubble.
   return (
     <div className="flex flex-col items-end gap-1.5">
-      {(command || files.length > 0 || elements.length > 0 || reviews.length > 0) && (
+      {(command || files.length > 0 || elements.length > 0 || reviews.length > 0 || pasted.length > 0) && (
         <div className="flex max-w-[80%] flex-wrap justify-end gap-1.5">
           {command && (
             <span
@@ -84,23 +85,39 @@ export function UserRow({
               </span>
             </span>
           ))}
+          {pasted.map((paste) => (
+            // Pasted-text chips: the sent-turn mirror of the composer's compressed long
+            // pastes — the bracketed placeholder, full text (capped) in the tooltip.
+            <span
+              key={paste.id}
+              data-pasted-chip
+              title={paste.text.length > 400 ? `${paste.text.slice(0, 400)}…` : paste.text}
+              className="inline-flex max-w-full items-center gap-1 rounded-md border border-[var(--accent-tint-border)] bg-[var(--accent-tint)] px-1.5 py-0.5 font-mono text-xs leading-none text-accent-text"
+            >
+              <Clipboard className="size-3 shrink-0" aria-hidden />
+              <span className="truncate">{pastedLabel(paste)}</span>
+            </span>
+          ))}
         </div>
       )}
-      <div className="max-w-[80%] rounded-2xl border border-border bg-surface px-3.5 py-2.5 text-[15px] leading-relaxed break-words whitespace-pre-wrap text-text-body">
-        {item.images && item.images.length > 0 && (
-          <div className="mb-2 flex flex-wrap justify-end gap-2">
-            {item.images.map((img, i) => (
-              <img
-                key={i}
-                className="max-h-[200px] max-w-[200px] rounded-lg border border-border"
-                src={img.previewUrl}
-                alt="attachment"
-              />
-            ))}
-          </div>
-        )}
-        {cleanText}
-      </div>
+      {/* Chip-only prompts (e.g. a bare long paste) skip the bubble — an empty pill reads broken. */}
+      {(cleanText.length > 0 || (item.images && item.images.length > 0)) && (
+        <div className="max-w-[80%] rounded-2xl border border-border bg-surface px-3.5 py-2.5 text-[15px] leading-relaxed break-words whitespace-pre-wrap text-text-body">
+          {item.images && item.images.length > 0 && (
+            <div className="mb-2 flex flex-wrap justify-end gap-2">
+              {item.images.map((img, i) => (
+                <img
+                  key={i}
+                  className="max-h-[200px] max-w-[200px] rounded-lg border border-border"
+                  src={img.previewUrl}
+                  alt="attachment"
+                />
+              ))}
+            </div>
+          )}
+          {cleanText}
+        </div>
+      )}
     </div>
   )
 }
@@ -112,40 +129,33 @@ export function AssistantRow({ item, streaming }: { item: AssistantItem; streami
   return (
     <div className="group flex flex-col gap-1.5">
       <Response className="text-[15px] leading-relaxed text-text-body" text={item.text} />
-      {/* Actions bar (#116): a hover-reveal row under the answer. Copy is the only
-          FUNCTIONAL action (clipboard + anchored toast); thumbs up/down + retry are
-          designed affordances from the mockup — present + styled but not yet wired to
-          any backend (no feedback store, no re-submit) so we don't invent behavior.
-          Hidden while the answer streams (a half-written reply isn't copyable) and for
-          an empty item. `focus-within` also reveals it for keyboard users. */}
+      {/* Actions bar (#116): a hover-reveal row under the answer, holding the Copy
+          control (clipboard + anchored toast). Hidden while the answer streams (a
+          half-written reply isn't copyable) and for an empty item. `focus-within`
+          also reveals it for keyboard users. */}
       {!streaming && item.text.trim().length > 0 && (
         <div className="flex items-center gap-0.5 opacity-0 transition-opacity duration-150 group-hover:opacity-100 focus-within:opacity-100">
           <MessageCopyButton text={item.text} />
-          <IconButton size="icon-xs" className="text-muted hover:text-text" aria-label="Good response" title="Good response">
-            <ThumbsUp className="size-3.5" aria-hidden />
-          </IconButton>
-          <IconButton size="icon-xs" className="text-muted hover:text-text" aria-label="Bad response" title="Bad response">
-            <ThumbsDown className="size-3.5" aria-hidden />
-          </IconButton>
-          <IconButton size="icon-xs" className="text-muted hover:text-text" aria-label="Retry" title="Retry">
-            <RotateCcw className="size-3.5" aria-hidden />
-          </IconButton>
         </div>
       )}
     </div>
   )
 }
 
+/** How long the click feedback ("Copied!" / "Failed to copy") stays up — t3code's 1s. */
+const COPY_FEEDBACK_MS = 1000
+
 /**
- * The copy control on the assistant actions bar (#116, mirrors t3code `MessageCopyButton`).
- * Writes the answer to the clipboard, flips the icon to a check, and floats an ANCHORED
- * "Copied!" toast above the button (a popover positioned on the button, NOT an inline
- * label) that clears after a beat. Self-contained: no toast manager, just local state +
- * a positioned span. The timer is cleared on unmount so a fast switch-away can't set
- * state on a dead component.
+ * The copy control on the assistant actions bar (#116, mirrors t3code `MessageCopyButton`):
+ * a hover tooltip ("Copy to clipboard"), and on click an ANCHORED tooltip-style label —
+ * "Copied!" with the icon flipped to a check (button disabled for the beat), or
+ * "Failed to copy" when the clipboard write rejects (never silent). The hover tooltip
+ * yields while the click feedback shows so the two chips don't stack. Self-contained:
+ * no toast manager, just local state + a positioned span; the timer is cleared on
+ * unmount so a fast switch-away can't set state on a dead component.
  */
 function MessageCopyButton({ text }: { text: string }): JSX.Element {
-  const [copied, setCopied] = useState(false)
+  const [feedback, setFeedback] = useState<'copied' | 'failed' | null>(null)
   const timeoutRef = useRef<number | null>(null)
   const mountedRef = useRef(true)
   useEffect(
@@ -155,36 +165,49 @@ function MessageCopyButton({ text }: { text: string }): JSX.Element {
     },
     [],
   )
+  function showFeedback(next: 'copied' | 'failed'): void {
+    // The clipboard write is async — bail if we unmounted between click and settle.
+    if (!mountedRef.current) return
+    setFeedback(next)
+    if (timeoutRef.current !== null) window.clearTimeout(timeoutRef.current)
+    timeoutRef.current = window.setTimeout(() => setFeedback(null), COPY_FEEDBACK_MS)
+  }
   function onCopy(): void {
-    void navigator.clipboard.writeText(text).then(() => {
-      // The clipboard write is async — bail if we unmounted between click and resolve.
-      if (!mountedRef.current) return
-      setCopied(true)
-      if (timeoutRef.current !== null) window.clearTimeout(timeoutRef.current)
-      timeoutRef.current = window.setTimeout(() => setCopied(false), 1200)
-    })
+    navigator.clipboard.writeText(text).then(
+      () => showFeedback('copied'),
+      () => showFeedback('failed'),
+    )
   }
   return (
     <span className="relative inline-flex">
-      <IconButton
-        size="icon-xs"
-        className="text-muted hover:text-text"
-        aria-label="Copy message"
-        title="Copy"
-        onClick={onCopy}
-      >
-        {copied ? (
-          <Check className="size-3.5 text-accent-text" aria-hidden />
-        ) : (
-          <Copy className="size-3.5" aria-hidden />
-        )}
-      </IconButton>
-      {copied && (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <IconButton
+                size="icon-xs"
+                className="text-muted hover:text-text"
+                aria-label="Copy message"
+                disabled={feedback === 'copied'}
+                onClick={onCopy}
+              />
+            }
+          >
+            {feedback === 'copied' ? (
+              <Check className="size-3.5 text-accent-text" aria-hidden />
+            ) : (
+              <Copy className="size-3.5" aria-hidden />
+            )}
+          </TooltipTrigger>
+          {feedback === null && <TooltipContent>Copy to clipboard</TooltipContent>}
+        </Tooltip>
+      </TooltipProvider>
+      {feedback && (
         <span
           role="status"
-          className="pointer-events-none absolute bottom-full left-1/2 mb-1 -translate-x-1/2 rounded-sm bg-text px-2 py-1 text-xs whitespace-nowrap text-bg shadow-md"
+          className="pointer-events-none absolute bottom-full left-1/2 z-50 mb-1 -translate-x-1/2 rounded-sm bg-text px-2 py-1 text-xs whitespace-nowrap text-bg shadow-md"
         >
-          Copied!
+          {feedback === 'copied' ? 'Copied!' : 'Failed to copy'}
         </span>
       )}
     </span>

--- a/src/renderer/src/conversation/pending-contexts.test.ts
+++ b/src/renderer/src/conversation/pending-contexts.test.ts
@@ -4,6 +4,10 @@ import {
   contextKey,
   extractAttachedFiles,
   extractPromptContexts,
+  isLongPaste,
+  LONG_PASTE_CHARS,
+  LONG_PASTE_LINES,
+  pastedLabel,
   removeContext,
   serializeForSend,
   type PendingContext,
@@ -111,6 +115,7 @@ describe('extractPromptContexts — display mirror for the full payload', () => 
       cleanText: '/teach style this',
       files: [reducerFile],
       reviews: [],
+      pasted: [],
       elements: [
         {
           kind: 'element',
@@ -148,6 +153,7 @@ describe('extractPromptContexts — display mirror for the full payload', () => 
       files: [],
       elements: [],
       reviews: [],
+      pasted: [],
     })
   })
 })
@@ -249,5 +255,73 @@ describe('review-comment chips (#239)', () => {
     const text = 'what does <review_comments> mean here?\nnothing.'
     expect(extractPromptContexts(text).cleanText).toBe(text)
     expect(extractPromptContexts(text).reviews).toEqual([])
+  })
+})
+
+describe('pasted-text chips (long-paste compression)', () => {
+  const blob = Array.from({ length: 30 }, (_, i) => `line ${i}`).join('\n')
+  const paste1: PendingContext = { kind: 'pasted', id: 'paste:0', text: blob }
+  const paste2: PendingContext = { kind: 'pasted', id: 'paste:1', text: 'const x = 1\nconst y = 2\n' }
+
+  describe('isLongPaste', () => {
+    it('compresses past EITHER bound — chars or lines', () => {
+      expect(isLongPaste('x'.repeat(LONG_PASTE_CHARS + 1))).toBe(true)
+      expect(isLongPaste('short\n'.repeat(LONG_PASTE_LINES + 1))).toBe(true)
+    })
+
+    it('leaves an ordinary paste alone', () => {
+      expect(isLongPaste('a normal sentence')).toBe(false)
+      expect(isLongPaste('x'.repeat(LONG_PASTE_CHARS))).toBe(false)
+      expect(isLongPaste(Array(LONG_PASTE_LINES).fill('l').join('\n'))).toBe(false)
+    })
+  })
+
+  it('labels the chip in brackets with a line count (chars for a single line)', () => {
+    expect(pastedLabel({ kind: 'pasted', id: 'p', text: blob })).toBe('[pasted text · 30 lines]')
+    expect(pastedLabel({ kind: 'pasted', id: 'p', text: 'x'.repeat(1200) })).toBe(
+      '[pasted text · 1200 chars]',
+    )
+  })
+
+  it('accumulates pastes (each id its own chip) and removes by key', () => {
+    const staged = addContext(addContext([], paste1), paste2)
+    expect(staged).toEqual([paste1, paste2])
+    expect(removeContext(staged, contextKey(paste1))).toEqual([paste2])
+  })
+
+  it('serializes as a trailing <pasted_text> block carrying the text VERBATIM', () => {
+    expect(serializeForSend('explain this', [paste1])).toBe(
+      `explain this\n\n<pasted_text>\n${blob}\n</pasted_text>`,
+    )
+  })
+
+  it('round-trips through the display mirror, preserving a trailing newline in the paste', () => {
+    const wire = serializeForSend('compare these', [paste1, paste2])
+    const extracted = extractPromptContexts(wire)
+    expect(extracted.cleanText).toBe('compare these')
+    expect(extracted.pasted.map((p) => p.text)).toEqual([blob, 'const x = 1\nconst y = 2\n'])
+  })
+
+  it('coexists with the other chip kinds — pastes serialize LAST and extract first', () => {
+    const wire = serializeForSend('style this', [teach, reducerFile, button, paste1])
+    const extracted = extractPromptContexts(wire)
+    expect(extracted.cleanText).toBe('/teach style this')
+    expect(extracted.files).toEqual([reducerFile])
+    expect(extracted.elements.length).toBe(1)
+    expect(extracted.pasted.map((p) => p.text)).toEqual([blob])
+  })
+
+  it('sends a paste with no prose as a bare block the mirror fully recovers', () => {
+    const wire = serializeForSend('', [paste1])
+    expect(wire).toBe(`<pasted_text>\n${blob}\n</pasted_text>`)
+    const extracted = extractPromptContexts(wire)
+    expect(extracted.cleanText).toBe('')
+    expect(extracted.pasted.map((p) => p.text)).toEqual([blob])
+  })
+
+  it('hand-typed text mentioning <pasted_text> mid-prose passes through untouched', () => {
+    const text = 'what does <pasted_text> mean here?\nnothing.'
+    expect(extractPromptContexts(text).cleanText).toBe(text)
+    expect(extractPromptContexts(text).pasted).toEqual([])
   })
 })

--- a/src/renderer/src/conversation/pending-contexts.ts
+++ b/src/renderer/src/conversation/pending-contexts.ts
@@ -53,8 +53,44 @@ export interface ReviewCommentContext {
   excerpt: string
 }
 
+/**
+ * A LONG clipboard paste staged as a chip instead of splicing into the draft (mirrors
+ * t3code's inline-token treatment of big text blobs): the composer stays compact — the
+ * chip shows a bracketed placeholder — and the full text rides a trailing
+ * `<pasted_text>` block only at send. `id` is composer-minted; several pastes accumulate.
+ */
+export interface PastedTextContext {
+  kind: 'pasted'
+  id: string
+  text: string
+}
+
 /** A context chip staged in the composer awaiting send. */
-export type PendingContext = SkillContext | FileContext | ElementContext | ReviewCommentContext
+export type PendingContext =
+  | SkillContext
+  | FileContext
+  | ElementContext
+  | ReviewCommentContext
+  | PastedTextContext
+
+/** A paste is compressed into a chip past EITHER bound — enough characters to balloon
+ *  the textarea, or enough lines to push the controls off-screen. */
+export const LONG_PASTE_CHARS = 1000
+export const LONG_PASTE_LINES = 10
+
+/** Whether a clipboard text paste should stage as a chip instead of entering the draft. */
+export function isLongPaste(text: string): boolean {
+  return text.length > LONG_PASTE_CHARS || text.split('\n').length > LONG_PASTE_LINES
+}
+
+/** The bracketed placeholder a pasted-text chip displays, in the composer and on the
+ *  echoed user turn — sized in lines (or characters for a single long line). */
+export function pastedLabel(context: PastedTextContext): string {
+  const lines = context.text.split('\n').length
+  return lines > 1
+    ? `[pasted text · ${lines} lines]`
+    : `[pasted text · ${context.text.length} chars]`
+}
 
 /** The stable identity of a chip — the React key, the remove handle, and the dedupe key. */
 export function contextKey(context: PendingContext): string {
@@ -67,6 +103,8 @@ export function contextKey(context: PendingContext): string {
       return `element:${context.id}`
     case 'review':
       return `review:${context.id}`
+    case 'pasted':
+      return `pasted:${context.id}`
   }
 }
 
@@ -108,6 +146,11 @@ const ELEMENT_CONTEXT_CLOSE = '</element_context>'
 /** The marker element fencing review comments in the wire text (#239). */
 const REVIEW_COMMENTS_OPEN = '<review_comments>'
 const REVIEW_COMMENTS_CLOSE = '</review_comments>'
+
+/** The marker element fencing one long paste's VERBATIM text in the wire — one block
+ *  per chip (pastes are opaque blobs; there is no entry shape to pack several into one). */
+const PASTED_TEXT_OPEN = '<pasted_text>'
+const PASTED_TEXT_CLOSE = '</pasted_text>'
 
 /** One review comment's lines inside the block (#239): a head line naming the file +
  *  line range, a single-line `note:` (whitespace-normalized, like element text), then
@@ -226,6 +269,7 @@ export interface ExtractedPromptContexts {
   files: FileContext[]
   elements: ElementContext[]
   reviews: ReviewCommentContext[]
+  pasted: PastedTextContext[]
 }
 
 /**
@@ -240,7 +284,30 @@ export function extractPromptContexts(text: string): ExtractedPromptContexts {
   let working = text
   let elements: ElementContext[] = []
   let reviews: ReviewCommentContext[] = []
-  // Reviews serialize LAST (#239), so they strip FIRST.
+  const pasted: PastedTextContext[] = []
+  // Pasted-text blocks serialize LAST of all, so they strip FIRST — one block per
+  // chip, back-to-front (unshift keeps staged order). The inner slice drops exactly
+  // the one newline we added on each side of the verbatim text, so the paste
+  // round-trips byte-for-byte (including its own trailing newline, if any).
+  for (;;) {
+    const pasteTrimmed = working.trimEnd()
+    if (!pasteTrimmed.endsWith(PASTED_TEXT_CLOSE)) break
+    const open = pasteTrimmed.lastIndexOf(PASTED_TEXT_OPEN)
+    if (open === -1) break
+    const inner = pasteTrimmed.slice(
+      open + PASTED_TEXT_OPEN.length,
+      pasteTrimmed.length - PASTED_TEXT_CLOSE.length,
+    )
+    pasted.unshift({
+      kind: 'pasted',
+      id: `paste-extract:${open}`,
+      text: inner.replace(/^\n/, '').replace(/\n$/, ''),
+    })
+    working = pasteTrimmed.slice(0, open).replace(/\n+$/, '')
+  }
+  // Re-key extracted pastes in document order (the loop keys by offset while stripping).
+  pasted.forEach((chip, i) => (chip.id = `paste-extract:${i}`))
+  // Reviews serialize LAST of the entry-shaped blocks (#239), so they strip next.
   const reviewTrimmed = working.trimEnd()
   if (reviewTrimmed.endsWith(REVIEW_COMMENTS_CLOSE)) {
     const open = reviewTrimmed.lastIndexOf(REVIEW_COMMENTS_OPEN)
@@ -276,7 +343,7 @@ export function extractPromptContexts(text: string): ExtractedPromptContexts {
     }
   }
   const { cleanText, files } = extractAttachedFiles(working)
-  return { cleanText, files, elements, reviews }
+  return { cleanText, files, elements, reviews, pasted }
 }
 
 /**
@@ -284,8 +351,9 @@ export function extractPromptContexts(text: string): ExtractedPromptContexts {
  * leading `/name ` invocation (bare `/name` when there is no prose); file chips become
  * a TRAILING `<attached_files>` block of `@path` mentions the agent expands itself
  * (ADR-0002 — plain text, no client-side expansion); element chips become a final
- * `<element_context>` block of descriptive prose. The prose itself is trimmed exactly
- * like the send path trims the draft.
+ * `<element_context>` block of descriptive prose; long pastes become trailing
+ * `<pasted_text>` blocks, one per chip. The prose itself is trimmed exactly like the
+ * send path trims the draft.
  */
 export function serializeForSend(text: string, contexts: readonly PendingContext[]): string {
   const prose = text.trim()
@@ -307,6 +375,12 @@ export function serializeForSend(text: string, contexts: readonly PendingContext
     parts.push(
       [REVIEW_COMMENTS_OPEN, ...reviews.flatMap(formatReviewEntry), REVIEW_COMMENTS_CLOSE].join('\n'),
     )
+  }
+  // Long pastes go LAST, one block each, text VERBATIM (an opaque blob — normalizing
+  // or entry-shaping it would corrupt code/log pastes). Extraction strips these first.
+  for (const paste of contexts) {
+    if (paste.kind !== 'pasted') continue
+    parts.push(`${PASTED_TEXT_OPEN}\n${paste.text}\n${PASTED_TEXT_CLOSE}`)
   }
   return parts.filter((p) => p.length > 0).join('\n\n')
 }


### PR DESCRIPTION
Three conversation-surface refinements, each ported from a t3code pattern onto our own primitives:

## Long-paste compression (composer)
- A text paste over **1000 chars or 10 lines** stages as a pending-context chip — `[pasted text · N lines]` — instead of splicing into the textarea, so the composer never balloons. Short pastes are untouched.
- New `pasted` kind in `pending-contexts.ts` (ADR-0017 flatten-to-text — t3code does this with Lexical inline tokens; we reuse the chips mechanism): the text rides a trailing `<pasted_text>` block at send, verbatim, one block per chip.
- The echoed user turn extracts the block back into a chip (tooltip previews the text) — live and on JSONL replay. Chip-only prompts skip the empty bubble.
- Send button enables when only chips are staged (a bare paste/skill/file send serializes to non-empty wire text).

## Copy-button feedback (assistant actions bar)
- Hover tooltip "Copy to clipboard" — first consumer of the `ui/tooltip` Base UI primitive, composed via `TooltipTrigger render={<IconButton/>}` exactly like t3code's `MessageCopyButton`.
- Click: anchored "Copied!" chip for 1s, icon flips to a check, button disabled for the beat.
- A rejected clipboard write now shows "Failed to copy" (previously silent).

## Actions bar cleanup
- Dropped the never-wired thumbs up/down + retry mockup placeholders; Copy is the only action.

## Tests
- New suite for pasted-text chips: thresholds, bracketed labels, verbatim serialization, byte-for-byte round-trips (incl. trailing newline), coexistence with skill/file/element/review chips, hand-typed `<pasted_text>` prose untouched.
- Gates: lint, typecheck, build, 1356 tests across 111 files — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)