### PR TITLE
feat(persistence): slice 3 — TranscriptStore on SQLite (global-seq event log) + JSONL import + cascading deletes (#295)

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -66,11 +66,12 @@ import {
   resolvePermissionEntry,
   sessionIdFromPayload,
   titleFromSessionInfoUpdate,
-  TranscriptStore,
   turnCompleteEntry,
   turnErrorEntry,
   userPromptEntry,
 } from './persistence/transcript'
+import type { TranscriptStoreApi } from './persistence/transcript-store-api'
+import { createTranscriptStore } from './persistence/create-transcript-store'
 import { TranscriptBridge } from './persistence/transcript-bridge'
 import { AttachmentStore } from './persistence/attachment-store'
 import { WorkspaceAgent, WorkspaceAgentError } from './workspace-agent'
@@ -361,7 +362,7 @@ let terminalManager: TerminalManager | null = null
  */
 interface MainDeps {
   store: MetadataStoreApi
-  transcript: TranscriptStore | null
+  transcript: TranscriptStoreApi | null
   bridge: TranscriptBridge
   /** Null when the attachments dir `mkdir` failed — image persistence no-ops (logged). */
   attachments: AttachmentStore | null
@@ -1309,22 +1310,18 @@ app.whenReady().then(async () => {
   // open/import — and performs the one-time `metadata.json` -> SQLite import
   // (renaming the legacy file to `.bak` on success). Never throws; a failed
   // load degrades to empty state INSIDE the store — see `MainDeps`.
-  const { store, engine } = await createMetadataStore({ userDataDir: app.getPath('userData') })
+  const { store, stateDb, engine } = await createMetadataStore({ userDataDir: app.getPath('userData') })
   await store.load()
   console.log(`[main] metadata store engine: ${engine}`)
 
-  // The per-Thread transcript dir (ADR-0005). `appendFile` won't create parent
-  // dirs, so ensure it exists once here; a failure leaves `transcript` null and
-  // teeing becomes a silent no-op inside the bridge (best-effort — the
-  // conversation is fine).
+  // The per-Thread transcript store (ADR-0005/0019). Its engine FOLLOWS the
+  // metadata store's (same `state.sqlite`, never split-brain) via the stateDb
+  // handle; the SQLite path runs the one-time JSONL import (dir renamed to
+  // `transcripts.bak` when fully handled), the legacy path keeps the mkdir —
+  // a failure leaves `transcript` null and teeing becomes a silent no-op
+  // inside the bridge (best-effort — the conversation is fine).
   const transcriptsDir = join(app.getPath('userData'), 'transcripts')
-  let transcript: TranscriptStore | null
-  try {
-    await mkdir(transcriptsDir, { recursive: true })
-    transcript = new TranscriptStore({ dir: transcriptsDir })
-  } catch {
-    transcript = null
-  }
+  const { transcript } = await createTranscriptStore({ stateDb, transcriptsDir })
 
   // The per-Thread prompt-image attachments dir (sibling of the transcripts —
   // the store mkdirs each Thread's subdir itself, but probe the root once here

--- a/apps/desktop/src/main/persistence/create-transcript-store.test.ts
+++ b/apps/desktop/src/main/persistence/create-transcript-store.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, afterAll } from 'vitest'
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createTranscriptStore } from './create-transcript-store'
+import { openStateDb } from './sqlite-db'
+import { SqliteMetadataStore } from './sqlite-metadata-store'
+import { SqliteTranscriptStore } from './sqlite-transcript-store'
+import { STATE_MIGRATIONS } from './state-migrations'
+import { TranscriptStore, userPromptEntry } from './transcript'
+
+/**
+ * The transcript-store construction seam (ADR-0019): the engine follows the
+ * metadata store's stateDb (never split-brain), with the one-time JSONL import
+ * wired into the SQLite path.
+ */
+
+const root = mkdtempSync(join(tmpdir(), 'vibe-create-transcript-'))
+afterAll(() => rmSync(root, { recursive: true, force: true }))
+
+let seq = 0
+function freshDir(): string {
+  const dir = join(root, `case-${++seq}`)
+  mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+describe('createTranscriptStore', () => {
+  it('selects SQLite when a stateDb is provided and imports legacy JSONL on the way', async () => {
+    const stateDb = openStateDb({ path: ':memory:', migrations: STATE_MIGRATIONS })
+    const meta = new SqliteMetadataStore({ stateDb })
+    const ws = await meta.upsertWorkspace({ dir: '/proj/a' })
+    await meta.upsertThread({ id: 't1', workspaceId: ws.id })
+
+    const transcriptsDir = join(freshDir(), 'transcripts')
+    mkdirSync(transcriptsDir)
+    writeFileSync(join(transcriptsDir, 't1.jsonl'), JSON.stringify(userPromptEntry('u1', 'legacy')) + '\n')
+
+    const { transcript, engine } = await createTranscriptStore({ stateDb, transcriptsDir })
+
+    expect(engine).toBe('sqlite')
+    expect(transcript).toBeInstanceOf(SqliteTranscriptStore)
+    expect(await transcript?.read('t1')).toEqual([userPromptEntry('u1', 'legacy')])
+    expect(existsSync(transcriptsDir)).toBe(false)
+    expect(existsSync(`${transcriptsDir}.bak`)).toBe(true)
+    stateDb.close()
+  })
+
+  it('selects the legacy JSONL store when stateDb is null (engines move together)', async () => {
+    const transcriptsDir = join(freshDir(), 'transcripts')
+    const { transcript, engine } = await createTranscriptStore({ stateDb: null, transcriptsDir })
+
+    expect(engine).toBe('json')
+    expect(transcript).toBeInstanceOf(TranscriptStore)
+    expect(existsSync(transcriptsDir)).toBe(true) // legacy path mkdirs its home
+  })
+
+  it('skips the import on a LOCKED stateDb (fail-closed) but still serves the store', async () => {
+    const path = join(freshDir(), 'locked.sqlite')
+    const raw = openStateDb({ path, migrations: STATE_MIGRATIONS })
+    raw.db.exec('PRAGMA user_version = 99')
+    raw.close()
+    const stateDb = openStateDb({ path, migrations: STATE_MIGRATIONS })
+    expect(stateDb.locked).toBe(true)
+
+    const transcriptsDir = join(freshDir(), 'transcripts')
+    mkdirSync(transcriptsDir)
+    writeFileSync(join(transcriptsDir, 't1.jsonl'), JSON.stringify(userPromptEntry('u1', 'x')) + '\n')
+
+    const { transcript, engine } = await createTranscriptStore({ stateDb, transcriptsDir })
+
+    expect(engine).toBe('sqlite')
+    expect(await transcript?.read('t1')).toEqual([]) // locked reads empty
+    expect(existsSync(transcriptsDir)).toBe(true) // nothing imported or renamed
+    stateDb.close()
+  })
+})

--- a/apps/desktop/src/main/persistence/create-transcript-store.ts
+++ b/apps/desktop/src/main/persistence/create-transcript-store.ts
@@ -1,0 +1,55 @@
+import { mkdir } from 'node:fs/promises'
+import { importLegacyTranscripts } from './import-legacy-transcripts'
+import { SqliteTranscriptStore } from './sqlite-transcript-store'
+import { TranscriptStore } from './transcript'
+import type { TranscriptStoreApi } from './transcript-store-api'
+import type { StateDb } from './sqlite-db'
+
+/**
+ * The transcript-store construction seam (ADR-0019). The engine FOLLOWS the
+ * metadata store's: `stateDb` is non-null exactly when `createMetadataStore`
+ * selected SQLite, so both stores always run on the same engine — never a
+ * split-brain where metadata rows and transcript files disagree about where
+ * truth lives. Runs the one-time JSONL import (per-file self-gating; the dir
+ * renames to `transcripts.bak` when fully handled).
+ *
+ * The legacy path keeps its existing semantics: mkdir the transcripts dir and
+ * return null on failure — teeing then no-ops inside the bridge (best-effort).
+ */
+
+export interface CreateTranscriptStoreResult {
+  transcript: TranscriptStoreApi | null
+  engine: 'sqlite' | 'json'
+}
+
+export interface CreateTranscriptStoreDeps {
+  /** From `createMetadataStore` — non-null selects the SQLite engine. */
+  stateDb: StateDb | null
+  /** The legacy `userData/transcripts` dir (import source / legacy home). */
+  transcriptsDir: string
+}
+
+export async function createTranscriptStore(
+  deps: CreateTranscriptStoreDeps,
+): Promise<CreateTranscriptStoreResult> {
+  if (deps.stateDb) {
+    const store = new SqliteTranscriptStore({ stateDb: deps.stateDb })
+    if (!deps.stateDb.locked) {
+      // Best-effort: a failed import logs and leaves the dir for the next
+      // launch's retry — it must never block the store (or launch) itself.
+      try {
+        await importLegacyTranscripts({ dir: deps.transcriptsDir, store })
+      } catch (err) {
+        console.error('[create-transcript-store] legacy transcript import failed:', err)
+      }
+    }
+    return { transcript: store, engine: 'sqlite' }
+  }
+
+  try {
+    await mkdir(deps.transcriptsDir, { recursive: true })
+    return { transcript: new TranscriptStore({ dir: deps.transcriptsDir }), engine: 'json' }
+  } catch {
+    return { transcript: null, engine: 'json' }
+  }
+}

--- a/apps/desktop/src/main/persistence/import-legacy-transcripts.test.ts
+++ b/apps/desktop/src/main/persistence/import-legacy-transcripts.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, afterAll } from 'vitest'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { importLegacyTranscripts } from './import-legacy-transcripts'
+import { openStateDb, type StateDb } from './sqlite-db'
+import { SqliteMetadataStore } from './sqlite-metadata-store'
+import { SqliteTranscriptStore } from './sqlite-transcript-store'
+import { STATE_MIGRATIONS } from './state-migrations'
+import { turnCompleteEntry, userPromptEntry } from './transcript'
+
+/**
+ * The one-time JSONL -> SQLite transcript import (ADR-0019). Real temp-dir
+ * transcript files (with the v1 version header and torn trailing lines) into
+ * `:memory:` target stores, covering the per-file self-gating: already-imported
+ * skip, orphan skip, partial failure keeping the dir, and the `.bak` rename.
+ */
+
+const root = mkdtempSync(join(tmpdir(), 'vibe-import-transcripts-'))
+afterAll(() => rmSync(root, { recursive: true, force: true }))
+
+let seq = 0
+function freshDir(): string {
+  const dir = join(root, `transcripts-${++seq}`)
+  mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+const HEADER = '{"t":"__transcript_header","v":1}'
+
+function writeJsonl(dir: string, threadId: string, lines: string[]): void {
+  writeFileSync(join(dir, `${threadId}.jsonl`), lines.join('\n') + '\n')
+}
+
+interface Fixture {
+  stateDb: StateDb
+  meta: SqliteMetadataStore
+  store: SqliteTranscriptStore
+}
+
+async function fixture(): Promise<Fixture> {
+  const stateDb = openStateDb({ path: ':memory:', migrations: STATE_MIGRATIONS })
+  const meta = new SqliteMetadataStore({ stateDb })
+  const store = new SqliteTranscriptStore({ stateDb })
+  return { stateDb, meta, store }
+}
+
+async function boundThread(meta: SqliteMetadataStore, id: string): Promise<void> {
+  const ws = await meta.upsertWorkspace({ dir: `/proj/${id}` })
+  await meta.upsertThread({ id, workspaceId: ws.id })
+}
+
+describe('importLegacyTranscripts', () => {
+  it('imports every file (header + torn line tolerated) and renames the dir to .bak', async () => {
+    const dir = freshDir()
+    const { meta, store } = await fixture()
+    await boundThread(meta, 't1')
+    await boundThread(meta, 't2')
+    writeJsonl(dir, 't1', [
+      HEADER,
+      JSON.stringify(userPromptEntry('u1', 'hello')),
+      JSON.stringify(turnCompleteEntry()),
+      '{ torn trailing wri', // crash mid-append — must be skipped, not fatal
+    ])
+    writeJsonl(dir, 't2', [JSON.stringify(userPromptEntry('u2', 'legacy header-less'))])
+
+    const result = await importLegacyTranscripts({ dir, store })
+
+    expect(result).toMatchObject({ outcome: 'imported', imported: 2, failures: 0 })
+    expect(await store.read('t1')).toEqual([userPromptEntry('u1', 'hello'), turnCompleteEntry()])
+    expect(await store.read('t2')).toEqual([userPromptEntry('u2', 'legacy header-less')])
+    // The dir moved wholesale to .bak — bytes preserved, originals gone.
+    expect(existsSync(dir)).toBe(false)
+    expect(readFileSync(join(`${dir}.bak`, 't1.jsonl'), 'utf8')).toContain('torn trailing wri')
+  })
+
+  it('skips when the transcripts dir is absent (the steady state after migration)', async () => {
+    const { store } = await fixture()
+    const result = await importLegacyTranscripts({ dir: join(root, 'never-existed'), store })
+    expect(result.outcome).toBe('skipped-absent')
+  })
+
+  it('skips orphan files (no metadata row) but still completes and renames', async () => {
+    const dir = freshDir()
+    const { meta, store } = await fixture()
+    await boundThread(meta, 'kept')
+    writeJsonl(dir, 'kept', [JSON.stringify(userPromptEntry('u1', 'kept'))])
+    writeJsonl(dir, 'orphan', [JSON.stringify(userPromptEntry('u2', 'lost thread'))])
+
+    const result = await importLegacyTranscripts({ dir, store })
+
+    expect(result).toMatchObject({ outcome: 'imported', imported: 1, orphans: 1, failures: 0 })
+    expect(await store.read('orphan')).toEqual([])
+    expect(existsSync(join(`${dir}.bak`, 'orphan.jsonl'))).toBe(true) // preserved bytes
+  })
+
+  it('a per-file failure keeps the dir, and the retry imports ONLY what is missing', async () => {
+    const dir = freshDir()
+    const { meta, store } = await fixture()
+    await boundThread(meta, 'ok')
+    await boundThread(meta, 'flaky')
+    writeJsonl(dir, 'ok', [JSON.stringify(userPromptEntry('u1', 'fine'))])
+    writeJsonl(dir, 'flaky', [JSON.stringify(userPromptEntry('u2', 'fails first'))])
+
+    // First run: reading flaky.jsonl blows up.
+    const failing = await importLegacyTranscripts({
+      dir,
+      store,
+      readFileAt: async (path) => {
+        if (path.endsWith('flaky.jsonl')) throw new Error('EIO')
+        return readFileSync(path, 'utf8')
+      },
+    })
+    expect(failing).toMatchObject({ outcome: 'partial', imported: 1, failures: 1 })
+    expect(existsSync(dir)).toBe(true) // kept for retry
+    expect(await store.read('ok')).toEqual([userPromptEntry('u1', 'fine')])
+
+    // Retry (healthy fs): 'ok' is skipped via hasEntries — never duplicated —
+    // and 'flaky' lands; the dir then renames.
+    const retry = await importLegacyTranscripts({ dir, store })
+    expect(retry).toMatchObject({ outcome: 'imported', imported: 1, skipped: 1, failures: 0 })
+    expect(await store.read('ok')).toEqual([userPromptEntry('u1', 'fine')]) // still exactly one
+    expect(await store.read('flaky')).toEqual([userPromptEntry('u2', 'fails first')])
+    expect(existsSync(dir)).toBe(false)
+    expect(existsSync(`${dir}.bak`)).toBe(true)
+  })
+
+  it("a failed dir rename still reports 'imported'; the next run only retries the rename", async () => {
+    const dir = freshDir()
+    const { meta, store } = await fixture()
+    await boundThread(meta, 't1')
+    writeJsonl(dir, 't1', [JSON.stringify(userPromptEntry('u1', 'text'))])
+
+    const result = await importLegacyTranscripts({
+      dir,
+      store,
+      renameDir: async () => {
+        throw new Error('EACCES')
+      },
+    })
+    expect(result.outcome).toBe('imported')
+    expect(existsSync(dir)).toBe(true)
+
+    const again = await importLegacyTranscripts({ dir, store })
+    expect(again).toMatchObject({ outcome: 'imported', imported: 0, skipped: 1 })
+    expect(await store.read('t1')).toHaveLength(1) // no duplication
+    expect(existsSync(`${dir}.bak`)).toBe(true)
+  })
+
+  it('ignores non-JSONL files (they ride along into the .bak)', async () => {
+    const dir = freshDir()
+    const { store } = await fixture()
+    writeFileSync(join(dir, '.DS_Store'), 'junk')
+
+    const result = await importLegacyTranscripts({ dir, store })
+    expect(result).toMatchObject({ outcome: 'imported', imported: 0 })
+    expect(existsSync(join(`${dir}.bak`, '.DS_Store'))).toBe(true)
+  })
+})

--- a/apps/desktop/src/main/persistence/import-legacy-transcripts.ts
+++ b/apps/desktop/src/main/persistence/import-legacy-transcripts.ts
@@ -1,0 +1,105 @@
+import { readdir, readFile, rename } from 'node:fs/promises'
+import { join } from 'node:path'
+import { parseTranscript } from './transcript'
+import type { SqliteTranscriptStore } from './sqlite-transcript-store'
+
+/**
+ * One-time import of the legacy per-Thread JSONL transcripts into the SQLite
+ * event log (ADR-0019). Runs at every launch after the metadata import (the FK
+ * needs the Thread rows) and self-gates PER FILE, so a partial failure is
+ * self-healing:
+ *
+ * - transcripts dir absent → nothing to do (the steady state after migration);
+ * - a Thread that already has entries → skipped (imported on a previous run);
+ * - an ORPHAN file (no metadata row — its Thread was lost before the swap) →
+ *   skipped-but-handled: it could never render anyway, and the `.bak` rename
+ *   preserves the bytes;
+ * - otherwise → parse through the legacy tolerant line parser (torn trailing
+ *   lines and the version header handled for free) and insert in file order
+ *   inside one transaction per file.
+ *
+ * Only when EVERY file was handled is the whole dir renamed to
+ * `transcripts.bak` — kept, never deleted, as the rollback path. Any per-file
+ * failure leaves the dir in place; the next launch retries just the files that
+ * didn't land (the per-Thread `hasEntries` gate skips the ones that did).
+ */
+
+export interface ImportLegacyTranscriptsResult {
+  outcome: 'imported' | 'skipped-absent' | 'partial'
+  imported: number
+  skipped: number
+  orphans: number
+  failures: number
+}
+
+export interface ImportLegacyTranscriptsDeps {
+  /** The legacy `userData/transcripts` dir. */
+  dir: string
+  store: SqliteTranscriptStore
+  /** fs seams (tests) — default to node:fs/promises. */
+  readdirDir?: (dir: string) => Promise<string[]>
+  readFileAt?: (path: string) => Promise<string>
+  renameDir?: (from: string, to: string) => Promise<void>
+}
+
+export async function importLegacyTranscripts(
+  deps: ImportLegacyTranscriptsDeps,
+): Promise<ImportLegacyTranscriptsResult> {
+  const readdirDir = deps.readdirDir ?? ((dir: string) => readdir(dir))
+  const readFileAt = deps.readFileAt ?? ((path: string) => readFile(path, 'utf8'))
+  const renameDir = deps.renameDir ?? rename
+
+  let names: string[]
+  try {
+    names = await readdirDir(deps.dir)
+  } catch {
+    return { outcome: 'skipped-absent', imported: 0, skipped: 0, orphans: 0, failures: 0 }
+  }
+
+  let imported = 0
+  let skipped = 0
+  let orphans = 0
+  let failures = 0
+
+  for (const name of names) {
+    if (!name.endsWith('.jsonl')) continue // foreign files ride along into the .bak
+    const threadId = name.slice(0, -'.jsonl'.length)
+    try {
+      if (deps.store.hasEntries(threadId)) {
+        skipped++ // landed on a previous (partially-failed) run
+        continue
+      }
+      if (!deps.store.threadExists(threadId)) {
+        orphans++ // no metadata row — unreachable data, preserved in the .bak
+        continue
+      }
+      const entries = parseTranscript(await readFileAt(join(deps.dir, name)))
+      deps.store.importEntries(threadId, entries)
+      imported++
+    } catch (err) {
+      failures++
+      console.error(`[import-legacy-transcripts] ${name} failed (will retry next launch):`, err)
+    }
+  }
+
+  if (failures > 0) {
+    console.error(
+      `[import-legacy-transcripts] ${failures} file(s) failed — keeping ${deps.dir} for retry`,
+    )
+    return { outcome: 'partial', imported, skipped, orphans, failures }
+  }
+
+  try {
+    await renameDir(deps.dir, `${deps.dir}.bak`)
+  } catch (err) {
+    // Everything imported; only the tombstone rename failed. Next launch skips
+    // every file via the per-Thread gate and retries the rename here.
+    console.error(`[import-legacy-transcripts] rename to .bak failed (retried next launch):`, err)
+  }
+  if (imported + skipped + orphans > 0) {
+    console.log(
+      `[import-legacy-transcripts] done: ${imported} imported, ${skipped} already-imported, ${orphans} orphan(s)`,
+    )
+  }
+  return { outcome: 'imported', imported, skipped, orphans, failures }
+}

--- a/apps/desktop/src/main/persistence/sqlite-transcript-store.test.ts
+++ b/apps/desktop/src/main/persistence/sqlite-transcript-store.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, afterAll } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+import { openStateDb, readUserVersion, type StateDb } from './sqlite-db'
+import { SqliteMetadataStore } from './sqlite-metadata-store'
+import { SqliteTranscriptStore } from './sqlite-transcript-store'
+import { STATE_MIGRATIONS } from './state-migrations'
+import {
+  acpEventEntry,
+  agentReboundEntry,
+  resolvePermissionEntry,
+  turnCompleteEntry,
+  turnErrorEntry,
+  userPromptEntry,
+} from './transcript'
+
+/**
+ * The SQLite transcript event log (ADR-0019) behind `TranscriptStoreApi` — the
+ * behavior spec transcript.test.ts pins for the JSONL engine (append ordering,
+ * all six entry kinds, image refs, torn-record tolerance, idempotent delete),
+ * re-pointed at `:memory:` databases, plus the SQLite-specific pieces: the FK
+ * cascade from the metadata delete and the fail-closed locked db.
+ */
+
+const dir = mkdtempSync(join(tmpdir(), 'vibe-sqlite-transcript-'))
+afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+interface Fixture {
+  stateDb: StateDb
+  meta: SqliteMetadataStore
+  store: SqliteTranscriptStore
+  /** A bound Thread id (metadata row present, FK satisfied). */
+  threadId: string
+  workspaceId: string
+}
+
+async function fixture(path = ':memory:'): Promise<Fixture> {
+  const stateDb = openStateDb({ path, migrations: STATE_MIGRATIONS })
+  const meta = new SqliteMetadataStore({ stateDb })
+  const store = new SqliteTranscriptStore({ stateDb })
+  const ws = await meta.upsertWorkspace({ dir: '/proj/x' })
+  const thread = await meta.upsertThread({ workspaceId: ws.id, sessionId: 'sess-1' })
+  return { stateDb, meta, store, threadId: thread.id, workspaceId: ws.id }
+}
+
+describe('SqliteTranscriptStore append/read round-trip', () => {
+  it('persists all six entry kinds in call order and reads them back', async () => {
+    const { store, threadId } = await fixture()
+    const entries = [
+      userPromptEntry('u1', 'fix the bug', [{ file: 'img.png', mimeType: 'image/png' }]),
+      acpEventEntry({ method: 'session/update', params: { sessionId: 'sess-1', update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'On it' } } } }),
+      resolvePermissionEntry(7, 'allow', null),
+      agentReboundEntry(),
+      turnErrorEntry('boom'),
+      turnCompleteEntry(),
+    ]
+    for (const e of entries) await store.append(threadId, e)
+
+    const back = await store.read(threadId)
+    expect(back).toEqual(entries) // exact order, exact shapes (image refs included)
+  })
+
+  it('keeps interleaved Threads separate (the global seq orders, the thread_id partitions)', async () => {
+    const { store, meta, workspaceId, threadId: a } = await fixture()
+    const b = (await meta.upsertThread({ workspaceId, sessionId: 'sess-2' })).id
+
+    await store.append(a, userPromptEntry('u1', 'first in A'))
+    await store.append(b, userPromptEntry('u2', 'first in B'))
+    await store.append(a, turnCompleteEntry())
+
+    expect(await store.read(a)).toEqual([userPromptEntry('u1', 'first in A'), turnCompleteEntry()])
+    expect(await store.read(b)).toEqual([userPromptEntry('u2', 'first in B')])
+  })
+
+  it('an unwritten Thread reads back empty', async () => {
+    const { store } = await fixture()
+    expect(await store.read('never-written')).toEqual([])
+  })
+
+  it('is durable across a close + reopen of the same file db', async () => {
+    const path = join(dir, 'durable.sqlite')
+    const first = await fixture(path)
+    await first.store.append(first.threadId, userPromptEntry('u1', 'survives'))
+    first.stateDb.close()
+
+    const stateDb = openStateDb({ path, migrations: STATE_MIGRATIONS })
+    const reopened = new SqliteTranscriptStore({ stateDb })
+    expect(await reopened.read(first.threadId)).toEqual([userPromptEntry('u1', 'survives')])
+    stateDb.close()
+  })
+
+  it('skips a garbled payload row on read (torn-record tolerance parity), never throws', async () => {
+    const { stateDb, store, threadId } = await fixture()
+    await store.append(threadId, userPromptEntry('u1', 'good'))
+    stateDb.db
+      .prepare('INSERT INTO transcript_entries (thread_id, kind, payload, created_at) VALUES (?, ?, ?, ?)')
+      .run(threadId, 'acp-event', '{ torn json', 0)
+    stateDb.db
+      .prepare('INSERT INTO transcript_entries (thread_id, kind, payload, created_at) VALUES (?, ?, ?, ?)')
+      .run(threadId, 'foreign', JSON.stringify({ t: 'not-an-entry' }), 0)
+    await store.append(threadId, turnCompleteEntry())
+
+    expect(await store.read(threadId)).toEqual([userPromptEntry('u1', 'good'), turnCompleteEntry()])
+  })
+
+  it('an append for a Thread with no metadata row (FK) is swallowed, not thrown', async () => {
+    const { store } = await fixture()
+    await expect(store.append('no-such-thread', turnCompleteEntry())).resolves.toBeUndefined()
+    expect(await store.read('no-such-thread')).toEqual([])
+  })
+})
+
+describe('SqliteTranscriptStore delete + cascade', () => {
+  it('delete drops only that Thread and is idempotent', async () => {
+    const { store, meta, workspaceId, threadId: a } = await fixture()
+    const b = (await meta.upsertThread({ workspaceId })).id
+    await store.append(a, userPromptEntry('u1', 'in A'))
+    await store.append(b, userPromptEntry('u2', 'in B'))
+
+    await store.delete(a)
+    await expect(store.delete(a)).resolves.toBeUndefined() // idempotent
+    expect(await store.read(a)).toEqual([])
+    expect(await store.read(b)).toEqual([userPromptEntry('u2', 'in B')])
+  })
+
+  it('deleting the Thread metadata row CASCADES its entries away', async () => {
+    const { store, meta, threadId } = await fixture()
+    await store.append(threadId, userPromptEntry('u1', 'text'))
+    await meta.deleteThread(threadId)
+    expect(await store.read(threadId)).toEqual([])
+  })
+
+  it('removing the Workspace CASCADES every hosted Thread’s entries away', async () => {
+    const { store, meta, workspaceId, threadId } = await fixture()
+    const other = (await meta.upsertThread({ workspaceId })).id
+    await store.append(threadId, userPromptEntry('u1', 'one'))
+    await store.append(other, userPromptEntry('u2', 'two'))
+
+    await meta.removeWorkspace(workspaceId)
+
+    expect(await store.read(threadId)).toEqual([])
+    expect(await store.read(other)).toEqual([])
+  })
+})
+
+describe('SqliteTranscriptStore fail-closed (locked db)', () => {
+  it('reads empty and swallows writes on a newer-build database', async () => {
+    const path = join(dir, 'locked.sqlite')
+    const raw = new DatabaseSync(path)
+    raw.exec('PRAGMA user_version = 99')
+    raw.close()
+
+    const stateDb = openStateDb({ path, migrations: STATE_MIGRATIONS })
+    expect(stateDb.locked).toBe(true)
+    const store = new SqliteTranscriptStore({ stateDb })
+
+    await expect(store.append('t1', turnCompleteEntry())).resolves.toBeUndefined()
+    expect(await store.read('t1')).toEqual([])
+    await expect(store.delete('t1')).resolves.toBeUndefined()
+    expect(store.hasEntries('t1')).toBe(false)
+    expect(() => store.importEntries('t1', [])).toThrow()
+    stateDb.close()
+
+    const verify = new DatabaseSync(path)
+    expect(readUserVersion(verify)).toBe(99) // untouched
+    verify.close()
+  })
+})
+
+describe('SqliteTranscriptStore.importEntries (one-time legacy import)', () => {
+  it('inserts a file’s entries in order inside one transaction', async () => {
+    const { store, threadId } = await fixture()
+    const entries = [userPromptEntry('u1', 'from jsonl'), turnCompleteEntry()]
+    store.importEntries(threadId, entries)
+    expect(await store.read(threadId)).toEqual(entries)
+    expect(store.hasEntries(threadId)).toBe(true)
+  })
+
+  it('rolls the whole file back when an insert fails (FK: orphan thread)', async () => {
+    const { store } = await fixture()
+    expect(() => store.importEntries('orphan-thread', [turnCompleteEntry()])).toThrow()
+    expect(await store.read('orphan-thread')).toEqual([])
+    expect(store.hasEntries('orphan-thread')).toBe(false)
+  })
+
+  it('threadExists mirrors the metadata rows (the importer’s FK pre-check)', async () => {
+    const { store, threadId } = await fixture()
+    expect(store.threadExists(threadId)).toBe(true)
+    expect(store.threadExists('nope')).toBe(false)
+  })
+})

