### PR TITLE
feat(app-update): electron-updater with passive restart-to-apply chip (#270)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "chokidar": "^5.0.0",
+    "electron-updater": "^6.6.2",
     "node-pty": "^1.1.0"
   },
   "devDependencies": {

--- a/apps/desktop/src/main/app-update.test.ts
+++ b/apps/desktop/src/main/app-update.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import {
+  APP_UPDATE_INITIAL,
+  reduceUpdaterEvent,
+  resolveUpdaterMode,
+  sameStatus,
+  type UpdaterEvent,
+} from './app-update'
+import type { AppUpdateStatusEvent } from '../shared/ipc'
+
+function run(events: UpdaterEvent[]): AppUpdateStatusEvent {
+  return events.reduce(reduceUpdaterEvent, APP_UPDATE_INITIAL)
+}
+
+describe('reduceUpdaterEvent', () => {
+  it('walks the happy path: checking → downloading → ready', () => {
+    expect(run([{ kind: 'checking' }])).toEqual({ phase: 'checking', version: null, error: null })
+    expect(run([{ kind: 'checking' }, { kind: 'update-available', version: '0.2.0' }])).toEqual({
+      phase: 'downloading',
+      version: '0.2.0',
+      error: null,
+    })
+    expect(
+      run([
+        { kind: 'checking' },
+        { kind: 'update-available', version: '0.2.0' },
+        { kind: 'update-downloaded', version: '0.2.0' },
+      ]),
+    ).toEqual({ phase: 'ready', version: '0.2.0', error: null })
+  })
+
+  it('returns to idle when the check finds nothing', () => {
+    expect(run([{ kind: 'checking' }, { kind: 'update-not-available' }])).toEqual(
+      APP_UPDATE_INITIAL,
+    )
+  })
+
+  it('records an error and lets the next cycle restart from it', () => {
+    const errored = run([{ kind: 'checking' }, { kind: 'error', message: 'net::DISCONNECTED' }])
+    expect(errored).toEqual({ phase: 'error', version: null, error: 'net::DISCONNECTED' })
+    expect(reduceUpdaterEvent(errored, { kind: 'checking' })).toEqual({
+      phase: 'checking',
+      version: null,
+      error: null,
+    })
+  })
+
+  it('ready is absorbing — later checks, misses, and errors never hide the affordance', () => {
+    const ready = run([
+      { kind: 'update-available', version: '0.2.0' },
+      { kind: 'update-downloaded', version: '0.2.0' },
+    ])
+    for (const event of [
+      { kind: 'checking' },
+      { kind: 'update-not-available' },
+      { kind: 'error', message: 'offline' },
+      { kind: 'update-available', version: '0.3.0' },
+    ] satisfies UpdaterEvent[]) {
+      expect(reduceUpdaterEvent(ready, event)).toBe(ready)
+    }
+  })
+})
+
+describe('sameStatus', () => {
+  it('matches identical payloads and catches any field change', () => {
+    const a: AppUpdateStatusEvent = { phase: 'downloading', version: '0.2.0', error: null }
+    expect(sameStatus(a, { ...a })).toBe(true)
+    expect(sameStatus(a, { ...a, phase: 'ready' })).toBe(false)
+    expect(sameStatus(a, { ...a, version: '0.3.0' })).toBe(false)
+    expect(sameStatus(a, { ...a, error: 'x' })).toBe(false)
+  })
+})
+
+describe('resolveUpdaterMode', () => {
+  it('packaged builds run against the embedded feed', () => {
+    expect(resolveUpdaterMode({ isPackaged: true, feedUrlOverride: undefined })).toEqual({
+      enabled: true,
+      feedUrl: null,
+    })
+  })
+
+  it('dev runs are updater-off', () => {
+    expect(resolveUpdaterMode({ isPackaged: false, feedUrlOverride: undefined })).toEqual({
+      enabled: false,
+      feedUrl: null,
+    })
+    expect(resolveUpdaterMode({ isPackaged: false, feedUrlOverride: '   ' })).toEqual({
+      enabled: false,
+      feedUrl: null,
+    })
+  })
+
+  it('the mock-feed env forces the updater on with a generic feed (dev AND packaged)', () => {
+    expect(
+      resolveUpdaterMode({ isPackaged: false, feedUrlOverride: 'http://localhost:8099' }),
+    ).toEqual({ enabled: true, feedUrl: 'http://localhost:8099' })
+    expect(
+      resolveUpdaterMode({ isPackaged: true, feedUrlOverride: 'http://localhost:8099 ' }),
+    ).toEqual({ enabled: true, feedUrl: 'http://localhost:8099' })
+  })
+})

--- a/apps/desktop/src/main/app-update.ts
+++ b/apps/desktop/src/main/app-update.ts
@@ -1,0 +1,81 @@
+/**
+ * Pure App-update logic (#270, ADR-0018): the status reducer electron-updater's
+ * events feed, and the mode resolution that decides whether the updater runs at
+ * all. The electron-updater wiring itself is a thin adapter in `index.ts` (the
+ * established pure-module/thin-handler split); everything decision-shaped lives
+ * here with tests.
+ */
+import type { AppUpdateStatusEvent } from '../shared/ipc'
+
+/** electron-updater's event stream, retagged as a plain union the reducer can consume. */
+export type UpdaterEvent =
+  | { kind: 'checking' }
+  | { kind: 'update-available'; version: string }
+  | { kind: 'update-not-available' }
+  | { kind: 'update-downloaded'; version: string }
+  | { kind: 'error'; message: string }
+
+export const APP_UPDATE_INITIAL: AppUpdateStatusEvent = {
+  phase: 'idle',
+  version: null,
+  error: null,
+}
+
+/**
+ * Fold one updater event into the current status. `ready` is ABSORBING: once an
+ * update is downloaded, a later periodic check (checking / not-available / a
+ * transient network error) must not hide the restart affordance — the downloaded
+ * Release installs on quit regardless, so the truthful state stays `ready`.
+ * Errors otherwise reset the cycle (autoDownload retries on the next check).
+ */
+export function reduceUpdaterEvent(
+  prev: AppUpdateStatusEvent,
+  event: UpdaterEvent,
+): AppUpdateStatusEvent {
+  if (prev.phase === 'ready') return prev
+  switch (event.kind) {
+    case 'checking':
+      return { phase: 'checking', version: null, error: null }
+    case 'update-available':
+      return { phase: 'downloading', version: event.version, error: null }
+    case 'update-not-available':
+      return { phase: 'idle', version: null, error: null }
+    case 'update-downloaded':
+      return { phase: 'ready', version: event.version, error: null }
+    case 'error':
+      return { phase: 'error', version: null, error: event.message }
+  }
+}
+
+/** Two statuses carry the same information (used to suppress no-op pushes). */
+export function sameStatus(a: AppUpdateStatusEvent, b: AppUpdateStatusEvent): boolean {
+  return a.phase === b.phase && a.version === b.version && a.error === b.error
+}
+
+export interface UpdaterMode {
+  /** Whether the updater should run at all this launch. */
+  enabled: boolean
+  /**
+   * Generic-provider feed URL override (the mock-feed seam), or null to use the
+   * app-update.yml electron-builder embedded in the bundle (the GitHub Releases
+   * stable channel).
+   */
+  feedUrl: string | null
+}
+
+/**
+ * Decide the updater's mode for this launch. Packaged builds update from the
+ * embedded feed; a dev/unpackaged run is updater-OFF unless the mock-feed env
+ * (`VIBE_MISTRO_UPDATE_URL`) forces it — the seam the #270 demo and any local
+ * end-to-end run drive (t3code's mock-update-server pattern).
+ */
+export function resolveUpdaterMode(input: {
+  isPackaged: boolean
+  feedUrlOverride: string | undefined
+}): UpdaterMode {
+  const feedUrl = input.feedUrlOverride?.trim() ? input.feedUrlOverride.trim() : null
+  return { enabled: input.isPackaged || feedUrl !== null, feedUrl }
+}
+
+/** Background re-check cadence after the launch check (passive; no UI ticker). */
+export const APP_UPDATE_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow, dialog, ipcMain, Menu, nativeImage, shell, type WebContents } from 'electron'
+import electronUpdater, { type UpdateInfo } from 'electron-updater'
 import { mkdir } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import { basename, join } from 'node:path'
