### PR TITLE
feat(shell): wire the header back/forward arrows to a nav-history stack

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -40,7 +40,8 @@ import { Logo } from './shell/logo'
 import { firstRunState } from './shell/first-run'
 import { installBannerMessage } from './shell/install-banner'
 import { InstallBanner } from './shell/InstallBanner'
-import { findSelectedThread, initialNavState, navReducer } from './shell/nav-reducer'
+import { findSelectedThread } from './shell/nav-reducer'
+import { initialNavHistory, navHistoryReducer } from './shell/nav-history'
 import {
   getSidebarCollapsed,
   setSidebarCollapsed as setSidebarCollapsedStore,
@@ -112,7 +113,10 @@ export function App(): JSX.Element {
   }, [])
   // Navigation (decision 2): WHICH Workspace/Thread the user is looking at —
   // lifted here so the connect flow (Open project, Continue, sign-in) can drive it.
-  const [nav, navDispatch] = useReducer(navReducer, initialNavState)
+  // Wrapped in the pure history reducer so the header's back/forward arrows walk
+  // real moves; NavAction dispatches pass through unchanged (nav-history.ts).
+  const [navHistory, navDispatch] = useReducer(navHistoryReducer, initialNavHistory)
+  const nav = navHistory.present
   // Per-Workspace connection registry (decision 3): one ConnectState per warm
   // Workspace, so switching between two is instant and both keep streaming.
   const [connections, connDispatch] = useReducer(connectionsReducer, initialConnections)