--- a/apps/desktop/src/main/persistence/sqlite-transcript-store.ts
+++ b/apps/desktop/src/main/persistence/sqlite-transcript-store.ts
@@ -1,0 +1,126 @@
+import type { TranscriptEntry } from '../../shared/ipc'
+import { isTranscriptEntry } from './transcript'
+import type { TranscriptStoreApi } from './transcript-store-api'
+import type { StateDb } from './sqlite-db'
+
+/**
+ * The per-Thread transcript on SQLite (ADR-0019): the `transcript_entries`
+ * event log — the source of truth the read projections (FTS prose, fold
+ * snapshots; later slices) derive from. A drop-in behind `TranscriptStoreApi`.
+ *
+ * ORDERING: appends are synchronous single-row inserts in call order, and the
+ * global `seq` AUTOINCREMENT is the total order — the legacy store's per-Thread
+ * serialized promise chain (which existed to keep fire-and-forget `appendFile`s
+ * from racing) has no SQLite equivalent to need.
+ *
+ * BEST-EFFORT (ADR-0005, unchanged): an append into a locked db, for a Thread
+ * whose metadata row is gone (the FK rejects it — e.g. a tee racing a delete,
+ * behind the bridge's tombstone guard), or hitting any SQLite error is logged
+ * and swallowed — a transcript write failure must never break the live turn.
+ *
+ * The version-header machinery of the JSONL format has no row equivalent: the
+ * schema version of every entry is the database's `user_version` (ADR-0019).
+ */
+
+export interface SqliteTranscriptStoreDeps {
+  stateDb: StateDb
+  now?: () => number
+}
+
+export class SqliteTranscriptStore implements TranscriptStoreApi {
+  private readonly stateDb: StateDb
+  private readonly now: () => number
+
+  constructor(deps: SqliteTranscriptStoreDeps) {
+    this.stateDb = deps.stateDb
+    this.now = deps.now ?? Date.now
+  }
+
+  private get db() {
+    return this.stateDb.db
+  }
+
+  async append(threadId: string, entry: TranscriptEntry): Promise<void> {
+    if (this.stateDb.locked) return
+    try {
+      this.db
+        .prepare('INSERT INTO transcript_entries (thread_id, kind, payload, created_at) VALUES (?, ?, ?, ?)')
+        .run(threadId, entry.t, JSON.stringify(entry), this.now())
+    } catch (err) {
+      // Non-fatal by design — the conversation proceeds; the entry is lost.
+      console.error(`[SqliteTranscriptStore] append failed for Thread ${threadId}:`, err)
+    }
+  }
+
+  async read(threadId: string): Promise<TranscriptEntry[]> {
+    if (this.stateDb.locked) return []
+    const rows = this.db
+      .prepare('SELECT payload FROM transcript_entries WHERE thread_id = ? ORDER BY seq')
+      .all(threadId) as unknown as { payload: string }[]
+    const entries: TranscriptEntry[] = []
+    for (const row of rows) {
+      // Guard each row like a JSONL line (parseTranscript's tolerance): a
+      // garbled payload is skipped, never fatal — the valid rest still replays.
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(row.payload)
+      } catch {
+        continue
+      }
+      if (isTranscriptEntry(parsed)) entries.push(parsed)
+    }
+    return entries
+  }
+
+  async delete(threadId: string): Promise<void> {
+    if (this.stateDb.locked) return
+    try {
+      // Usually already gone: the metadata delete cascades the entries. This
+      // covers the orchestrators' explicit call and any cascade-less path.
+      this.db.prepare('DELETE FROM transcript_entries WHERE thread_id = ?').run(threadId)
+    } catch (err) {
+      console.error(`[SqliteTranscriptStore] delete failed for Thread ${threadId}:`, err)
+    }
+  }
+
+  /** Whether a Thread already has entries — the importer's per-file skip gate. */
+  hasEntries(threadId: string): boolean {
+    if (this.stateDb.locked) return false
+    const row = this.db
+      .prepare('SELECT 1 AS one FROM transcript_entries WHERE thread_id = ? LIMIT 1')
+      .get(threadId) as { one: number } | undefined
+    return row !== undefined
+  }
+
+  /** Whether the Thread's metadata row exists (same db) — the importer's FK pre-check. */
+  threadExists(threadId: string): boolean {
+    if (this.stateDb.locked) return false
+    const row = this.db.prepare('SELECT 1 AS one FROM threads WHERE id = ? LIMIT 1').get(threadId) as
+      | { one: number }
+      | undefined
+    return row !== undefined
+  }
+
+  /**
+   * One-time legacy import (ADR-0019): insert one Thread's parsed JSONL entries
+   * in file order inside a single transaction — a failure rolls the whole file
+   * back so the importer can retry it next launch. Only the importer calls this.
+   */
+  importEntries(threadId: string, entries: readonly TranscriptEntry[]): void {
+    if (this.stateDb.locked) throw new Error('cannot import into a locked state db')
+    this.db.exec('BEGIN')
+    try {
+      const insert = this.db.prepare(
+        'INSERT INTO transcript_entries (thread_id, kind, payload, created_at) VALUES (?, ?, ?, ?)',
+      )
+      const ts = this.now()
+      for (const entry of entries) {
+        insert.run(threadId, entry.t, JSON.stringify(entry), ts)
+      }
+      this.db.exec('COMMIT')
+    } catch (err) {
+      this.db.exec('ROLLBACK')
+      throw err
+    }
+  }
+}

