### PR TITLE
fix(conversation): cap the transcript at the composer's 830px reading measure

### DIFF
--- a/src/renderer/src/conversation/ColdThread.tsx
+++ b/src/renderer/src/conversation/ColdThread.tsx
@@ -103,26 +103,28 @@ export function ColdThread({
       <UsageBar state={view} />
 
       <div className="messages">
-        {state === null ? (
-          <p className="hint">Loading conversation…</p>
-        ) : view.items.length === 0 ? (
-          <p className="hint">This thread has no saved conversation yet.</p>
-        ) : (
-          view.items.map((item) => (
-            // Read-only reopened history: no live turn, so reasoning renders collapsed.
-            // The retroactive skill chip (PR #213) matches against the Workspace-level
-            // commands cache (#241) — no agent runs here, so there is no session list.
-            // The data-item-id wrapper is the Search jump anchor (#174 slice 3).
-            <div key={item.id} data-item-id={item.id} className="rounded-lg">
-              <Item
-                item={item}
-                streaming={false}
-                onPermission={noPermission}
-                availableCommands={getWorkspaceCommands(window.localStorage, thread.workspaceId)}
-              />
-            </div>
-          ))
-        )}
+        <div className="conv-measure flex flex-col gap-3">
+          {state === null ? (
+            <p className="hint">Loading conversation…</p>
+          ) : view.items.length === 0 ? (
+            <p className="hint">This thread has no saved conversation yet.</p>
+          ) : (
+            view.items.map((item) => (
+              // Read-only reopened history: no live turn, so reasoning renders collapsed.
+              // The retroactive skill chip (PR #213) matches against the Workspace-level
+              // commands cache (#241) — no agent runs here, so there is no session list.
+              // The data-item-id wrapper is the Search jump anchor (#174 slice 3).
+              <div key={item.id} data-item-id={item.id} className="rounded-lg">
+                <Item
+                  item={item}
+                  streaming={false}
+                  onPermission={noPermission}
+                  availableCommands={getWorkspaceCommands(window.localStorage, thread.workspaceId)}
+                />
+              </div>
+            ))
+          )}
+        </div>
       </div>
 
       <p className="hint">

--- a/src/renderer/src/conversation/Composer.tsx
+++ b/src/renderer/src/conversation/Composer.tsx
@@ -411,7 +411,7 @@ export function Composer({
     // @container: the composer adapts to ITS OWN width (container queries), not the
     // viewport's — with the sidebar + side panel open the chat column narrows while
     // the window stays wide, so viewport breakpoints would never fire.
-    <div className="mx-auto w-full max-w-[830px] @container">
+    <div className="conv-measure @container">
       {/* shadow-xs: a lighter lift than the Card default — the composer sits over the
           transcript, so the full shadow-sm read as a heavy smudge under it. */}
       <Card className="gap-0 p-0 shadow-xs">

--- a/src/renderer/src/conversation/MessageScroller.tsx
+++ b/src/renderer/src/conversation/MessageScroller.tsx
@@ -37,7 +37,7 @@ export function MessageScroller({
     // `.conv` column leaves over, keeping the Composer sibling pinned below.
     <div className={cn('relative flex min-h-0 flex-1 flex-col', className)}>
       <div ref={scrollRef} className="messages">
-        <div ref={contentRef} className="flex flex-col gap-3">
+        <div ref={contentRef} className="conv-measure flex flex-col gap-3">
           {children}
         </div>
       </div>

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -491,6 +491,15 @@ body {
   font-weight: 600;
 }
 
+/* The conversation column's shared reading measure: transcript content and the
+   Composer cap to the same centered width, so collapsing the sidebar/side panel
+   widens the outlet without the transcript sprawling past the composer. */
+.conv-measure {
+  width: 100%;
+  max-width: 830px;
+  margin-inline: auto;
+}
+
 .messages {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Problem

With the sidebar and side panel collapsed, the outlet widens and the transcript sprawls to the full window width while the Composer stays centered at its 830px cap — the two only looked aligned by accident when the open panels ate the difference. Prose lines running ~1900px wide are also well past a comfortable reading measure.

## Fix

One shared `.conv-measure` class (`width: 100%; max-width: 830px; margin-inline: auto`) in `styles.css` is now the single source of truth for the conversation column's reading width, applied in three places so they can't drift apart:

- **`MessageScroller.tsx`** — the live transcript's inner content div; the scroll container stays full-width so the scrollbar remains at the window edge
- **`ColdThread.tsx`** — the process-free reopened-history view, via an inner wrapper matching the live layout
- **`Composer.tsx`** — replaces its hardcoded `mx-auto w-full max-w-[830px]`

The thread header row and usage bar intentionally stay full-width — they read as chrome, not content.

## Gates

`bun run lint && bun run typecheck && bun run build && bun run test` — all pass (1386 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)