### PR TITLE
fix(web): two-column fold + Astro scoping bug that kept the page left-anchored

### DIFF
--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -54,64 +54,66 @@ const VIBE_CLI_URL = 'https://docs.mistral.ai/vibe/code/cli/install-setup'
     </header>
 
     <main>
-      <section class="hero">
-        <h1>
-          Conduct your <span class="flame">Mistral&nbsp;Vibe</span> agents.
-        </h1>
-        <p class="pitch">
-          Vibe Mistro is a macOS desktop app that runs and orchestrates Mistral Vibe coding
-          agents across your local projects — parallel workspaces, streamed tool calls,
-          approvals, git, and a terminal, all in one calm window.
-        </p>
-        <div class="cta">
-          <a class="download" href={DOWNLOAD_URL}>
-            <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" class="apple">
-              <path
-                d="M17.05 20.28c-.98.95-2.05.86-3.08.38-1.09-.5-2.08-.53-3.2 0-1.44.62-2.2.44-3.06-.38C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.53 4.08ZM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25Z"
-              ></path>
-            </svg>
-            Download for macOS
-          </a>
-          <p class="cta-note">
-            Apple&nbsp;Silicon · free &amp; open source · requires the&nbsp;<a
-              href={VIBE_CLI_URL}
-              target="_blank"
-              rel="noreferrer">Mistral Vibe CLI</a
-            >
+      <section class="fold">
+        <div class="hero">
+          <h1>
+            Conduct your <span class="flame">Mistral&nbsp;Vibe</span> agents.
+          </h1>
+          <p class="pitch">
+            Vibe Mistro is a macOS desktop app that runs and orchestrates Mistral Vibe coding
+            agents across your local projects — parallel workspaces, streamed tool calls,
+            approvals, git, and a terminal, all in one calm window.
           </p>
-        </div>
-      </section>
-
-      <section class="session" aria-label="A Vibe Mistro conversation, illustrated">
-        <div class="window">
-          <div class="chrome">
-            <span class="light red"></span>
-            <span class="light amber"></span>
-            <span class="light green"></span>
-            <span class="thread-title">payments-api · Fix flaky webhook test</span>
-          </div>
-          <div class="rows">
-            <p class="row user">Find out why test_webhook_retry is flaky and fix it.</p>
-            <p class="row reasoning">Reading the test… the retry clock is real time — the assertion races the 2s backoff.</p>
-            <div class="row tool">
-              <span class="tool-icon">✎</span>
-              <code>Edit&nbsp;tests/webhooks/test_retry.py</code>
-              <span class="tool-state ok">done</span>
-            </div>
-            <div class="row tool">
-              <span class="tool-icon">⌘</span>
-              <code>Run&nbsp;pytest tests/webhooks -q</code>
-              <span class="tool-state ask">Allow once</span>
-            </div>
-            <div class="row tool">
-              <span class="tool-icon">⌘</span>
-              <code>pytest · 34 passed</code>
-              <span class="tool-state ok">0 flakes</span>
-            </div>
-            <p class="row answer">
-              The test now freezes the retry clock with <code>freezegun</code> — deterministic
-              across 200 repeat runs. Want me to commit it?
+          <div class="cta">
+            <a class="download" href={DOWNLOAD_URL}>
+              <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" class="apple">
+                <path
+                  d="M17.05 20.28c-.98.95-2.05.86-3.08.38-1.09-.5-2.08-.53-3.2 0-1.44.62-2.2.44-3.06-.38C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.53 4.08ZM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25Z"
+                ></path>
+              </svg>
+              Download for macOS
+            </a>
+            <p class="cta-note">
+              Apple&nbsp;Silicon · free &amp; open source · requires the{' '}<a
+                href={VIBE_CLI_URL}
+                target="_blank"
+                rel="noreferrer">Mistral Vibe CLI</a
+              >
             </p>
+          </div>
+        </div>
+
+        <div class="session" aria-label="A Vibe Mistro conversation, illustrated">
+          <div class="window">
+            <div class="chrome">
+              <span class="light red"></span>
+              <span class="light amber"></span>
+              <span class="light green"></span>
+              <span class="thread-title">payments-api · Fix flaky webhook test</span>
+            </div>
+            <div class="rows">
+              <p class="row user">Find out why test_webhook_retry is flaky and fix it.</p>
+              <p class="row reasoning">Reading the test… the retry clock is real time — the assertion races the 2s backoff.</p>
+              <div class="row tool">
+                <span class="tool-icon">✎</span>
+                <code>Edit&nbsp;tests/webhooks/test_retry.py</code>
+                <span class="tool-state ok">done</span>
+              </div>
+              <div class="row tool">
+                <span class="tool-icon">⌘</span>
+                <code>Run&nbsp;pytest tests/webhooks -q</code>
+                <span class="tool-state ask">Allow once</span>
+              </div>
+              <div class="row tool">
+                <span class="tool-icon">⌘</span>
+                <code>pytest · 34 passed</code>
+                <span class="tool-state ok">0 flakes</span>
+              </div>
+              <p class="row answer">
+                The test now freezes the retry clock with <code>freezegun</code> — deterministic
+                across 200 repeat runs. Want me to commit it?
+              </p>
+            </div>
           </div>
         </div>
       </section>
