### PR TITLE
fix(packaging): publish Releases as non-draft

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -32,6 +32,10 @@ publish:
   provider: github
   owner: abdullahatrash
   repo: vibe-mistro
+  # electron-builder defaults to DRAFT releases, which `releases/latest` (the
+  # marketing button) and electron-updater both ignore — v0.1.0 needed a manual
+  # un-draft. Publish for real from the start.
+  releaseType: release
 
 mac:
   target:


### PR DESCRIPTION
electron-builder defaults to **draft** releases — invisible to both the `releases/latest` download URL and electron-updater's feed. v0.1.0 needed a manual un-draft (done); this sets `publish.releaseType: release` so future tags go live directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)