@@ -38,9 +39,18 @@ import {
   type ThreadConnection,
   type ThreadStatusEvent,
   type ThreadTitleEvent,
+  type AppUpdateStatusEvent,
 } from '../shared/ipc'
 import { detectVibe } from './vibe-detect'
 import { checkVibeUpdate } from './vibe-update'
+import {
+  APP_UPDATE_CHECK_INTERVAL_MS,
+  APP_UPDATE_INITIAL,
+  reduceUpdaterEvent,
+  resolveUpdaterMode,
+  sameStatus,
+  type UpdaterEvent,
+} from './app-update'
 import { getShellEnv } from './shell-env'
 import { getAccountWhoami, readKeychainApiKey, readVibeEnvFile } from './auth/whoami'
 import { searchThreads, tokenizeQuery } from './search/search-threads'
@@ -194,6 +204,66 @@ function emitThreadTitle(event: ThreadTitleEvent): void {
     if (win.webContents.isDestroyed()) continue
     win.webContents.send(IPC.threadTitle, event)
   }
+}
+
+/**
+ * App update (#270, ADR-0018): electron-updater against the Release feed —
+ * the app-update.yml electron-builder embeds (GitHub Releases, stable channel),
+ * or the `VIBE_MISTRO_UPDATE_URL` mock-feed override. Passive: check on launch
+ * + every {@link APP_UPDATE_CHECK_INTERVAL_MS}, download in the background,
+ * stream coarse status; the INSTALL only ever happens on the renderer's explicit
+ * restart action or on normal quit (`autoInstallOnAppQuit`) — never a forced
+ * restart, which would kill in-flight turns. Event mapping goes through the pure
+ * `reduceUpdaterEvent` (app-update.ts, tested); this is the thin adapter.
+ */
+let appUpdateStatus: AppUpdateStatusEvent = APP_UPDATE_INITIAL
+
+function applyUpdaterEvent(event: UpdaterEvent): void {
+  const next = reduceUpdaterEvent(appUpdateStatus, event)
+  if (sameStatus(appUpdateStatus, next)) return
+  appUpdateStatus = next
+  console.log(`[app-update] ${next.phase}${next.version ? ` v${next.version}` : ''}`)
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.webContents.isDestroyed()) win.webContents.send(IPC.appUpdateStatus, next)
+  }
+}
+
+function startAppUpdater(): void {
+  const mode = resolveUpdaterMode({
+    isPackaged: app.isPackaged,
+    feedUrlOverride: process.env.VIBE_MISTRO_UPDATE_URL,
+  })
+  if (!mode.enabled) return
+  // electron-updater is CJS; a named ESM import of `autoUpdater` fails at runtime,
+  // so it comes off the default-import interop object.
+  const { autoUpdater } = electronUpdater
+  autoUpdater.autoDownload = true
+  autoUpdater.autoInstallOnAppQuit = true
+  if (mode.feedUrl) {
+    // Mock-feed runs may be unpackaged; electron-updater refuses dev runs unless told.
+    autoUpdater.forceDevUpdateConfig = true
+    autoUpdater.setFeedURL({ provider: 'generic', url: mode.feedUrl })
+  }
+  autoUpdater.on('checking-for-update', () => applyUpdaterEvent({ kind: 'checking' }))
+  autoUpdater.on('update-available', (info: UpdateInfo) =>
+    applyUpdaterEvent({ kind: 'update-available', version: info.version }),
+  )
+  autoUpdater.on('update-not-available', () => applyUpdaterEvent({ kind: 'update-not-available' }))
+  autoUpdater.on('update-downloaded', (info: UpdateInfo) =>
+    applyUpdaterEvent({ kind: 'update-downloaded', version: info.version }),
+  )
+  autoUpdater.on('error', (err) => {
+    console.error('[app-update] updater error:', err)
+    applyUpdaterEvent({ kind: 'error', message: err instanceof Error ? err.message : String(err) })
+  })
+  const check = (): void => {
+    autoUpdater.checkForUpdates().catch((err: unknown) => {
+      // Also surfaced via the 'error' event; log-don't-swallow either way.
+      console.error('[app-update] check failed:', err)
+    })
+  }
+  check()
+  setInterval(check, APP_UPDATE_CHECK_INTERVAL_MS)
 }
 
 /**
@@ -688,6 +758,15 @@ function registerIpc(deps: MainDeps): void {
   ipcMain.handle(IPC.checkVibeUpdate, (_event, args: CheckVibeUpdateArgs) =>
     checkVibeUpdate(args.vibeVersion),
   )
+
+  ipcMain.handle(IPC.appUpdateGetStatus, (): AppUpdateStatusEvent => appUpdateStatus)
+
+  ipcMain.on(IPC.appUpdateRestart, () => {
+    // Only meaningful once a download is ready; a stray send is a no-op rather
+    // than a surprise relaunch.
+    if (appUpdateStatus.phase !== 'ready') return
+    electronUpdater.autoUpdater.quitAndInstall()
+  })
 
   ipcMain.handle(IPC.openWorkspaceDialog, async (event): Promise<string | null> => {
     const win = BrowserWindow.fromWebContents(event.sender)
@@ -1268,6 +1347,7 @@ app.whenReady().then(async () => {
   )
 
   registerIpc(deps)
+  startAppUpdater()
   createWindow()
 
   // The periodic sweep (TB5 #50): release any agent untouched past IDLE_EVICT_MS,

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -80,6 +80,7 @@ import {
   type VibeDetectResult,
   type CheckVibeUpdateArgs,
   type VibeUpdateResult,
+  type AppUpdateStatusEvent,
 } from '../shared/ipc'
 
 /**
@@ -100,6 +101,9 @@ const api = {
   detectVibe: (): Promise<VibeDetectResult> => ipcRenderer.invoke(IPC.detectVibe),
   checkVibeUpdate: (args: CheckVibeUpdateArgs): Promise<VibeUpdateResult> =>
     ipcRenderer.invoke(IPC.checkVibeUpdate, args),
+  getAppUpdateStatus: (): Promise<AppUpdateStatusEvent> =>
+    ipcRenderer.invoke(IPC.appUpdateGetStatus),
+  appUpdateRestart: (): void => ipcRenderer.send(IPC.appUpdateRestart),
   openWorkspaceDialog: (): Promise<string | null> => ipcRenderer.invoke(IPC.openWorkspaceDialog),
   startThread: (args: StartThreadArgs): Promise<StartThreadResult> =>
     ipcRenderer.invoke(IPC.startThread, args),
@@ -192,6 +196,7 @@ const api = {
   onThreadTitle: subscribe<ThreadTitleEvent>(IPC.threadTitle),
   onAgentEvicted: subscribe<AgentEvictedEvent>(IPC.agentEvicted),
   onMenuAction: subscribe<MenuActionEvent>(IPC.menuAction),
+  onAppUpdateStatus: subscribe<AppUpdateStatusEvent>(IPC.appUpdateStatus),
   onGitStatus: subscribe<GitStatusEvent>(IPC.gitStatus),
   onGitActionProgress: subscribe<GitActionProgressEvent>(IPC.gitActionProgress),
 }

--- a/apps/desktop/src/renderer/src/shell/Shell.tsx
+++ b/apps/desktop/src/renderer/src/shell/Shell.tsx
@@ -4,6 +4,7 @@ import type { ListMetadataResult } from '../../../shared/ipc'
 import type { NavState } from './nav-reducer'
 import type { UnifiedThreadRow } from './unified-threads'
 import { WorkspaceNav, type ThreadRowActions, type WorkspaceFlags } from './workspace-nav'
+import { UpdateReadyChip } from './UpdateReadyChip'
 import {
   clampSidebarWidth,
   DEFAULT_SIDEBAR_WIDTH,
@@ -172,6 +173,7 @@ export function Shell({
               actions={actions}
             />
           </div>
+          <UpdateReadyChip />
           <AccountChip onOpenSettings={onOpenSettings} />
         </div>
       </aside>

--- a/apps/desktop/src/renderer/src/shell/UpdateReadyChip.tsx
+++ b/apps/desktop/src/renderer/src/shell/UpdateReadyChip.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState, type JSX } from 'react'
+import { RefreshCw } from 'lucide-react'
+import type { AppUpdateStatusEvent } from '../../../shared/ipc'
+import { updateReadyLabel } from './app-update-view'
+import { Button } from '../ui/button'
+
+/**
+ * The passive App-update affordance (#270, ADR-0018): a quiet full-width chip in
+ * the sidebar's pinned bottom band, rendered ONLY once a downloaded Release is
+ * ready (`updateReadyLabel`). Clicking restarts into the new version; ignoring it
+ * installs on normal quit — main never force-restarts. Self-contained: seeds from
+ * `getAppUpdateStatus` (a window that mounts mid-cycle) and follows the
+ * `app-update:status` stream, so Shell passes nothing in.
+ */
+export function UpdateReadyChip(): JSX.Element | null {
+  const [status, setStatus] = useState<AppUpdateStatusEvent | null>(null)
+
+  useEffect(() => {
+    let mounted = true
+    void window.api.getAppUpdateStatus().then((seed) => {
+      // The stream may have delivered a fresher status while the seed was in
+      // flight; never let the seed clobber it.
+      if (mounted) setStatus((live) => live ?? seed)
+    })
+    const unsubscribe = window.api.onAppUpdateStatus((event) => setStatus(event))
+    return () => {
+      mounted = false
+      unsubscribe()
+    }
+  }, [])
+
+  const label = status ? updateReadyLabel(status) : null
+  if (label === null) return null
+  return (
+    <Button
+      variant="outline"
+      size="xs"
+      className="w-full flex-none justify-start gap-2"
+      onClick={() => window.api.appUpdateRestart()}
+      title="Restart to apply the update (it also installs on quit)"
+    >
+      <RefreshCw className="size-3.5 flex-none text-accent-text" aria-hidden />
+      <span className="min-w-0 flex-1 truncate text-left">{label}</span>
+      <span className="flex-none text-muted">Restart</span>
+    </Button>
+  )
+}