@@ -139,7 +141,12 @@ const VIBE_CLI_URL = 'https://docs.mistral.ai/vibe/code/cli/install-setup'
       <p class="fine">An open-source companion for the Mistral Vibe CLI. Not affiliated with Mistral AI.</p>
     </footer>
 
-    <style>
+    {/* is:global — Astro's default scoping rewrites `*` to an ATTRIBUTE selector
+        (specificity 0-1-0), which beats plain element selectors like `body`
+        (0-0-1): the `* { margin: 0 }` reset was killing `body { margin: 0 auto }`
+        and the page rendered left-anchored, never centered. One page, no
+        components — scoping buys nothing here. */}
+    <style is:global>
       :root {
         --bg: #fbfaf8;
         --sidebar: #f5f3ef;
@@ -172,7 +179,7 @@ const VIBE_CLI_URL = 'https://docs.mistral.ai/vibe/code/cli/install-setup'
         min-height: 100dvh;
         display: flex;
         flex-direction: column;
-        max-width: 68rem;
+        max-width: 74rem;
         margin: 0 auto;
         padding: 0 1.5rem;
         position: relative;
@@ -240,13 +247,24 @@ const VIBE_CLI_URL = 'https://docs.mistral.ai/vibe/code/cli/install-setup'
         color: var(--accent-text);
       }
 
+      /* The above-the-fold composition: hero copy left, the live session card
+         right as the visual counterweight — one complete viewport-height scene
+         on wide screens instead of a left-hugging column with dead air. */
+      .fold {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 32rem);
+        gap: clamp(2.5rem, 6vw, 5rem);
+        align-items: center;
+        min-height: min(calc(100dvh - 160px), 56rem);
+        padding: 1.5rem 0 3rem;
+      }
+
       .hero {
-        padding: clamp(3rem, 9vh, 6.5rem) 0 2.5rem;
-        max-width: 46rem;
+        max-width: 40rem;
       }
 
       h1 {
-        font-size: clamp(2.6rem, 6.5vw, 4.4rem);
+        font-size: clamp(2.6rem, 4.6vw, 4rem);
         line-height: 1.04;
         font-weight: 720;
         letter-spacing: -0.035em;
@@ -323,10 +341,6 @@ const VIBE_CLI_URL = 'https://docs.mistral.ai/vibe/code/cli/install-setup'
       }
 
       /* ------- the session card ------- */
-      .session {
-        padding: 1.5rem 0 1rem;
-      }
-
       .window {
         border: 1px solid var(--border);
         border-radius: 14px;
@@ -335,7 +349,18 @@ const VIBE_CLI_URL = 'https://docs.mistral.ai/vibe/code/cli/install-setup'
           0 1px 2px rgba(28, 28, 28, 0.05),
           0 24px 60px -30px rgba(82, 45, 20, 0.25);
         overflow: hidden;
-        max-width: 44rem;
+      }
+
+      @media (max-width: 980px) {
+        .fold {
+          grid-template-columns: 1fr;
+          gap: 3rem;
+          min-height: 0;
+          padding: 3rem 0 1.5rem;
+        }
+        .window {
+          max-width: 44rem;
+        }
       }
 
       .chrome {


### PR DESCRIPTION
User report: on a wide monitor the site hugs the left half with dead air on the right. Two real causes:

1. **The page was never centered.** Astro's default style scoping compiles `* { margin: 0 }` to `[data-astro-cid-…] { margin: 0 }` — an attribute selector (specificity 0-1-0) that beats plain `body` (0-0-1), so the reset overrode `body { margin: 0 auto }`. Fixed with `is:global` on the style block (single page, scoping buys nothing). Verified by computed-style probe: body `x = 408px` at a 2000px viewport — exactly `(2000 − 1184) / 2`.
2. **The layout didn't use the width.** The fold is now a two-column grid: hero copy left, the animated session card right, composed to ~one viewport height; collapses to a single column under 980px.

Plus: the cta-note's `&nbsp;` made it unbreakable on phones — replaced with an expression space that survives `compressHTML` and still wraps.

Screenshot-verified at 2000px and 390px. Merging auto-deploys to www.vibemistro.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)