### PR TITLE
feat(persistence): slice 2 — SqliteDb + migrations + MetadataStore on SQLite + one-time metadata import (#294)

### DIFF
--- a/apps/desktop/src/main/editors/register-ipc.ts
+++ b/apps/desktop/src/main/editors/register-ipc.ts
@@ -5,7 +5,7 @@ import {
   type EditorsOpenArgs,
   type EditorsOpenResult,
 } from '../../shared/ipc'
-import type { MetadataStore } from '../persistence/metadata-store'
+import type { MetadataStoreApi } from '../persistence/metadata-store-api'
 import { getShellEnv } from '../shell-env'
 import { detectAvailableEditors } from './detect'
 import { launchEditor } from './launch'
@@ -19,7 +19,7 @@ import { launchEditor } from './launch'
  * path), so the affordance works for any selected Workspace — warm agent or not,
  * and it never keeps a warm agent alive past its idle window.
  */
-export function registerEditorsIpc(deps: { store: MetadataStore }): void {
+export function registerEditorsIpc(deps: { store: MetadataStoreApi }): void {
   // Session-lifetime detection cache: the installed-editor set doesn't change
   // mid-run, so the first probe's promise is shared by every later call (also
   // coalescing concurrent invokes). A probe FAILURE is not cached — the slot

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -57,7 +57,9 @@ import { getShellEnv } from './shell-env'
 import { getAccountWhoami, readKeychainApiKey, readVibeEnvFile } from './auth/whoami'
 import { searchThreads, tokenizeQuery } from './search/search-threads'
 import { proseEntries, type ProseEntry } from './search/transcript-prose'
-import { groupThreadsByWorkspace, MetadataStore } from './persistence/metadata-store'
+import { groupThreadsByWorkspace } from './persistence/metadata-store'
+import type { MetadataStoreApi } from './persistence/metadata-store-api'
+import { createMetadataStore } from './persistence/create-metadata-store'
 import {
   acpEventEntry,
   agentReboundEntry,
@@ -350,13 +352,15 @@ let terminalManager: TerminalManager | null = null
 /**
  * The stores + transcript bridge every conversation-flow handler needs, created at
  * app-ready (they need `userData`) and injected into `registerIpc` — the DI seam
- * `docs/conventions.md` prescribes. `store` is NON-null: `MetadataStore.load()`
- * degrades to empty state internally (never a throw), so the old `| null` type and
- * its per-handler degraded forks were unreachable. `transcript` nullability IS real
+ * `docs/conventions.md` prescribes. `store` is NON-null: the construction seam
+ * (`createMetadataStore`, ADR-0019) always yields a working store — SQLite when
+ * `state.sqlite` opens, the legacy JSON store otherwise — and `load()` degrades
+ * to empty state internally (never a throw), so the old `| null` type and its
+ * per-handler degraded forks were unreachable. `transcript` nullability IS real
  * (the dir `mkdir` can fail) — the bridge folds that into a silent-no-op tee.
  */
 interface MainDeps {
-  store: MetadataStore
+  store: MetadataStoreApi
   transcript: TranscriptStore | null
   bridge: TranscriptBridge
   /** Null when the attachments dir `mkdir` failed — image persistence no-ops (logged). */
@@ -1298,12 +1302,16 @@ function registerIpc(deps: MainDeps): void {
 }
 
 app.whenReady().then(async () => {
-  // Load the persisted index before the first window so the renderer's launch
+  // Build the metadata store before the first window so the renderer's launch
   // fetch sees prior Workspaces/Threads. `userData` is only valid once ready.
-  // A failed load degrades to empty state INSIDE `load()` (never a throw), so the
-  // store is unconditionally present — see `MainDeps`.
-  const store = new MetadataStore({ filePath: join(app.getPath('userData'), 'metadata.json') })
+  // The construction seam (ADR-0019) selects the engine — SQLite `state.sqlite`
+  // normally, the legacy JSON store on VIBE_MISTRO_FORCE_JSON=1 or a failed
+  // open/import — and performs the one-time `metadata.json` -> SQLite import
+  // (renaming the legacy file to `.bak` on success). Never throws; a failed
+  // load degrades to empty state INSIDE the store — see `MainDeps`.
+  const { store, engine } = await createMetadataStore({ userDataDir: app.getPath('userData') })
   await store.load()
+  console.log(`[main] metadata store engine: ${engine}`)
 
   // The per-Thread transcript dir (ADR-0005). `appendFile` won't create parent
   // dirs, so ensure it exists once here; a failure leaves `transcript` null and

--- a/apps/desktop/src/main/persistence/create-metadata-store.test.ts
+++ b/apps/desktop/src/main/persistence/create-metadata-store.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, afterAll } from 'vitest'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createMetadataStore } from './create-metadata-store'
+import { METADATA_SCHEMA_VERSION, MetadataStore } from './metadata-store'
+import { SqliteMetadataStore } from './sqlite-metadata-store'
+
+/**
+ * The engine-selection construction seam (ADR-0019): SQLite normally, legacy
+ * JSON behind the escape hatch or when the db can't open, with the one-time
+ * import wired in. Real temp-dir `userData` layouts, no Electron.
+ */
+
+const root = mkdtempSync(join(tmpdir(), 'vibe-create-store-'))
+afterAll(() => rmSync(root, { recursive: true, force: true }))
+
+let seq = 0
+function freshUserData(): string {
+  const dir = join(root, `userdata-${++seq}`)
+  mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+describe('createMetadataStore', () => {
+  it('selects SQLite, creates state.sqlite, and the store round-trips', async () => {
+    const userDataDir = freshUserData()
+    const result = await createMetadataStore({ userDataDir })
+
+    expect(result.engine).toBe('sqlite')
+    expect(result.store).toBeInstanceOf(SqliteMetadataStore)
+    expect(result.stateDb).not.toBeNull()
+    expect(existsSync(join(userDataDir, 'state.sqlite'))).toBe(true)
+
+    const ws = await result.store.upsertWorkspace({ dir: '/proj/x' })
+    expect(result.store.snapshot().workspaces.map((w) => w.id)).toEqual([ws.id])
+    result.stateDb?.close()
+  })
+
+  it('imports a legacy metadata.json on first launch and renames it to .bak', async () => {
+    const userDataDir = freshUserData()
+    writeFileSync(
+      join(userDataDir, 'metadata.json'),
+      JSON.stringify({
+        schemaVersion: METADATA_SCHEMA_VERSION,
+        workspaces: [{ id: 'w1', dir: '/legacy', displayName: 'L', lastOpenedAt: 5 }],
+        threads: [
+          { id: 't1', workspaceId: 'w1', sessionId: 'sess', title: 'kept', createdAt: 1, lastActiveAt: 2 },
+        ],
+      }),
+    )
+
+    const result = await createMetadataStore({ userDataDir })
+
+    expect(result.engine).toBe('sqlite')
+    expect(result.store.snapshot().threads[0]).toMatchObject({ id: 't1', title: 'kept' })
+    expect(existsSync(join(userDataDir, 'metadata.json'))).toBe(false)
+    expect(existsSync(join(userDataDir, 'metadata.json.bak'))).toBe(true)
+
+    // Second launch: steady state — no legacy file, data served from SQLite.
+    result.stateDb?.close()
+    const again = await createMetadataStore({ userDataDir })
+    expect(again.engine).toBe('sqlite')
+    expect(again.store.snapshot().threads.map((t) => t.id)).toEqual(['t1'])
+    again.stateDb?.close()
+  })
+
+  it('honors the VIBE_MISTRO_FORCE_JSON escape hatch (legacy engine, no db created)', async () => {
+    const userDataDir = freshUserData()
+    const result = await createMetadataStore({ userDataDir, forceJson: true })
+
+    expect(result.engine).toBe('json')
+    expect(result.store).toBeInstanceOf(MetadataStore)
+    expect(result.stateDb).toBeNull()
+    expect(existsSync(join(userDataDir, 'state.sqlite'))).toBe(false)
+  })
+
+  it('falls back to the legacy JSON store when state.sqlite cannot open', async () => {
+    const userDataDir = freshUserData()
+    // Occupy the db path with a DIRECTORY so the open throws.
+    mkdirSync(join(userDataDir, 'state.sqlite'))
+
+    const result = await createMetadataStore({ userDataDir })
+
+    expect(result.engine).toBe('json')
+    expect(result.store).toBeInstanceOf(MetadataStore)
+    // The legacy store still works for the session.
+    await result.store.load()
+    const ws = await result.store.upsertWorkspace({ dir: '/proj/fallback' })
+    expect(result.store.snapshot().workspaces.map((w) => w.id)).toEqual([ws.id])
+  })
+})

--- a/apps/desktop/src/main/persistence/create-metadata-store.ts
+++ b/apps/desktop/src/main/persistence/create-metadata-store.ts
@@ -1,0 +1,72 @@
+import { join } from 'node:path'
+import { MetadataStore } from './metadata-store'
+import type { MetadataStoreApi } from './metadata-store-api'
+import { importLegacyMetadata } from './import-legacy-metadata'
+import { openStateDb, type StateDb } from './sqlite-db'
+import { SqliteMetadataStore } from './sqlite-metadata-store'
+import { STATE_MIGRATIONS } from './state-migrations'
+
+/**
+ * The metadata-store construction seam (ADR-0019): decides which engine this
+ * session runs on and performs the one-time legacy import. `index.ts` calls
+ * this once at ready and types everything downstream as `MetadataStoreApi`.
+ *
+ * Engine selection, in order:
+ * 1. `VIBE_MISTRO_FORCE_JSON=1` → the legacy JSON store (field escape hatch,
+ *    removed with the legacy store after the soak release — #298).
+ * 2. `state.sqlite` opens → SQLite store. A LOCKED open (db written by a newer
+ *    build) still selects SQLite: the store presents empty + read-only and
+ *    `isLocked()` drives the same honest upgrade notice the JSON store did.
+ * 3. The open THROWS (unreadable path/disk) → legacy JSON store, logged. The
+ *    legacy import also falling over ('failed') runs this session on JSON and
+ *    retries next launch — the transaction rollback left the db empty.
+ */
+
+export interface CreateMetadataStoreResult {
+  store: MetadataStoreApi
+  /** Non-null only when the SQLite engine was selected. */
+  stateDb: StateDb | null
+  engine: 'sqlite' | 'json'
+}
+
+export interface CreateMetadataStoreDeps {
+  userDataDir: string
+  /** Env override (tests pin it; production reads VIBE_MISTRO_FORCE_JSON). */
+  forceJson?: boolean
+}
+
+export async function createMetadataStore(
+  deps: CreateMetadataStoreDeps,
+): Promise<CreateMetadataStoreResult> {
+  const legacyPath = join(deps.userDataDir, 'metadata.json')
+  const forceJson = deps.forceJson ?? process.env.VIBE_MISTRO_FORCE_JSON === '1'
+
+  if (forceJson) {
+    console.log('[create-metadata-store] VIBE_MISTRO_FORCE_JSON=1 — using the legacy JSON store')
+    return jsonStore(legacyPath, null)
+  }
+
+  let stateDb: StateDb
+  try {
+    stateDb = openStateDb({ path: join(deps.userDataDir, 'state.sqlite'), migrations: STATE_MIGRATIONS })
+  } catch (err) {
+    console.error('[create-metadata-store] state.sqlite failed to open — falling back to JSON:', err)
+    return jsonStore(legacyPath, null)
+  }
+
+  const store = new SqliteMetadataStore({ stateDb })
+  if (!stateDb.locked) {
+    const imported = await importLegacyMetadata({ filePath: legacyPath, store })
+    if (imported === 'failed') {
+      // Rolled back to an empty db; run this session on the legacy JSON store
+      // (the file is still in place) and retry the import next launch.
+      stateDb.close()
+      return jsonStore(legacyPath, null)
+    }
+  }
+  return { store, stateDb, engine: 'sqlite' }
+}
+
+function jsonStore(legacyPath: string, stateDb: StateDb | null): CreateMetadataStoreResult {
+  return { store: new MetadataStore({ filePath: legacyPath }), stateDb, engine: 'json' }
+}

--- a/apps/desktop/src/main/persistence/import-legacy-metadata.test.ts
+++ b/apps/desktop/src/main/persistence/import-legacy-metadata.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, afterAll } from 'vitest'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { importLegacyMetadata } from './import-legacy-metadata'
+import { METADATA_SCHEMA_VERSION } from './metadata-store'
+import { openStateDb } from './sqlite-db'
+import { SqliteMetadataStore } from './sqlite-metadata-store'
+import { STATE_MIGRATIONS } from './state-migrations'
+
+/**
+ * The one-time `metadata.json` -> SQLite import (ADR-0019). Exercised over real
+ * temp-dir files (the legacy JSON + `:memory:` target stores), covering the
+ * self-gating branches: absent, newer-schema lock, non-empty db, failure
+ * rollback, and the `.bak` rename (including its crash-retry).
+ */
+
+const dir = mkdtempSync(join(tmpdir(), 'vibe-import-meta-'))
+afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+let seq = 0
+function legacyFileWith(content: unknown): string {
+  const path = join(dir, `metadata-${++seq}.json`)
+  writeFileSync(path, typeof content === 'string' ? content : JSON.stringify(content))
+  return path
+}
+
+function memoryStore(): SqliteMetadataStore {
+  return new SqliteMetadataStore({
+    stateDb: openStateDb({ path: ':memory:', migrations: STATE_MIGRATIONS }),
+  })
+}
+
+const LEGACY_FIXTURE = {
+  schemaVersion: METADATA_SCHEMA_VERSION,
+  workspaces: [
+    { id: 'w1', dir: '/proj/a', displayName: 'A', lastOpenedAt: 100 },
+    { id: 'w2', dir: '/proj/b', displayName: 'B', lastOpenedAt: 300 },
+  ],
+  threads: [
+    { id: 't1', workspaceId: 'w1', sessionId: 'sess-1', title: 'one', createdAt: 1, lastActiveAt: 10, pinned: true },
+    { id: 't2', workspaceId: 'w1', sessionId: null, title: null, createdAt: 2, lastActiveAt: 50, archived: true },
+    { id: 't3', workspaceId: 'w2', sessionId: 'sess-3', title: 'three', createdAt: 3, lastActiveAt: 20 },
+  ],
+}
+
+describe('importLegacyMetadata', () => {
+  it('imports the legacy index verbatim and renames the file to .bak (kept, not deleted)', async () => {
+    const filePath = legacyFileWith(LEGACY_FIXTURE)
+    const store = memoryStore()
+
+    const result = await importLegacyMetadata({ filePath, store })
+
+    expect(result).toBe('imported')
+    const snap = store.snapshot()
+    expect(snap.workspaces.map((w) => w.id)).toEqual(['w2', 'w1'])
+    const t1 = snap.threads.find((t) => t.id === 't1')
+    expect(t1).toMatchObject({ sessionId: 'sess-1', title: 'one', createdAt: 1, pinned: true })
+    expect(snap.threads.find((t) => t.id === 't2')?.archived).toBe(true)
+    expect(snap.threads.find((t) => t.id === 't2')?.sessionId).toBeNull()
+
+    // The original is gone; the .bak holds the pre-import bytes (rollback path).
+    expect(existsSync(filePath)).toBe(false)
+    expect(JSON.parse(readFileSync(`${filePath}.bak`, 'utf8'))).toEqual(LEGACY_FIXTURE)
+  })
+
+  it('skips when the legacy file is absent (the steady state after migration)', async () => {
+    const store = memoryStore()
+    const result = await importLegacyMetadata({ filePath: join(dir, 'never-existed.json'), store })
+    expect(result).toBe('skipped-absent')
+    expect(store.isEmpty()).toBe(true)
+  })
+
+  it('leaves a NEWER-schema legacy file untouched (fail-closed carries into the import)', async () => {
+    const future = { schemaVersion: METADATA_SCHEMA_VERSION + 99, workspaces: [], threads: [] }
+    const filePath = legacyFileWith(future)
+    const store = memoryStore()
+
+    const result = await importLegacyMetadata({ filePath, store })
+
+    expect(result).toBe('skipped-locked')
+    expect(store.isEmpty()).toBe(true)
+    expect(existsSync(filePath)).toBe(true) // not renamed, byte-for-byte preserved
+    expect(JSON.parse(readFileSync(filePath, 'utf8'))).toEqual(future)
+  })
+
+  it('never merges into a non-empty database — only retries the .bak rename', async () => {
+    const filePath = legacyFileWith(LEGACY_FIXTURE)
+    const store = memoryStore()
+    // Real SQLite data already present (e.g. a crash after commit, before rename).
+    const ws = await store.upsertWorkspace({ dir: '/proj/existing' })
+    await store.upsertThread({ workspaceId: ws.id, title: 'existing' })
+
+    const result = await importLegacyMetadata({ filePath, store })
+
+    expect(result).toBe('skipped-nonempty')
+    // Nothing merged: the existing rows are exactly what the store holds.
+    expect(store.snapshot().workspaces.map((w) => w.dir)).toEqual(['/proj/existing'])
+    // The rename retry landed: original gone, .bak present.
+    expect(existsSync(filePath)).toBe(false)
+    expect(existsSync(`${filePath}.bak`)).toBe(true)
+  })
+
+  it('a corrupt legacy file imports as empty (degrade-to-empty parity) and is .bak-ed', async () => {
+    const filePath = legacyFileWith('{ not valid json ]')
+    const store = memoryStore()
+
+    const result = await importLegacyMetadata({ filePath, store })
+
+    expect(result).toBe('imported')
+    expect(store.isEmpty()).toBe(true)
+    expect(existsSync(`${filePath}.bak`)).toBe(true)
+  })
+
+  it("returns 'failed' and leaves the db empty + the file in place when the insert throws", async () => {
+    // Duplicate Thread ids both pass the legacy per-record guards, then violate
+    // the PRIMARY KEY inside the import transaction — the classic mid-way failure.
+    const filePath = legacyFileWith({
+      schemaVersion: METADATA_SCHEMA_VERSION,
+      workspaces: [{ id: 'w1', dir: '/a', displayName: 'a', lastOpenedAt: 1 }],
+      threads: [
+        { id: 'dup', workspaceId: 'w1', sessionId: null, title: null, createdAt: 1, lastActiveAt: 1 },
+        { id: 'dup', workspaceId: 'w1', sessionId: null, title: null, createdAt: 2, lastActiveAt: 2 },
+      ],
+    })
+    const store = memoryStore()
+
+    const result = await importLegacyMetadata({ filePath, store })
+
+    expect(result).toBe('failed')
+    expect(store.isEmpty()).toBe(true) // rolled back — retry next launch
+    expect(existsSync(filePath)).toBe(true) // still in place for that retry
+    expect(existsSync(`${filePath}.bak`)).toBe(false)
+  })
+
+  it("still returns 'imported' when only the .bak rename fails, and the next run retries it", async () => {
+    const filePath = legacyFileWith(LEGACY_FIXTURE)
+    const store = memoryStore()
+
+    const result = await importLegacyMetadata({
+      filePath,
+      store,
+      renameFile: async () => {
+        throw new Error('EACCES')
+      },
+    })
+
+    expect(result).toBe('imported') // the data is safely committed
+    expect(existsSync(filePath)).toBe(true) // rename failed — file remains
+
+    // Next launch: non-empty db + file present → rename retried (real fs now).
+    const again = await importLegacyMetadata({ filePath, store })
+    expect(again).toBe('skipped-nonempty')
+    expect(existsSync(filePath)).toBe(false)
+    expect(existsSync(`${filePath}.bak`)).toBe(true)
+    // And the retry never duplicated the imported records.
+    expect(store.snapshot().threads).toHaveLength(3)
+  })
+})

--- a/apps/desktop/src/main/persistence/import-legacy-metadata.ts
+++ b/apps/desktop/src/main/persistence/import-legacy-metadata.ts
@@ -1,0 +1,94 @@
+import { access, rename } from 'node:fs/promises'
+import { MetadataStore } from './metadata-store'
+import type { SqliteMetadataStore } from './sqlite-metadata-store'
+
+/**
+ * One-time import of the legacy `metadata.json` into the SQLite metadata store
+ * (ADR-0019). Runs at every launch and self-gates:
+ *
+ * - legacy file absent → nothing to do (the steady state after migration);
+ * - legacy file written by a NEWER schema (fail-closed lock) → left untouched;
+ * - state db non-empty → already imported; only the `.bak` rename is retried
+ *   (covers a crash between commit and rename) — records are NEVER merged into
+ *   existing data, so a re-run can't clobber newer SQLite rows with stale JSON;
+ * - otherwise → parse through the legacy store itself (its envelope handling,
+ *   per-record shape guards, and flag normalization for free), insert verbatim
+ *   in one transaction, then rename the file to `metadata.json.bak` — kept, not
+ *   deleted, as the rollback path.
+ *
+ * A failed import rolls back (the db stays empty) and returns 'failed' so the
+ * construction seam can run THIS session on the legacy JSON store and retry on
+ * the next launch. A failed rename after a successful import is best-effort:
+ * logged, retried next launch via the non-empty branch.
+ */
+
+export type ImportLegacyMetadataResult =
+  | 'imported'
+  | 'skipped-absent'
+  | 'skipped-locked'
+  | 'skipped-nonempty'
+  | 'failed'
+
+export interface ImportLegacyMetadataDeps {
+  /** Absolute path of the legacy `metadata.json`. */
+  filePath: string
+  store: SqliteMetadataStore
+  /** fs seams (tests) — default to node:fs/promises. */
+  exists?: (path: string) => Promise<boolean>
+  renameFile?: (from: string, to: string) => Promise<void>
+}
+
+export async function importLegacyMetadata(
+  deps: ImportLegacyMetadataDeps,
+): Promise<ImportLegacyMetadataResult> {
+  const exists = deps.exists ?? defaultExists
+  const renameFile = deps.renameFile ?? rename
+  const bakPath = `${deps.filePath}.bak`
+
+  if (!(await exists(deps.filePath))) return 'skipped-absent'
+
+  const legacy = new MetadataStore({ filePath: deps.filePath })
+  await legacy.load()
+  if (legacy.isLocked()) {
+    // Written by a newer build than even this one understands — preserve it.
+    console.error(`[import-legacy-metadata] ${deps.filePath} is newer than this build; left as-is`)
+    return 'skipped-locked'
+  }
+
+  if (!deps.store.isEmpty()) {
+    // Already imported (or real SQLite data exists) — never merge. Retry only
+    // the rename a previous run may have crashed before.
+    try {
+      await renameFile(deps.filePath, bakPath)
+      console.log(`[import-legacy-metadata] retried rename of ${deps.filePath} -> .bak`)
+    } catch (err) {
+      console.error(`[import-legacy-metadata] rename retry failed:`, err)
+    }
+    return 'skipped-nonempty'
+  }
+
+  try {
+    deps.store.importSnapshot(legacy.snapshot())
+  } catch (err) {
+    console.error(`[import-legacy-metadata] import failed (rolled back):`, err)
+    return 'failed'
+  }
+
+  try {
+    await renameFile(deps.filePath, bakPath)
+  } catch (err) {
+    // Import committed; only the tombstone rename failed. Next launch hits the
+    // non-empty branch and retries it — never a re-import.
+    console.error(`[import-legacy-metadata] imported, but rename to .bak failed:`, err)
+  }
+  return 'imported'
+}
+
+async function defaultExists(path: string): Promise<boolean> {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/apps/desktop/src/main/persistence/metadata-store-api.ts
+++ b/apps/desktop/src/main/persistence/metadata-store-api.ts
@@ -1,0 +1,33 @@
+import type {
+  MetadataSnapshot,
+  ThreadInput,
+  ThreadRecord,
+  WorkspaceInput,
+  WorkspaceRecord,
+} from './metadata-store'
+
+/**
+ * The public surface of the Workspace/Thread metadata store — the SEAM CONTRACT
+ * boundary from ADR-0005, now shared by two implementations: the legacy JSON
+ * `MetadataStore` (kept for one release behind the construction seam, ADR-0019)
+ * and the SQLite `SqliteMetadataStore`. Everything in main types against THIS,
+ * so the engine swap never touches orchestration code.
+ */
+export interface MetadataStoreApi {
+  /** Prepare the store for reads. JSON: parse the index file. SQLite: no-op. */
+  load(): Promise<void>
+  /**
+   * Whether the on-disk data was written by a NEWER build (fail-closed): the
+   * store presents empty and refuses every write so a rollback can't clobber it.
+   */
+  isLocked(): boolean
+  upsertWorkspace(input: WorkspaceInput): Promise<WorkspaceRecord>
+  upsertThread(input: ThreadInput): Promise<ThreadRecord>
+  touchThread(id: string): Promise<void>
+  setThreadFlags(id: string, flags: { pinned?: boolean; archived?: boolean }): Promise<void>
+  setThreadTitle(id: string, title: string | null): Promise<boolean>
+  deleteThread(id: string): Promise<void>
+  removeWorkspace(id: string): Promise<string[]>
+  findThreadIdBySessionId(sessionId: string | null | undefined): string | null
+  snapshot(): MetadataSnapshot
+}

--- a/apps/desktop/src/main/persistence/sqlite-db.test.ts
+++ b/apps/desktop/src/main/persistence/sqlite-db.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, afterAll } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+import { openStateDb, readUserVersion, type Migration } from './sqlite-db'
+import { STATE_MIGRATIONS } from './state-migrations'
+
+/**
+ * The state-db opener + forward-only migration runner (ADR-0019). Exercised on
+ * `:memory:` databases plus a real temp-dir file where reopen/durability is the
+ * point — no `userData`, mirroring metadata-store.test.ts.
+ */
+
+const dir = mkdtempSync(join(tmpdir(), 'vibe-sqlite-db-'))
+afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+/** A tiny migration writing a marker row, for runner-order tests. */
+function marker(id: number): Migration {
+  return {
+    id,
+    name: `marker-${id}`,
+    up: (db) => {
+      db.exec(`CREATE TABLE IF NOT EXISTS applied (id INTEGER)`)
+      db.exec(`INSERT INTO applied (id) VALUES (${id})`)
+    },
+  }
+}
+
+describe('openStateDb migration runner', () => {
+  it('brings a fresh database to the latest version, applying migrations in order', () => {
+    const state = openStateDb({ path: ':memory:', migrations: [marker(1), marker(2), marker(3)] })
+    expect(state.locked).toBe(false)
+    expect(readUserVersion(state.db)).toBe(3)
+    const applied = state.db.prepare('SELECT id FROM applied ORDER BY rowid').all() as unknown as {
+      id: number
+    }[]
+    expect(applied.map((r) => r.id)).toEqual([1, 2, 3])
+    state.close()
+  })
+
+  it('applies only the PENDING migrations on an already-migrated database', () => {
+    const path = join(dir, 'pending.sqlite')
+    openStateDb({ path, migrations: [marker(1)] }).close()
+
+    // Reopen with a longer history: only 2 and 3 run.
+    const state = openStateDb({ path, migrations: [marker(1), marker(2), marker(3)] })
+    expect(readUserVersion(state.db)).toBe(3)
+    const applied = state.db.prepare('SELECT id FROM applied ORDER BY rowid').all() as unknown as {
+      id: number
+    }[]
+    expect(applied.map((r) => r.id)).toEqual([1, 2, 3])
+    state.close()
+
+    // A third open with the same history is a no-op (no duplicate markers).
+    const again = openStateDb({ path, migrations: [marker(1), marker(2), marker(3)] })
+    const rows = again.db.prepare('SELECT COUNT(*) AS n FROM applied').get() as { n: number }
+    expect(rows.n).toBe(3)
+    again.close()
+  })
+
+  it('FAILS CLOSED on a database from a newer build: locked, no migrations run, file preserved', () => {
+    const path = join(dir, 'future.sqlite')
+    const raw = new DatabaseSync(path)
+    raw.exec('PRAGMA user_version = 99')
+    raw.exec('CREATE TABLE future_data (x)')
+    raw.exec("INSERT INTO future_data VALUES ('written by the future')")
+    raw.close()
+
+    const state = openStateDb({ path, migrations: [marker(1)] })
+    expect(state.locked).toBe(true)
+    // Nothing ran: version untouched, no marker table, future data intact.
+    expect(readUserVersion(state.db)).toBe(99)
+    const tables = state.db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
+      .all() as unknown as { name: string }[]
+    expect(tables.map((t) => t.name)).toEqual(['future_data'])
+    state.close()
+  })
+
+  it('rolls back and rethrows when a migration fails mid-way (no partial version bump)', () => {
+    const path = join(dir, 'broken.sqlite')
+    const broken: Migration = {
+      id: 2,
+      name: 'boom',
+      up: (db) => {
+        db.exec('CREATE TABLE half (x)')
+        throw new Error('boom')
+      },
+    }
+    expect(() => openStateDb({ path, migrations: [marker(1), broken] })).toThrow('boom')
+
+    // Version stopped at 1 and the failed migration's table was rolled back.
+    const raw = new DatabaseSync(path)
+    expect(readUserVersion(raw)).toBe(1)
+    const tables = raw
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'half'")
+      .all()
+    expect(tables).toHaveLength(0)
+    raw.close()
+  })
+
+  it('enables WAL journaling and foreign-key enforcement on a file database', () => {
+    const path = join(dir, 'pragmas.sqlite')
+    const state = openStateDb({ path, migrations: STATE_MIGRATIONS })
+    const mode = state.db.prepare('PRAGMA journal_mode').get() as { journal_mode: string }
+    expect(mode.journal_mode).toBe('wal')
+    const fk = state.db.prepare('PRAGMA foreign_keys').get() as { foreign_keys: number }
+    expect(fk.foreign_keys).toBe(1)
+    state.close()
+  })
+})
+
+describe('STATE_MIGRATIONS registry', () => {
+  it('is strictly increasing from 1 (the runner contract)', () => {
+    expect(STATE_MIGRATIONS.length).toBeGreaterThan(0)
+    STATE_MIGRATIONS.forEach((m, i) => expect(m.id).toBe(i + 1))
+  })
+
+  it('creates the metadata tables', () => {
+    const state = openStateDb({ path: ':memory:', migrations: STATE_MIGRATIONS })
+    const tables = state.db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
+      .all() as unknown as { name: string }[]
+    expect(tables.map((t) => t.name)).toEqual(expect.arrayContaining(['threads', 'workspaces']))
+    state.close()
+  })
+})

--- a/apps/desktop/src/main/persistence/sqlite-db.ts
+++ b/apps/desktop/src/main/persistence/sqlite-db.ts
@@ -1,0 +1,92 @@
+import { DatabaseSync } from 'node:sqlite'
+
+/**
+ * The one SQLite database for everything we persist (ADR-0019): `state.sqlite`
+ * under `userData`, opened by main — the single writer — with WAL journaling.
+ *
+ * SEAM CONTRACT: this module is the ONLY place a `DatabaseSync` is constructed
+ * for the state database. Stores receive the opened `StateDb` injected (tests
+ * pass `:memory:` or a temp-dir path) and never derive the path themselves.
+ *
+ * SCHEMA VERSIONING (fail-closed, carried over from the JSON MetadataStore):
+ * the version lives in `PRAGMA user_version`. Migrations are forward-only,
+ * statically registered in a numbered array (no filesystem discovery — survives
+ * bundling), and run automatically at open, each inside a transaction. A file
+ * whose `user_version` is NEWER than this build's latest migration is refused:
+ * the db opens LOCKED — no migrations run, stores present empty and write
+ * nothing — so an older build can never clobber data written by a newer one.
+ */
+
+export interface Migration {
+  /** Strictly increasing, starting at 1. Becomes `user_version` once applied. */
+  id: number
+  name: string
+  up: (db: DatabaseSync) => void
+}
+
+export interface StateDbDeps {
+  /** Absolute db path, or `:memory:` (tests). */
+  path: string
+  migrations: readonly Migration[]
+}
+
+export interface StateDb {
+  db: DatabaseSync
+  /** True when the file was written by a newer build — see module doc. */
+  locked: boolean
+  close(): void
+}
+
+/** Read `PRAGMA user_version` (0 on a fresh database). */
+export function readUserVersion(db: DatabaseSync): number {
+  const row = db.prepare('PRAGMA user_version').get() as { user_version?: number } | undefined
+  return typeof row?.user_version === 'number' ? row.user_version : 0
+}
+
+/**
+ * Open (creating if absent) the state database, apply pragmas, and bring the
+ * schema forward. Throws on an unopenable path — the caller (the construction
+ * seam in `create-metadata-store.ts`) catches and falls back to the legacy
+ * JSON stores rather than wedging launch.
+ */
+export function openStateDb(deps: StateDbDeps): StateDb {
+  const db = new DatabaseSync(deps.path)
+  db.exec('PRAGMA journal_mode = WAL')
+  db.exec('PRAGMA synchronous = NORMAL')
+  db.exec('PRAGMA foreign_keys = ON')
+
+  const latest = deps.migrations.length ? deps.migrations[deps.migrations.length - 1].id : 0
+  const current = readUserVersion(db)
+  if (current > latest) {
+    console.error(
+      `[SqliteDb] ${deps.path} is user_version ${current}; this build supports ${latest}. ` +
+        `Refusing to migrate or write so a newer build's data is preserved. ` +
+        `Upgrade vibe-mistro to open these Workspaces/Threads.`,
+    )
+    return { db, locked: true, close: () => closeQuietly(db) }
+  }
+
+  for (const migration of deps.migrations) {
+    if (migration.id <= current) continue
+    db.exec('BEGIN')
+    try {
+      migration.up(db)
+      db.exec(`PRAGMA user_version = ${migration.id}`)
+      db.exec('COMMIT')
+    } catch (err) {
+      db.exec('ROLLBACK')
+      closeQuietly(db)
+      throw err
+    }
+  }
+
+  return { db, locked: false, close: () => closeQuietly(db) }
+}
+
+function closeQuietly(db: DatabaseSync): void {
+  try {
+    db.close()
+  } catch {
+    // already closed — nothing to release
+  }
+}

--- a/apps/desktop/src/main/persistence/sqlite-metadata-store.test.ts
+++ b/apps/desktop/src/main/persistence/sqlite-metadata-store.test.ts
@@ -1,0 +1,420 @@
+import { describe, it, expect, afterAll } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+import { groupThreadsByWorkspace } from './metadata-store'
+import { openStateDb, readUserVersion } from './sqlite-db'
+import { SqliteMetadataStore } from './sqlite-metadata-store'
+import { STATE_MIGRATIONS } from './state-migrations'
+
+/**
+ * The SQLite metadata store (ADR-0019) behind `MetadataStoreApi` — the SAME
+ * behavior spec metadata-store.test.ts pins for the JSON engine, re-pointed at
+ * `:memory:` databases (plus a temp-dir file where reopen durability is the
+ * point). Where the JSON suite asserted "no disk write" via injected fs seams,
+ * this one asserts the observable equivalent: no state change.
+ */
+
+const dir = mkdtempSync(join(tmpdir(), 'vibe-sqlite-meta-'))
+afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+function memoryStore(now?: () => number): SqliteMetadataStore {
+  return new SqliteMetadataStore({
+    stateDb: openStateDb({ path: ':memory:', migrations: STATE_MIGRATIONS }),
+    ...(now ? { now } : {}),
+  })
+}
+
+function fileStore(file: string, now?: () => number): SqliteMetadataStore {
+  return new SqliteMetadataStore({
+    stateDb: openStateDb({ path: join(dir, file), migrations: STATE_MIGRATIONS }),
+    ...(now ? { now } : {}),
+  })
+}
+
+describe('SqliteMetadataStore round-trip', () => {
+  it('persists Workspaces + Threads and reads them back through a new instance', async () => {
+    const store = fileStore('roundtrip.sqlite')
+    await store.load()
+    const ws = await store.upsertWorkspace({ dir: '/proj/alpha', displayName: 'alpha' })
+    await store.upsertThread({ workspaceId: ws.id, sessionId: 'sess-1', title: 'first' })
+
+    const reopened = fileStore('roundtrip.sqlite')
+    await reopened.load()
+    const snap = reopened.snapshot()
+
+    expect(snap.workspaces).toHaveLength(1)
+    expect(snap.workspaces[0]).toMatchObject({ dir: '/proj/alpha', displayName: 'alpha' })
+    expect(snap.threads).toHaveLength(1)
+    expect(snap.threads[0]).toMatchObject({ workspaceId: ws.id, sessionId: 'sess-1', title: 'first' })
+  })
+
+  it('mints a Thread id distinct from its ACP sessionId, and allows a null sessionId', async () => {
+    const store = memoryStore()
+    const ws = await store.upsertWorkspace({ dir: '/proj/beta' })
+
+    const bound = await store.upsertThread({ workspaceId: ws.id, sessionId: 'acp-session-xyz' })
+    expect(bound.id).not.toBe(bound.sessionId)
+    expect(bound.id.length).toBeGreaterThan(0)
+
+    const cold = await store.upsertThread({ workspaceId: ws.id })
+    expect(cold.sessionId).toBeNull()
+    expect(cold.id).not.toBe(bound.id)
+  })
+
+  it('upserts a Workspace by dir (no duplicate), refreshing lastOpenedAt and re-ordering', async () => {
+    let clock = 1000
+    const store = memoryStore(() => clock)
+    const a = await store.upsertWorkspace({ dir: '/proj/a' })
+    clock = 2000
+    await store.upsertWorkspace({ dir: '/proj/b' })
+    clock = 3000
+    const aAgain = await store.upsertWorkspace({ dir: '/proj/a' })
+
+    expect(aAgain.id).toBe(a.id)
+    expect(aAgain.lastOpenedAt).toBe(3000)
+    const dirs = store.snapshot().workspaces.map((w) => w.dir)
+    expect(dirs).toEqual(['/proj/a', '/proj/b'])
+  })
+
+  it('preserves a Workspace displayName across a re-open upsert that omits it', async () => {
+    const store = memoryStore()
+    await store.upsertWorkspace({ dir: '/proj/named', displayName: 'Nice Name' })
+    const again = await store.upsertWorkspace({ dir: '/proj/named' })
+    expect(again.displayName).toBe('Nice Name')
+  })
+
+  it('upserts a Thread by id (no duplicate), refreshing lastActiveAt and re-ordering', async () => {
+    let clock = 1000
+    const store = memoryStore(() => clock)
+    const ws = await store.upsertWorkspace({ dir: '/proj/c' })
+
+    clock = 1100
+    const t1 = await store.upsertThread({ workspaceId: ws.id, sessionId: 's1' })
+    clock = 1200
+    const t2 = await store.upsertThread({ workspaceId: ws.id, sessionId: 's2' })
+    clock = 1300
+    const t1Again = await store.upsertThread({ id: t1.id, workspaceId: ws.id, sessionId: 's1b' })
+
+    expect(t1Again.id).toBe(t1.id)
+    expect(t1Again.createdAt).toBe(1100)
+    expect(t1Again.lastActiveAt).toBe(1300)
+    expect(t1Again.sessionId).toBe('s1b')
+    expect(store.snapshot().threads.map((t) => t.id)).toEqual([t1.id, t2.id])
+  })
+
+  it('touchThread bumps lastActiveAt, re-heads the order, and is durable across reopen', async () => {
+    let clock = 1000
+    const store = fileStore('touch.sqlite', () => clock)
+    const ws = await store.upsertWorkspace({ dir: '/proj/touch' })
+    clock = 1100
+    const t1 = await store.upsertThread({ workspaceId: ws.id, sessionId: 's1', title: 'old' })
+    clock = 1200
+    const t2 = await store.upsertThread({ workspaceId: ws.id, sessionId: 's2' })
+
+    clock = 1300
+    await store.touchThread(t1.id)
+
+    const t1After = store.snapshot().threads.find((t) => t.id === t1.id)
+    expect(t1After?.lastActiveAt).toBe(1300)
+    expect(t1After?.createdAt).toBe(1100)
+    expect(t1After?.title).toBe('old')
+    expect(t1After?.sessionId).toBe('s1')
+    expect(store.snapshot().threads.map((t) => t.id)).toEqual([t1.id, t2.id])
+
+    const reopened = fileStore('touch.sqlite')
+    expect(reopened.snapshot().threads.find((t) => t.id === t1.id)?.lastActiveAt).toBe(1300)
+  })
+
+  it('touchThread is a no-op for an unknown id', async () => {
+    const store = memoryStore()
+    await expect(store.touchThread('nope')).resolves.toBeUndefined()
+    expect(store.snapshot().threads).toEqual([])
+  })
+
+  it('setThreadTitle renames in place: sets title, holds position, does NOT bump lastActiveAt', async () => {
+    let clock = 1000
+    const store = memoryStore(() => clock)
+    const ws = await store.upsertWorkspace({ dir: '/proj/rename' })
+    clock = 1100
+    const t1 = await store.upsertThread({ workspaceId: ws.id, sessionId: 's1' })
+    clock = 1200
+    const t2 = await store.upsertThread({ workspaceId: ws.id, sessionId: 's2', pinned: true })
+
+    clock = 9999
+    expect(await store.setThreadTitle(t1.id, 'Renamed thread')).toBe(true)
+
+    const t1After = store.snapshot().threads.find((t) => t.id === t1.id)
+    expect(t1After?.title).toBe('Renamed thread')
+    expect(t1After?.lastActiveAt).toBe(1100)
+    expect(t1After?.sessionId).toBe('s1')
+    expect(store.snapshot().threads.map((t) => t.id)).toEqual([t2.id, t1.id])
+    expect(store.snapshot().threads.find((t) => t.id === t2.id)?.pinned).toBe(true)
+  })
+
+  it('setThreadTitle returns false (no change) for an unknown id or unchanged title', async () => {
+    const store = memoryStore()
+    const ws = await store.upsertWorkspace({ dir: '/proj/noop' })
+    const t = await store.upsertThread({ workspaceId: ws.id, title: 'Same' })
+
+    expect(await store.setThreadTitle('no-such-thread', 'X')).toBe(false)
+    expect(await store.setThreadTitle(t.id, 'Same')).toBe(false) // absorbs the echo
+    expect(store.snapshot().threads.find((x) => x.id === t.id)?.title).toBe('Same')
+  })
+
+  it('sets a Thread title by id (auto-title capture) preserving session + createdAt', async () => {
+    let clock = 500
+    const store = fileStore('title-set.sqlite', () => clock)
+    const ws = await store.upsertWorkspace({ dir: '/proj/title' })
+    clock = 600
+    const t = await store.upsertThread({ workspaceId: ws.id, sessionId: 'sess-x' })
+    expect(t.title).toBeNull()
+
+    clock = 700
+    const titled = await store.upsertThread({ id: t.id, workspaceId: ws.id, title: 'Fix @auth.py bug' })
+
+    expect(titled.id).toBe(t.id)
+    expect(titled.title).toBe('Fix @auth.py bug')
+    expect(titled.sessionId).toBe('sess-x')
+    expect(titled.createdAt).toBe(600)
+
+    const reopened = fileStore('title-set.sqlite')
+    expect(reopened.snapshot().threads.find((x) => x.id === t.id)?.title).toBe('Fix @auth.py bug')
+  })
+
+  it('presents an empty index on a fresh database', async () => {
+    const store = memoryStore()
+    await expect(store.load()).resolves.toBeUndefined()
+    expect(store.snapshot()).toEqual({ workspaces: [], threads: [] })
+    expect(store.isEmpty()).toBe(true)
+  })
+})
+
+describe('SqliteMetadataStore fail-closed (ADR-0019, carried from ADR-0005)', () => {
+  it('a newer-build database loads empty, locks, and never writes', async () => {
+    const path = join(dir, 'future-meta.sqlite')
+    const raw = new DatabaseSync(path)
+    raw.exec('PRAGMA user_version = 99')
+    raw.exec("CREATE TABLE future_data (x); INSERT INTO future_data VALUES ('newer')")
+    raw.close()
+
+    const stateDb = openStateDb({ path, migrations: STATE_MIGRATIONS })
+    const store = new SqliteMetadataStore({ stateDb })
+    await store.load()
+
+    expect(store.isLocked()).toBe(true)
+    expect(store.snapshot()).toEqual({ workspaces: [], threads: [] })
+
+    // Mutations are non-durable no-ops; the newer data + version are preserved.
+    await store.upsertWorkspace({ dir: '/proj/should-not-persist' })
+    await store.touchThread('any')
+    expect(await store.setThreadTitle('any', 'x')).toBe(false)
+    expect(await store.removeWorkspace('any')).toEqual([])
+    expect(store.findThreadIdBySessionId('any')).toBeNull()
+    stateDb.close()
+
+    const verify = new DatabaseSync(path)
+    expect(readUserVersion(verify)).toBe(99)
+    const rows = verify.prepare('SELECT x FROM future_data').all() as unknown as { x: string }[]
+    expect(rows).toEqual([{ x: 'newer' }])
+    const tables = verify
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'workspaces'")
+      .all()
+    expect(tables).toHaveLength(0) // no schema was created on the locked file
+    verify.close()
+  })
+})
+
+describe('SqliteMetadataStore.deleteThread', () => {
+  it('removes a Thread record so it no longer lists, leaving siblings intact (durable)', async () => {
+    const store = fileStore('delete-thread.sqlite')
+    const ws = await store.upsertWorkspace({ dir: '/proj/del' })
+    const keep = await store.upsertThread({ workspaceId: ws.id, sessionId: 'keep' })
+    const drop = await store.upsertThread({ workspaceId: ws.id, sessionId: 'drop' })
+
+    await store.deleteThread(drop.id)
+    expect(store.snapshot().threads.map((t) => t.id)).toEqual([keep.id])
+
+    const reopened = fileStore('delete-thread.sqlite')
+    expect(reopened.snapshot().threads.map((t) => t.id)).toEqual([keep.id])
+  })
+
+  it('is a no-op for an unknown id (idempotent, no throw)', async () => {
+    const store = memoryStore()
+    const ws = await store.upsertWorkspace({ dir: '/proj/del-unknown' })
+    const t = await store.upsertThread({ workspaceId: ws.id })
+
+    await expect(store.deleteThread('no-such-thread')).resolves.toBeUndefined()
+    await store.deleteThread(t.id)
+    await expect(store.deleteThread(t.id)).resolves.toBeUndefined()
+    expect(store.snapshot().threads).toEqual([])
+  })
+})
+
+describe('SqliteMetadataStore.removeWorkspace', () => {
+  it('removes the Workspace + all its Threads (FK cascade) and returns their ids', async () => {
+    const store = fileStore('remove-ws.sqlite')
+    const ws = await store.upsertWorkspace({ dir: '/proj/rm' })
+    const t1 = await store.upsertThread({ workspaceId: ws.id, sessionId: 's1' })
+    const t2 = await store.upsertThread({ workspaceId: ws.id, sessionId: 's2' })
+
+    const removed = await store.removeWorkspace(ws.id)
+
+    expect(removed).toEqual(expect.arrayContaining([t1.id, t2.id]))
+    expect(removed).toHaveLength(2)
+    expect(store.snapshot()).toEqual({ workspaces: [], threads: [] })
+
+    const reopened = fileStore('remove-ws.sqlite')
+    expect(reopened.snapshot()).toEqual({ workspaces: [], threads: [] })
+  })
+
+  it('leaves other Workspaces and their Threads intact', async () => {
+    const store = memoryStore()
+    const drop = await store.upsertWorkspace({ dir: '/proj/drop' })
+    const keep = await store.upsertWorkspace({ dir: '/proj/keep' })
+    const dropThread = await store.upsertThread({ workspaceId: drop.id })
+    const keepThread = await store.upsertThread({ workspaceId: keep.id })
+
+    const removed = await store.removeWorkspace(drop.id)
+
+    expect(removed).toEqual([dropThread.id])
+    expect(store.snapshot().workspaces.map((w) => w.id)).toEqual([keep.id])
+    expect(store.snapshot().threads.map((t) => t.id)).toEqual([keepThread.id])
+  })
+
+  it('is a no-op for an unknown id — returns [] and changes nothing', async () => {
+    const store = memoryStore()
+    await store.upsertWorkspace({ dir: '/proj/present' })
+    await expect(store.removeWorkspace('no-such-workspace')).resolves.toEqual([])
+    expect(store.snapshot().workspaces).toHaveLength(1)
+  })
+})
+
+describe('SqliteMetadataStore.setThreadFlags (#132 pin / #133 archive)', () => {
+  it('patches only the passed flag, leaving the other untouched, and round-trips', async () => {
+    const store = fileStore('flags.sqlite')
+    const ws = await store.upsertWorkspace({ dir: '/proj/flags' })
+    const t = await store.upsertThread({ workspaceId: ws.id, sessionId: 's1' })
+
+    await store.setThreadFlags(t.id, { pinned: true })
+    let rec = store.snapshot().threads.find((x) => x.id === t.id)
+    expect(rec?.pinned).toBe(true)
+    expect(rec?.archived).toBeUndefined() // never set — stays undefined, not false
+
+    await store.setThreadFlags(t.id, { archived: true })
+    rec = store.snapshot().threads.find((x) => x.id === t.id)
+    expect(rec?.pinned).toBe(true)
+    expect(rec?.archived).toBe(true)
+
+    const reopened = fileStore('flags.sqlite')
+    const back = reopened.snapshot().threads.find((x) => x.id === t.id)
+    expect(back?.pinned).toBe(true)
+    expect(back?.archived).toBe(true)
+
+    // Unpin clears just that flag — and an explicit false reads back as false.
+    await reopened.setThreadFlags(t.id, { pinned: false })
+    expect(reopened.snapshot().threads.find((x) => x.id === t.id)?.pinned).toBe(false)
+    expect(reopened.snapshot().threads.find((x) => x.id === t.id)?.archived).toBe(true)
+  })
+
+  it('holds the record list POSITION (a flag toggle is not activity)', async () => {
+    let clock = 1000
+    const store = memoryStore(() => clock)
+    const ws = await store.upsertWorkspace({ dir: '/proj/flags-order' })
+    clock = 1100
+    const t1 = await store.upsertThread({ workspaceId: ws.id })
+    clock = 1200
+    const t2 = await store.upsertThread({ workspaceId: ws.id })
+
+    await store.setThreadFlags(t1.id, { pinned: true })
+    expect(store.snapshot().threads.map((t) => t.id)).toEqual([t2.id, t1.id])
+  })
+
+  it('is a no-op for an unknown id (no throw)', async () => {
+    const store = memoryStore()
+    await expect(store.setThreadFlags('no-such-thread', { pinned: true })).resolves.toBeUndefined()
+    expect(store.snapshot().threads).toEqual([])
+  })
+
+  it('upsertThread PRESERVES pinned/archived across a routine activity re-target', async () => {
+    const store = memoryStore()
+    const ws = await store.upsertWorkspace({ dir: '/proj/flags-preserve' })
+    const t = await store.upsertThread({ workspaceId: ws.id })
+    await store.setThreadFlags(t.id, { pinned: true, archived: true })
+
+    const again = await store.upsertThread({ id: t.id, workspaceId: ws.id, sessionId: 's-new' })
+    expect(again.pinned).toBe(true)
+    expect(again.archived).toBe(true)
+  })
+})
+
+describe('findThreadIdBySessionId (transcript routing)', () => {
+  it('resolves the minted Thread id from its bound ACP sessionId, else null', async () => {
+    const store = memoryStore()
+    const ws = await store.upsertWorkspace({ dir: '/proj/route' })
+    const bound = await store.upsertThread({ workspaceId: ws.id, sessionId: 'sess-route' })
+    await store.upsertThread({ workspaceId: ws.id }) // null session — must not match
+
+    expect(store.findThreadIdBySessionId('sess-route')).toBe(bound.id)
+    expect(store.findThreadIdBySessionId('no-such-session')).toBeNull()
+    expect(store.findThreadIdBySessionId(null)).toBeNull()
+  })
+})
+
+describe('SqliteMetadataStore.importSnapshot (one-time legacy import)', () => {
+  it('imports records VERBATIM — ids, timestamps, flags, nulls preserved', async () => {
+    const store = memoryStore()
+    store.importSnapshot({
+      workspaces: [{ id: 'w1', dir: '/legacy', displayName: 'L', lastOpenedAt: 5 }],
+      threads: [
+        { id: 't1', workspaceId: 'w1', sessionId: null, title: null, createdAt: 1, lastActiveAt: 2 },
+        {
+          id: 't2',
+          workspaceId: 'w1',
+          sessionId: 'sess-2',
+          title: 'kept',
+          createdAt: 3,
+          lastActiveAt: 4,
+          pinned: true,
+        },
+      ],
+    })
+
+    const snap = store.snapshot()
+    expect(snap.workspaces).toEqual([{ id: 'w1', dir: '/legacy', displayName: 'L', lastOpenedAt: 5 }])
+    expect(snap.threads.map((t) => t.id)).toEqual(['t2', 't1']) // recent-first
+    const t2 = snap.threads.find((t) => t.id === 't2')
+    expect(t2).toMatchObject({ sessionId: 'sess-2', title: 'kept', createdAt: 3, pinned: true })
+    expect(t2?.archived).toBeUndefined()
+    expect(store.isEmpty()).toBe(false)
+    // The renderer's grouped launch list works off the imported rows.
+    expect(groupThreadsByWorkspace(snap)[0].threads).toHaveLength(2)
+  })
+
+  it('drops orphan Threads (Workspace record lost) instead of failing the import', async () => {
+    const store = memoryStore()
+    store.importSnapshot({
+      workspaces: [{ id: 'w1', dir: '/a', displayName: 'a', lastOpenedAt: 1 }],
+      threads: [
+        { id: 't1', workspaceId: 'w1', sessionId: null, title: null, createdAt: 1, lastActiveAt: 1 },
+        { id: 'tOrphan', workspaceId: 'gone', sessionId: null, title: null, createdAt: 2, lastActiveAt: 2 },
+      ],
+    })
+    expect(store.snapshot().threads.map((t) => t.id)).toEqual(['t1'])
+  })
+
+  it('rolls back to an empty database when the import fails mid-way', async () => {
+    const store = memoryStore()
+    expect(() =>
+      store.importSnapshot({
+        workspaces: [{ id: 'w1', dir: '/a', displayName: 'a', lastOpenedAt: 1 }],
+        threads: [
+          { id: 'dup', workspaceId: 'w1', sessionId: null, title: null, createdAt: 1, lastActiveAt: 1 },
+          { id: 'dup', workspaceId: 'w1', sessionId: null, title: null, createdAt: 2, lastActiveAt: 2 },
+        ],
+      }),
+    ).toThrow()
+    expect(store.isEmpty()).toBe(true) // the transaction rolled everything back
+  })
+})

--- a/apps/desktop/src/main/persistence/sqlite-metadata-store.ts
+++ b/apps/desktop/src/main/persistence/sqlite-metadata-store.ts
@@ -1,0 +1,308 @@
+import { randomUUID } from 'node:crypto'
+import type { MetadataStoreApi } from './metadata-store-api'
+import type {
+  MetadataSnapshot,
+  ThreadInput,
+  ThreadRecord,
+  WorkspaceInput,
+  WorkspaceRecord,
+} from './metadata-store'
+import type { StateDb } from './sqlite-db'
+
+/**
+ * The Workspace/Thread metadata store on SQLite (ADR-0019), a drop-in behind
+ * `MetadataStoreApi` — the same behaviors the JSON `MetadataStore` pins in its
+ * suite, re-pointed at `workspaces`/`threads` rows. Mutations are single-row
+ * statements (the per-turn `touchThread` no longer rewrites an index file);
+ * every write is synchronous inside the async signatures the seam keeps.
+ *
+ * LOCKED state (db written by a newer build, `openStateDb`): the store presents
+ * empty and every mutation is a no-op — mirroring the JSON store's fail-closed
+ * envelope rule — so the caller can surface an honest "upgrade to open your
+ * data" notice instead of showing empty as real.
+ *
+ * Thread flags are stored 0/1/NULL: NULL = never set (reads as `undefined`),
+ * 0 = explicitly false, 1 = true. This keeps `setThreadFlags(id, { pinned:
+ * false })` reading back `false` while an untouched flag stays `undefined`,
+ * exactly like the in-memory shape the renderer's pin/archive logic expects.
+ */
+
+interface WorkspaceRow {
+  id: string
+  dir: string
+  display_name: string
+  last_opened_at: number
+}
+
+interface ThreadRow {
+  id: string
+  workspace_id: string
+  session_id: string | null
+  title: string | null
+  created_at: number
+  last_active_at: number
+  pinned: number | null
+  archived: number | null
+}
+
+export interface SqliteMetadataStoreDeps {
+  stateDb: StateDb
+  now?: () => number
+  mintId?: () => string
+}
+
+export class SqliteMetadataStore implements MetadataStoreApi {
+  private readonly stateDb: StateDb
+  private readonly now: () => number
+  private readonly mintId: () => string
+
+  constructor(deps: SqliteMetadataStoreDeps) {
+    this.stateDb = deps.stateDb
+    this.now = deps.now ?? Date.now
+    this.mintId = deps.mintId ?? randomUUID
+  }
+
+  private get db() {
+    return this.stateDb.db
+  }
+
+  /** No-op for SQLite (schema is brought forward at open); seam parity only. */
+  async load(): Promise<void> {}
+
+  isLocked(): boolean {
+    return this.stateDb.locked
+  }
+
+  async upsertWorkspace(input: WorkspaceInput): Promise<WorkspaceRecord> {
+    const fallback: WorkspaceRecord = {
+      id: this.mintId(),
+      dir: input.dir,
+      displayName: input.displayName ?? input.dir,
+      lastOpenedAt: input.lastOpenedAt ?? this.now(),
+    }
+    if (this.stateDb.locked) return fallback // non-durable, like the locked JSON store
+
+    const existing = this.db
+      .prepare('SELECT * FROM workspaces WHERE dir = ?')
+      .get(input.dir) as WorkspaceRow | undefined
+    const record: WorkspaceRecord = {
+      id: existing?.id ?? fallback.id,
+      dir: input.dir,
+      displayName: input.displayName ?? existing?.display_name ?? input.dir,
+      lastOpenedAt: input.lastOpenedAt ?? this.now(),
+    }
+    this.db
+      .prepare(
+        `INSERT INTO workspaces (id, dir, display_name, last_opened_at) VALUES (?, ?, ?, ?)
+         ON CONFLICT(dir) DO UPDATE SET display_name = excluded.display_name,
+                                        last_opened_at = excluded.last_opened_at`,
+      )
+      .run(record.id, record.dir, record.displayName, record.lastOpenedAt)
+    return record
+  }
+
+  async upsertThread(input: ThreadInput): Promise<ThreadRecord> {
+    const ts = this.now()
+    const existing =
+      !this.stateDb.locked && input.id
+        ? ((this.db.prepare('SELECT * FROM threads WHERE id = ?').get(input.id) as
+            | ThreadRow
+            | undefined) ?? undefined)
+        : undefined
+    const record: ThreadRecord = {
+      id: existing?.id ?? input.id ?? this.mintId(),
+      workspaceId: input.workspaceId,
+      sessionId: input.sessionId ?? existing?.session_id ?? null,
+      title: input.title ?? existing?.title ?? null,
+      createdAt: input.createdAt ?? existing?.created_at ?? ts,
+      lastActiveAt: input.lastActiveAt ?? ts,
+      pinned: input.pinned ?? flagFromColumn(existing?.pinned),
+      archived: input.archived ?? flagFromColumn(existing?.archived),
+    }
+    if (this.stateDb.locked) return record // non-durable, like the locked JSON store
+
+    this.db
+      .prepare(
+        `INSERT INTO threads (id, workspace_id, session_id, title, created_at, last_active_at, pinned, archived)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET workspace_id = excluded.workspace_id,
+                                       session_id = excluded.session_id,
+                                       title = excluded.title,
+                                       created_at = excluded.created_at,
+                                       last_active_at = excluded.last_active_at,
+                                       pinned = excluded.pinned,
+                                       archived = excluded.archived`,
+      )
+      .run(
+        record.id,
+        record.workspaceId,
+        record.sessionId,
+        record.title,
+        record.createdAt,
+        record.lastActiveAt,
+        flagToColumn(record.pinned),
+        flagToColumn(record.archived),
+      )
+    return record
+  }
+
+  async touchThread(id: string): Promise<void> {
+    if (this.stateDb.locked) return
+    this.db.prepare('UPDATE threads SET last_active_at = ? WHERE id = ?').run(this.now(), id)
+  }
+
+  async setThreadFlags(id: string, flags: { pinned?: boolean; archived?: boolean }): Promise<void> {
+    if (this.stateDb.locked) return
+    const sets: string[] = []
+    const params: (number | string)[] = []
+    if (flags.pinned !== undefined) {
+      sets.push('pinned = ?')
+      params.push(flags.pinned ? 1 : 0)
+    }
+    if (flags.archived !== undefined) {
+      sets.push('archived = ?')
+      params.push(flags.archived ? 1 : 0)
+    }
+    if (!sets.length) return
+    this.db.prepare(`UPDATE threads SET ${sets.join(', ')} WHERE id = ?`).run(...params, id)
+  }
+
+  async setThreadTitle(id: string, title: string | null): Promise<boolean> {
+    if (this.stateDb.locked) return false
+    // `IS NOT` is NULL-safe, so the unchanged-title no-op (which absorbs the
+    // vibe-acp `session_info_update` echo after our own rename) covers nulls too.
+    const result = this.db
+      .prepare('UPDATE threads SET title = ? WHERE id = ? AND title IS NOT ?')
+      .run(title, id, title)
+    return result.changes > 0
+  }
+
+  async deleteThread(id: string): Promise<void> {
+    if (this.stateDb.locked) return
+    this.db.prepare('DELETE FROM threads WHERE id = ?').run(id)
+  }
+
+  async removeWorkspace(id: string): Promise<string[]> {
+    if (this.stateDb.locked) return []
+    const rows = this.db
+      .prepare('SELECT id FROM threads WHERE workspace_id = ?')
+      .all(id) as Array<Pick<ThreadRow, 'id'>>
+    // The FK cascade drops the Threads with the Workspace row (one atomic
+    // statement); Threads whose Workspace row is already gone (defensive) are
+    // swept explicitly so the returned ids always match what was removed.
+    this.db.prepare('DELETE FROM workspaces WHERE id = ?').run(id)
+    this.db.prepare('DELETE FROM threads WHERE workspace_id = ?').run(id)
+    return rows.map((r) => r.id)
+  }
+
+  findThreadIdBySessionId(sessionId: string | null | undefined): string | null {
+    if (!sessionId || this.stateDb.locked) return null
+    const row = this.db
+      .prepare('SELECT id FROM threads WHERE session_id = ? ORDER BY last_active_at DESC LIMIT 1')
+      .get(sessionId) as Pick<ThreadRow, 'id'> | undefined
+    return row?.id ?? null
+  }
+
+  snapshot(): MetadataSnapshot {
+    if (this.stateDb.locked) return { workspaces: [], threads: [] }
+    const workspaces = (
+      this.db
+        .prepare('SELECT * FROM workspaces ORDER BY last_opened_at DESC, rowid DESC')
+        .all() as unknown as WorkspaceRow[]
+    ).map(workspaceFromRow)
+    const threads = (
+      this.db
+        .prepare('SELECT * FROM threads ORDER BY last_active_at DESC, rowid DESC')
+        .all() as unknown as ThreadRow[]
+    ).map(threadFromRow)
+    return { workspaces, threads }
+  }
+
+  /** Whether the database holds no metadata yet — the one-time import gate. */
+  isEmpty(): boolean {
+    if (this.stateDb.locked) return false
+    const row = this.db
+      .prepare('SELECT (SELECT COUNT(*) FROM workspaces) + (SELECT COUNT(*) FROM threads) AS n')
+      .get() as { n: number }
+    return row.n === 0
+  }
+
+  /**
+   * One-time legacy import (ADR-0019): insert records VERBATIM — ids, timestamps
+   * and flags preserved, nothing minted — inside one transaction so a failure
+   * rolls back to the empty database it found. Only the importer calls this.
+   */
+  importSnapshot(snapshot: MetadataSnapshot): void {
+    if (this.stateDb.locked) throw new Error('cannot import into a locked state db')
+    // Orphan Threads (their Workspace record was lost) exist only in legacy
+    // data — the FK would reject them and fail the whole import, so drop them
+    // exactly like `groupThreadsByWorkspace` already drops them from every list.
+    const workspaceIds = new Set(snapshot.workspaces.map((w) => w.id))
+    const threads = snapshot.threads.filter((t) => workspaceIds.has(t.workspaceId))
+    const orphans = snapshot.threads.length - threads.length
+    if (orphans > 0) {
+      console.error(`[SqliteMetadataStore] import: dropping ${orphans} orphan Thread record(s)`)
+    }
+    this.db.exec('BEGIN')
+    try {
+      const insertWorkspace = this.db.prepare(
+        'INSERT INTO workspaces (id, dir, display_name, last_opened_at) VALUES (?, ?, ?, ?)',
+      )
+      for (const w of snapshot.workspaces) {
+        insertWorkspace.run(w.id, w.dir, w.displayName, w.lastOpenedAt)
+      }
+      const insertThread = this.db.prepare(
+        `INSERT INTO threads (id, workspace_id, session_id, title, created_at, last_active_at, pinned, archived)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      for (const t of threads) {
+        insertThread.run(
+          t.id,
+          t.workspaceId,
+          t.sessionId,
+          t.title,
+          t.createdAt,
+          t.lastActiveAt,
+          flagToColumn(t.pinned),
+          flagToColumn(t.archived),
+        )
+      }
+      this.db.exec('COMMIT')
+    } catch (err) {
+      this.db.exec('ROLLBACK')
+      throw err
+    }
+  }
+}
+
+function workspaceFromRow(row: WorkspaceRow): WorkspaceRecord {
+  return {
+    id: row.id,
+    dir: row.dir,
+    displayName: row.display_name,
+    lastOpenedAt: row.last_opened_at,
+  }
+}
+
+function threadFromRow(row: ThreadRow): ThreadRecord {
+  return {
+    id: row.id,
+    workspaceId: row.workspace_id,
+    sessionId: row.session_id,
+    title: row.title,
+    createdAt: row.created_at,
+    lastActiveAt: row.last_active_at,
+    pinned: flagFromColumn(row.pinned),
+    archived: flagFromColumn(row.archived),
+  }
+}
+
+/** 0/1/NULL column → boolean|undefined flag (NULL = never set). */
+function flagFromColumn(value: number | null | undefined): boolean | undefined {
+  return value === null || value === undefined ? undefined : value !== 0
+}
+
+/** boolean|undefined flag → 0/1/NULL column. */
+function flagToColumn(value: boolean | undefined): number | null {
+  return value === undefined ? null : value ? 1 : 0
+}

--- a/apps/desktop/src/main/persistence/state-migrations.ts
+++ b/apps/desktop/src/main/persistence/state-migrations.ts
@@ -1,0 +1,43 @@
+import type { Migration } from './sqlite-db'
+
+/**
+ * The state database's forward-only migration history (ADR-0019). Statically
+ * registered — append new migrations to the END with the next id; never edit or
+ * reorder an applied one. `user_version` tracks the last applied id; a database
+ * ahead of this list fails closed in `openStateDb`.
+ *
+ * Schema conventions (ADR-0019): timestamps are epoch-millisecond INTEGERs
+ * (matching the `shared/ipc` wire types), booleans are 0/1 INTEGERs — except
+ * the Thread flags, which are 0/1/NULL so "explicitly false" and "never set"
+ * round-trip distinctly (the legacy store's normalize-on-load semantics).
+ */
+export const STATE_MIGRATIONS: readonly Migration[] = [
+  {
+    id: 1,
+    name: 'metadata-tables',
+    up: (db) => {
+      db.exec(`
+        CREATE TABLE workspaces (
+          id             TEXT PRIMARY KEY,
+          dir            TEXT NOT NULL UNIQUE,
+          display_name   TEXT NOT NULL,
+          last_opened_at INTEGER NOT NULL
+        );
+
+        CREATE TABLE threads (
+          id             TEXT PRIMARY KEY,
+          workspace_id   TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+          session_id     TEXT,
+          title          TEXT,
+          created_at     INTEGER NOT NULL,
+          last_active_at INTEGER NOT NULL,
+          pinned         INTEGER,
+          archived       INTEGER
+        );
+
+        CREATE INDEX idx_threads_workspace_active ON threads(workspace_id, last_active_at DESC);
+        CREATE INDEX idx_threads_session ON threads(session_id);
+      `)
+    },
+  },
+]


### PR DESCRIPTION
Closes #294. Slice 2 of the SQLite persistence epic (#292), built on ADR-0019 (merged in #299).

## What this does

The database foundation plus the first real store on it — everything behind the existing SEAM CONTRACT, so orchestration code barely changes (two type imports).

- **`sqlite-db.ts`** — the one place `state.sqlite` opens (WAL, `synchronous=NORMAL`, FKs ON) with the forward-only migration runner: statically-registered numbered array, `PRAGMA user_version`, each migration in its own transaction. **Fail-closed**: a db written by a newer build opens LOCKED — no migrations run, stores present empty, every write no-ops — so a rollback can't clobber newer data (the JSON store's envelope rule, carried over).
- **`state-migrations.ts`** — migration 1: `workspaces` + `threads` (epoch-int timestamps, FK cascade, `(workspace_id, last_active_at DESC)` + `session_id` indexes). Thread flags are **0/1/NULL** so "explicitly false" and "never set" round-trip distinctly, matching the in-memory shape the pin/archive logic expects.
- **`sqlite-metadata-store.ts`** — the metadata store re-implemented behind `MetadataStoreApi`: single-row statements (the per-turn `touchThread` no longer rewrites a whole index file), NULL-safe title-echo absorption (`title IS NOT ?`), cascade-backed `removeWorkspace`, and a verbatim `importSnapshot` that drops orphan Threads exactly like `groupThreadsByWorkspace` drops them from every list.
- **`metadata-store-api.ts`** — the seam as an interface; `MainDeps` and the editors registrar type against it so both engines are drop-ins.
- **`import-legacy-metadata.ts`** — self-gating one-time import: parses **through the legacy store itself** (envelope handling, per-record shape guards, flag normalization for free), inserts in one transaction, renames `metadata.json` → `.bak` (kept, never deleted). Branches: absent → steady state; newer-schema → left untouched; non-empty db → never merges, only retries a crashed rename; failure → rolls back, session runs on legacy JSON, retries next launch.
- **`create-metadata-store.ts`** — engine selection: SQLite normally; legacy JSON on `VIBE_MISTRO_FORCE_JSON=1`, a failed open, or a failed import.

## Tests

**+43** (1455 total green): migration runner (fresh create / pending-only / fail-closed with file preserved byte-level / mid-migration rollback), the full ported metadata behavior spec on `:memory:` + temp-dir dbs (round-trips, ordering, echo absorption, flags, cascade, idempotent deletes, session routing), all import branches including the rename-crash retry (proving no re-import duplication), and engine selection including the escape hatch and open-failure fallback.

## Packaged-app smoke (real migrated profile)

Built the arm64 app and launched it against an isolated `VIBE_MISTRO_USER_DATA` seeded with a **copy of the real profile** (2 workspaces, 5 threads):

- `state.sqlite` + `-wal`/`-shm` created under userData; boot log: `metadata store engine: sqlite`
- `metadata.json` → `metadata.json.bak`
- Row-level fidelity check vs the `.bak`: all 5 threads verbatim (ids, session cursors, titles, timestamps); workspaces verbatim except `lastOpenedAt`, which the live session legitimately bumped by re-opening the Workspaces on launch

## Notes for review

- Transcripts/attachments are untouched this slice (still JSONL/files) — they move in #295.
- The interface keeps `load()` (no-op on SQLite) so `index.ts`'s call order is unchanged for both engines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QsAPKdeg6ML7Shm1sVYYZ