### PR TITLE
fix(app-update): menu Check for Updates drives the real updater

### DIFF
--- a/apps/desktop/src/main/app-update.test.ts
+++ b/apps/desktop/src/main/app-update.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   APP_UPDATE_INITIAL,
+  describeUpdateCheck,
+  describeUpdaterDisabled,
   reduceUpdaterEvent,
   resolveUpdaterMode,
   sameStatus,
@@ -97,5 +99,45 @@ describe('resolveUpdaterMode', () => {
     expect(
       resolveUpdaterMode({ isPackaged: true, feedUrlOverride: 'http://localhost:8099 ' }),
     ).toEqual({ enabled: true, feedUrl: 'http://localhost:8099' })
+  })
+})
+
+describe('describeUpdateCheck', () => {
+  const at = (phase: AppUpdateStatusEvent['phase'], version: string | null = null, error: string | null = null): AppUpdateStatusEvent => ({ phase, version, error })
+
+  it('offers the restart only when a download is staged', () => {
+    const ready = describeUpdateCheck(at('ready', '0.2.0'), '0.1.2', 'Vibe Mistro (Beta)')
+    expect(ready.offerRestart).toBe(true)
+    expect(ready.message).toBe('Vibe Mistro (Beta) 0.2.0 is ready to install')
+    for (const phase of ['idle', 'checking', 'downloading', 'error'] as const) {
+      expect(describeUpdateCheck(at(phase), '0.1.2', 'X').offerRestart).toBe(false)
+    }
+  })
+
+  it('reports up-to-date with the running version when nothing is newer', () => {
+    const copy = describeUpdateCheck(at('idle'), '0.1.2', 'Vibe Mistro (Beta)')
+    expect(copy.message).toBe('Vibe Mistro (Beta) 0.1.2')
+    expect(copy.detail).toContain('latest version')
+  })
+
+  it('points at the sidebar chip while a download is in flight', () => {
+    const copy = describeUpdateCheck(at('downloading', '0.2.0'), '0.1.2', 'V')
+    expect(copy.message).toContain('0.2.0')
+    expect(copy.detail).toContain('chip')
+  })
+
+  it('surfaces the check error, never silently', () => {
+    const copy = describeUpdateCheck(at('error', null, 'net::DISCONNECTED'), '0.1.2', 'V')
+    expect(copy.message).toBe('Could not check for updates')
+    expect(copy.detail).toContain('net::DISCONNECTED')
+  })
+})
+
+describe('describeUpdaterDisabled', () => {
+  it('explains dev builds do not self-update and never offers a restart', () => {
+    const copy = describeUpdaterDisabled('0.1.2', 'Vibe Mistro (Beta)')
+    expect(copy.offerRestart).toBe(false)
+    expect(copy.message).toBe('Vibe Mistro (Beta) 0.1.2')
+    expect(copy.detail).toContain('packaged app')
   })
 })