--- a/apps/desktop/src/renderer/src/shell/app-update-view.test.ts
+++ b/apps/desktop/src/renderer/src/shell/app-update-view.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { updateReadyLabel } from './app-update-view'
+import type { AppUpdateStatusEvent } from '../../../shared/ipc'
+
+describe('updateReadyLabel', () => {
+  it('renders nothing for every non-ready phase — the affordance is passive', () => {
+    for (const phase of ['idle', 'checking', 'downloading', 'error'] as const) {
+      const status: AppUpdateStatusEvent = { phase, version: '0.2.0', error: null }
+      expect(updateReadyLabel(status)).toBeNull()
+    }
+  })
+
+  it('labels a ready download with its Release version', () => {
+    expect(updateReadyLabel({ phase: 'ready', version: '0.2.0', error: null })).toBe(
+      'Update ready · v0.2.0',
+    )
+  })
+
+  it('falls back to a plain label when the feed carried no version', () => {
+    expect(updateReadyLabel({ phase: 'ready', version: null, error: null })).toBe('Update ready')
+  })
+})

--- a/apps/desktop/src/renderer/src/shell/app-update-view.ts
+++ b/apps/desktop/src/renderer/src/shell/app-update-view.ts
@@ -1,0 +1,13 @@
+/**
+ * Pure view logic for the App-update affordance (#270): the chip is PASSIVE and
+ * appears only once a downloaded Release is ready to install — checking,
+ * downloading, and errors stay invisible (errors are main-log diagnostics; the
+ * next periodic check retries). See CONTEXT.md "App update".
+ */
+import type { AppUpdateStatusEvent } from '../../../shared/ipc'
+
+/** The chip's label, or null when nothing should render. */
+export function updateReadyLabel(status: AppUpdateStatusEvent): string | null {
+  if (status.phase !== 'ready') return null
+  return status.version ? `Update ready · v${status.version}` : 'Update ready'
+}

