### PR TITLE
feat(skills): slice 2 — in-app SKILL.md preview (#259)

### DIFF
--- a/src/main/skills/parse-skill.test.ts
+++ b/src/main/skills/parse-skill.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { parseSkillFrontmatter } from './parse-skill'
+import { parseSkillFrontmatter, skillBody } from './parse-skill'
 
 function skillMd(frontmatter: string, body = 'Do the thing.'): string {
   return `---\n${frontmatter}\n---\n\n${body}\n`
@@ -67,5 +67,24 @@ describe('parseSkillFrontmatter', () => {
     expect(parseSkillFrontmatter(skillMd('name: -lead\ndescription: d'))).toBeNull()
     expect(parseSkillFrontmatter(skillMd(`name: ${'a'.repeat(65)}\ndescription: d`))).toBeNull()
     expect(parseSkillFrontmatter(skillMd('name: ok-2\ndescription: d'))).not.toBeNull()
+  })
+})
+
+describe('skillBody', () => {
+  it('returns the trimmed markdown after the frontmatter', () => {
+    expect(skillBody('---\nname: x\ndescription: d\n---\n\n# Title\n\nDo things.\n')).toBe(
+      '# Title\n\nDo things.',
+    )
+  })
+
+  it('is defensive: content without valid fences comes back as-is (trimmed)', () => {
+    expect(skillBody('just markdown, no fences\n')).toBe('just markdown, no fences')
+    expect(skillBody('---\nnever closed')).toBe('---\nnever closed')
+  })
+
+  it('keeps --- horizontal rules INSIDE the body (only the first fence pair is frontmatter)', () => {
+    expect(skillBody('---\nname: x\ndescription: d\n---\nabove\n\n---\n\nbelow')).toBe(
+      'above\n\n---\n\nbelow',
+    )
   })
 })

--- a/src/main/skills/parse-skill.ts
+++ b/src/main/skills/parse-skill.ts
@@ -68,6 +68,27 @@ export function parseSkillFrontmatter(content: string): SkillFrontmatter | null 
   }
 
   const name = fields.get('name') ?? ''
