### PR TITLE
fix(release): notarize via Apple-ID triple (#269)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,13 @@
 # Gatekeeper-blocked for every downloader and rejected by the updater, so the
 # workflow fails loudly when secrets are missing instead of shipping one.
 #
-# Repository secrets:
-#   CSC_LINK              base64 .p12 export of the Developer ID Application cert
-#   CSC_KEY_PASSWORD      the .p12 passphrase
-#   APPLE_API_KEY         App Store Connect API key CONTENT (the .p8 body)
-#   APPLE_API_KEY_ID      its key id
-#   APPLE_API_ISSUER      its issuer id
+# Repository secrets (the Apple-ID notarization route — matches the user's
+# prior notarized app; no App Store Connect API key involved):
+#   CSC_LINK                     base64 .p12 export of the Developer ID Application cert
+#   CSC_KEY_PASSWORD             the .p12 passphrase
+#   APPLE_ID                     the Apple ID email
+#   APPLE_APP_SPECIFIC_PASSWORD  app-specific password from account.apple.com
+#   APPLE_TEAM_ID                the 10-char team id (37K9GJSVX9)
 name: Release
 
 on:
@@ -60,12 +61,12 @@ jobs:
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
-          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           missing=()
-          for name in CSC_LINK CSC_KEY_PASSWORD APPLE_API_KEY APPLE_API_KEY_ID APPLE_API_ISSUER; do
+          for name in CSC_LINK CSC_KEY_PASSWORD APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID; do
             [[ -n "${!name}" ]] || missing+=("$name")
           done
           if (( ${#missing[@]} > 0 )); then
@@ -78,16 +79,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY }}
-          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-        run: |
-          # electron-builder's notarize step wants APPLE_API_KEY as a file PATH
-          # (t3code does the same dance): materialize the secret's content.
-          key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
-          printf '%s' "$APPLE_API_KEY_CONTENT" > "$key_path"
-          export APPLE_API_KEY="$key_path"
-          bun run --cwd apps/desktop release
+          # electron-builder notarizes with the Apple-ID credential triple when
+          # these are present in the env — no API key file needed.
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: bun run --cwd apps/desktop release
 
       - name: Gatekeeper assessment of the published app
         run: |


### PR DESCRIPTION
Switches notarization auth from the App Store Connect API key to the Apple-ID credential triple (`APPLE_ID` / `APPLE_APP_SPECIFIC_PASSWORD` / `APPLE_TEAM_ID`) — matching the setup proven by your previously notarized app. Drops the .p8 file dance; the guard now checks the new five-secret set. Still no unsigned fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)