--- a/apps/desktop/src/shared/ipc/app-update.ts
+++ b/apps/desktop/src/shared/ipc/app-update.ts
@@ -1,0 +1,34 @@
+/**
+ * App-update domain of the shared IPC contract (#270, ADR-0018): vibe-mistro
+ * updating ITSELF from the GitHub Releases stable feed via electron-updater.
+ * Distinct from a Vibe update (the CLI's PyPI check, `vibe:check-update` in
+ * ./core) — see CONTEXT.md. Passive by design: main checks and downloads in the
+ * background and streams coarse status; the renderer shows a quiet "restart to
+ * apply" affordance once a download is ready; the install happens on the user's
+ * explicit restart or on normal quit — never by force-restarting mid-turn.
+ */
+
+/** The app-update channel entries, merged into the single `IPC` const in `./index`. */
+export const appUpdateChannels = {
+  /** Renderer -> main: current status snapshot (re-seeds a window that mounts mid-cycle). */
+  appUpdateGetStatus: 'app-update:get-status',
+  /** Renderer -> main: quit and install the downloaded update now (the user clicked restart). */
+  appUpdateRestart: 'app-update:restart',
+  /** Main -> renderer: streamed status change — see {@link AppUpdateStatusEvent}. */
+  appUpdateStatus: 'app-update:status',
+} as const
+
+/**
+ * Coarse lifecycle of one update cycle. Deliberately no download-progress
+ * granularity: the flow is passive, so the renderer only needs to know when
+ * `ready` flips the affordance on (and `error` is log/diagnostic detail).
+ */
+export type AppUpdatePhase = 'idle' | 'checking' | 'downloading' | 'ready' | 'error'
+
+export interface AppUpdateStatusEvent {
+  phase: AppUpdatePhase
+  /** The Release being downloaded / ready to install (e.g. `0.2.0`); null otherwise. */
+  version: string | null
+  /** Best-effort message when `phase` is `error`; null otherwise. */
+  error: string | null
+}

