### PR TITLE
feat(persistence): slice 5 — durable fold snapshots + tiered hydrate: reopen any Thread in O(tail) (#297)

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -11,7 +11,9 @@ import {
   type GitStatusEvent,
   type ListMetadataResult,
   type OpenThreadArgs,
+  type ReadTranscriptArgs,
   type ReadTranscriptResult,
+  type ThreadSnapshotPutArgs,
   type ReadThreadAttachmentsResult,
   type TranscriptImageRef,
   type RemoveWorkspaceResult,
@@ -1293,12 +1295,28 @@ function registerIpc(deps: MainDeps): void {
     },
   )
 
-  ipcMain.handle(IPC.readTranscript, (_event, threadId: string): Promise<ReadTranscriptResult> => {
-    // The process-free reopen source (ADR-0005, TB3): hand the renderer the
-    // Thread's logged input stream so it can replay through the reducer with NO
-    // `vibe-acp` spawned. A missing/absent log reads back as [] (never throws).
-    if (!deps.transcript) return Promise.resolve([])
-    return deps.transcript.read(threadId)
+  ipcMain.handle(
+    IPC.readTranscript,
+    (_event, args: ReadTranscriptArgs): Promise<ReadTranscriptResult> => {
+      // The process-free reopen source (ADR-0005, TB3), tiered since ADR-0019
+      // (#297): a reducer-version-matched fold snapshot + only the entry tail
+      // beyond it — the renderer folds O(tail) instead of O(conversation). No
+      // usable snapshot (legacy engine, first open, version bump, forceFull
+      // corruption fallback) degrades to the whole log as the tail. A missing
+      // log reads back empty (never throws).
+      if (!deps.transcript) return Promise.resolve({ snapshot: null, tail: [], lastSeq: 0 })
+      return deps.transcript.readWithSnapshot(args.threadId, args.reducerVersion, args.forceFull)
+    },
+  )
+
+  ipcMain.on(IPC.threadSnapshotPut, (_event, args: ThreadSnapshotPutArgs) => {
+    // Fire-and-forget (ADR-0019, #297): store the renderer's folded view as an
+    // OPAQUE blob — main never parses it (ADR-0001). Best-effort like every
+    // persistence write; the store refuses regressions and unknown Threads.
+    if (!deps.transcript) return
+    if (!args || typeof args.threadId !== 'string' || typeof args.state !== 'string') return
+    if (typeof args.reducerVersion !== 'number' || typeof args.lastSeq !== 'number') return
+    void deps.transcript.putSnapshot(args)
   })
 
   ipcMain.handle(

--- a/apps/desktop/src/main/persistence/snapshot-tiering.test.ts
+++ b/apps/desktop/src/main/persistence/snapshot-tiering.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, afterAll } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+import { openStateDb, type StateDb } from './sqlite-db'
+import { SqliteMetadataStore } from './sqlite-metadata-store'
+import { SqliteTranscriptStore } from './sqlite-transcript-store'
+import { STATE_MIGRATIONS } from './state-migrations'
+import { TranscriptStore, turnCompleteEntry, userPromptEntry } from './transcript'
+import type { TranscriptStoreApi } from './transcript-store-api'
+
+/**
+ * The durable fold-snapshot tiering (ADR-0019, #297): `readWithSnapshot` /
+ * `putSnapshot` on the SQLite store — version gating, horizon math, regression
+ * refusal, cascade cleanup, fail-closed — plus the legacy engine's trivial
+ * no-snapshot behavior behind the same seam.
+ */
+
+const dir = mkdtempSync(join(tmpdir(), 'vibe-snapshot-tiering-'))
+afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+const V = 1 // the reducer version under test
+
+interface Fixture {
+  stateDb: StateDb
+  meta: SqliteMetadataStore
+  store: SqliteTranscriptStore
+  threadId: string
+}
+
+async function fixture(): Promise<Fixture> {
+  const stateDb = openStateDb({ path: ':memory:', migrations: STATE_MIGRATIONS })
+  const meta = new SqliteMetadataStore({ stateDb })
+  const store = new SqliteTranscriptStore({ stateDb })
+  const ws = await meta.upsertWorkspace({ dir: '/proj/x' })
+  const thread = await meta.upsertThread({ workspaceId: ws.id })
+  return { stateDb, meta, store, threadId: thread.id }
+}
+
+describe('SqliteTranscriptStore.readWithSnapshot', () => {
+  it('with no stored snapshot: the whole log as the tail, lastSeq = the horizon', async () => {
+    const { store, threadId } = await fixture()
+    await store.append(threadId, userPromptEntry('u1', 'one'))
+    await store.append(threadId, turnCompleteEntry())
+
+    const result = await store.readWithSnapshot(threadId, V)
+
+    expect(result.snapshot).toBeNull()
+    expect(result.tail).toEqual([userPromptEntry('u1', 'one'), turnCompleteEntry()])
+    expect(result.lastSeq).toBeGreaterThan(0)
+  })
+
+  it('an empty log reads { null, [], 0 }', async () => {
+    const { store, threadId } = await fixture()
+    expect(await store.readWithSnapshot(threadId, V)).toEqual({
+      snapshot: null,
+      tail: [],
+      lastSeq: 0,
+    })
+  })
+
+  it('put then read: the snapshot returns with an EMPTY tail (the O(1) reopen)', async () => {
+    const { store, threadId } = await fixture()
+    await store.append(threadId, userPromptEntry('u1', 'one'))
+    const first = await store.readWithSnapshot(threadId, V)
+    await store.putSnapshot({
+      threadId,
+      reducerVersion: V,
+      lastSeq: first.lastSeq,
+      state: '{"folded":true}',
+    })
+
+    const result = await store.readWithSnapshot(threadId, V)
+
+    expect(result.snapshot).toEqual({ state: '{"folded":true}', lastSeq: first.lastSeq })
+    expect(result.tail).toEqual([]) // nothing beyond the horizon
+    expect(result.lastSeq).toBe(first.lastSeq)
+  })
+
+  it('entries appended AFTER the snapshot return as the tail beyond its horizon', async () => {
+    const { store, threadId } = await fixture()
+    await store.append(threadId, userPromptEntry('u1', 'covered'))
+    const first = await store.readWithSnapshot(threadId, V)
+    await store.putSnapshot({ threadId, reducerVersion: V, lastSeq: first.lastSeq, state: '{}' })
+
+    await store.append(threadId, userPromptEntry('u2', 'newer'))
+    await store.append(threadId, turnCompleteEntry())
+
+    const result = await store.readWithSnapshot(threadId, V)
+    expect(result.snapshot?.lastSeq).toBe(first.lastSeq)
+    expect(result.tail).toEqual([userPromptEntry('u2', 'newer'), turnCompleteEntry()])
+    expect(result.lastSeq).toBeGreaterThan(first.lastSeq)
+  })
+
+  it('a version-MISMATCHED snapshot is ignored, DELETED, and the full log returns', async () => {
+    const { stateDb, store, threadId } = await fixture()
+    await store.append(threadId, userPromptEntry('u1', 'text'))
+    const first = await store.readWithSnapshot(threadId, V)
+    await store.putSnapshot({ threadId, reducerVersion: V, lastSeq: first.lastSeq, state: '{}' })
+
+    const result = await store.readWithSnapshot(threadId, V + 1) // "the app upgraded"
+
+    expect(result.snapshot).toBeNull()
+    expect(result.tail).toEqual([userPromptEntry('u1', 'text')]) // full fold path
+    // The stale projection is gone — disposable by design.
+    const rows = stateDb.db.prepare('SELECT COUNT(*) AS n FROM thread_snapshots').get() as {
+      n: number
+    }
+    expect(rows.n).toBe(0)
+  })
+
+  it('forceFull bypasses a valid snapshot (corruption fallback) but KEEPS the row', async () => {
+    const { stateDb, store, threadId } = await fixture()
+    await store.append(threadId, userPromptEntry('u1', 'text'))
+    const first = await store.readWithSnapshot(threadId, V)
+    await store.putSnapshot({ threadId, reducerVersion: V, lastSeq: first.lastSeq, state: '{}' })
+
+    const result = await store.readWithSnapshot(threadId, V, true)
+
+    expect(result.snapshot).toBeNull()
+    expect(result.tail).toEqual([userPromptEntry('u1', 'text')])
+    // Same-version row survives — the next healthy put simply overwrites it.
+    const rows = stateDb.db.prepare('SELECT COUNT(*) AS n FROM thread_snapshots').get() as {
+      n: number
+    }
+    expect(rows.n).toBe(1)
+  })
+})
+
+describe('SqliteTranscriptStore.putSnapshot', () => {
+  it('refuses a horizon REGRESSION at the same version (a stale racer cannot clobber)', async () => {
+    const { store, threadId } = await fixture()
+    await store.append(threadId, userPromptEntry('u1', 'one'))
+    const horizon = (await store.readWithSnapshot(threadId, V)).lastSeq
+    await store.putSnapshot({ threadId, reducerVersion: V, lastSeq: horizon, state: '{"new":1}' })
+
+    await store.putSnapshot({ threadId, reducerVersion: V, lastSeq: horizon - 1, state: '{"old":1}' })
+
+    const result = await store.readWithSnapshot(threadId, V)
+    expect(result.snapshot?.state).toBe('{"new":1}') // the newer horizon won
+  })
+
+  it('accepts a DIFFERENT-version put regardless of horizon (the bump path)', async () => {
+    const { store, threadId } = await fixture()
+    await store.append(threadId, userPromptEntry('u1', 'one'))
+    const horizon = (await store.readWithSnapshot(threadId, V)).lastSeq
+    await store.putSnapshot({ threadId, reducerVersion: V, lastSeq: horizon, state: '{"v1":1}' })
+
+    await store.putSnapshot({ threadId, reducerVersion: V + 1, lastSeq: horizon, state: '{"v2":1}' })
+
+    expect((await store.readWithSnapshot(threadId, V + 1)).snapshot?.state).toBe('{"v2":1}')
+  })
+
+  it('swallows a put for an unknown Thread (FK) and refuses empty/negative args', async () => {
+    const { store, threadId } = await fixture()
+    await expect(
+      store.putSnapshot({ threadId: 'nope', reducerVersion: V, lastSeq: 1, state: '{}' }),
+    ).resolves.toBeUndefined()
+    await store.putSnapshot({ threadId, reducerVersion: V, lastSeq: -1, state: '{}' })
+    await store.putSnapshot({ threadId, reducerVersion: V, lastSeq: 1, state: '' })
+    expect((await store.readWithSnapshot(threadId, V)).snapshot).toBeNull()
+  })
+})
+
+describe('snapshot cleanup + fail-closed', () => {
+  it('deleting the Thread metadata row cascades the snapshot away', async () => {
+    const { stateDb, meta, store, threadId } = await fixture()
+    await store.append(threadId, userPromptEntry('u1', 'x'))
+    const h = (await store.readWithSnapshot(threadId, V)).lastSeq
+    await store.putSnapshot({ threadId, reducerVersion: V, lastSeq: h, state: '{}' })
+
+    await meta.deleteThread(threadId)
+
+    const rows = stateDb.db.prepare('SELECT COUNT(*) AS n FROM thread_snapshots').get() as {
+      n: number
+    }
+    expect(rows.n).toBe(0)
+  })
+
+  it("the store's own delete clears the snapshot too", async () => {
+    const { stateDb, store, threadId } = await fixture()
+    await store.append(threadId, userPromptEntry('u1', 'x'))
+    const h = (await store.readWithSnapshot(threadId, V)).lastSeq
+    await store.putSnapshot({ threadId, reducerVersion: V, lastSeq: h, state: '{}' })
+
+    await store.delete(threadId)
+
+    const rows = stateDb.db.prepare('SELECT COUNT(*) AS n FROM thread_snapshots').get() as {
+      n: number
+    }
+    expect(rows.n).toBe(0)
+  })
+
+  it('a locked (newer-build) db reads empty and swallows puts', async () => {
+    const path = join(dir, 'locked.sqlite')
+    const raw = new DatabaseSync(path)
+    raw.exec('PRAGMA user_version = 99')
+    raw.close()
+    const stateDb = openStateDb({ path, migrations: STATE_MIGRATIONS })
+    const store = new SqliteTranscriptStore({ stateDb })
+
+    expect(await store.readWithSnapshot('t1', V)).toEqual({ snapshot: null, tail: [], lastSeq: 0 })
+    await expect(
+      store.putSnapshot({ threadId: 't1', reducerVersion: V, lastSeq: 1, state: '{}' }),
+    ).resolves.toBeUndefined()
+    stateDb.close()
+  })
+})
+
+describe('legacy TranscriptStore behind the same seam', () => {
+  it('readWithSnapshot answers the whole log as the tail with lastSeq 0; putSnapshot no-ops', async () => {
+    const legacyDir = join(dir, 'legacy-jsonl')
+    const { mkdirSync } = await import('node:fs')
+    mkdirSync(legacyDir, { recursive: true })
+    // Typed as the seam interface — the class implementation legitimately
+    // declares fewer parameters (it ignores them), but callers use the API.
+    const store: TranscriptStoreApi = new TranscriptStore({ dir: legacyDir })
+    await store.append('t1', userPromptEntry('u1', 'legacy'))
+
+    const result = await store.readWithSnapshot('t1', V)
+    expect(result).toEqual({
+      snapshot: null,
+      tail: [userPromptEntry('u1', 'legacy')],
+      lastSeq: 0, // the renderer's put policy keys off this — never snapshots
+    })
+    await expect(
+      store.putSnapshot({ threadId: 't1', reducerVersion: V, lastSeq: 5, state: '{}' }),
+    ).resolves.toBeUndefined()
+    expect(await store.readWithSnapshot('t1', V)).toEqual(result) // nothing stored
+  })
+})

--- a/apps/desktop/src/main/persistence/sqlite-transcript-store.ts
+++ b/apps/desktop/src/main/persistence/sqlite-transcript-store.ts
@@ -1,4 +1,4 @@
-import type { TranscriptEntry } from '../../shared/ipc'
+import type { ReadTranscriptResult, ThreadSnapshotPutArgs, TranscriptEntry } from '../../shared/ipc'
 import { projectEntryProse } from './prose-projection'
 import { isTranscriptEntry } from './transcript'
 import type { TranscriptStoreApi } from './transcript-store-api'
@@ -83,6 +83,84 @@ export class SqliteTranscriptStore implements TranscriptStoreApi {
     return entries
   }
 
+  /**
+   * The tiered reopen read (ADR-0019, #297). A stored snapshot whose
+   * `reducer_version` matches the renderer's (and no `forceFull` corruption
+   * fallback) returns with only the entry TAIL beyond its horizon; a stale
+   * (version-mismatched) snapshot is DELETED — it's a disposable projection —
+   * and the whole log returns as the tail for one full fold. `lastSeq` is the
+   * horizon this reply covers, echoed back verbatim by the next `putSnapshot`.
+   */
+  async readWithSnapshot(
+    threadId: string,
+    reducerVersion: number,
+    forceFull?: boolean,
+  ): Promise<ReadTranscriptResult> {
+    if (this.stateDb.locked) return { snapshot: null, tail: [], lastSeq: 0 }
+    const row = this.db
+      .prepare('SELECT reducer_version, last_seq, state FROM thread_snapshots WHERE thread_id = ?')
+      .get(threadId) as { reducer_version: number; last_seq: number; state: string } | undefined
+
+    let fromSeq = 0
+    let snapshot: ReadTranscriptResult['snapshot'] = null
+    if (row && !forceFull && row.reducer_version === reducerVersion) {
+      snapshot = { state: row.state, lastSeq: row.last_seq }
+      fromSeq = row.last_seq
+    } else if (row && row.reducer_version !== reducerVersion) {
+      // A projection for a reducer shape this build no longer runs — disposable.
+      try {
+        this.db.prepare('DELETE FROM thread_snapshots WHERE thread_id = ?').run(threadId)
+      } catch {
+        // best-effort — a surviving stale row just re-triggers this branch
+      }
+    }
+
+    const rows = this.db
+      .prepare('SELECT seq, payload FROM transcript_entries WHERE thread_id = ? AND seq > ? ORDER BY seq')
+      .all(threadId, fromSeq) as unknown as { seq: number; payload: string }[]
+    const tail: TranscriptEntry[] = []
+    let lastSeq = fromSeq
+    for (const r of rows) {
+      lastSeq = r.seq
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(r.payload)
+      } catch {
+        continue // garbled row — same tolerance as read()
+      }
+      if (isTranscriptEntry(parsed)) tail.push(parsed)
+    }
+    return { snapshot, tail, lastSeq }
+  }
+
+  /**
+   * Store the renderer's folded view (ADR-0019, #297). The blob is OPAQUE —
+   * main never parses it (ADR-0001); this only upserts the row. Best-effort:
+   * refused on a locked db, an unknown Thread (FK), or a horizon REGRESSION
+   * (an older read racing a newer stored snapshot must not clobber it).
+   */
+  async putSnapshot(args: ThreadSnapshotPutArgs): Promise<void> {
+    if (this.stateDb.locked) return
+    if (!args.state || args.lastSeq < 0) return
+    try {
+      this.db
+        .prepare(
+          `INSERT INTO thread_snapshots (thread_id, reducer_version, last_seq, state, updated_at)
+           VALUES (?, ?, ?, ?, ?)
+           ON CONFLICT(thread_id) DO UPDATE SET
+             reducer_version = excluded.reducer_version,
+             last_seq = excluded.last_seq,
+             state = excluded.state,
+             updated_at = excluded.updated_at
+           WHERE excluded.last_seq >= thread_snapshots.last_seq
+              OR excluded.reducer_version <> thread_snapshots.reducer_version`,
+        )
+        .run(args.threadId, args.reducerVersion, args.lastSeq, args.state, this.now())
+    } catch (err) {
+      console.error(`[SqliteTranscriptStore] putSnapshot failed for Thread ${args.threadId}:`, err)
+    }
+  }
+
   async delete(threadId: string): Promise<void> {
     if (this.stateDb.locked) return
     try {
@@ -91,6 +169,7 @@ export class SqliteTranscriptStore implements TranscriptStoreApi {
       // (the prose delete fires the FTS trigger, so the index stays clean).
       this.db.prepare('DELETE FROM transcript_entries WHERE thread_id = ?').run(threadId)
       this.db.prepare('DELETE FROM prose_items WHERE thread_id = ?').run(threadId)
+      this.db.prepare('DELETE FROM thread_snapshots WHERE thread_id = ?').run(threadId)
     } catch (err) {
       console.error(`[SqliteTranscriptStore] delete failed for Thread ${threadId}:`, err)
     }

--- a/apps/desktop/src/main/persistence/state-migrations.ts
+++ b/apps/desktop/src/main/persistence/state-migrations.ts
@@ -120,4 +120,25 @@ export const STATE_MIGRATIONS: readonly Migration[] = [
       }
     },
   },
+  {
+    id: 4,
+    name: 'thread-snapshots',
+    up: (db) => {
+      // The fold-snapshot projection (ADR-0019, #297): the renderer's folded
+      // ConversationState as an OPAQUE blob (main never parses it — ADR-0001),
+      // versioned by the renderer's reducer schema constant and anchored to the
+      // log horizon (`last_seq`) it folds up to. Disposable and rebuildable —
+      // NOT backfilled here: snapshots populate lazily on each Thread's first
+      // open (one last full fold each), because only the renderer can fold.
+      db.exec(`
+        CREATE TABLE thread_snapshots (
+          thread_id       TEXT PRIMARY KEY REFERENCES threads(id) ON DELETE CASCADE,
+          reducer_version INTEGER NOT NULL,
+          last_seq        INTEGER NOT NULL,
+          state           TEXT NOT NULL,
+          updated_at      INTEGER NOT NULL
+        );
+      `)
+    },
+  },
 ]

--- a/apps/desktop/src/main/persistence/transcript-store-api.ts
+++ b/apps/desktop/src/main/persistence/transcript-store-api.ts
@@ -1,4 +1,4 @@
-import type { TranscriptEntry } from '../../shared/ipc'
+import type { ReadTranscriptResult, ThreadSnapshotPutArgs, TranscriptEntry } from '../../shared/ipc'
 
 /**
  * The public surface of the per-Thread transcript store — the SEAM CONTRACT
@@ -12,6 +12,15 @@ export interface TranscriptStoreApi {
   append(threadId: string, entry: TranscriptEntry): Promise<void>
   /** A Thread's full entry log (the replay source). Missing/unwritten Thread reads `[]`. */
   read(threadId: string): Promise<TranscriptEntry[]>
+  /**
+   * The tiered reopen read (ADR-0019, #297): the stored fold snapshot when its
+   * `reducer_version` matches (and `forceFull` isn't set) + the entry tail
+   * beyond it — else no snapshot and the whole log as the tail. The legacy
+   * JSONL engine never snapshots: it always answers full-tail/`lastSeq: 0`.
+   */
+  readWithSnapshot(threadId: string, reducerVersion: number, forceFull?: boolean): Promise<ReadTranscriptResult>
+  /** Store the renderer's folded view (opaque blob), best-effort. Legacy engine: no-op. */
+  putSnapshot(args: ThreadSnapshotPutArgs): Promise<void>
   /** Drop a Thread's log. Idempotent, best-effort. */
   delete(threadId: string): Promise<void>
 }