--- a/apps/desktop/src/main/app-update.ts
+++ b/apps/desktop/src/main/app-update.ts
@@ -67,7 +67,7 @@ export interface UpdaterMode {
  * Decide the updater's mode for this launch. Packaged builds update from the
  * embedded feed; a dev/unpackaged run is updater-OFF unless the mock-feed env
  * (`VIBE_MISTRO_UPDATE_URL`) forces it — the seam the #270 demo and any local
- * end-to-end run drive (t3code's mock-update-server pattern).
+ * end-to-end run drive (a static feed claiming a higher version).
  */
 export function resolveUpdaterMode(input: {
   isPackaged: boolean
@@ -79,3 +79,62 @@ export function resolveUpdaterMode(input: {
 
 /** Background re-check cadence after the launch check (passive; no UI ticker). */
 export const APP_UPDATE_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000
+
+/** What the menu-bar "Check for Updates…" dialog should say (pure; tested). */
+export interface UpdateDialogCopy {
+  message: string
+  detail: string
+  /** Show "Restart Now" as the primary button (a download is already staged). */
+  offerRestart: boolean
+}
+
+/**
+ * Map the post-check status to the dialog. The menu item is the ACTIVE
+ * counterpart of the passive chip: it runs a check on demand and reports where
+ * the cycle stands — up to date, downloading (the chip will follow), ready
+ * (offer the restart right here), or the check failed.
+ */
+export function describeUpdateCheck(
+  status: AppUpdateStatusEvent,
+  appVersion: string,
+  displayName: string,
+): UpdateDialogCopy {
+  switch (status.phase) {
+    case 'ready':
+      return {
+        message: `${displayName} ${status.version ?? ''} is ready to install`.replace('  ', ' '),
+        detail:
+          'It was downloaded in the background. Restart now to apply it — or keep working, and it installs when you quit.',
+        offerRestart: true,
+      }
+    case 'downloading':
+      return {
+        message: `${displayName} ${status.version ?? ''} is on its way`.replace('  ', ' '),
+        detail:
+          'Downloading in the background. The "Update ready — Restart" chip appears at the bottom of the sidebar when it\'s done.',
+        offerRestart: false,
+      }
+    case 'error':
+      return {
+        message: 'Could not check for updates',
+        detail: `${status.error ?? 'Unknown error'}. The app retries automatically in the background.`,
+        offerRestart: false,
+      }
+    default:
+      return {
+        message: `${displayName} ${appVersion}`,
+        detail: "You're on the latest version.",
+        offerRestart: false,
+      }
+  }
+}
+
+/** The dialog for a run where the updater is off (dev / unpackaged). */
+export function describeUpdaterDisabled(appVersion: string, displayName: string): UpdateDialogCopy {
+  return {
+    message: `${displayName} ${appVersion}`,
+    detail:
+      'Automatic App updates run only in the packaged app. Download a Release from GitHub — dev builds update by pulling main and rebuilding.',
+    offerRestart: false,
+  }
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -46,6 +46,8 @@ import { checkVibeUpdate } from './vibe-update'
 import {
   APP_UPDATE_CHECK_INTERVAL_MS,
   APP_UPDATE_INITIAL,
+  describeUpdateCheck,
+  describeUpdaterDisabled,
   reduceUpdaterEvent,
   resolveUpdaterMode,
   sameStatus,
@@ -217,6 +219,8 @@ function emitThreadTitle(event: ThreadTitleEvent): void {
  * `reduceUpdaterEvent` (app-update.ts, tested); this is the thin adapter.
  */
 let appUpdateStatus: AppUpdateStatusEvent = APP_UPDATE_INITIAL
+/** Whether startAppUpdater actually armed the updater (packaged / mock-feed runs). */
+let appUpdaterEnabled = false
 
 function applyUpdaterEvent(event: UpdaterEvent): void {
   const next = reduceUpdaterEvent(appUpdateStatus, event)
@@ -234,6 +238,7 @@ function startAppUpdater(): void {
     feedUrlOverride: process.env.VIBE_MISTRO_UPDATE_URL,
   })
   if (!mode.enabled) return
+  appUpdaterEnabled = true
   // electron-updater is CJS; a named ESM import of `autoUpdater` fails at runtime,
   // so it comes off the default-import interop object.
   const { autoUpdater } = electronUpdater
@@ -264,6 +269,38 @@ function startAppUpdater(): void {
   }
   check()
   setInterval(check, APP_UPDATE_CHECK_INTERVAL_MS)
+}
+
+/**
+ * The menu bar's "Check for Updates…" — the ACTIVE counterpart of the passive
+ * sidebar chip. Runs a real check against the Release feed, then reports where
+ * the cycle stands via the pure `describeUpdateCheck`; when a download is
+ * already staged it offers the restart right in the dialog.
+ */
+async function handleMenuCheckForUpdates(): Promise<void> {
+  const icon = nativeImage.createFromPath(APP_ICON_PNG)
+  const copy = appUpdaterEnabled
+    ? await (async () => {
+        if (appUpdateStatus.phase !== 'ready') {
+          // Resolves once the check settles (available/none); the download, if
+          // any, continues in the background. Failures fold into the 'error'
+          // event and thus into the status we describe.
+          await electronUpdater.autoUpdater.checkForUpdates().catch(() => {})
+        }
+        return describeUpdateCheck(appUpdateStatus, app.getVersion(), APP_DISPLAY_NAME)
+      })()
+    : describeUpdaterDisabled(app.getVersion(), APP_DISPLAY_NAME)
+  const { response } = await dialog.showMessageBox({
+    type: 'info',
+    title: 'Check for Updates',
+    message: copy.message,
+    detail: copy.detail,
+    buttons: copy.offerRestart ? ['Restart Now', 'Later'] : ['OK'],
+    defaultId: 0,
+    cancelId: copy.offerRestart ? 1 : 0,
+    icon,
+  })
+  if (copy.offerRestart && response === 0) electronUpdater.autoUpdater.quitAndInstall()
 }
 
 /**
@@ -1313,27 +1350,16 @@ app.whenReady().then(async () => {
     }
   }
 
-  // The native application menu (app-menu.ts template — t3code's layout).
+  // The native application menu (app-menu.ts template).
   // "Settings…" is fulfilled by the renderer (it owns navigation), broadcast over
   // the typed `menu:action` channel like every other main->renderer push.
-  // "Check for Updates…" is honest about the beta: no updater is wired up yet, so
-  // it reports the running version — the item exists from day one and the flow
-  // deepens in place when a real updater lands.
+  // "Check for Updates…" drives the real updater (#270) via
+  // `handleMenuCheckForUpdates` — the on-demand counterpart of the passive chip.
   Menu.setApplicationMenu(
     Menu.buildFromTemplate(
       buildMenuTemplate(process.platform, {
         onCheckForUpdates: () => {
-          void dialog.showMessageBox({
-            type: 'info',
-            title: 'Check for Updates',
-            message: `${APP_DISPLAY_NAME} ${app.getVersion()}`,
-            detail:
-              'Automatic updates are not available in the beta. Pull the latest main and rebuild to update.',
-            buttons: ['OK'],
-            // Explicit brand icon: macOS otherwise stamps the dialog with the
-            // BUNDLE icon, which icon-services caches as Electron's in dev.
-            icon: nativeImage.createFromPath(APP_ICON_PNG),
-          })
+          void handleMenuCheckForUpdates()
         },
         onOpenSettings: () => {
           for (const win of BrowserWindow.getAllWindows()) {


### PR DESCRIPTION
User report: "Check for Updates…" in the menu still showed the pre-#270 placeholder ("Automatic updates are not available in the beta"). It now performs a real on-demand check and reports via the pure, tested `describeUpdateCheck`:

- **up to date** — running version named
- **downloading** — points at the sidebar chip that will follow
- **ready** — offers **Restart Now** right in the dialog (guarded `quitAndInstall`)
- **error** — surfaced, never silent; background retries continue
- **dev/unpackaged** — plainly states the updater only runs in packaged builds

Note: users on ≤0.1.2 still see the old dialog until they're on a release carrying this — the passive chip updates them regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)