### PR TITLE
fix(web): text-only wordmark in the site header

### DIFF
--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -35,16 +35,6 @@ const VIBE_CLI_URL = 'https://docs.mistral.ai/vibe/code/cli/install-setup'
 
     <header class="site-header">
       <a class="brand" href="/">
-        <svg class="mark" viewBox="0 0 191 135" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-          <path d="M54.3221 0H27.1531V27.0892H54.3221V0Z" fill="#FFD800"></path>
-          <path d="M162.984 0H135.815V27.0892H162.984V0Z" fill="#FFD800"></path>
-          <path d="M81.4823 27.0918H27.1531V54.181H81.4823V27.0918Z" fill="#FFAF00"></path>
-          <path d="M162.99 27.0918H108.661V54.181H162.99V27.0918Z" fill="#FFAF00"></path>
-          <path d="M162.972 54.168H27.1531V81.2572H162.972V54.168Z" fill="#FF8205"></path>
-          <path d="M54 81H27V135H54V81Z" fill="#FA500F"></path>
-          <path d="M108.661 81.2598H81.4917V108.349H108.661V81.2598Z" fill="#FA500F"></path>
-          <path d="M163 81H136V135H163V81Z" fill="#FA500F"></path>
-        </svg>
         <span class="wordmark">Vibe Mistro</span>
         <span class="beta-chip">Beta</span>
       </a>
@@ -193,15 +183,10 @@ const VIBE_CLI_URL = 'https://docs.mistral.ai/vibe/code/cli/install-setup'
         color: var(--text);
       }
 
-      .mark {
-        height: 26px;
-        width: auto;
-      }
-
       .wordmark {
-        font-weight: 650;
-        font-size: 1.05rem;
-        letter-spacing: -0.01em;
+        font-weight: 680;
+        font-size: 1.15rem;
+        letter-spacing: -0.015em;
       }
 
       .beta-chip {


### PR DESCRIPTION
Per Abdullah: the header drops the stepped-M mark and shows only the **Vibe Mistro** wordmark (bumped to 1.15rem/680 so it holds the corner alone) + Beta chip. Favicon untouched for now. Merging auto-deploys to www.vibemistro.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)