--- a/apps/desktop/src/main/persistence/transcript.ts
+++ b/apps/desktop/src/main/persistence/transcript.ts
@@ -1,6 +1,6 @@
 import { appendFile, readFile, unlink } from 'node:fs/promises'
 import { join } from 'node:path'
-import type { TranscriptEntry, TranscriptImageRef } from '../../shared/ipc'
+import type { ReadTranscriptResult, TranscriptEntry, TranscriptImageRef } from '../../shared/ipc'
 
 /**
  * The per-Thread visible-conversation transcript we OWN (ADR-0005). The main
@@ -272,6 +272,19 @@ export class TranscriptStore {
     }
     return parseTranscript(raw)
   }
+
+  /**
+   * The tiered-read seam method (ADR-0019, #297) on the LEGACY engine: JSONL
+   * never snapshots, so this is always the full log as the tail with no
+   * snapshot and a meaningless-by-design `lastSeq: 0` (the renderer's put is
+   * a no-op below, so the horizon is never echoed anywhere).
+   */
+  async readWithSnapshot(threadId: string): Promise<ReadTranscriptResult> {
+    return { snapshot: null, tail: await this.read(threadId), lastSeq: 0 }
+  }
+
+  /** Fold snapshots don't exist on the legacy engine — a documented no-op. */
+  async putSnapshot(): Promise<void> {}
 
   /**
    * Delete a Thread's log (TB6 #35). Best-effort by design, mirroring the guarded

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -45,7 +45,9 @@ import {
   type GitStatusEvent,
   type GitStatusSubscriptionArgs,
   type ListMetadataResult,
+  type ReadTranscriptArgs,
   type ReadTranscriptResult,
+  type ThreadSnapshotPutArgs,
   type ReadThreadAttachmentsResult,
   type RemoveWorkspaceResult,
   type RespondPermissionArgs,
@@ -134,8 +136,11 @@ const api = {
     ipcRenderer.invoke(IPC.setThreadFlags, args),
   setThreadTitle: (args: SetThreadTitleArgs): Promise<SetThreadTitleResult> =>
     ipcRenderer.invoke(IPC.setThreadTitle, args),
-  readTranscript: (threadId: string): Promise<ReadTranscriptResult> =>
-    ipcRenderer.invoke(IPC.readTranscript, threadId),
+  readTranscript: (args: ReadTranscriptArgs): Promise<ReadTranscriptResult> =>
+    ipcRenderer.invoke(IPC.readTranscript, args),
+  putThreadSnapshot: (args: ThreadSnapshotPutArgs): void => {
+    ipcRenderer.send(IPC.threadSnapshotPut, args)
+  },
   readThreadAttachments: (threadId: string): Promise<ReadThreadAttachmentsResult> =>
     ipcRenderer.invoke(IPC.readThreadAttachments, threadId),
   searchQuery: (args: SearchQueryArgs): Promise<SearchQueryResult> =>

--- a/apps/desktop/src/renderer/src/conversation/ColdThread.tsx
+++ b/apps/desktop/src/renderer/src/conversation/ColdThread.tsx
@@ -2,8 +2,12 @@ import { useEffect, useRef, useState, type JSX } from 'react'
 import type { ThreadMeta } from '../../../shared/ipc'
 import { Item } from './items/Item'
 import { UsageBar } from './items/UsageBar'
-import { initialConversationState, type ConversationState } from './reducer'
-import { replayTranscript, transcriptHasImages } from './replay'
+import {
+  initialConversationState,
+  REDUCER_SCHEMA_VERSION,
+  type ConversationState,
+} from './reducer'
+import { foldTranscriptTail, parseSnapshotState, transcriptHasImages } from './replay'
 import { replayCache } from './replay-cache'
 import { useJumpToItem } from './use-jump-to-item'
 import { getWorkspaceCommands } from './workspace-commands'
@@ -50,14 +54,34 @@ export function ColdThread({
       return
     }
     let active = true
-    void window.api.readTranscript(thread.id).then(async (entries) => {
+    const hydrateFromStore = async (): Promise<void> => {
+      // Tiered read (ADR-0019, #297) like Conversation's, minus the durable put
+      // (this is an edge-state fallback view — the live path owns snapshotting).
+      let result = await window.api.readTranscript({
+        threadId: thread.id,
+        reducerVersion: REDUCER_SCHEMA_VERSION,
+      })
+      let base = initialConversationState
+      if (result.snapshot) {
+        const parsed = parseSnapshotState(result.snapshot.state)
+        if (parsed) {
+          base = parsed
+        } else {
+          result = await window.api.readTranscript({
+            threadId: thread.id,
+            reducerVersion: REDUCER_SCHEMA_VERSION,
+            forceFull: true,
+          })
+        }
+      }
       // Resolve persisted image attachments (one batched IPC) ONLY when the
-      // transcript references any — an image-less reopen costs nothing extra.
-      const attachments = transcriptHasImages(entries)
+      // tail references any — an image-less reopen costs nothing extra.
+      const attachments = transcriptHasImages(result.tail)
         ? await window.api.readThreadAttachments(thread.id)
         : undefined
-      if (active) setState(replayTranscript(entries, attachments))
-    })
+      if (active) setState(foldTranscriptTail(base, result.tail, attachments))
+    }
+    void hydrateFromStore()
     return () => {
       active = false
     }

--- a/apps/desktop/src/renderer/src/conversation/Conversation.tsx
+++ b/apps/desktop/src/renderer/src/conversation/Conversation.tsx
@@ -11,13 +11,19 @@ import { FileOpenProvider } from './file-open-context'
 import { isRejectOption } from './permission-option'
 import type { FileLink } from './file-link'
 import {
+  REDUCER_SCHEMA_VERSION,
   conversationReducer,
   initialConversationState,
   type PermissionItem,
   type PermissionOption,
 } from './reducer'
 import { eventBelongsToThread } from './event-routing'
-import { replayTranscript, transcriptHasImages } from './replay'
+import {
+  foldTranscriptTail,
+  parseSnapshotState,
+  shouldPutSnapshot,
+  transcriptHasImages,
+} from './replay'
 import { replayCache } from './replay-cache'
 import { peekPendingJump } from '../search/jump-store'
 import { useJumpToItem } from './use-jump-to-item'
@@ -150,22 +156,67 @@ export function Conversation({
       return
     }
     let active = true
-    void window.api.readTranscript(thread.threadId).then(async (entries) => {
+    const hydrateFromStore = async (): Promise<void> => {
+      // Tiered read (ADR-0019, #297): a reducer-version-matched fold snapshot +
+      // only the tail beyond it. An unparseable blob falls back to one forced
+      // full read — a bad snapshot costs a re-fold, never a broken view.
+      let result = await window.api.readTranscript({
+        threadId: thread.threadId,
+        reducerVersion: REDUCER_SCHEMA_VERSION,
+      })
+      let base = initialConversationState
+      let usedSnapshot = false
+      if (result.snapshot) {
+        const parsed = parseSnapshotState(result.snapshot.state)
+        if (parsed) {
+          base = parsed
+          usedSnapshot = true
+        } else {
+          result = await window.api.readTranscript({
+            threadId: thread.threadId,
+            reducerVersion: REDUCER_SCHEMA_VERSION,
+            forceFull: true,
+          })
+        }
+      }
       // Resolve persisted image attachments (one batched IPC) ONLY when the
-      // transcript references any — an image-less reopen costs nothing extra.
-      const attachments = transcriptHasImages(entries)
+      // TAIL references any — the snapshot-covered part embeds its own (and the
+      // put policy below keeps image-bearing states out of snapshots anyway).
+      const tailHasImages = transcriptHasImages(result.tail)
+      const attachments = tailHasImages
         ? await window.api.readThreadAttachments(thread.threadId)
         : undefined
       if (!active || liveSeen.current) return
       // Hydrated even when the transcript is EMPTY — a legitimately empty
       // Thread may cache as empty; only an unresolved read must not.
       hydratedRef.current = true
-      const replayed = replayTranscript(entries, attachments)
+      const replayed = foldTranscriptTail(base, result.tail, attachments)
       if (replayed.items.length > 0) {
         stateRef.current = replayed // pre-render sync, same poison guard as above
         dispatch({ type: 'hydrate', state: replayed })
       }
-    })
+      // Durable put (fire-and-forget): persist this fold when it improves on
+      // what's stored, so the NEXT open of this Thread — beyond the in-memory
+      // LRU, past a restart — hydrates in O(tail). Policy in shouldPutSnapshot;
+      // the liveSeen guard above means this state reflects exactly the read.
+      if (
+        shouldPutSnapshot({
+          usedSnapshot,
+          tailLength: result.tail.length,
+          hasImages: tailHasImages,
+          itemCount: replayed.items.length,
+          lastSeq: result.lastSeq,
+        })
+      ) {
+        window.api.putThreadSnapshot({
+          threadId: thread.threadId,
+          reducerVersion: REDUCER_SCHEMA_VERSION,
+          lastSeq: result.lastSeq,
+          state: JSON.stringify(replayed),
+        })
+      }
+    }
+    void hydrateFromStore()
     return () => {
       active = false
     }

--- a/apps/desktop/src/renderer/src/conversation/reducer.ts
+++ b/apps/desktop/src/renderer/src/conversation/reducer.ts
@@ -179,6 +179,18 @@ export interface ConversationState {
 export const REBOUND_NOTICE =
   "Agent context was reset — the agent couldn't resume this thread, so it starts fresh and won't recall earlier turns. Your conversation history above is preserved."
 
+/**
+ * The DURABLE FOLD-SNAPSHOT schema version (ADR-0019, #297). A folded
+ * `ConversationState` is persisted as an opaque blob keyed by this constant and
+ * re-hydrated by a LATER app run — so it must be bumped in ANY PR that changes
+ * the shape of `ConversationState` or a `ConversationItem` in a way an old
+ * blob wouldn't satisfy (renamed/removed fields, changed discriminants, new
+ * REQUIRED fields). Additive OPTIONAL fields don't need a bump. The cost of a
+ * bump is one full re-fold per Thread, lazily, on its next open — never data
+ * loss (snapshots are disposable projections of the transcript event log).
+ */
+export const REDUCER_SCHEMA_VERSION = 1
+
 export const initialConversationState: ConversationState = {
   items: [],
   title: null,

--- a/apps/desktop/src/renderer/src/conversation/replay-snapshot.test.ts
+++ b/apps/desktop/src/renderer/src/conversation/replay-snapshot.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest'
+import type { TranscriptEntry } from '../../../shared/ipc'
+import {
+  foldTranscriptTail,
+  parseSnapshotState,
+  replayTranscript,
+  shouldPutSnapshot,
+} from './replay'
+
+/**
+ * The renderer half of the durable fold snapshots (ADR-0019, #297), as pure
+ * modules (node env, no DOM): the snapshot+tail fold must equal the full fold
+ * (the correctness core of the tiered reopen), blob parsing must fail safe,
+ * and the put policy is pinned as a matrix.
+ */
+
+function chunk(text: string, messageId: string): TranscriptEntry {
+  return {
+    t: 'acp-event',
+    payload: {
+      method: 'session/update',
+      params: {
+        sessionId: 'sess-1',
+        update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text }, messageId },
+      },
+    },
+  }
+}
+
+function permissionRequest(requestId: number): TranscriptEntry {
+  return {
+    t: 'acp-event',
+    payload: {
+      method: 'session/request_permission',
+      id: requestId,
+      params: {
+        sessionId: 'sess-1',
+        toolCall: { toolCallId: 'tc-1', title: 'Run tests' },
+        options: [
+          { optionId: 'allow', name: 'Allow', kind: 'allow_once' },
+          { optionId: 'reject', name: 'Reject', kind: 'reject_once' },
+        ],
+      },
+    },
+  }
+}
+
+const FULL_LOG: TranscriptEntry[] = [
+  { t: 'user-prompt', id: 'u1', text: 'run the tests' },
+  chunk('Running ', 'm1'),
+  permissionRequest(7),
+  { t: 'resolve-permission', requestId: 7, optionId: 'allow', name: null },
+  chunk('them now.', 'm1'),
+  { t: 'turn-complete' },
+  { t: 'user-prompt', id: 'u2', text: 'and lint too' },
+  chunk('Linting.', 'm2'),
+  { t: 'turn-error', message: 'agent exited' },
+]
+
+describe('foldTranscriptTail ≡ full fold (the tiering correctness core)', () => {
+  it('snapshot(prefix) + fold(tail) equals replay(whole log) at EVERY split point', () => {
+    const full = replayTranscript(FULL_LOG)
+    for (let split = 0; split <= FULL_LOG.length; split++) {
+      // The durable round-trip: the prefix state goes through JSON like a real blob.
+      const prefix = replayTranscript(FULL_LOG.slice(0, split))
+      const base = parseSnapshotState(JSON.stringify(prefix))
+      expect(base).not.toBeNull()
+      const tiered = foldTranscriptTail(base!, FULL_LOG.slice(split))
+      expect(tiered).toEqual(full)
+    }
+  })
+
+  it('recovers a permission option name from the BASE state when the resolve is in the tail', () => {
+    // The request folded into the snapshot; the answer arrives in the tail —
+    // the reopen-only name recovery must see across the boundary.
+    const base = replayTranscript(FULL_LOG.slice(0, 3)) // ends after permissionRequest(7)
+    const tiered = foldTranscriptTail(
+      parseSnapshotState(JSON.stringify(base))!,
+      FULL_LOG.slice(3, 6), // resolve-permission + closing chunk + turn-complete
+    )
+    const permission = tiered.items.find((i) => i.kind === 'permission')
+    expect(permission?.kind).toBe('permission')
+    // The resolved option shows its display NAME, recovered from the base's item.
+    expect(JSON.stringify(permission)).toContain('Allow')
+  })
+
+  it('forces isProcessing false after folding a tail cut off mid-turn', () => {
+    const base = replayTranscript(FULL_LOG.slice(0, 6))
+    // Tail ends on a user-prompt with no terminal entry (app closed mid-turn).
+    const tiered = foldTranscriptTail(base, [{ t: 'user-prompt', id: 'u3', text: 'cut off' }])
+    expect(tiered.isProcessing).toBe(false)
+  })
+
+  it('an empty tail returns the base state as-is (the O(1) reopen)', () => {
+    const base = replayTranscript(FULL_LOG)
+    expect(foldTranscriptTail(base, [])).toEqual(base)
+  })
+})
+
+describe('parseSnapshotState (fail-safe blob parsing)', () => {
+  it('round-trips a real folded state', () => {
+    const state = replayTranscript(FULL_LOG)
+    expect(parseSnapshotState(JSON.stringify(state))).toEqual(state)
+  })
+
+  it.each([
+    ['torn JSON', '{"items":[1,'],
+    ['not an object', '"just a string"'],
+    ['null', 'null'],
+    ['missing items', '{"isProcessing":false,"availableCommands":[]}'],
+    ['items not an array', '{"items":{},"isProcessing":false,"availableCommands":[]}'],
+    ['missing isProcessing', '{"items":[],"availableCommands":[]}'],
+    ['missing availableCommands', '{"items":[],"isProcessing":false}'],
+  ])('rejects %s with null (caller falls back to forceFull)', (_label, blob) => {
+    expect(parseSnapshotState(blob)).toBeNull()
+  })
+})
+
+describe('shouldPutSnapshot (the put policy matrix)', () => {
+  const base = { usedSnapshot: false, tailLength: 3, hasImages: false, itemCount: 5, lastSeq: 42 }
+
+  it('puts after a fresh full fold', () => {
+    expect(shouldPutSnapshot(base)).toBe(true)
+  })
+  it('puts after a snapshot hydrate that folded a non-empty tail (horizon advanced)', () => {
+    expect(shouldPutSnapshot({ ...base, usedSnapshot: true })).toBe(true)
+  })
+  it('skips when the snapshot was used and the tail was empty (nothing improved)', () => {
+    expect(shouldPutSnapshot({ ...base, usedSnapshot: true, tailLength: 0 })).toBe(false)
+  })
+  it('skips on the legacy engine (lastSeq 0) — it never snapshots', () => {
+    expect(shouldPutSnapshot({ ...base, lastSeq: 0 })).toBe(false)
+  })
+  it('skips an empty view', () => {
+    expect(shouldPutSnapshot({ ...base, itemCount: 0 })).toBe(false)
+  })
+  it('skips image-bearing states (data URLs must not copy image bytes into the db)', () => {
+    expect(shouldPutSnapshot({ ...base, hasImages: true })).toBe(false)
+  })
+})