--- a/apps/desktop/src/main/persistence/state-migrations.ts
+++ b/apps/desktop/src/main/persistence/state-migrations.ts
@@ -40,4 +40,25 @@ export const STATE_MIGRATIONS: readonly Migration[] = [
       `)
     },
   },
+  {
+    id: 2,
+    name: 'transcript-entries',
+    up: (db) => {
+      // The transcript event log (ADR-0019): the source of truth the projections
+      // derive from. `seq` is the global total order (replacing per-file append
+      // order); `payload` holds the WHOLE TranscriptEntry as JSON, so the wire
+      // type in shared/ipc is unchanged. Cascades with its Thread.
+      db.exec(`
+        CREATE TABLE transcript_entries (
+          seq        INTEGER PRIMARY KEY AUTOINCREMENT,
+          thread_id  TEXT NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
+          kind       TEXT NOT NULL,
+          payload    TEXT NOT NULL,
+          created_at INTEGER NOT NULL
+        );
+
+        CREATE INDEX idx_transcript_entries_thread ON transcript_entries(thread_id, seq);
+      `)
+    },
+  },
 ]

--- a/apps/desktop/src/main/persistence/transcript-store-api.ts
+++ b/apps/desktop/src/main/persistence/transcript-store-api.ts
@@ -1,0 +1,17 @@
+import type { TranscriptEntry } from '../../shared/ipc'
+
+/**
+ * The public surface of the per-Thread transcript store — the SEAM CONTRACT
+ * boundary from ADR-0005, shared by the legacy JSONL `TranscriptStore` (kept
+ * for one release behind the construction seam, ADR-0019) and the SQLite
+ * `SqliteTranscriptStore`. The bridge's `TranscriptSink` is the append subset
+ * of this; `MainDeps` carries the full surface.
+ */
+export interface TranscriptStoreApi {
+  /** Persist one conversation entry, in call order. Best-effort: never rejects the live flow. */
+  append(threadId: string, entry: TranscriptEntry): Promise<void>
+  /** A Thread's full entry log (the replay source). Missing/unwritten Thread reads `[]`. */
+  read(threadId: string): Promise<TranscriptEntry[]>
+  /** Drop a Thread's log. Idempotent, best-effort. */
+  delete(threadId: string): Promise<void>
+}

--- a/apps/desktop/src/main/persistence/transcript.ts
+++ b/apps/desktop/src/main/persistence/transcript.ts
@@ -324,8 +324,10 @@ export function parseTranscript(raw: string): TranscriptEntry[] {
   return entries
 }
 
-/** Shape-guard a parsed line to a known entry tag — drops foreign/garbled JSON. */
-function isTranscriptEntry(value: unknown): value is TranscriptEntry {
+/** Shape-guard a parsed line to a known entry tag — drops foreign/garbled JSON.
+ * Exported for the SQLite store (ADR-0019), which guards each row's payload the
+ * same way a JSONL line is guarded here. */
+export function isTranscriptEntry(value: unknown): value is TranscriptEntry {
   if (!value || typeof value !== 'object') return false
   const t = (value as { t?: unknown }).t
   return (


### PR DESCRIPTION
Closes #295. Slice 3 of the SQLite persistence epic (#292) — the transcript becomes the `transcript_entries` event log, the source of truth slices 4 (FTS) and 5 (fold snapshots) will project from.

## What this does

- **Migration 2**: `transcript_entries` — global `seq` AUTOINCREMENT (total order, replacing per-file append order), `thread_id` FK `ON DELETE CASCADE`, entry kind, and the **whole `TranscriptEntry` as JSON payload** — the wire type in `shared/ipc` is unchanged, so the renderer/replay path needed zero changes.
- **`SqliteTranscriptStore`** behind a new `TranscriptStoreApi` seam: appends are synchronous single-row inserts in call order — the legacy per-Thread serialized promise chain (which existed to stop fire-and-forget `appendFile` races) has nothing left to fix. Best-effort is verbatim: a locked db, an FK-rejected append (tee racing a delete, behind the bridge's tombstone), or any SQLite error is logged and swallowed — the live turn never breaks. Reads guard each row's payload exactly like a torn JSONL line.
- **Cascades**: deleting a Thread's metadata row (or removing a Workspace) drops its entries in the same statement; the orchestrators' explicit `transcript.delete` stays as an idempotent no-op-after-cascade.
- **`import-legacy-transcripts`** — per-file self-gating: already-imported Threads skip via `hasEntries` (a retry can never duplicate), **orphan files** (no metadata row — deleted Threads' leftovers) skip-but-count, one transaction per file. The dir renames wholesale to `transcripts.bak` only when every file was handled; a partial failure keeps it for the next launch's self-healing retry.
- **`create-transcript-store`** — the engine follows the metadata store's `stateDb` (same database, never a split-brain where metadata rows and transcript files disagree). Legacy path keeps its mkdir-or-null semantics. The bridge (`TranscriptSink`) and delete/remove orchestrators (structural deps) needed no changes at all.

## Tests

**+22** (1477 total green): round-trip of all six entry kinds (image refs included), interleaved Threads over the global seq, garbled-row read tolerance, FK-swallowed appends, both cascade paths, locked-db fail-closed byte-level, and all import branches — orphans, partial-failure retry proving no duplication, rename-crash retry, non-JSONL files riding into the `.bak`.

## Packaged-app smoke (reconstructed real profile)

Rebuilt the legacy layout from the real profile's `.bak` (18 JSONL files, 1.9 MB, 5,645 lines — 5 bound Threads + 13 orphans from previously-deleted Threads) and cold-launched the packaged arm64 app on it:

- Boot log: `5 imported, 0 already-imported, 13 orphan(s)`; `transcripts/` → `transcripts.bak/`
- **Byte-for-byte fidelity**: all 5,613 imported rows prefix-match their JSONL entry-by-entry
- **0 orphan rows** in the db — FK integrity held
- **Live tee proven end-to-end**: the launch's own `available_commands_update` session events (from the auto-resumed Threads) landed as new rows in `transcript_entries`, timestamped at launch

## Notes for review

- Search still reads via `transcript.read` per query — it now hits SQLite instead of files, but stays a linear scan until #296 replaces it with FTS.
- `isTranscriptEntry` is now exported from `transcript.ts` so the SQLite store guards rows with the same shape-guard JSONL lines get.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QsAPKdeg6ML7Shm1sVYYZ