--- a/apps/desktop/src/shared/ipc/index.ts
+++ b/apps/desktop/src/shared/ipc/index.ts
@@ -20,6 +20,7 @@ import { terminalChannels } from './terminal'
 import { browserChannels } from './browser'
 import { searchChannels } from './search'
 import { skillsChannels } from './skills'
+import { appUpdateChannels } from './app-update'
 
 /**
  * The one typed channel map. ONE exported object — the channel names are the wire
@@ -38,6 +39,7 @@ export const IPC = {
   ...browserChannels,
   ...searchChannels,
   ...skillsChannels,
+  ...appUpdateChannels,
 } as const
 
 export * from './core'
@@ -51,3 +53,4 @@ export * from './terminal'
 export * from './browser'
 export * from './search'
 export * from './skills'
+export * from './app-update'


### PR DESCRIPTION
Closes #270 (ADR-0018 App-update slice). **Stacked on #274** — merge #274 first, then retarget/rebase this onto main (I'll handle the retarget if you merge in order).

## What

- **`src/main/app-update.ts`** — pure, tested: the event→status reducer (`ready` is **absorbing**: a later check or transient error never hides the affordance, since the download installs on quit regardless) and mode resolution (packaged → embedded GitHub Releases feed; `VIBE_MISTRO_UPDATE_URL` → generic mock feed, incl. dev via `forceDevUpdateConfig`; plain dev → updater off).
- **Main wiring** (thin adapter in `index.ts`) — check on launch + every 4h, `autoDownload` + `autoInstallOnAppQuit`, status streamed on the new `app-update:*` IPC domain; `app-update:restart` → `quitAndInstall`, guarded to phase `ready`.
- **`UpdateReadyChip`** — a quiet chip in the sidebar's pinned bottom band, rendered only at `ready` ("Update ready · v0.2.0 — Restart"); self-contained (seeds + subscribes itself), so Shell passes nothing.
- **Terminology** — code and copy follow CONTEXT.md: this is an **App update**, distinct from the Settings card's **Vibe update**.
- electron-updater in `dependencies` (runtime, packed); CJS default-import interop (named ESM import of `autoUpdater` fails at runtime).

## Demoed (mock feed)

Packaged 0.0.1 against a static local feed claiming 0.2.0:

```
[app-update] checking
[app-update] downloading v0.2.0
[app-update] ready v0.2.0
[app-update] updater error: Code signature … did not pass validation
```

The error is Squirrel's install-time signature check rejecting the ad-hoc build — expected until #268's Developer ID step, it fires *after* `ready`, and the absorbing reducer held the affordance through it (exactly the designed behavior). Full install-and-relaunch e2e becomes possible once the cert is in the keychain.

## Verification

- 1407 tests (reducer transitions incl. absorbing-ready, mode resolution, chip label) — all four gates green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