--- a/apps/desktop/src/renderer/src/conversation/replay.ts
+++ b/apps/desktop/src/renderer/src/conversation/replay.ts
@@ -40,11 +40,75 @@ export function replayTranscript(
   entries: TranscriptEntry[],
   attachments?: AttachmentMap,
 ): ConversationState {
-  let state = initialConversationState
+  return foldTranscriptTail(initialConversationState, entries, attachments)
+}
+
+/**
+ * Fold a transcript TAIL onto an already-folded base state (ADR-0019, #297) —
+ * the incremental half of the tiered reopen: hydrate the durable fold snapshot,
+ * then fold only the entries beyond its horizon through the SAME reducer. With
+ * `initialConversationState` as the base this IS the full replay, so both paths
+ * share one fold (and the same reopen-only corrections: permission-name
+ * recovery sees the base's items; `isProcessing` is forced false at the end —
+ * a cold reopen is never mid-turn).
+ */
+export function foldTranscriptTail(
+  base: ConversationState,
+  entries: TranscriptEntry[],
+  attachments?: AttachmentMap,
+): ConversationState {
+  let state = base
   for (const entry of entries) {
     state = conversationReducer(state, toAction(entry, state, attachments))
   }
   return state.isProcessing ? { ...state, isProcessing: false } : state
+}
+
+/**
+ * Parse a durable fold snapshot's blob back into a `ConversationState`, or null
+ * when it doesn't parse or doesn't look like one (torn write, hand-edit, a
+ * shape drift the version constant should have caught). Null sends the caller
+ * down the `forceFull` full-fold path — a bad snapshot costs one re-fold,
+ * never a broken view (snapshots are disposable projections).
+ */
+export function parseSnapshotState(blob: string): ConversationState | null {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(blob)
+  } catch {
+    return null
+  }
+  if (!parsed || typeof parsed !== 'object') return null
+  const state = parsed as ConversationState
+  if (!Array.isArray(state.items)) return null
+  if (typeof state.isProcessing !== 'boolean') return null
+  if (!Array.isArray(state.availableCommands)) return null
+  return state
+}
+
+/**
+ * Whether a freshly-hydrated view should be persisted as the durable fold
+ * snapshot (ADR-0019, #297). Pure, so the policy is pinned by tests:
+ *  - only a view that reflects an exact read horizon (`lastSeq > 0`; the legacy
+ *    JSONL engine answers 0 — it never snapshots);
+ *  - only when it IMPROVES on what's stored (a fresh fold or a non-empty tail —
+ *    re-putting an unchanged snapshot is write noise);
+ *  - never an empty view (nothing to accelerate);
+ *  - never a view with image attachments: replay embeds them as data URLs, so
+ *    the blob would copy image bytes INTO the database (ADR-0019 keeps bytes
+ *    out) — image-bearing Threads keep the full-fold path for now.
+ */
+export function shouldPutSnapshot(args: {
+  usedSnapshot: boolean
+  tailLength: number
+  hasImages: boolean
+  itemCount: number
+  lastSeq: number
+}): boolean {
+  if (args.lastSeq <= 0) return false
+  if (args.itemCount === 0) return false
+  if (args.hasImages) return false
+  return !args.usedSnapshot || args.tailLength > 0
 }
 
 /** Map one logged entry to its reducer action (using `state` to recover names). */

