### PR TITLE
feat(search): slice 4 — FTS5 prose projection replaces the per-query transcript scan (#296)

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -60,6 +60,7 @@ import { proseEntries, type ProseEntry } from './search/transcript-prose'
 import { groupThreadsByWorkspace } from './persistence/metadata-store'
 import type { MetadataStoreApi } from './persistence/metadata-store-api'
 import { createMetadataStore } from './persistence/create-metadata-store'
+import type { StateDb } from './persistence/sqlite-db'
 import {
   acpEventEntry,
   agentReboundEntry,
@@ -73,6 +74,7 @@ import {
 import type { TranscriptStoreApi } from './persistence/transcript-store-api'
 import { createTranscriptStore } from './persistence/create-transcript-store'
 import { TranscriptBridge } from './persistence/transcript-bridge'
+import { ftsProseByThread } from './search/fts-prose'
 import { AttachmentStore } from './persistence/attachment-store'
 import { WorkspaceAgent, WorkspaceAgentError } from './workspace-agent'
 import { AgentPool } from './agent-pool'
@@ -363,6 +365,8 @@ let terminalManager: TerminalManager | null = null
 interface MainDeps {
   store: MetadataStoreApi
   transcript: TranscriptStoreApi | null
+  /** The SQLite engine's handle (ADR-0019); null on the legacy JSON engine. */
+  stateDb: StateDb | null
   bridge: TranscriptBridge
   /** Null when the attachments dir `mkdir` failed — image persistence no-ops (logged). */
   attachments: AttachmentStore | null
@@ -1251,31 +1255,39 @@ function registerIpc(deps: MainDeps): void {
   ipcMain.handle(
     IPC.searchQuery,
     async (_event, args: SearchQueryArgs): Promise<SearchQueryResult> => {
-      // The Search palette's ranked hits (#174): a pure scan over the same cold
-      // metadata snapshot listMetadata serves — no agent involved. A NON-empty
-      // query also scans transcript prose (slice 2): read every Thread's JSONL
-      // through the TranscriptStore seam (its only reader, ADR-0005) and extract
-      // the conversation proper; scan-on-query per the epic decision (no index
-      // until measured slow). Best-effort per thread — a failed read degrades
-      // that thread to title-only matching, never the query.
+      // The Search palette's ranked hits (#174): title/Workspace ranking over
+      // the same cold metadata snapshot listMetadata serves — no agent involved.
+      // A NON-empty query also searches transcript prose via the FTS projection
+      // (ADR-0019, #296) — the "measured slow" moment ADR-0005 deferred the
+      // index for arrived with the epic.
       const snapshot = groupThreadsByWorkspace(deps.store.snapshot())
       let prose: Map<string, ProseEntry[]> | undefined
-      if (deps.transcript && tokenizeQuery(args.query).length > 0) {
-        const store = deps.transcript
-        const threads = snapshot.flatMap((ws) => ws.threads)
-        const loaded = await Promise.all(
-          threads.map(async (thread) => {
-            try {
-              return [thread.id, proseEntries(await store.read(thread.id))] as const
-            } catch (err) {
-              console.error(
-                `[vibe-mistro:search] transcript read failed (${thread.id}): ${String(err)}`,
-              )
-              return [thread.id, [] as ProseEntry[]] as const
-            }
-          }),
-        )
-        prose = new Map(loaded)
+      const tokens = tokenizeQuery(args.query)
+      if (tokens.length > 0) {
+        if (deps.stateDb && !deps.stateDb.locked) {
+          // SQLite engine (#296): ONE indexed FTS query feeds the same pure
+          // ranking `searchThreads` always ran — the scan-per-query is gone.
+          prose = ftsProseByThread(deps.stateDb.db, tokens)
+        } else if (deps.transcript) {
+          // Legacy JSON engine only (removed with it in #298): the original
+          // read-every-transcript scan, best-effort per thread — a failed read
+          // degrades that thread to title-only matching, never the query.
+          const store = deps.transcript
+          const threads = snapshot.flatMap((ws) => ws.threads)
+          const loaded = await Promise.all(
+            threads.map(async (thread) => {
+              try {
+                return [thread.id, proseEntries(await store.read(thread.id))] as const
+              } catch (err) {
+                console.error(
+                  `[vibe-mistro:search] transcript read failed (${thread.id}): ${String(err)}`,
+                )
+                return [thread.id, [] as ProseEntry[]] as const
+              }
+            }),
+          )
+          prose = new Map(loaded)
+        }
       }
       return searchThreads(snapshot, args.query, args.limit, prose)
     },
@@ -1323,6 +1335,7 @@ app.whenReady().then(async () => {
   const transcriptsDir = join(app.getPath('userData'), 'transcripts')
   const { transcript } = await createTranscriptStore({ stateDb, transcriptsDir })
 
+
   // The per-Thread prompt-image attachments dir (sibling of the transcripts —
   // the store mkdirs each Thread's subdir itself, but probe the root once here
   // so a broken `userData` degrades to null exactly like the transcript store).
@@ -1341,7 +1354,7 @@ app.whenReady().then(async () => {
     sink: transcript,
     resolveBySession: (sessionId) => store.findThreadIdBySessionId(sessionId),
   })
-  const deps: MainDeps = { store, transcript, bridge, attachments }
+  const deps: MainDeps = { store, transcript, bridge, attachments, stateDb }
 
   // Replace Electron's default Dock icon with the brand mark (dev-run parity with
   // a packaged bundle's icon.icns; t3code does the same). Dev-only: a packaged

--- a/apps/desktop/src/main/persistence/prose-projection.test.ts
+++ b/apps/desktop/src/main/persistence/prose-projection.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect } from 'vitest'
+import { openStateDb, type StateDb } from './sqlite-db'
+import { SqliteMetadataStore } from './sqlite-metadata-store'
+import { SqliteTranscriptStore } from './sqlite-transcript-store'
+import { STATE_MIGRATIONS } from './state-migrations'
+import { acpEventEntry, turnCompleteEntry, userPromptEntry } from './transcript'
+import type { TranscriptEntry } from '../../shared/ipc'
+
+/**
+ * The prose write-path projection + FTS index (ADR-0019, #296): what lands in
+ * `prose_items`/`prose_fts` as entries append — one row per conversation item,
+ * chunks concatenated — plus the migration-3 backfill for databases that
+ * imported their entries before this slice existed.
+ */
+
+function chunkEntry(text: string, messageId?: string): TranscriptEntry {
+  return acpEventEntry({
+    method: 'session/update',
+    params: {
+      sessionId: 'sess-1',
+      update: {
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text },
+        ...(messageId ? { messageId } : {}),
+      },
+    },
+  })
+}
+
+function thoughtEntry(text: string): TranscriptEntry {
+  return acpEventEntry({
+    method: 'session/update',
+    params: {
+      sessionId: 'sess-1',
+      update: { sessionUpdate: 'agent_thought_chunk', content: { type: 'text', text } },
+    },
+  })
+}
+
+interface Fixture {
+  stateDb: StateDb
+  store: SqliteTranscriptStore
+  meta: SqliteMetadataStore
+  threadId: string
+}
+
+async function fixture(): Promise<Fixture> {
+  const stateDb = openStateDb({ path: ':memory:', migrations: STATE_MIGRATIONS })
+  const meta = new SqliteMetadataStore({ stateDb })
+  const store = new SqliteTranscriptStore({ stateDb })
+  const ws = await meta.upsertWorkspace({ dir: '/proj/x' })
+  const thread = await meta.upsertThread({ workspaceId: ws.id })
+  return { stateDb, store, meta, threadId: thread.id }
+}
+
+function proseRows(stateDb: StateDb, threadId: string) {
+  return stateDb.db
+    .prepare('SELECT item_id, first_seq, text FROM prose_items WHERE thread_id = ? ORDER BY first_seq')
+    .all(threadId) as unknown as { item_id: string | null; first_seq: number; text: string }[]
+}
+
+function ftsCount(stateDb: StateDb, match: string): number {
+  return (
+    stateDb.db.prepare('SELECT COUNT(*) AS n FROM prose_fts WHERE prose_fts MATCH ?').get(match) as {
+      n: number
+    }
+  ).n
+}
+
+describe('prose projection on append', () => {
+  it('projects a user prompt as one row keyed by the prompt id', async () => {
+    const { stateDb, store, threadId } = await fixture()
+    await store.append(threadId, userPromptEntry('u1', 'fix the login bug'))
+
+    expect(proseRows(stateDb, threadId)).toEqual([
+      expect.objectContaining({ item_id: 'u1', text: 'fix the login bug' }),
+    ])
+    expect(ftsCount(stateDb, '"login"*')).toBe(1)
+  })
+
+  it('CONCATENATES streamed chunks into ONE row per message (keyed assistant:<messageId>)', async () => {
+    const { stateDb, store, threadId } = await fixture()
+    await store.append(threadId, chunkEntry('The pool ', 'm1'))
+    await store.append(threadId, chunkEntry('evicts idle ', 'm1'))
+    await store.append(threadId, chunkEntry('agents.', 'm1'))
+    await store.append(threadId, chunkEntry('A new message.', 'm2'))
+
+    const rows = proseRows(stateDb, threadId)
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toMatchObject({ item_id: 'assistant:m1', text: 'The pool evicts idle agents.' })
+    expect(rows[1]).toMatchObject({ item_id: 'assistant:m2', text: 'A new message.' })
+    // Tokens SPANNING a chunk boundary now match within the item (the #296
+    // concatenation decision) — 'idle agents' lives across two chunks.
+    expect(ftsCount(stateDb, '"idle" "agents"')).toBe(1)
+    // first_seq stays the FIRST chunk's seq (the jump target is the message start).
+    expect(rows[0].first_seq).toBeLessThan(rows[1].first_seq)
+  })
+
+  it('a chunk with no messageId gets its own un-jumpable row (item_id NULL)', async () => {
+    const { stateDb, store, threadId } = await fixture()
+    await store.append(threadId, chunkEntry('anonymous chunk one'))
+    await store.append(threadId, chunkEntry('anonymous chunk two'))
+
+    const rows = proseRows(stateDb, threadId)
+    expect(rows).toHaveLength(2) // NOT concatenated — no key to concatenate on
+    expect(rows.every((r) => r.item_id === null)).toBe(true)
+    expect(ftsCount(stateDb, '"anonymous"*')).toBe(2)
+  })
+
+  it('reasoning and non-prose entries are NOT indexed (the #174 exclusion)', async () => {
+    const { stateDb, store, threadId } = await fixture()
+    await store.append(threadId, thoughtEntry('secret reasoning about grep'))
+    await store.append(threadId, turnCompleteEntry())
+    await store.append(
+      threadId,
+      acpEventEntry({
+        method: 'session/update',
+        params: {
+          sessionId: 'sess-1',
+          update: { sessionUpdate: 'tool_call', rawInput: { command: 'grep secret' } },
+        },
+      }),
+    )
+
+    expect(proseRows(stateDb, threadId)).toEqual([])
+    expect(ftsCount(stateDb, '"secret"*')).toBe(0)
+  })
+
+  it('importEntries projects prose exactly like the live append', async () => {
+    const { stateDb, store, threadId } = await fixture()
+    store.importEntries(threadId, [
+      userPromptEntry('u1', 'imported prompt'),
+      chunkEntry('imported ', 'm1'),
+      chunkEntry('reply', 'm1'),
+    ])
+
+    const rows = proseRows(stateDb, threadId)
+    expect(rows).toHaveLength(2)
+    expect(rows[1]).toMatchObject({ item_id: 'assistant:m1', text: 'imported reply' })
+    expect(ftsCount(stateDb, '"imported"*')).toBe(2)
+  })
+})
+
+describe('prose cleanup', () => {
+  it('deleting the Thread metadata row cascades prose AND the FTS index', async () => {
+    const { stateDb, store, meta, threadId } = await fixture()
+    await store.append(threadId, userPromptEntry('u1', 'cascade me away'))
+    expect(ftsCount(stateDb, '"cascade"*')).toBe(1)
+
+    await meta.deleteThread(threadId)
+
+    expect(proseRows(stateDb, threadId)).toEqual([])
+    expect(ftsCount(stateDb, '"cascade"*')).toBe(0) // the delete trigger cleaned FTS
+  })
+
+  it('removing the Workspace cascades every hosted Thread’s prose away', async () => {
+    const { stateDb, store, meta, threadId } = await fixture()
+    const wsId = (
+      stateDb.db.prepare('SELECT workspace_id AS w FROM threads WHERE id = ?').get(threadId) as {
+        w: string
+      }
+    ).w
+    await store.append(threadId, userPromptEntry('u1', 'workspace teardown'))
+
+    await meta.removeWorkspace(wsId)
+
+    expect(ftsCount(stateDb, '"teardown"*')).toBe(0)
+  })
+
+  it('the store’s own delete clears prose + FTS too (cascade-less path)', async () => {
+    const { stateDb, store, threadId } = await fixture()
+    await store.append(threadId, userPromptEntry('u1', 'explicit delete'))
+
+    await store.delete(threadId)
+
+    expect(proseRows(stateDb, threadId)).toEqual([])
+    expect(ftsCount(stateDb, '"explicit"*')).toBe(0)
+  })
+})
+
+describe('migration 3 backfill', () => {
+  it('re-folds pre-existing entries into the projection when the migration lands', async () => {
+    // A database exactly as slice 3 left it: migrations 1-2, entries imported.
+    const stateDb = openStateDb({ path: ':memory:', migrations: STATE_MIGRATIONS.slice(0, 2) })
+    const meta = new SqliteMetadataStore({ stateDb })
+    const ws = await meta.upsertWorkspace({ dir: '/proj/old' })
+    const thread = await meta.upsertThread({ workspaceId: ws.id })
+    // Seed entries the way a v2-era build wrote them: raw inserts, no projection
+    // (the current store assumes the migrated schema, as production always has).
+    const insert = stateDb.db.prepare(
+      'INSERT INTO transcript_entries (thread_id, kind, payload, created_at) VALUES (?, ?, ?, ?)',
+    )
+    for (const entry of [
+      userPromptEntry('u1', 'pre-existing prompt'),
+      chunkEntry('backfilled ', 'm1'),
+      chunkEntry('answer', 'm1'),
+      thoughtEntry('not indexed'),
+    ]) {
+      insert.run(thread.id, entry.t, JSON.stringify(entry), 0)
+    }
+    // Slice 3's schema has no prose tables yet.
+    expect(
+      stateDb.db
+        .prepare("SELECT name FROM sqlite_master WHERE name = 'prose_items'")
+        .all(),
+    ).toHaveLength(0)
+
+    // "Upgrade the app": migration 3 runs on the same database.
+    // (:memory: can't reopen, so run the pending migration's up() directly —
+    //  same code path the runner takes.)
+    const migration3 = STATE_MIGRATIONS[2]
+    stateDb.db.exec('BEGIN')
+    migration3.up(stateDb.db)
+    stateDb.db.exec('COMMIT')
+
+    const rows = stateDb.db
+      .prepare('SELECT item_id, text FROM prose_items WHERE thread_id = ? ORDER BY first_seq')
+      .all(thread.id) as unknown as { item_id: string | null; text: string }[]
+    expect(rows).toEqual([
+      { item_id: 'u1', text: 'pre-existing prompt' },
+      { item_id: 'assistant:m1', text: 'backfilled answer' }, // concatenated in seq order
+    ])
+    expect(ftsCount({ ...stateDb }, '"backfilled"*')).toBe(1)
+    stateDb.close()
+  })
+
+  it('a file db upgrades 2 -> 3 through the real runner and backfills once', async () => {
+    const { mkdtempSync, rmSync } = await import('node:fs')
+    const { tmpdir } = await import('node:os')
+    const { join } = await import('node:path')
+    const dir = mkdtempSync(join(tmpdir(), 'vibe-prose-backfill-'))
+    const path = join(dir, 'state.sqlite')
+    try {
+      const v2 = openStateDb({ path, migrations: STATE_MIGRATIONS.slice(0, 2) })
+      const meta = new SqliteMetadataStore({ stateDb: v2 })
+      const ws = await meta.upsertWorkspace({ dir: '/proj/upgrade' })
+      const thread = await meta.upsertThread({ workspaceId: ws.id })
+      const entry = userPromptEntry('u1', 'upgraded content')
+      v2.db
+        .prepare('INSERT INTO transcript_entries (thread_id, kind, payload, created_at) VALUES (?, ?, ?, ?)')
+        .run(thread.id, entry.t, JSON.stringify(entry), 0)
+      v2.close()
+
+      const v3 = openStateDb({ path, migrations: STATE_MIGRATIONS })
+      expect(ftsCount(v3, '"upgraded"*')).toBe(1)
+      v3.close()
+
+      // Reopening again is a no-op (user_version gate) — no duplicate rows.
+      const again = openStateDb({ path, migrations: STATE_MIGRATIONS })
+      expect(
+        (again.db.prepare('SELECT COUNT(*) AS n FROM prose_items').get() as { n: number }).n,
+      ).toBe(1)
+      again.close()
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/apps/desktop/src/main/persistence/prose-projection.ts
+++ b/apps/desktop/src/main/persistence/prose-projection.ts
@@ -1,0 +1,45 @@
+import type { DatabaseSync } from 'node:sqlite'
+import type { TranscriptEntry } from '../../shared/ipc'
+import { extractProse } from '../search/transcript-prose'
+
+/**
+ * The prose write-path projection (ADR-0019, #296): fold a transcript entry's
+ * searchable prose into `prose_items` as the entry lands, one row per
+ * CONVERSATION ITEM — a user prompt is one row; an agent message's streamed
+ * chunks UPSERT-CONCATENATE onto their item's row (keyed by the reducer item id
+ * `assistant:<messageId>`), one row per message regardless of chunk count. A
+ * chunk with no derivable item id gets its own un-jumpable row (item_id NULL).
+ *
+ * What counts as prose — user prompts + agent message chunks, never reasoning
+ * or tool payloads — is `extractProse`'s decision (#174), unchanged.
+ *
+ * The FTS index over these rows is maintained by triggers (see migration 3),
+ * so this module only touches `prose_items`. Callers run it INSIDE the same
+ * transaction as the entry insert — the projection can never drift from the log.
+ */
+
+export function projectEntryProse(
+  db: DatabaseSync,
+  threadId: string,
+  seq: number | bigint,
+  entry: TranscriptEntry,
+): void {
+  const prose = extractProse(entry)
+  if (!prose) return
+
+  if (prose.itemId !== null) {
+    const existing = db
+      .prepare('SELECT rowid FROM prose_items WHERE thread_id = ? AND item_id = ?')
+      .get(threadId, prose.itemId) as { rowid: number } | undefined
+    if (existing) {
+      db.prepare('UPDATE prose_items SET text = text || ? WHERE rowid = ?').run(
+        prose.text,
+        existing.rowid,
+      )
+      return
+    }
+  }
+  db.prepare(
+    'INSERT INTO prose_items (thread_id, item_id, first_seq, text) VALUES (?, ?, ?, ?)',
+  ).run(threadId, prose.itemId, seq, prose.text)
+}

--- a/apps/desktop/src/main/persistence/sqlite-transcript-store.ts
+++ b/apps/desktop/src/main/persistence/sqlite-transcript-store.ts
@@ -1,4 +1,5 @@
 import type { TranscriptEntry } from '../../shared/ipc'
+import { projectEntryProse } from './prose-projection'
 import { isTranscriptEntry } from './transcript'
 import type { TranscriptStoreApi } from './transcript-store-api'
 import type { StateDb } from './sqlite-db'
@@ -42,12 +43,22 @@ export class SqliteTranscriptStore implements TranscriptStoreApi {
 
   async append(threadId: string, entry: TranscriptEntry): Promise<void> {
     if (this.stateDb.locked) return
+    // Entry + its prose projection land in ONE transaction (ADR-0019, #296) so
+    // the search index can never drift from the event log.
+    this.db.exec('BEGIN')
     try {
-      this.db
+      const inserted = this.db
         .prepare('INSERT INTO transcript_entries (thread_id, kind, payload, created_at) VALUES (?, ?, ?, ?)')
         .run(threadId, entry.t, JSON.stringify(entry), this.now())
+      projectEntryProse(this.db, threadId, inserted.lastInsertRowid, entry)
+      this.db.exec('COMMIT')
     } catch (err) {
       // Non-fatal by design — the conversation proceeds; the entry is lost.
+      try {
+        this.db.exec('ROLLBACK')
+      } catch {
+        // BEGIN itself failed — nothing to roll back
+      }
       console.error(`[SqliteTranscriptStore] append failed for Thread ${threadId}:`, err)
     }
   }
@@ -75,9 +86,11 @@ export class SqliteTranscriptStore implements TranscriptStoreApi {
   async delete(threadId: string): Promise<void> {
     if (this.stateDb.locked) return
     try {
-      // Usually already gone: the metadata delete cascades the entries. This
-      // covers the orchestrators' explicit call and any cascade-less path.
+      // Usually already gone: the metadata delete cascades entries AND prose.
+      // This covers the orchestrators' explicit call and any cascade-less path
+      // (the prose delete fires the FTS trigger, so the index stays clean).
       this.db.prepare('DELETE FROM transcript_entries WHERE thread_id = ?').run(threadId)
+      this.db.prepare('DELETE FROM prose_items WHERE thread_id = ?').run(threadId)
     } catch (err) {
       console.error(`[SqliteTranscriptStore] delete failed for Thread ${threadId}:`, err)
     }
@@ -115,7 +128,8 @@ export class SqliteTranscriptStore implements TranscriptStoreApi {
       )
       const ts = this.now()
       for (const entry of entries) {
-        insert.run(threadId, entry.t, JSON.stringify(entry), ts)
+        const inserted = insert.run(threadId, entry.t, JSON.stringify(entry), ts)
+        projectEntryProse(this.db, threadId, inserted.lastInsertRowid, entry)
       }
       this.db.exec('COMMIT')
     } catch (err) {

--- a/apps/desktop/src/main/persistence/state-migrations.ts
+++ b/apps/desktop/src/main/persistence/state-migrations.ts
@@ -1,4 +1,6 @@
 import type { Migration } from './sqlite-db'
+import { projectEntryProse } from './prose-projection'
+import { isTranscriptEntry } from './transcript'
 
 /**
  * The state database's forward-only migration history (ADR-0019). Statically
@@ -59,6 +61,63 @@ export const STATE_MIGRATIONS: readonly Migration[] = [
 
         CREATE INDEX idx_transcript_entries_thread ON transcript_entries(thread_id, seq);
       `)
+    },
+  },
+  {
+    id: 3,
+    name: 'prose-fts',
+    up: (db) => {
+      // The search projection (ADR-0019, #296): one prose row per conversation
+      // item (see prose-projection.ts) + an FTS5 external-content index kept in
+      // sync by triggers. `item_id` is NULL for un-jumpable chunks, so the
+      // one-row-per-item uniqueness is a partial index. Cascade deletes fire
+      // the delete trigger (spike-verified), so FTS never holds ghost rows.
+      db.exec(`
+        CREATE TABLE prose_items (
+          thread_id TEXT NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
+          item_id   TEXT,
+          first_seq INTEGER NOT NULL,
+          text      TEXT NOT NULL
+        );
+
+        CREATE UNIQUE INDEX idx_prose_items_thread_item
+          ON prose_items(thread_id, item_id) WHERE item_id IS NOT NULL;
+        CREATE INDEX idx_prose_items_thread ON prose_items(thread_id, first_seq);
+
+        CREATE VIRTUAL TABLE prose_fts USING fts5(
+          text, content='prose_items', content_rowid='rowid',
+          tokenize='unicode61 remove_diacritics 2'
+        );
+
+        CREATE TRIGGER prose_items_ai AFTER INSERT ON prose_items BEGIN
+          INSERT INTO prose_fts(rowid, text) VALUES (new.rowid, new.text);
+        END;
+        CREATE TRIGGER prose_items_ad AFTER DELETE ON prose_items BEGIN
+          INSERT INTO prose_fts(prose_fts, rowid, text) VALUES ('delete', old.rowid, old.text);
+        END;
+        CREATE TRIGGER prose_items_au AFTER UPDATE ON prose_items BEGIN
+          INSERT INTO prose_fts(prose_fts, rowid, text) VALUES ('delete', old.rowid, old.text);
+          INSERT INTO prose_fts(rowid, text) VALUES (new.rowid, new.text);
+        END;
+      `)
+
+      // Backfill from the event log: databases migrated before this slice
+      // (or mid-import crashes) already hold entries — re-fold them through
+      // the same projection the live append uses. Projections are derived, so
+      // this is a re-fold, not a data migration; the runner's transaction makes
+      // it atomic and the user_version gate makes it once-only.
+      const rows = db
+        .prepare('SELECT thread_id, seq, payload FROM transcript_entries ORDER BY seq')
+        .all() as unknown as { thread_id: string; seq: number; payload: string }[]
+      for (const row of rows) {
+        let parsed: unknown
+        try {
+          parsed = JSON.parse(row.payload)
+        } catch {
+          continue // a garbled payload row carries no searchable prose
+        }
+        if (isTranscriptEntry(parsed)) projectEntryProse(db, row.thread_id, row.seq, parsed)
+      }
     },
   },
 ]

--- a/apps/desktop/src/main/search/fts-prose.test.ts
+++ b/apps/desktop/src/main/search/fts-prose.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest'
+import { openStateDb, type StateDb } from '../persistence/sqlite-db'
+import { SqliteMetadataStore } from '../persistence/sqlite-metadata-store'
+import { SqliteTranscriptStore } from '../persistence/sqlite-transcript-store'
+import { STATE_MIGRATIONS } from '../persistence/state-migrations'
+import { acpEventEntry, userPromptEntry } from '../persistence/transcript'
+import { groupThreadsByWorkspace } from '../persistence/metadata-store'
+import type { TranscriptEntry } from '../../shared/ipc'
+import { ftsProseByThread } from './fts-prose'
+import { searchThreads, tokenizeQuery } from './search-threads'
+import { proseEntries } from './transcript-prose'
+
+/**
+ * The FTS prose feeder (#296): one indexed query replaces the per-query
+ * transcript scan, feeding the SAME pure `searchThreads` ranking. Includes a
+ * parity check: for word-boundary tokens, FTS-fed hits equal scan-fed hits.
+ */
+
+function chunkEntry(text: string, messageId: string): TranscriptEntry {
+  return acpEventEntry({
+    method: 'session/update',
+    params: {
+      sessionId: 'sess-1',
+      update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text }, messageId },
+    },
+  })
+}
+
+interface Fixture {
+  stateDb: StateDb
+  meta: SqliteMetadataStore
+  store: SqliteTranscriptStore
+}
+
+async function fixture(): Promise<Fixture> {
+  const stateDb = openStateDb({ path: ':memory:', migrations: STATE_MIGRATIONS })
+  return {
+    stateDb,
+    meta: new SqliteMetadataStore({ stateDb }),
+    store: new SqliteTranscriptStore({ stateDb }),
+  }
+}
+
+describe('ftsProseByThread', () => {
+  it('returns matching items grouped per Thread, in replay order, with entry_index + itemId', async () => {
+    const { stateDb, meta, store } = await fixture()
+    const ws = await meta.upsertWorkspace({ dir: '/proj/a' })
+    const t1 = (await meta.upsertThread({ workspaceId: ws.id })).id
+    await store.append(t1, userPromptEntry('u1', 'where is the eviction policy'))
+    await store.append(t1, chunkEntry('The eviction policy lives in the pool.', 'm1'))
+    const t2 = (await meta.upsertThread({ workspaceId: ws.id })).id
+    await store.append(t2, userPromptEntry('u2', 'unrelated question'))
+
+    const prose = ftsProseByThread(stateDb.db, tokenizeQuery('eviction'))
+
+    expect([...prose.keys()]).toEqual([t1]) // t2 has no match
+    const entries = prose.get(t1) ?? []
+    expect(entries).toHaveLength(2)
+    expect(entries[0]).toMatchObject({ index: 0, itemId: 'u1' }) // replay order
+    expect(entries[1]).toMatchObject({ index: 1, itemId: 'assistant:m1' })
+    stateDb.close()
+  })
+
+  it('matches case- and accent-insensitively and on word prefixes', async () => {
+    const { stateDb, meta, store } = await fixture()
+    const ws = await meta.upsertWorkspace({ dir: '/proj/b' })
+    const t = (await meta.upsertThread({ workspaceId: ws.id })).id
+    await store.append(t, userPromptEntry('u1', 'Réviser la Configuration complète'))
+
+    expect(ftsProseByThread(stateDb.db, tokenizeQuery('reviser')).size).toBe(1)
+    expect(ftsProseByThread(stateDb.db, tokenizeQuery('CONFIG')).size).toBe(1) // prefix
+    expect(ftsProseByThread(stateDb.db, tokenizeQuery('missing')).size).toBe(0)
+    stateDb.close()
+  })
+
+  it('feeds OR-of-tokens so scattered-across-items matching still works downstream', async () => {
+    const { stateDb, meta, store } = await fixture()
+    const ws = await meta.upsertWorkspace({ dir: '/proj/c' })
+    const t = (await meta.upsertThread({ workspaceId: ws.id, title: null })).id
+    // 'alpha' and 'omega' live in DIFFERENT items — no single strong entry.
+    await store.append(t, userPromptEntry('u1', 'alpha first'))
+    await store.append(t, chunkEntry('omega later', 'm1'))
+
+    const tokens = tokenizeQuery('alpha omega')
+    const prose = ftsProseByThread(stateDb.db, tokens)
+    expect(prose.get(t)).toHaveLength(2) // OR query returned both items
+
+    const snapshot = groupThreadsByWorkspace({
+      workspaces: [{ id: ws.id, dir: '/proj/c', displayName: 'c', lastOpenedAt: 1 }],
+      threads: [{ id: t, workspaceId: ws.id, sessionId: null, title: null, createdAt: 1, lastActiveAt: 1 }],
+    })
+    const hits = searchThreads(snapshot, 'alpha omega', 20, prose)
+    expect(hits.map((h) => h.threadId)).toEqual([t]) // scattered match still hits
+    expect(hits[0]?.snippet).toBeUndefined() // no single strong entry -> no snippet
+    stateDb.close()
+  })
+
+  it('empty tokens return an empty map (the resting palette does no FTS work)', async () => {
+    const { stateDb } = await fixture()
+    expect(ftsProseByThread(stateDb.db, []).size).toBe(0)
+    stateDb.close()
+  })
+
+  it('quotes exotic tokens defensively (no MATCH syntax injection)', async () => {
+    const { stateDb, meta, store } = await fixture()
+    const ws = await meta.upsertWorkspace({ dir: '/proj/d' })
+    const t = (await meta.upsertThread({ workspaceId: ws.id })).id
+    await store.append(t, userPromptEntry('u1', 'weird "quoted" AND NOT tokens'))
+
+    // Raw FTS operators and quotes must be treated as literal-ish tokens, not syntax.
+    expect(() => ftsProseByThread(stateDb.db, tokenizeQuery('"quoted" AND NOT'))).not.toThrow()
+    expect(ftsProseByThread(stateDb.db, tokenizeQuery('quoted')).size).toBe(1)
+    stateDb.close()
+  })
+})
+
+describe('FTS-fed vs scan-fed parity (the #296 baseline)', () => {
+  it('produces identical SearchHits for word-boundary queries', async () => {
+    const { stateDb, meta, store } = await fixture()
+    const ws = await meta.upsertWorkspace({ dir: '/proj/parity', displayName: 'Parity' })
+    const t1 = (await meta.upsertThread({ workspaceId: ws.id, title: 'eviction thread' })).id
+    await store.append(t1, userPromptEntry('u1', 'how does the eviction policy work'))
+    await store.append(t1, chunkEntry('The eviction policy is LRU with idle sweep.', 'm1'))
+    const t2 = (await meta.upsertThread({ workspaceId: ws.id, title: 'other' })).id
+    await store.append(t2, userPromptEntry('u2', 'eviction mentioned once here'))
+    const t3 = (await meta.upsertThread({ workspaceId: ws.id, title: 'silent' })).id
+    await store.append(t3, userPromptEntry('u3', 'nothing relevant'))
+
+    const snapshot = groupThreadsByWorkspace(meta.snapshot())
+    const query = 'eviction policy'
+    const tokens = tokenizeQuery(query)
+
+    // The legacy feed: read every transcript, extract all prose (the old scan).
+    const scanFed = new Map(
+      await Promise.all(
+        snapshot
+          .flatMap((w) => w.threads)
+          .map(async (th) => [th.id, proseEntries(await store.read(th.id))] as const),
+      ),
+    )
+    // The new feed: one FTS query.
+    const ftsFed = ftsProseByThread(stateDb.db, tokens)
+
+    const scanHits = searchThreads(snapshot, query, 20, scanFed)
+    const ftsHits = searchThreads(snapshot, query, 20, ftsFed)
+
+    expect(ftsHits.map((h) => h.threadId)).toEqual(scanHits.map((h) => h.threadId))
+    expect(ftsHits.map((h) => h.snippet)).toEqual(scanHits.map((h) => h.snippet))
+    expect(ftsHits.map((h) => h.jumpItemId)).toEqual(scanHits.map((h) => h.jumpItemId))
+    expect(ftsHits.map((h) => h.hitCount)).toEqual(scanHits.map((h) => h.hitCount))
+    stateDb.close()
+  })
+})

--- a/apps/desktop/src/main/search/fts-prose.ts
+++ b/apps/desktop/src/main/search/fts-prose.ts
@@ -1,0 +1,61 @@
+import type { DatabaseSync } from 'node:sqlite'
+import type { ProseEntry } from './transcript-prose'
+
+/**
+ * The FTS-backed prose feeder (#296): replace the read-every-transcript scan
+ * with one indexed query, keeping `searchThreads` — the pinned ranking brain —
+ * untouched. The MATCH is an OR of PREFIX tokens (`"fix"* OR "bug"*`), i.e.
+ * every item containing ANY query token, because `searchThreads` implements
+ * BOTH match modes over what it's fed: "strong" (all tokens in one item — it
+ * re-checks with its own folded-substring test, which every FTS prefix hit
+ * passes) and "scattered" (tokens spread across title/Workspace/items). An
+ * AND query would starve the scattered mode.
+ *
+ * Semantics delta vs the scan (accepted in #296): FTS matches word PREFIXES
+ * (unicode61, diacritics folded like `foldSearchText`), so a token matching
+ * only the MIDDLE of a word (`gent` → "agent") no longer hits prose. Titles
+ * and Workspace names keep full substring matching in `searchThreads`.
+ *
+ * Rows return per Thread in `first_seq` order — replay order — so "the FIRST
+ * strong entry seeds the snippet" behaves exactly as the scan did. `index` is
+ * the entry's position in the Thread's replayed array (what jump-to-message
+ * scrolls by), computed from the log; `itemId` rides straight from the row.
+ */
+export function ftsProseByThread(
+  db: DatabaseSync,
+  tokens: readonly string[],
+): Map<string, ProseEntry[]> {
+  const prose = new Map<string, ProseEntry[]>()
+  if (tokens.length === 0) return prose
+
+  const match = tokens.map((token) => `"${token.replaceAll('"', '""')}"*`).join(' OR ')
+  let rows: { thread_id: string; item_id: string | null; text: string; entry_index: number }[]
+  try {
+    rows = db
+      .prepare(
+        `SELECT p.thread_id, p.item_id, p.text,
+                (SELECT COUNT(*) FROM transcript_entries te
+                  WHERE te.thread_id = p.thread_id AND te.seq < p.first_seq) AS entry_index
+           FROM prose_fts
+           JOIN prose_items p ON p.rowid = prose_fts.rowid
+          WHERE prose_fts MATCH ?
+          ORDER BY p.thread_id, p.first_seq`,
+      )
+      .all(match) as unknown as typeof rows
+  } catch (err) {
+    // A malformed MATCH (defensive — tokens are quoted) or a missing index
+    // degrades to title-only search, never a failed query (best-effort).
+    console.error('[fts-prose] MATCH failed — degrading to title-only search:', err)
+    return prose
+  }
+
+  for (const row of rows) {
+    let list = prose.get(row.thread_id)
+    if (!list) {
+      list = []
+      prose.set(row.thread_id, list)
+    }
+    list.push({ index: row.entry_index, itemId: row.item_id, text: row.text })
+  }
+  return prose
+}


### PR DESCRIPTION
Closes #296. Slice 4 of the SQLite persistence epic (#292) — ⌘K transcript search stops reading every transcript on every keystroke.

## Design in one line

`searchThreads` — the pinned, 13-test ranking brain — stays byte-identical; only its **feeder** changes: one indexed FTS5 MATCH replaces the read-every-transcript scan.

## What this does

- **Migration 3**: `prose_items` (one row per conversation item; `item_id NULL` for un-jumpable chunks under a partial-unique index) + `prose_fts` (FTS5 external-content, `unicode61 remove_diacritics 2`) kept in sync by triggers — FK-cascade deletes fire them, spike-verified, so the index never holds ghost rows. The migration **backfills from `transcript_entries`**: projections are derived, so a slice-3 database upgrades by re-folding, once-only via the `user_version` gate.
- **Write path** (`prose-projection.ts`): a user prompt is one row; an agent message's streamed chunks **upsert-concatenate** onto their item row (keyed `assistant:<messageId>`, `first_seq` = message start — the jump target). `extractProse` (#174) still decides what counts as prose: reasoning and tool payloads stay out. Projection runs **inside the same transaction** as the entry insert in both `append` and `importEntries` — the index can never drift from the log.
- **Read path** (`fts-prose.ts`): the MATCH is an **OR of quoted prefix tokens**, deliberately not AND — `searchThreads` implements both match modes over what it's fed, so OR preserves *strong* (all tokens in one item; every FTS prefix hit passes its substring re-check) *and* *scattered* (tokens across title/Workspace/items). Rows return in `first_seq` order so "the first strong entry seeds the snippet" behaves exactly as the scan did. `entryIndex` is computed from the log; `jumpItemId` rides from the row. Same `SearchHit` wire shape.
- **Handler**: SQLite engine → FTS feeder. The legacy scan survives **only** as the JSON-engine fallback (escape hatch) and is deleted with it in #298.

## Two deliberate deviations from the issue text, with reasons

1. **No `bm25()`/`snippet()`**: the issue named them as implementation guidance, but the AC pins *behavioral parity with the existing ranking suites*. Reusing `searchThreads` + `buildSnippet` gives exact parity (tiers, recency tiebreak, snippet format) — bm25 would have changed ordering semantics for no user-visible gain. FTS is pure acceleration here.
2. **Accepted recall delta** (was already implicit in adopting FTS): prose tokens now match **word prefixes** (`evic` → "eviction") rather than arbitrary mid-word substrings (`gent` → "agent" no longer hits prose). Titles and Workspace names keep full substring matching.

## Tests & perf

**+16 tests (1493 total green)**: projection shapes (concatenation across chunk boundaries — tokens spanning chunks now match, the #296 decision), NULL-item chunks, exclusions, cleanup via both cascades + explicit delete with FTS verified clean, migration-3 backfill including a real 2→3 file-db runner upgrade and once-only idempotence, feeder semantics (replay order, entry_index, diacritics/case/prefix, MATCH-injection quoting), and an **FTS-fed vs scan-fed `SearchHit` parity test**.

Perf on the real migrated profile (5,615 entries): **backfill 18 ms; queries 0.03–0.09 ms.** The data also validated the one-row-per-item design: 1,789 streamed chunks collapsed to exactly 5 assistant rows. The old scan read + JSON.parsed all 5,615 payloads per keystroke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QsAPKdeg6ML7Shm1sVYYZ