@@ -171,6 +175,16 @@ export function App(): JSX.Element {
    */
   function selectThreadInWorkspace(workspaceId: string, threadId: string): void {
     navDispatch({ type: 'select-thread', workspaceId, threadId })
+    hostSelectedThread(workspaceId, threadId)
+  }
+
+  /**
+   * The NON-nav half of a Thread selection: host it live / auto-continue it. Split
+   * from `selectThreadInWorkspace` so a history jump (back/forward) can replay the
+   * same side effects — nav alone moves the sidebar highlight, but the mounted
+   * conversation follows `workspaceThreads`' active pointer, which lives here.
+   */
+  function hostSelectedThread(workspaceId: string, threadId: string): void {
     const status = connections[workspaceId]?.status
     if (status === 'connected') {
       wtDispatch({ type: 'open', workspaceId, threadId })
@@ -182,6 +196,22 @@ export function App(): JSX.Element {
     if (status === undefined) {
       const meta = threadsForWorkspace(recents, workspaceId).find((t) => t.id === threadId)
       if (meta) void continueColdThread(meta)
+    }
+  }
+
+  /**
+   * Header back/forward (#future no more): move the nav-history pointer, then
+   * replay the target's Thread through the same hosting side effects a sidebar
+   * click runs — otherwise the highlight would move while the mounted view stayed.
+   * Settings/skills/workspace-only targets need no side effects (outlet reads nav).
+   */
+  function goNavHistory(direction: 'history-back' | 'history-forward'): void {
+    const target =
+      direction === 'history-back' ? navHistory.past.at(-1) : navHistory.future[0]
+    if (!target) return
+    navDispatch({ type: direction })
+    if (target.view === 'conversation' && target.selectedWorkspaceId && target.selectedThreadId) {
+      hostSelectedThread(target.selectedWorkspaceId, target.selectedThreadId)
     }
   }
 
@@ -719,21 +749,35 @@ export function App(): JSX.Element {
 
   return (
     <div className="flex h-screen flex-col bg-bg text-text">
-      {/* Window chrome (#113): a draggable top bar. Back/forward are STATIC placeholders
-          (#future) — styled but non-functional; the top-right layout controls are live.
-          The bar stays `-webkit-app-region: drag` so the window moves; every interactive
-          control opts back out with `[-webkit-app-region:no-drag]`. On macOS we pad the
+      {/* Window chrome (#113): a draggable top bar. Back/forward walk the nav history
+          (nav-history.ts); the top-right layout controls are live. The bar stays
+          `-webkit-app-region: drag` so the window moves; every interactive control
+          opts back out with `[-webkit-app-region:no-drag]`. On macOS we pad the
           left edge so the OS traffic lights don't collide with our controls. */}
       <header
         className="flex h-11 flex-none items-center gap-2 border-b border-border px-3 [-webkit-app-region:drag]"
         style={isMac ? { paddingLeft: 78 } : undefined}
       >
-        {/* placeholder — back / forward navigation (#future) */}
+        {/* Back / forward: walk the nav history (nav-history.ts) — every real move
+            (workspace, thread, settings, skills) is a step; disabled at the ends so
+            the state reads before the click, like the right-region controls. */}
         <div className="flex items-center gap-0.5 [-webkit-app-region:no-drag]">
-          <IconButton size="icon-sm" aria-label="Back" title="Back">
+          <IconButton
+            size="icon-sm"
+            aria-label="Back"
+            title="Back"
+            disabled={navHistory.past.length === 0}
+            onClick={() => goNavHistory('history-back')}
+          >
             <ArrowLeft className="size-4" aria-hidden />
           </IconButton>
-          <IconButton size="icon-sm" aria-label="Forward" title="Forward">
+          <IconButton
+            size="icon-sm"
+            aria-label="Forward"
+            title="Forward"
+            disabled={navHistory.future.length === 0}
+            onClick={() => goNavHistory('history-forward')}
+          >
             <ArrowRight className="size-4" aria-hidden />
           </IconButton>
         </div>

--- a/src/renderer/src/shell/nav-history.test.ts
+++ b/src/renderer/src/shell/nav-history.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import {
+  initialNavHistory,
+  navHistoryReducer,
+  MAX_NAV_HISTORY,
+  type NavHistoryAction,
+  type NavHistoryState,
+} from './nav-history'
+import { initialNavState } from './nav-reducer'
+
+function run(actions: NavHistoryAction[], from: NavHistoryState = initialNavHistory) {
+  return actions.reduce(navHistoryReducer, from)
+}
+
+describe('navHistoryReducer', () => {
+  it('forwards NavActions to navReducer and records the prior state', () => {
+    const state = run([{ type: 'select-workspace', workspaceId: 'ws1' }])
+    expect(state.present.selectedWorkspaceId).toBe('ws1')
+    expect(state.past).toEqual([initialNavState])
+    expect(state.future).toEqual([])
+  })
+
+  it('history-back returns to the previous state and populates future', () => {
+    const moved = run([
+      { type: 'select-workspace', workspaceId: 'ws1' },
+      { type: 'select-thread', workspaceId: 'ws1', threadId: 't1' },
+    ])
+    const back = navHistoryReducer(moved, { type: 'history-back' })
+    expect(back.present.selectedThreadId).toBeNull()
+    expect(back.present.selectedWorkspaceId).toBe('ws1')
+    expect(back.future).toEqual([moved.present])
+  })
+
+  it('history-forward re-applies an undone move', () => {
+    const moved = run([
+      { type: 'select-workspace', workspaceId: 'ws1' },
+      { type: 'open-settings' },
+    ])
+    const roundTrip = run([{ type: 'history-back' }, { type: 'history-forward' }], moved)
+    expect(roundTrip.present).toEqual(moved.present)
+    expect(roundTrip.future).toEqual([])
+  })
+
+  it('history-back on an empty past is a referential no-op', () => {
+    expect(navHistoryReducer(initialNavHistory, { type: 'history-back' })).toBe(initialNavHistory)
+  })
+
+  it('history-forward on an empty future is a referential no-op', () => {
+    const moved = run([{ type: 'select-workspace', workspaceId: 'ws1' }])
+    expect(navHistoryReducer(moved, { type: 'history-forward' })).toBe(moved)
+  })
+
+  it('a referential no-op NavAction records no history entry', () => {
+    const moved = run([{ type: 'select-workspace', workspaceId: 'ws1' }])
+    // Re-selecting the SAME Workspace while already in the conversation view is a
+    // referential no-op in navReducer — the arrows must not walk phantom moves.
+    const again = navHistoryReducer(moved, { type: 'select-workspace', workspaceId: 'ws1' })
+    expect(again).toBe(moved)
+  })
+
+  it('a new move clears the forward stack (browser semantics)', () => {
+    const moved = run([
+      { type: 'select-workspace', workspaceId: 'ws1' },
+      { type: 'select-workspace', workspaceId: 'ws2' },
+      { type: 'history-back' },
+      { type: 'select-workspace', workspaceId: 'ws3' },
+    ])
+    expect(moved.present.selectedWorkspaceId).toBe('ws3')
+    expect(moved.future).toEqual([])
+    // Back walks ws3 -> ws1 -> initial; ws2 was pruned.
+    const back = navHistoryReducer(moved, { type: 'history-back' })
+    expect(back.present.selectedWorkspaceId).toBe('ws1')
+  })
+
+  it('caps the past stack at MAX_NAV_HISTORY', () => {
+    const actions: NavHistoryAction[] = []
+    for (let i = 0; i < MAX_NAV_HISTORY + 10; i++) {
+      actions.push({ type: 'select-workspace', workspaceId: `ws${i}` })
+    }
+    const state = run(actions)
+    expect(state.past.length).toBe(MAX_NAV_HISTORY)
+    // The OLDEST entries fell off; the newest survive.
+    expect(state.past.at(-1)?.selectedWorkspaceId).toBe(`ws${MAX_NAV_HISTORY + 8}`)
+  })
+})

--- a/src/renderer/src/shell/nav-history.ts
+++ b/src/renderer/src/shell/nav-history.ts
@@ -1,0 +1,67 @@
+import { initialNavState, navReducer, type NavAction, type NavState } from './nav-reducer'
+
+/**
+ * Browser-style back/forward over shell navigation: a pure history wrapper around
+ * `navReducer` (the undo/redo shape — past / present / future). The header's arrow
+ * buttons dispatch `history-back` / `history-forward`; every ordinary NavAction
+ * flows through unchanged, so `navDispatch` call sites don't know history exists.
+ *
+ * Two rules keep the stack honest:
+ * - A referential no-op from navReducer (re-selecting the current Thread, opening
+ *   Settings while in Settings) records NOTHING — the arrows only walk real moves.
+ * - Any new move CLEARS the forward stack, exactly like a browser.
+ *
+ * History is renderer-session-only (not persisted): like a browser tab, a fresh
+ * window starts with no past.
+ */
+export interface NavHistoryState {
+  past: NavState[]
+  present: NavState
+  future: NavState[]
+}
+
+export type NavHistoryAction = NavAction | { type: 'history-back' } | { type: 'history-forward' }
+
+export const initialNavHistory: NavHistoryState = {
+  past: [],
+  present: initialNavState,
+  future: [],
+}
+
+/** Bound so a long session can't grow the stack without limit (browser-like cap). */
+export const MAX_NAV_HISTORY = 50
+
+export function navHistoryReducer(
+  state: NavHistoryState,
+  action: NavHistoryAction,
+): NavHistoryState {
+  switch (action.type) {
+    case 'history-back': {
+      const previous = state.past.at(-1)
+      if (previous === undefined) return state
+      return {
+        past: state.past.slice(0, -1),
+        present: previous,
+        future: [state.present, ...state.future],
+      }
+    }
+    case 'history-forward': {
+      const [next, ...rest] = state.future
+      if (next === undefined) return state
+      return {
+        past: [...state.past, state.present],
+        present: next,
+        future: rest,
+      }
+    }
+    default: {
+      const next = navReducer(state.present, action)
+      if (next === state.present) return state
+      return {
+        past: [...state.past, state.present].slice(-MAX_NAV_HISTORY),
+        present: next,
+        future: [],
+      }
+    }
+  }
+}

--- a/src/renderer/src/shell/nav-reducer.test.ts
+++ b/src/renderer/src/shell/nav-reducer.test.ts
@@ -35,6 +35,20 @@ describe('navReducer', () => {
     expect(next).toBe(start) // same reference: no spurious re-render or cleared Thread
   })
 
+  it('re-selecting the current Thread while in the conversation view is a no-op (same reference)', () => {
+    // Keeps a connect's redundant re-select (applyConnectResult) out of the
+    // back/forward history — nav-history only records referentially-new states.
+    const start: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 't1', view: 'conversation' }
+    const next = navReducer(start, { type: 'select-thread', workspaceId: 'w1', threadId: 't1' })
+    expect(next).toBe(start)
+  })
+
+  it('re-selecting the current Thread FROM Settings still returns to the conversation view', () => {
+    const start: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 't1', view: 'settings' }
+    const next = navReducer(start, { type: 'select-thread', workspaceId: 'w1', threadId: 't1' })
+    expect(next).toEqual({ selectedWorkspaceId: 'w1', selectedThreadId: 't1', view: 'conversation' })
+  })
+
   it('clear resets to nothing selected in the conversation view', () => {
     const start: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 't1', view: 'settings' }
     expect(navReducer(start, { type: 'clear' })).toEqual(initialNavState)

--- a/src/renderer/src/shell/nav-reducer.ts
+++ b/src/renderer/src/shell/nav-reducer.ts
@@ -53,6 +53,16 @@ export function navReducer(state: NavState, action: NavAction): NavState {
     case 'select-thread':
       // Selecting a Thread pins its Workspace too, so the two never disagree — and
       // leaves Settings (picking a thread returns to the conversation view).
+      // Re-selecting the CURRENT Thread in the conversation view is a referential
+      // no-op (uniform with select-workspace) — it keeps a connect's redundant
+      // re-select (applyConnectResult) out of the back/forward history.
+      if (
+        state.selectedWorkspaceId === action.workspaceId &&
+        state.selectedThreadId === action.threadId &&
+        state.view === 'conversation'
+      ) {
+        return state
+      }
       return { selectedWorkspaceId: action.workspaceId, selectedThreadId: action.threadId, view: 'conversation' }
     case 'open-settings':
       // Swap the outlet for the Settings page, PRESERVING the current selection.


### PR DESCRIPTION
## Problem

The header's back/forward arrows were static placeholders (#113, tagged `#future`) — styled but non-functional.

## What this does

Wires them as real browser-style back/forward over shell navigation:

- **`shell/nav-history.ts`** (new, tested) — a pure past/present/future history wrapper around `navReducer`. Every real move (workspace, thread, settings, skills) is a step; referential no-ops record nothing; a new move clears the forward stack (browser semantics); the past stack caps at 50. `NavAction` dispatches pass through unchanged, so `navDispatch` call sites don't know history exists.
- **`App.tsx`** — the arrows dispatch `history-back` / `history-forward` and disable at the ends (never a silent no-op, matching the right-region controls' contract).

## Correctness fixes underneath

1. **History jumps replay hosting side effects.** A sidebar thread click does more than set nav state — it hosts the thread live / auto-continues a cold one. That half is extracted into `hostSelectedThread`, and a history jump to a conversation target replays it, so the mounted view follows the highlight.
2. **Identical `select-thread` is now a referential no-op** in `navReducer` (uniform with `select-workspace`). Without it, `applyConnectResult`'s redundant re-select after a connect would record phantom history entries, making Back need two clicks.

## Gates

`bun run lint && bun run typecheck && bun run build && bun run test` — all pass (1396 tests, 10 new: 8 in `nav-history.test.ts`, 2 in `nav-reducer.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)