### PR TITLE
feat(settings): check PyPI for a newer Vibe CLI in the Environment card

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -22,6 +22,7 @@ import {
   type AccountWhoamiResult,
   type CheckAuthStatusArgs,
   type CheckAuthStatusResult,
+  type CheckVibeUpdateArgs,
   type SetThreadConfigArgs,
   type SetThreadConfigResult,
   type SetThreadFlagsArgs,
@@ -39,6 +40,7 @@ import {
   type ThreadTitleEvent,
 } from '../shared/ipc'
 import { detectVibe } from './vibe-detect'
+import { checkVibeUpdate } from './vibe-update'
 import { getShellEnv } from './shell-env'
 import { getAccountWhoami, readKeychainApiKey, readVibeEnvFile } from './auth/whoami'
 import { searchThreads, tokenizeQuery } from './search/search-threads'
@@ -682,6 +684,10 @@ function registerIpc(deps: MainDeps): void {
   registerBrowserIpc()
 
   ipcMain.handle(IPC.detectVibe, () => detectVibe())
+
+  ipcMain.handle(IPC.checkVibeUpdate, (_event, args: CheckVibeUpdateArgs) =>
+    checkVibeUpdate(args.vibeVersion),
+  )
 
   ipcMain.handle(IPC.openWorkspaceDialog, async (event): Promise<string | null> => {
     const win = BrowserWindow.fromWebContents(event.sender)

--- a/src/main/vibe-update.test.ts
+++ b/src/main/vibe-update.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import { checkVibeUpdate, compareVersions, parseVibeVersion } from './vibe-update'
+
+describe('parseVibeVersion', () => {
+  it('extracts the dotted version from a `vibe --version` line', () => {
+    expect(parseVibeVersion('vibe 2.18.4')).toBe('2.18.4')
+  })
+
+  it('handles uv-tool-style lines with a v prefix', () => {
+    expect(parseVibeVersion('mistral-vibe v2.18.4')).toBe('2.18.4')
+  })
+
+  it('returns the bare version unchanged', () => {
+    expect(parseVibeVersion('2.18.4')).toBe('2.18.4')
+  })
+
+  it('returns null for null, empty, or version-free input', () => {
+    expect(parseVibeVersion(null)).toBeNull()
+    expect(parseVibeVersion('')).toBeNull()
+    expect(parseVibeVersion('vibe')).toBeNull()
+  })
+})
+
+describe('compareVersions', () => {
+  it('orders by major, minor, patch', () => {
+    expect(compareVersions('2.18.4', '2.19.0')).toBeLessThan(0)
+    expect(compareVersions('2.19.0', '2.18.4')).toBeGreaterThan(0)
+    expect(compareVersions('2.18.4', '2.18.4')).toBe(0)
+    expect(compareVersions('1.9.9', '2.0.0')).toBeLessThan(0)
+    expect(compareVersions('2.18.4', '2.18.10')).toBeLessThan(0)
+  })
+
+  it('treats missing segments as zero', () => {
+    expect(compareVersions('2.18', '2.18.0')).toBe(0)
+    expect(compareVersions('2.18', '2.18.1')).toBeLessThan(0)
+  })
+
+  it('reads the leading digits of a suffixed segment', () => {
+    expect(compareVersions('2.19.0rc1', '2.19.0')).toBe(0)
+    expect(compareVersions('2.18.4', '2.19.0rc1')).toBeLessThan(0)
+  })
+})
+
+/** A minimal fetch stub returning the given response once. */
+function fetchStub(response: { ok: boolean; status?: number; json?: () => Promise<unknown> }): typeof fetch {
+  return (() =>
+    Promise.resolve({
+      ok: response.ok,
+      status: response.status ?? 200,
+      json: response.json ?? (() => Promise.resolve({})),
+    })) as unknown as typeof fetch
+}
+
+const pypiBody = (version: string): (() => Promise<unknown>) =>
+  () => Promise.resolve({ info: { version } })
+
+describe('checkVibeUpdate', () => {
+  it('reports an update when PyPI is ahead of the installed version', async () => {
+    const result = await checkVibeUpdate('vibe 2.18.4', fetchStub({ ok: true, json: pypiBody('2.19.0') }))
+    expect(result).toEqual({
+      installedVersion: '2.18.4',
+      latestVersion: '2.19.0',
+      updateAvailable: true,
+      error: null,
+    })
+  })
+
+  it('reports no update when versions match', async () => {
+    const result = await checkVibeUpdate('vibe 2.18.4', fetchStub({ ok: true, json: pypiBody('2.18.4') }))
+    expect(result.updateAvailable).toBe(false)
+    expect(result.latestVersion).toBe('2.18.4')
+    expect(result.error).toBeNull()
+  })
+
+  it('reports no update when the installed build is ahead of PyPI', async () => {
+    const result = await checkVibeUpdate('vibe 2.20.0', fetchStub({ ok: true, json: pypiBody('2.19.0') }))
+    expect(result.updateAvailable).toBe(false)
+  })
+
+  it('still reports the latest version when the installed one is unknown', async () => {
+    const result = await checkVibeUpdate(null, fetchStub({ ok: true, json: pypiBody('2.19.0') }))
+    expect(result.installedVersion).toBeNull()
+    expect(result.latestVersion).toBe('2.19.0')
+    expect(result.updateAvailable).toBe(false)
+  })
+
+  it('sets error on a non-2xx response instead of rejecting', async () => {
+    const result = await checkVibeUpdate('vibe 2.18.4', fetchStub({ ok: false, status: 503 }))
+    expect(result.error).toBe('PyPI responded 503')
+    expect(result.latestVersion).toBeNull()
+    expect(result.updateAvailable).toBe(false)
+  })
+
+  it('sets error on a malformed body instead of rejecting', async () => {
+    const result = await checkVibeUpdate(
+      'vibe 2.18.4',
+      fetchStub({ ok: true, json: () => Promise.resolve({ info: {} }) }),
+    )
+    expect(result.error).toBe('PyPI response had no version')
+  })
+
+  it('sets error when fetch itself throws (offline)', async () => {
+    const offline = (() => Promise.reject(new Error('network down'))) as unknown as typeof fetch
+    const result = await checkVibeUpdate('vibe 2.18.4', offline)
+    expect(result.error).toBe('network down')
+    expect(result.updateAvailable).toBe(false)
+  })
+})

--- a/src/main/vibe-update.ts
+++ b/src/main/vibe-update.ts
@@ -1,0 +1,85 @@
+import type { VibeUpdateResult } from '../shared/ipc'
+
+/**
+ * The same source of truth Vibe's own update notifier polls (mistral-vibe's
+ * `PyPIUpdateGateway`): PyPI's JSON API for the `mistral-vibe` distribution.
+ * `info.version` is the latest non-yanked release.
+ */
+export const VIBE_PYPI_JSON_URL = 'https://pypi.org/pypi/mistral-vibe/json'
+
+const FETCH_TIMEOUT_MS = 10_000
+
+/** Pull the dotted version out of a raw `vibe --version` line (e.g. `vibe 2.18.4`). */
+export function parseVibeVersion(raw: string | null): string | null {
+  if (!raw) return null
+  const match = raw.match(/\d+(?:\.\d+)+/)
+  return match ? match[0] : null
+}
+
+/**
+ * Compare dotted versions numerically per segment (missing segments count as 0);
+ * a non-numeric suffix on a segment (`2.19.0rc1`) keeps its leading digits.
+ * Negative when `a` is older than `b`, 0 when equal, positive when newer.
+ */
+export function compareVersions(a: string, b: string): number {
+  const parse = (v: string): number[] =>
+    v.split('.').map((seg) => Number.parseInt(seg, 10) || 0)
+  const as = parse(a)
+  const bs = parse(b)
+  const len = Math.max(as.length, bs.length)
+  for (let i = 0; i < len; i++) {
+    const diff = (as[i] ?? 0) - (bs[i] ?? 0)
+    if (diff !== 0) return diff
+  }
+  return 0
+}
+
+/**
+ * Check PyPI for a newer `mistral-vibe` than the installed CLI. Best-effort like
+ * detection: every failure path resolves with `error` set, never a rejection.
+ * `fetchImpl` is injectable for tests only.
+ */
+export async function checkVibeUpdate(
+  rawInstalledVersion: string | null,
+  fetchImpl: typeof fetch = fetch,
+): Promise<VibeUpdateResult> {
+  const installedVersion = parseVibeVersion(rawInstalledVersion)
+  const result: VibeUpdateResult = {
+    installedVersion,
+    latestVersion: null,
+    updateAvailable: false,
+    error: null,
+  }
+
+  try {
+    const response = await fetchImpl(VIBE_PYPI_JSON_URL, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: { Accept: 'application/json' },
+    })
+    if (!response.ok) {
+      result.error = `PyPI responded ${response.status}`
+      return result
+    }
+    const body: unknown = await response.json()
+    const latest = extractLatestVersion(body)
+    if (!latest) {
+      result.error = 'PyPI response had no version'
+      return result
+    }
+    result.latestVersion = latest
+    result.updateAvailable =
+      installedVersion !== null && compareVersions(installedVersion, latest) < 0
+  } catch (err) {
+    result.error = err instanceof Error ? err.message : String(err)
+  }
+
+  return result
+}
+
+function extractLatestVersion(body: unknown): string | null {
+  if (typeof body !== 'object' || body === null) return null
+  const info = (body as { info?: unknown }).info
+  if (typeof info !== 'object' || info === null) return null
+  const version = (info as { version?: unknown }).version
+  return typeof version === 'string' && version.length > 0 ? version : null
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -78,6 +78,8 @@ import {
   type ThreadStatusEvent,
   type ThreadTitleEvent,
   type VibeDetectResult,
+  type CheckVibeUpdateArgs,
+  type VibeUpdateResult,
 } from '../shared/ipc'
 
 /**
@@ -96,6 +98,8 @@ function subscribe<T>(channel: string): (listener: (event: T) => void) => () => 
 
 const api = {
   detectVibe: (): Promise<VibeDetectResult> => ipcRenderer.invoke(IPC.detectVibe),
+  checkVibeUpdate: (args: CheckVibeUpdateArgs): Promise<VibeUpdateResult> =>
+    ipcRenderer.invoke(IPC.checkVibeUpdate, args),
   openWorkspaceDialog: (): Promise<string | null> => ipcRenderer.invoke(IPC.openWorkspaceDialog),
   startThread: (args: StartThreadArgs): Promise<StartThreadResult> =>
     ipcRenderer.invoke(IPC.startThread, args),

--- a/src/renderer/src/settings/Environment.tsx
+++ b/src/renderer/src/settings/Environment.tsx
@@ -1,8 +1,9 @@
-import type { JSX } from 'react'
-import type { VibeDetectResult } from '../../../shared/ipc'
+import { useEffect, useState, type JSX } from 'react'
+import type { VibeDetectResult, VibeUpdateResult } from '../../../shared/ipc'
 import { INSTALL_DOCS_URL } from '../../../shared/install-guidance'
 import { Button } from '../ui/button'
 import { CodeText } from '../ui/code-text'
+import { describeUpdateStatus } from './update-status'
 
 /** The environment check: whether `vibe` / `vibe-acp` are installed + reachable. */
 export function Environment({
@@ -14,6 +15,8 @@ export function Environment({
   loading: boolean
   onRecheck: () => void
 }): JSX.Element {
+  const update = useVibeUpdate(detect)
+  const updateStatus = describeUpdateStatus(update)
   return (
     <div className="flex flex-col gap-2.5 rounded-[9px] border border-border p-3">
       <div className="flex items-center justify-between text-[13px] font-semibold text-text-strong">
@@ -30,6 +33,18 @@ export function Environment({
             <span className="status__label">version</span>
             <span className="status__value">{detect.vibeVersion ?? '—'}</span>
           </li>
+          {updateStatus && (
+            <li className="status__row">
+              <span className="status__label">latest</span>
+              <span className="status__value">{updateStatus}</span>
+            </li>
+          )}
+          {update?.updateAvailable && (
+            <li className="text-[13px] leading-normal text-faint">
+              Update with <CodeText text="uv tool upgrade mistral-vibe" /> (or{' '}
+              <CodeText text="brew upgrade mistral-vibe" />), then Re-check.
+            </li>
+          )}
           {detect.error && (
             <li className="status__error">
               <CodeText text={detect.error} />{' '}
@@ -42,6 +57,29 @@ export function Environment({
       )}
     </div>
   )
+}
+
+/**
+ * Check PyPI (via main) for a newer `mistral-vibe` once per detection result —
+ * a Re-check mints a fresh `detect` object, so it also re-runs this. Skipped
+ * until the CLI is actually found; a check failure renders as its own row copy.
+ */
+function useVibeUpdate(detect: VibeDetectResult | null): VibeUpdateResult | null {
+  const [update, setUpdate] = useState<VibeUpdateResult | null>(null)
+  useEffect(() => {
+    if (!detect?.vibeFound) {
+      setUpdate(null)
+      return
+    }
+    let cancelled = false
+    void window.api.checkVibeUpdate({ vibeVersion: detect.vibeVersion }).then((result) => {
+      if (!cancelled) setUpdate(result)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [detect])
+  return update
 }
 
 function StatusRow({ ok, label }: { ok: boolean; label: string }): JSX.Element {

--- a/src/renderer/src/settings/update-status.test.ts
+++ b/src/renderer/src/settings/update-status.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { describeUpdateStatus } from './update-status'
+import type { VibeUpdateResult } from '../../../shared/ipc'
+
+const base: VibeUpdateResult = {
+  installedVersion: '2.18.4',
+  latestVersion: '2.18.4',
+  updateAvailable: false,
+  error: null,
+}
+
+describe('describeUpdateStatus', () => {
+  it('renders nothing before a check has run', () => {
+    expect(describeUpdateStatus(null)).toBeNull()
+  })
+
+  it('announces an available update with the latest version', () => {
+    expect(
+      describeUpdateStatus({ ...base, latestVersion: '2.19.0', updateAvailable: true }),
+    ).toBe('2.19.0 — update available')
+  })
+
+  it('confirms up to date when PyPI matches the installed version', () => {
+    expect(describeUpdateStatus(base)).toBe('2.18.4 — up to date')
+  })
+
+  it('treats a dev build ahead of PyPI as up to date', () => {
+    expect(describeUpdateStatus({ ...base, installedVersion: '2.20.0' })).toBe(
+      '2.18.4 — up to date',
+    )
+  })
+
+  it('surfaces a failed check instead of swallowing it', () => {
+    expect(
+      describeUpdateStatus({ ...base, latestVersion: null, error: 'network down' }),
+    ).toBe('update check failed')
+  })
+
+  it('renders nothing when the check produced no version and no error', () => {
+    expect(describeUpdateStatus({ ...base, latestVersion: null })).toBeNull()
+  })
+})

--- a/src/renderer/src/settings/update-status.ts
+++ b/src/renderer/src/settings/update-status.ts
@@ -1,0 +1,14 @@
+import type { VibeUpdateResult } from '../../../shared/ipc'
+
+/**
+ * The Environment card's "latest" row copy for a PyPI update-check result.
+ * Null means render no row (not checked yet, or nothing meaningful to say).
+ */
+export function describeUpdateStatus(update: VibeUpdateResult | null): string | null {
+  if (!update) return null
+  if (update.error) return 'update check failed'
+  if (!update.latestVersion) return null
+  if (update.updateAvailable) return `${update.latestVersion} — update available`
+  // Also covers an installed dev build ahead of PyPI: still "nothing to do".
+  return `${update.latestVersion} — up to date`
+}

--- a/src/shared/ipc/core.ts
+++ b/src/shared/ipc/core.ts
@@ -10,6 +10,8 @@ import type { AuthMethod } from './auth'
 export const coreChannels = {
   /** Detect whether `vibe` / `vibe-acp` are installed and reachable. */
   detectVibe: 'vibe:detect',
+  /** Check PyPI for a newer `mistral-vibe` release than the installed CLI. */
+  checkVibeUpdate: 'vibe:check-update',
   /** Open a native directory picker to choose a Workspace. */
   openWorkspaceDialog: 'workspace:open-dialog',
   /** Start a Workspace agent, run the ACP handshake, and open a Thread. */
@@ -39,6 +41,25 @@ export interface VibeDetectResult {
   vibeVersion: string | null
   /** Resolved absolute path to the vibe-acp binary, when found. */
   vibeAcpPath: string | null
+  error: string | null
+}
+
+export interface CheckVibeUpdateArgs {
+  /** The raw `vibe --version` line from {@link VibeDetectResult.vibeVersion} (e.g. `vibe 2.18.4`). */
+  vibeVersion: string | null
+}
+
+/**
+ * Result of the PyPI update check. The comparison happens in main (the same
+ * `pypi.org` source Vibe's own update notifier queries); the renderer only renders.
+ * Best-effort like detection: a failed check sets `error`, never throws.
+ */
+export interface VibeUpdateResult {
+  /** Installed version parsed out of the `vibe --version` line, e.g. `2.18.4`. */
+  installedVersion: string | null
+  /** Latest release on PyPI, e.g. `2.19.0`. */
+  latestVersion: string | null
+  updateAvailable: boolean
   error: string | null
 }
 


### PR DESCRIPTION
## What

The Settings > Environment card now tells you when a newer Vibe CLI is available: a new **latest** row compares the detected `vibe --version` against the newest `mistral-vibe` release on PyPI and renders `2.19.0 — update available` (with the `uv tool upgrade mistral-vibe` / `brew upgrade mistral-vibe` hint) or `2.18.4 — up to date`. A failed check renders `update check failed` — logged, not swallowed.

## How

- **Source of truth**: `https://pypi.org/pypi/mistral-vibe/json` — the same source Vibe's own update notifier (`PyPIUpdateGateway`) polls. Deliberately NOT `vibe --check-upgrade`: that prints human-oriented text and touches Vibe's dismissal cache.
- **Main** (`src/main/vibe-update.ts`): pure `parseVibeVersion` / `compareVersions` + best-effort `checkVibeUpdate` (10s timeout, injectable fetch for tests, never rejects) — thin-wrapper handler per convention.
- **IPC**: new `vibe:check-update` invoke channel in `shared/ipc/core.ts` (`CheckVibeUpdateArgs` → `VibeUpdateResult`); comparison happens in main, the renderer only renders.
- **Renderer**: `useVibeUpdate` re-checks whenever detection refreshes, so Re-check refreshes the update status too; row copy lives in the pure `settings/update-status.ts`.

## Verification

- All four gates pass: lint, typecheck, build, **1379 tests** (22 new: 15 main-module, 6 row-copy, +1).
- Drove the built app with the Playwright e2e harness against live PyPI (throwaway spec, not committed): real CLI → `up to date`; fake older `vibe` on PATH via the `VIBE_MISTRO_SKIP_SHELL_ENV` seam → `update available` + hint; no CLI on PATH → existing error copy intact, no latest row.

**Slice 2 candidate** (not in this PR): an Update button that runs the upgrade — needs install-method detection, output streaming, and a no-upgrade-mid-turn guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)