### PR TITLE
fix(web): neutral V-monogram favicon

### DIFF
--- a/apps/web/public/favicon.svg
+++ b/apps/web/public/favicon.svg
@@ -1,10 +1,11 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 191 135">
-  <path d="M54.3221 0H27.1531V27.0892H54.3221V0Z" fill="#FFD800"/>
-  <path d="M162.984 0H135.815V27.0892H162.984V0Z" fill="#FFD800"/>
-  <path d="M81.4823 27.0918H27.1531V54.181H81.4823V27.0918Z" fill="#FFAF00"/>
-  <path d="M162.99 27.0918H108.661V54.181H162.99V27.0918Z" fill="#FFAF00"/>
-  <path d="M162.972 54.168H27.1531V81.2572H162.972V54.168Z" fill="#FF8205"/>
-  <path d="M54 81H27V135H54V81Z" fill="#FA500F"/>
-  <path d="M108.661 81.2598H81.4917V108.349H108.661V81.2598Z" fill="#FA500F"/>
-  <path d="M163 81H136V135H163V81Z" fill="#FA500F"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f6c445"/>
+      <stop offset=".55" stop-color="#ef8a3c"/>
+      <stop offset="1" stop-color="#e2452a"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#g)"/>
+  <path d="M19 19 L32 46 L45 19" stroke="#241a12" stroke-width="8.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
 </svg>


### PR DESCRIPTION
The favicon half of the de-Mistral pass (the header half merged in #286 — this commit just missed that train): a dark **V** monogram on the flame-gradient rounded square replaces the stepped-M mark. Warm palette kept, Mistral geometry gone. Merging auto-deploys; favicons cache hard, so check in a private window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)