### PR TITLE
chore(electron): slice 1 — Electron 42 upgrade + node:sqlite spike + ADR-0019 (#293)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -48,7 +48,7 @@
     "@xterm/xterm": "^6.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "electron": "^33.2.1",
+    "electron": "^42.5.2",
     "electron-builder": "26.8.1",
     "electron-vite": "^2.3.0",
     "eslint": "10.6.0",

--- a/apps/desktop/scripts/spike-node-sqlite.mjs
+++ b/apps/desktop/scripts/spike-node-sqlite.mjs
@@ -1,0 +1,125 @@
+// Spike for #293: prove `node:sqlite` fits the SQLite persistence epic (#292).
+//
+// Runs identically in the two runtimes that matter:
+//   dev-machine Node (vitest)  : node scripts/spike-node-sqlite.mjs
+//   Electron main              : electron scripts/spike-node-sqlite.mjs
+//
+// Checks: WAL journal mode, foreign-key enforcement, user_version pragma,
+// FTS5 (MATCH + snippet + bm25), and a perf smoke (50k inserts / full read /
+// FTS query). Prints a JSON report and exits non-zero on any failure.
+
+import { DatabaseSync } from 'node:sqlite'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const report = {
+  runtime: process.versions.electron ? `electron ${process.versions.electron}` : 'node',
+  node: process.versions.node,
+  checks: {},
+  perf: {},
+}
+let failed = false
+
+function check(name, fn) {
+  try {
+    const value = fn()
+    report.checks[name] = value === undefined ? 'ok' : value
+  } catch (err) {
+    report.checks[name] = `FAIL: ${err.message}`
+    failed = true
+  }
+}
+
+const dir = mkdtempSync(join(tmpdir(), 'spike-node-sqlite-'))
+const db = new DatabaseSync(join(dir, 'spike.sqlite'))
+
+check('wal', () => {
+  const mode = db.prepare('PRAGMA journal_mode = WAL').get()
+  if (String(Object.values(mode)[0]).toLowerCase() !== 'wal') throw new Error(`got ${JSON.stringify(mode)}`)
+})
+
+check('user_version', () => {
+  db.exec('PRAGMA user_version = 7')
+  const row = db.prepare('PRAGMA user_version').get()
+  if (Number(Object.values(row)[0]) !== 7) throw new Error(`got ${JSON.stringify(row)}`)
+})
+
+check('foreign_keys_enforced', () => {
+  db.exec('PRAGMA foreign_keys = ON')
+  db.exec(`CREATE TABLE threads (id TEXT PRIMARY KEY);
+           CREATE TABLE entries (seq INTEGER PRIMARY KEY AUTOINCREMENT,
+             thread_id TEXT NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
+             payload TEXT NOT NULL)`)
+  let threw = false
+  try {
+    db.prepare('INSERT INTO entries (thread_id, payload) VALUES (?, ?)').run('missing', '{}')
+  } catch {
+    threw = true
+  }
+  if (!threw) throw new Error('orphan insert was allowed')
+  db.prepare('INSERT INTO threads (id) VALUES (?)').run('t1')
+  db.prepare('INSERT INTO entries (thread_id, payload) VALUES (?, ?)').run('t1', '{}')
+  db.prepare('DELETE FROM threads WHERE id = ?').run('t1')
+  const left = db.prepare('SELECT COUNT(*) AS n FROM entries').get()
+  if (left.n !== 0) throw new Error('cascade delete left rows')
+})
+
+check('fts5_match_snippet_bm25', () => {
+  db.exec(`CREATE TABLE prose_items (item_id TEXT PRIMARY KEY, thread_id TEXT NOT NULL, text TEXT NOT NULL);
+           CREATE VIRTUAL TABLE prose_fts USING fts5(
+             text, content='prose_items', content_rowid='rowid',
+             tokenize='unicode61 remove_diacritics 2');
+           CREATE TRIGGER prose_ai AFTER INSERT ON prose_items BEGIN
+             INSERT INTO prose_fts (rowid, text) VALUES (new.rowid, new.text);
+           END`)
+  const ins = db.prepare('INSERT INTO prose_items (item_id, thread_id, text) VALUES (?, ?, ?)')
+  ins.run('i1', 't1', 'the warm agent pool evicts the least recently active workspace')
+  ins.run('i2', 't1', 'résumé of the sesión with diacritics folded')
+  const hit = db
+    .prepare(`SELECT p.item_id, snippet(prose_fts, 0, '[', ']', '…', 8) AS snip, bm25(prose_fts) AS rank
+              FROM prose_fts JOIN prose_items p ON p.rowid = prose_fts.rowid
+              WHERE prose_fts MATCH ? ORDER BY rank`)
+    .get('agent pool')
+  if (hit?.item_id !== 'i1' || !hit.snip.includes('[agent]')) throw new Error(JSON.stringify(hit))
+  const folded = db
+    .prepare('SELECT COUNT(*) AS n FROM prose_fts WHERE prose_fts MATCH ?')
+    .get('resume sesion')
+  if (folded.n !== 1) throw new Error('diacritic folding failed')
+  return hit.snip
+})
+
+check('perf_smoke', () => {
+  const N = 50_000
+  const payload = JSON.stringify({ t: 'acp-event', payload: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'x'.repeat(200) } } })
+  db.prepare('INSERT INTO threads (id) VALUES (?)').run('perf')
+  const ins = db.prepare('INSERT INTO entries (thread_id, payload) VALUES (?, ?)')
+  let t0 = performance.now()
+  db.exec('BEGIN')
+  for (let i = 0; i < N; i++) ins.run('perf', payload)
+  db.exec('COMMIT')
+  report.perf.insert50kMs = Math.round(performance.now() - t0)
+  t0 = performance.now()
+  const rows = db.prepare('SELECT seq, payload FROM entries WHERE thread_id = ? ORDER BY seq').all('perf')
+  report.perf.readAllMs = Math.round(performance.now() - t0)
+  if (rows.length !== N) throw new Error(`read ${rows.length}`)
+  t0 = performance.now()
+  ins.run('perf', payload) // single un-batched append, the live-turn shape
+  report.perf.singleInsertMs = +(performance.now() - t0).toFixed(3)
+  t0 = performance.now()
+  db.prepare('SELECT COUNT(*) AS n FROM prose_fts WHERE prose_fts MATCH ?').get('workspace')
+  report.perf.ftsQueryMs = +(performance.now() - t0).toFixed(3)
+})
+
+db.close()
+rmSync(dir, { recursive: true, force: true })
+
+console.log(JSON.stringify(report, null, 2))
+console.log(failed ? 'SPIKE: FAIL' : 'SPIKE: PASS')
+
+if (process.versions.electron) {
+  const { app } = await import('electron')
+  app.whenReady().then(() => app.exit(failed ? 1 : 0))
+} else {
+  process.exit(failed ? 1 : 0)
+}