--- a/apps/desktop/src/shared/ipc/thread.ts
+++ b/apps/desktop/src/shared/ipc/thread.ts
@@ -23,8 +23,12 @@ export const threadChannels = {
   threadTitle: 'thread:title',
   /** List persisted Workspaces + their Threads for the cold launch list (ADR-0005). */
   listMetadata: 'metadata:list',
-  /** Read a Thread's persisted JSONL transcript for a process-free reopen (TB3). */
+  /** Read a Thread's transcript for a process-free reopen (TB3): the stored fold
+   * snapshot (when its reducer version matches) + the entry tail beyond it (ADR-0019). */
   readTranscript: 'transcript:read',
+  /** Renderer -> main (fire-and-forget): store a Thread's folded view as the durable
+   * fold snapshot (ADR-0019, #297). Main stores the blob OPAQUELY — never parses it. */
+  threadSnapshotPut: 'thread:snapshot-put',
   /**
    * Read a Thread's persisted image attachments for replay — ONE batched read per
    * reopen (file name -> data URL), called only when the transcript references
@@ -369,8 +373,47 @@ export type TranscriptEntry =
   // a renderer-side constant, so the entry carries no payload.
   | { t: 'agent-rebound' }
 
-/** The `readTranscript` reply: a Thread's transcript entries (empty when none). */
-export type ReadTranscriptResult = TranscriptEntry[]
+/** The `readTranscript` request (ADR-0019, #297): the renderer states which
+ * reducer schema it can hydrate; `forceFull` bypasses a stored-but-unparseable
+ * snapshot (the renderer's corruption fallback). */
+export interface ReadTranscriptArgs {
+  threadId: string
+  reducerVersion: number
+  forceFull?: boolean
+}
+
+/** A stored fold snapshot: the renderer's own folded ConversationState as an
+ * opaque JSON string, plus the log horizon (`transcript_entries.seq`) it folds up to. */
+export interface TranscriptSnapshot {
+  state: string
+  lastSeq: number
+}
+
+/**
+ * The `readTranscript` reply (ADR-0019, #297): a version-matched fold snapshot
+ * (or null) + the entry `tail` BEYOND it — the renderer hydrates the snapshot
+ * and folds only the tail, making reopen O(tail) instead of O(conversation).
+ * With no usable snapshot, `tail` is the whole log (today's full-fold path).
+ * `lastSeq` is the log horizon this reply covers — echoed back verbatim in a
+ * later {@link ThreadSnapshotPutArgs} so a stored snapshot always corresponds
+ * to an exact read. 0 on an empty log or the legacy JSONL engine (which never
+ * snapshots — its `lastSeq` would be meaningless).
+ */
+export interface ReadTranscriptResult {
+  snapshot: TranscriptSnapshot | null
+  tail: TranscriptEntry[]
+  lastSeq: number
+}
+
+/** The fire-and-forget snapshot put (ADR-0019, #297). `state` is the renderer's
+ * folded view as JSON — opaque to main; `lastSeq` is the horizon echoed from the
+ * read this state folds up to (main refuses regressions past a newer snapshot). */
+export interface ThreadSnapshotPutArgs {
+  threadId: string
+  reducerVersion: number
+  lastSeq: number
+  state: string
+}
 
 /**
  * A persisted image attachment referenced by a `user-prompt` transcript entry.


### PR DESCRIPTION
Closes #297. Slice 5 of the SQLite persistence epic (#292) — the headline fast-load slice: reopening a Thread no longer pays for conversation length.

## How it works

**Three-tier hydrate** on Thread open:
1. In-memory LRU replay-cache (unchanged, tier 1)
2. **Durable fold snapshot** (new): `transcript:read` now answers `{ snapshot, tail, lastSeq }` — the renderer's own previously-folded `ConversationState` (a version-matched opaque blob) plus only the entries beyond its horizon. Hydrate the blob, fold just the tail. Usually the tail is empty → effectively O(1).
3. Full fold (today's path) — version bump, first open, corruption fallback — which then **puts** a fresh snapshot, so every Thread converges to tier 2.

**ADR-0001 stays intact**: the renderer folds; main stores the blob opaquely and never parses it. The snapshot always corresponds to an *exact read horizon* — the renderer echoes back the `lastSeq` it received, so no seq-guessing around live events (the existing `liveSeen` guard means a put only happens for a state that reflects precisely one read).

## Key decisions

- **`REDUCER_SCHEMA_VERSION`** lives beside the reducer with the bump-on-shape-change rule documented. A version-mismatched stored snapshot is *deleted* on read (disposable projection) and the full log returns — cost of a bump: one lazy re-fold per Thread, never data loss.
- **`putSnapshot` refuses horizon regressions** (`WHERE excluded.last_seq >= …`) so a stale racer can't clobber a newer snapshot; a different-version put always wins (the upgrade path).
- **Image-bearing states are never snapshotted** (pure `shouldPutSnapshot` policy): replay embeds attachments as data URLs, so the blob would copy image bytes into the database — ADR-0019 keeps bytes out. Image Threads keep the full-fold path for now (they also keep tier 1).
- **Legacy JSONL engine** answers full-tail/`lastSeq: 0` behind the same seam; the put policy keys off the 0, so it never snapshots — no split behavior, no `instanceof`.
- `ColdThread` (edge fallback) gets the tiered read minus the put.

## Tests (+31, 1524 total green)

- Store tiering: horizon math, version gating + stale-row delete, `forceFull` preserving the same-version row, regression refusal, both cascade paths + explicit delete, locked-db fail-closed, legacy-engine seam behavior.
- **The correctness core**: `snapshot(prefix) + fold(tail) ≡ replay(whole log)` at **every split point** of a log exercising permissions (display-name recovery across the snapshot boundary), streamed chunks, turn errors, and a mid-turn cutoff (isProcessing forced false).
- Blob-parse rejection matrix (torn JSON, wrong shapes → `forceFull` fallback) and the put-policy matrix.

## Measured on the real profile

| thread | entries | full fold | snapshot hydrate |
|---|---|---|---|
| largest | 4,574 | 5.2 ms | **0.29 ms** (18×) |
| typical | 179–401 | 0.1–0.6 ms | 0.03–0.07 ms |

The fold is O(conversation) and grows forever; the hydrate is O(blob) and stays put — at 50k entries the gap is ~57 ms vs ~0.3 ms, plus the eliminated read/parse of the covered entries.

**Packaged end-to-end**: the arm64 app migrated the real profile 2→4, then folded and **put snapshots for all 5 threads across two launches** — the second launch consumed the first launch's snapshots and advanced their horizons over the live event tail. Verified in `thread_snapshots` (reducer_version 1, correct `last_seq`, 14–26 KB blobs).

## Reviewer notes

- `transcript:read`'s wire shape changed (args object + `{snapshot, tail, lastSeq}` result); renderer and main ship together so there's no compat window, and both engines answer the same shape.
- Worth a quick manual pass: open an old long Thread cold (instant), send a prompt, quit, reopen (first open re-folds the tail, second is instant again).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QsAPKdeg6ML7Shm1sVYYZ