+  return validateFields(name, fields)
+}
+
+/**
+ * The Markdown BODY after the frontmatter — the skill's instructions, for the
+ * in-app preview. Defensive: content without valid fences returns as-is (the
+ * preview shows SOMETHING rather than nothing; the scanner already filtered
+ * unparseable skills out of the list).
+ */
+export function skillBody(content: string): string {
+  const lines = content.split(/\r?\n/)
+  if (lines[0]?.trim() !== '---') return content.trim()
+  const closing = lines.findIndex((line, i) => i > 0 && line.trim() === '---')
+  if (closing === -1) return content.trim()
+  return lines
+    .slice(closing + 1)
+    .join('\n')
+    .trim()
+}
+
+function validateFields(name: string, fields: Map<string, string>): SkillFrontmatter | null {
   const description = fields.get('description') ?? ''
   if (!NAME_PATTERN.test(name) || name.length > 64) return null
   if (!description) return null

--- a/src/main/skills/register-ipc.ts
+++ b/src/main/skills/register-ipc.ts
@@ -1,14 +1,21 @@
 import { ipcMain, shell } from 'electron'
+import { readFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import {
   IPC,
   type SkillsListArgs,
   type SkillsListResult,
+  type SkillsReadArgs,
+  type SkillsReadResult,
   type SkillsRevealArgs,
 } from '../../shared/ipc'
 import { getShellEnv } from '../shell-env'
 import { isListableSkillPath, listSkills } from './list-skills'
+import { skillBody } from './parse-skill'
 import { skillSearchDirs } from './skill-dirs'
+
+/** Preview cap — a SKILL.md is prose; anything past this is truncated, not an error. */
+const PREVIEW_MAX_CHARS = 512 * 1024
 
 /**
  * The Skills-browser IPC handlers (#259), registered beside their modules
@@ -20,6 +27,24 @@ import { skillSearchDirs } from './skill-dirs'
 export function registerSkillsIpc(): void {
   ipcMain.handle(IPC.skillsList, (_event, args: SkillsListArgs): Promise<SkillsListResult> => {
     return listSkills(skillSearchDirs(args.workspaceDir, getShellEnv(), homedir()))
+  })
+
+  ipcMain.handle(IPC.skillsRead, async (_event, args: SkillsReadArgs): Promise<SkillsReadResult> => {
+    // The in-app preview (#259 slice 2): SAME gate as reveal — only a SKILL.md a
+    // scan could have listed is readable, so this can't become a generic file-read
+    // channel. Returns the body only (frontmatter already rendered on the row).
+    const dirs = skillSearchDirs(args.workspaceDir, getShellEnv(), homedir())
+    if (!isListableSkillPath(args.path, dirs)) {
+      console.error(`[vibe-mistro:skills] read refused (outside skill dirs): ${args.path}`)
+      return { ok: false }
+    }
+    try {
+      const content = await readFile(args.path, 'utf8')
+      return { ok: true, markdown: skillBody(content).slice(0, PREVIEW_MAX_CHARS) }
+    } catch (err) {
+      console.error(`[vibe-mistro:skills] read failed (${args.path}): ${String(err)}`)
+      return { ok: false }
+    }
   })
 
   ipcMain.handle(IPC.skillsReveal, (_event, args: SkillsRevealArgs): void => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -54,6 +54,8 @@ import {
   type SearchQueryResult,
   type SkillsListArgs,
   type SkillsListResult,
+  type SkillsReadArgs,
+  type SkillsReadResult,
   type SkillsRevealArgs,
   type SendPromptArgs,
   type SendPromptResult,
@@ -134,6 +136,8 @@ const api = {
     ipcRenderer.invoke(IPC.skillsList, args),
   skillsReveal: (args: SkillsRevealArgs): Promise<void> =>
     ipcRenderer.invoke(IPC.skillsReveal, args),
+  skillsRead: (args: SkillsReadArgs): Promise<SkillsReadResult> =>
+    ipcRenderer.invoke(IPC.skillsRead, args),
   gitSubscribeStatus: (args: GitStatusSubscriptionArgs): Promise<void> =>
     ipcRenderer.invoke(IPC.gitSubscribeStatus, args),
   gitUnsubscribeStatus: (args: GitStatusSubscriptionArgs): Promise<void> =>

--- a/src/renderer/src/skills/SkillsView.tsx
+++ b/src/renderer/src/skills/SkillsView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, type JSX } from 'react'
 import { ArrowLeft, FolderSearch, Sparkles } from 'lucide-react'
 import type { SkillInfo } from '../../../shared/ipc'
+import { Response } from '../conversation/Response'
 import { Badge } from '../ui/badge'
 import { Button } from '../ui/button'
 import { IconButton } from '../ui/icon-button'
@@ -13,7 +14,10 @@ import { IconButton } from '../ui/icon-button'
  * there is no filesystem watching (#259 out of scope). Rows carry a scope badge
  * (project shadows global, Vibe's first-name-wins) and a "not invocable" badge
  * for `user-invocable: false` skills the `/` menu would hide — the browser shows
- * the on-disk truth. Reveal goes through the gated `skills:reveal` IPC.
+ * the on-disk truth. Clicking a row opens the skill's PREVIEW (slice 2): the
+ * SKILL.md body fetched over the gated `skills:read` and rendered read-only with
+ * the conversation's own markdown pipeline (`Response` works outside a
+ * Conversation — file chips render inert). Reveal goes through `skills:reveal`.
  */
 export function SkillsView({
   workspaceDir,
@@ -28,10 +32,13 @@ export function SkillsView({
 }): JSX.Element {
   // null = scanning; [] = scanned, nothing installed.
   const [skills, setSkills] = useState<SkillInfo[] | null>(null)
+  // The skill whose preview is open (slice 2), or null = the list.
+  const [openSkill, setOpenSkill] = useState<SkillInfo | null>(null)
 
   useEffect(() => {
     let active = true
     setSkills(null)
+    setOpenSkill(null) // a Workspace switch resets to that Workspace's list
     void window.api.skillsList({ workspaceDir }).then((result) => {
       if (active) setSkills(result)
     })
@@ -39,6 +46,16 @@ export function SkillsView({
       active = false
     }
   }, [workspaceDir])
+
+  if (openSkill) {
+    return (
+      <SkillPreview
+        skill={openSkill}
+        workspaceDir={workspaceDir}
+        onBack={() => setOpenSkill(null)}
+      />
+    )
+  }
 
   return (
     <div className="mx-auto flex w-full max-w-[560px] flex-col gap-5">
@@ -51,7 +68,7 @@ export function SkillsView({
       <p className="text-[13px] text-muted">
         The agent skills installed on this machine — invoked with <code>/name</code> in the
         composer. Project skills{workspaceName ? ` (${workspaceName})` : ''} shadow global ones
-        of the same name.
+        of the same name. Click a skill to read its instructions.
       </p>
 
       {skills === null ? (
@@ -74,45 +91,149 @@ export function SkillsView({
       ) : (
         <ul className="flex flex-col gap-2">
           {skills.map((skill) => (
+            // The open-preview button and the Reveal button are SIBLINGS (nested
+            // buttons are invalid HTML); the row's hover wash lives on the <li>.
             <li
               key={skill.name}
-              className="flex items-start gap-3 rounded-[9px] border border-border p-3"
+              className="flex items-start gap-3 rounded-[9px] border border-border p-3 transition-colors hover:bg-accent/10 focus-within:bg-accent/10"
             >
-              <Sparkles className="mt-0.5 size-4 shrink-0 text-muted" aria-hidden />
-              <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-                <span className="flex min-w-0 items-center gap-1.5">
-                  <span className="truncate text-[13px] font-semibold text-text-strong">
-                    /{skill.name}
-                  </span>
-                  <Badge
-                    variant={skill.scope === 'project' ? 'accent' : 'outline'}
-                    className="shrink-0 px-1.5 py-0 text-[10px]"
-                  >
-                    {skill.scope === 'project' ? 'Project' : 'Global'}
-                  </Badge>
-                  {!skill.userInvocable && (
-                    <Badge variant="outline" className="shrink-0 px-1.5 py-0 text-[10px] text-muted">
-                      not invocable
-                    </Badge>
-                  )}
-                </span>
-                <span className="text-[13px] text-muted">{skill.description}</span>
-                <span className="truncate text-[11px] text-faint">{skill.path}</span>
-              </span>
-              <Button
-                variant="outline"
-                size="sm"
-                className="shrink-0"
-                title="Reveal SKILL.md in the file manager"
-                onClick={() => void window.api.skillsReveal({ workspaceDir, path: skill.path })}
+              <button
+                type="button"
+                onClick={() => setOpenSkill(skill)}
+                aria-label={`Open /${skill.name}`}
+                className="flex min-w-0 flex-1 cursor-pointer items-start gap-3 text-left outline-none"
               >
-                <FolderSearch className="size-3.5" aria-hidden />
-                Reveal
-              </Button>
+                <Sparkles className="mt-0.5 size-4 shrink-0 text-muted" aria-hidden />
+                <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                  <SkillHeading skill={skill} />
+                  <span className="text-[13px] text-muted">{skill.description}</span>
+                  <span className="truncate text-[11px] text-faint">{skill.path}</span>
+                </span>
+              </button>
+              <RevealButton skill={skill} workspaceDir={workspaceDir} />
             </li>
           ))}
         </ul>
       )}
     </div>
+  )
+}
+
+/**
+ * One skill's read-only preview (slice 2): the SKILL.md BODY (the instructions
+ * the agent receives) over the gated `skills:read`, rendered with the same
+ * markdown pipeline the conversation uses. A refused/failed read degrades to a
+ * hint — Reveal still works, so the file is never unreachable.
+ */
+function SkillPreview({
+  skill,
+  workspaceDir,
+  onBack,
+}: {
+  skill: SkillInfo
+  workspaceDir: string | null
+  onBack: () => void
+}): JSX.Element {
+  // undefined = loading; null = read refused/failed; string = the body.
+  const [markdown, setMarkdown] = useState<string | null | undefined>(undefined)
+
+  useEffect(() => {
+    let active = true
+    setMarkdown(undefined)
+    void window.api.skillsRead({ workspaceDir, path: skill.path }).then((result) => {
+      if (active) setMarkdown(result.ok ? result.markdown : null)
+    })
+    return () => {
+      active = false
+    }
+  }, [skill.path, workspaceDir])
+
+  return (
+    <div className="mx-auto flex w-full max-w-[560px] flex-col gap-5">
+      <div className="flex items-center gap-2">
+        <IconButton aria-label="Back to skills" title="Back to skills" onClick={onBack}>
+          <ArrowLeft className="size-4" aria-hidden />
+        </IconButton>
+        <h1 className="min-w-0 truncate text-[19px] font-semibold tracking-tight text-text-strong">
+          /{skill.name}
+        </h1>
+        <SkillBadges skill={skill} />
+        <span className="flex-1" />
+        <RevealButton skill={skill} workspaceDir={workspaceDir} />
+      </div>
+      <p className="text-[13px] text-muted">{skill.description}</p>
+      <p className="truncate text-[11px] text-faint">{skill.path}</p>
+
+      {markdown === undefined ? (
+        <div className="rounded-[9px] border border-border p-3 text-[13px] text-muted">
+          Reading SKILL.md…
+        </div>
+      ) : markdown === null ? (
+        <div className="rounded-[9px] border border-border p-3 text-[13px] text-muted">
+          Couldn’t read this skill’s file — it may have moved. Reveal it to inspect on disk.
+        </div>
+      ) : markdown === '' ? (
+        <div className="rounded-[9px] border border-border p-3 text-[13px] text-muted">
+          This skill has no instructions beyond its frontmatter.
+        </div>
+      ) : (
+        <div className="rounded-[9px] border border-border p-4">
+          <Response text={markdown} />
+        </div>
+      )}
+    </div>
+  )
+}
+
+function SkillHeading({ skill }: { skill: SkillInfo }): JSX.Element {
+  return (
+    <span className="flex min-w-0 items-center gap-1.5">
+      <span className="truncate text-[13px] font-semibold text-text-strong">/{skill.name}</span>
+      <SkillBadges skill={skill} />
+    </span>
+  )
+}
+
+function SkillBadges({ skill }: { skill: SkillInfo }): JSX.Element {
+  return (
+    <>
+      <Badge
+        variant={skill.scope === 'project' ? 'accent' : 'outline'}
+        className="shrink-0 px-1.5 py-0 text-[10px]"
+      >
+        {skill.scope === 'project' ? 'Project' : 'Global'}
+      </Badge>
+      {!skill.userInvocable && (
+        <Badge variant="outline" className="shrink-0 px-1.5 py-0 text-[10px] text-muted">
+          not invocable
+        </Badge>
+      )}
+    </>
+  )
+}
+
+/** Reveal SKILL.md in the OS file manager — stops propagation so a click inside
+ * a list row reveals WITHOUT opening the preview. */
+function RevealButton({
+  skill,
+  workspaceDir,
+}: {
+  skill: SkillInfo
+  workspaceDir: string | null
+}): JSX.Element {
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      className="shrink-0"
+      title="Reveal SKILL.md in the file manager"
+      onClick={(event) => {
+        event.stopPropagation()
+        void window.api.skillsReveal({ workspaceDir, path: skill.path })
+      }}
+    >
+      <FolderSearch className="size-3.5" aria-hidden />
+      Reveal
+    </Button>
   )
 }

--- a/src/shared/ipc/skills.ts
+++ b/src/shared/ipc/skills.ts
@@ -12,6 +12,8 @@ export const skillsChannels = {
   skillsList: 'skills:list',
   /** Reveal a LISTED skill's SKILL.md in the OS file manager (validated in main). */
   skillsReveal: 'skills:reveal',
+  /** Read a LISTED skill's SKILL.md body for the in-app preview (same gate as reveal). */
+  skillsRead: 'skills:read',
 } as const
 
 /** List installed skills. `workspaceDir` = the selected Workspace (null = global only). */
@@ -47,3 +49,16 @@ export interface SkillsRevealArgs {
   workspaceDir: string | null
   path: string
 }
+
+/** Read a skill's `SKILL.md` for the preview — same path gate as reveal. */
+export interface SkillsReadArgs {
+  workspaceDir: string | null
+  path: string
+}
+
+/**
+ * The preview content: the Markdown BODY after the frontmatter (the skill's
+ * instructions — name/description already live on the row). `ok: false` covers
+ * a refused path or a read failure; the renderer degrades to a hint.
+ */
+export type SkillsReadResult = { ok: true; markdown: string } | { ok: false }


### PR DESCRIPTION
## What

The final slice of the Skills epic: clicking a skill opens its **instructions rendered in-app** — the "open each skill" half of the original ask. Closes #259.

## How

- **`skills:read` IPC** — same gate as reveal (`isListableSkillPath`): only a `SKILL.md` directly under a *current* search dir is readable, so the channel can't become a generic file-read. 512KB truncation cap. Returns the body only (`skillBody`, tested: first fence pair = frontmatter; later `---` stay horizontal rules).
- **Preview pane** in `SkillsView` — header (`/name`, scope + invocable badges, description, path, Reveal), body rendered with the conversation's `Response` (sanitized markdown; file chips inert outside a Conversation per its null-opener contract). Loading / read-failed / empty-body states all covered.
- **Row restructure** — open-preview and Reveal buttons are siblings (nested buttons are invalid HTML); hover wash on the row.

## Verification

- Gates: lint, typecheck, build, test — 1359 tests green (3 new).
- Playwright harness with a seeded skill: folded `>-` description in the header, markdown body rendered (heading, list, bold, inline code, post-frontmatter `---` kept), frontmatter never leaked, back-to-list works.
- 🔍 Adversarial probes from the live renderer: `skillsRead('/etc/passwd')` and a traversal path both **refused** by the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)