--- a/docs/adr/0005-persistence-json-metadata-vibe-owns-history.md
+++ b/docs/adr/0005-persistence-json-metadata-vibe-owns-history.md
@@ -1,5 +1,9 @@
 # Persistence: JSON metadata + a per-Thread JSONL transcript we own; Vibe owns agent context
 
+> **Engine decision superseded by ADR-0019** (2026-07-03, #292): the deferred-SQLite trigger named
+> below — full-text queries at scale — fired with transcript search (#174). Storage moves to
+> `node:sqlite` (event log + projections); the three-way ownership split here still governs.
+
 vibe-mistro needs Workspaces and Threads to survive a restart: reopen the app and your
 Workspaces, their Threads, titles, last-active order, **and the visible conversation** are
 back — instantly, without spawning an agent. This ADR fixes the storage primitives for that

--- a/docs/adr/0019-sqlite-persistence-node-sqlite-event-log-projections.md
+++ b/docs/adr/0019-sqlite-persistence-node-sqlite-event-log-projections.md
@@ -1,0 +1,116 @@
+# Persistence engine: SQLite via `node:sqlite` — event log + disposable projections
+
+**Status: ACCEPTED** (2026-07-03, #292/#293). **Supersedes the engine decision of ADR-0005**
+(JSON metadata + per-Thread JSONL). ADR-0005's three-way ownership split — Workspace/Thread
+metadata is ours, the visible transcript is ours, agent context/memory is Vibe's (`session/load`)
+— is unchanged and restated here; only the storage engine and the load strategy change.
+
+## Context
+
+ADR-0005 deliberately deferred a database "until a feature concretely needs it — relational or
+full-text queries at scale". That trigger has fired: ⌘K transcript search (#174) ships as an
+explicit linear scan that reads and prose-parses **every Thread's JSONL on every query**, and
+reopening a Thread re-reads and re-folds its entire transcript unless it is one of the last 8 in
+the in-memory replay cache. Both costs grow with usage. Every store was written for this swap:
+each carries a SEAM CONTRACT comment pinning its public method surface as the migration boundary.
+
+The reference implementation persists with full event-sourcing over SQLite: an append-only,
+globally-sequenced event log as the source of truth, read-model tables as disposable projections,
+snapshot-then-incremental client sync, denormalized summary columns, WAL — and, notably, the
+built-in `node:sqlite` on Node rather than a native addon, and files-on-disk for image bytes.
+
+## Decision
+
+1. **One `state.sqlite` in `userData`, owned by the main process** (no separate server process —
+   the reference implementation's process split is transport machinery we don't need; its data
+   model works over our existing typed IPC). WAL journal mode, `synchronous=NORMAL`, foreign keys
+   ON. Main stays the single writer; synchronous queries on the main thread are microseconds-per-
+   write at our scale (spike numbers below). If that ever changes, the DB moves to a
+   `worker_thread` behind the same seams.
+2. **Engine: Node's built-in `node:sqlite`** — zero native dependency, which dissolves ADR-0005's
+   original objection (the Electron-ABI rebuild tax). This requires **Electron ≥ 37**; we upgraded
+   to Electron 42 (bundled Node 24.x, where `node:sqlite` is stable). Crucially the test suite
+   (vitest under the dev-machine Node ≥ 22.16) exercises the **same engine** the app ships —
+   the ABI split that makes `better-sqlite3` painful (dev/packaged Electron ABI vs test-runner
+   Node ABI over one node_modules copy) never exists.
+   **Pre-decided fallback**: `better-sqlite3` behind the same thin DB seam if `node:sqlite` had
+   failed the spike — accepting electron-rebuild in packaging, asarUnpack, and a test-ABI
+   strategy. The spike passed in both runtimes, so the fallback stays unexercised.
+3. **The transcript entry stream is the event log** — the source of truth. `transcript_entries`:
+   global `AUTOINCREMENT seq` (total order, replacing per-file append order), `thread_id`
+   (cascading from `threads`), entry kind, and the whole `TranscriptEntry` as a JSON payload —
+   the wire type in `shared/ipc` is unchanged. `workspaces` + `threads` tables replace
+   `metadata.json` (single-row updates replace whole-file rewrites). Timestamps stay epoch
+   numbers, booleans are 0/1 integers.
+4. **Exactly two projections, both disposable and rebuildable from the log** (not the reference
+   implementation's full CQRS pipeline — main is a single serialized writer, so per-stream
+   optimistic versioning and per-projector watermarks buy nothing here):
+   - **Prose/FTS**: `prose_items` (one row per conversation item; agent chunks upsert-concatenated
+     at write time) + an FTS5 external-content index (unicode61, `remove_diacritics 2`) kept in
+     sync by triggers. Replaces the per-query scan; reasoning/tool payloads stay excluded.
+   - **Fold snapshots**: per-Thread renderer-folded `ConversationState` stored as an **opaque
+     blob** with the highest folded `seq` and a `reducer_version`. Reopen = snapshot + fold only
+     the tail (usually empty) — O(new entries), not O(conversation). The renderer folds; main
+     never parses the blob — ADR-0001's ownership is untouched. Version mismatch or parse failure
+     falls back to a full fold that rewrites the snapshot: projections are caches, never truth.
+5. **Schema versioning fail-closed**: `PRAGMA user_version`, forward-only migrations statically
+   imported into a numbered array (no filesystem discovery — survives bundling), auto-run at
+   connection setup. A database written by a newer build makes stores read-only rather than
+   letting an older build clobber it (ADR-0005's rule, carried over).
+6. **No ORM.** Hand-written SQL behind the existing store seams + a minimal migration runner — no
+   Drizzle/Kysely. The schema is six frozen tables; the load-bearing SQL is SQLite-specific
+   (FTS5 virtual table + triggers, `MATCH`/`bm25()`/`snippet()`, pragmas, upsert-concatenate)
+   which ORMs can't manage; row-to-type mapping happens once per store against the existing
+   `shared/ipc` types. Revisit (Kysely, not an ORM) only if the table count grows materially.
+7. **Import & rollback**: on first launch with no database and legacy files present, import
+   metadata then each JSONL through the existing tolerant line parser, in chunked transactions.
+   On success the legacy files are renamed to `.bak` — kept, never deleted. On failure the
+   partial DB is dropped, the session runs on the legacy JSON stores (kept in-tree behind the
+   construction seam for one release, with an env escape hatch), and import retries next launch.
+   Fold snapshots are not imported; they populate lazily on first open.
+8. **Bytes stay out of the database**: attachments remain files on disk with refs in entries
+   (the reference implementation makes the same call). Best-effort discipline is unchanged — no
+   persistence write ever rejects a live flow.
+
+## Spike results (#293, `scripts/spike-node-sqlite.mjs`)
+
+Identical checks run in both runtimes; all pass (WAL, enforced+cascading foreign keys,
+`user_version`, FTS5 `MATCH`/`snippet()`/`bm25()` with diacritic folding):
+
+| runtime | node | 50k inserts (1 txn) | read 50k rows | single append | FTS query |
+|---|---|---|---|---|---|
+| dev-machine node | 22.22.1 | 106 ms | 38 ms | 0.24 ms | 0.09 ms |
+| Electron 42.5.2 main | 24.17.0 | 94 ms | 32 ms | 0.20 ms | 0.07 ms |
+
+A live-turn append costs ~0.2 ms; a 50k-entry conversation reads in ~35 ms; FTS queries are
+sub-millisecond. Per-event persistence and conversation loads are a non-issue.
+
+## Considered options
+
+- **Keep JSONL, add an on-disk search index only** — rejected. Leaves the O(conversation) reopen
+  fold, the whole-file metadata rewrites, and invents a bespoke index format SQLite gives us for
+  free, tested.
+- **`better-sqlite3` as primary** — rejected while `node:sqlite` passes. Mature and fast, but a
+  native addon: Electron-ABI rebuild in packaging, bun postinstall-trust friction, and one
+  node_modules copy that cannot serve both Electron (dev/app) and Node (vitest) ABIs at once.
+  Retained as the pre-decided fallback behind the same DB seam.
+- **An ORM (Drizzle/Kysely) for schema + migrations** — rejected (Decision 6).
+- **Full event-sourcing/CQRS with a separate DB process** (the reference implementation's shape)
+  — rejected as over-provisioned: we adopt its philosophy (log as truth, projections as caches,
+  snapshot-then-incremental, denormalize-at-write, bytes out of the DB), not its machinery.
+
+## Consequences
+
+- Electron is now ≥ 42 (Node 24 runtime in main). node-pty is unaffected (N-API prebuilds).
+  Packaged-app + updater smoke passed on 42.5.2; no native-rebuild config was added.
+- `bun run dist:unsigned` produces an ad-hoc-signed app whose **hardened runtime + library
+  validation** blocks direct launch (no shared Team ID). Pre-existing, unrelated to the upgrade;
+  real Developer-ID releases are unaffected. For local smokes, re-sign without the runtime flag:
+  `codesign --force --deep -s - "dist/mac-arm64/Vibe Mistro.app"`.
+- One database file concentrates what per-Thread JSONL spread out. WAL + transactions make torn
+  writes far rarer than torn JSONL lines; slice 6 (#298) decides a `VACUUM INTO` backup for the
+  residual risk.
+- Changing conversation item shapes requires bumping the reducer schema version constant — the
+  cost of a stale snapshot is one full re-fold per Thread, lazily.
+- The migration is delivered as slices #294–#298; this ADR is slice #293's output. No persistence
+  code changes ship with the upgrade itself.


### PR DESCRIPTION
Closes #293. Slice 1 of the SQLite persistence epic (#292) — the enabling upgrade and the engine decision gate.

## What this does

- **Electron `^33.2.1` → `^42.5.2`** (bundled Node 24.17, where `node:sqlite` is fully stable — beyond the ≥37 minimum the issue asked for; 42.x is the well-soaked line, deliberately not the fresh 43.0.0).
- **Committed spike** (`apps/desktop/scripts/spike-node-sqlite.mjs`) that runs identically under the dev-machine Node (what vitest uses) and Electron main, checking: WAL journal mode, enforced + cascading foreign keys, `PRAGMA user_version`, FTS5 (`MATCH`, `snippet()`, `bm25()`, `remove_diacritics 2` folding), and a perf smoke.
- **ADR-0019**: engine decision (`node:sqlite`; `better-sqlite3` fallback pre-decided but unexercised), fail-closed downgrade rule, event-log + two-projections shape, import/rollback story, and the **no-ORM** decision. ADR-0005 gets a supersession pointer; its ownership split still governs.
- **No persistence code changes** — the JSON/JSONL stores run untouched on the upgraded Electron.

## Spike results (both runtimes PASS)

| runtime | node | 50k inserts (1 txn) | read 50k rows | single append | FTS query |
|---|---|---|---|---|---|
| dev-machine node | 22.22.1 | 106 ms | 38 ms | 0.24 ms | 0.09 ms |
| Electron 42.5.2 main | 24.17.0 | 94 ms | 32 ms | 0.20 ms | 0.07 ms |

The engine question is settled: per-event persistence and conversation loads are a non-issue, and the test suite exercises the same engine the app ships (no ABI split — the reason better-sqlite3 stays a fallback).

## Verified on 42.5.2

- All four gates: lint, typecheck, build, **1412 tests pass**
- Dev boot via `electron-vite dev` — main/GPU/network/renderer up, clean log (postinstall Info.plist patch re-applied against the new binary)
- Packaged arm64 build via electron-builder 26.8.1 + app launch against an isolated `VIBE_MISTRO_USER_DATA` — stores initialize, **updater check runs correctly** ("0.1.3 is not available… downgrade is disallowed")
- node-pty unaffected (N-API prebuilds; no rebuild config needed)

## Known quirk (pre-existing, documented in the ADR)

`dist:unsigned` ad-hoc builds trip hardened-runtime **library validation** when launched directly (no shared Team ID between binary and Electron Framework; the entitlements file has no `disable-library-validation`, correctly). Developer-ID releases are unaffected. Local-smoke workaround recorded in ADR-0019.

## Reviewer notes

- Interactive surfaces (Browser Surface webview, Terminal dock, a real agent turn) got boot-level verification here — worth a quick manual pass on this branch before merge, since Electron 33→42 is a 9-major jump.
- `bun.lock` is git-ignored in this repo, so the version bump in `apps/desktop/package.json` is the entire dependency diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QsAPKdeg6ML7Shm1sVYYZ