### PR TITLE
chore(persistence): slice 6 — hardening + legacy engine removal: optimize-on-quit, rotating backups, sqlite-only (#298)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,13 +118,19 @@ Thread whose stored session isn't hosted by the fresh agent resumes via `session
 fresh on a resume failure, surfacing a "context reset" notice). `index.ts` signals the renderer via
 `thread:bound` the instant a session is minted, before any event streams.
 
-**Persistence** (`src/main/persistence/`, `docs/adr/0005`). Split three ways by owner: (1) Workspace +
-Thread **metadata** — ours, small — in `MetadataStore` (single-writer JSON index at
-`userData/metadata.json`); (2) a per-Thread **JSONL transcript** we own (`TranscriptStore` under
-`userData/transcripts/`), teed best-effort from main's conversation inputs, replayed on reopen with NO
-agent spawned; (3) agent **context/history** — Vibe owns it. The cold launch list and process-free
-reopen are both served from our stores alone. **Every persistence write is best-effort and must never
-reject the live flow** — on a store failure, synthesize ids and continue.
+**Persistence** (`src/main/persistence/`, `docs/adr/0019`; ownership split from `docs/adr/0005`).
+One SQLite database (`userData/state.sqlite`, WAL, opened only by `sqlite-db.ts`; forward-only
+migrations in `state-migrations.ts`, fail-closed on a newer `user_version`): (1) Workspace + Thread
+**metadata** — ours, small — rows behind `SqliteMetadataStore`; (2) the per-Thread **transcript
+event log** we own (`transcript_entries`, global `seq`, behind `SqliteTranscriptStore`), teed
+best-effort from main's conversation inputs, replayed on reopen with NO agent spawned; (3) agent
+**context/history** — Vibe owns it. Two disposable projections derive from the log at write time:
+the FTS5 **prose index** (⌘K search) and per-Thread **fold snapshots** (the renderer's folded view
+as an opaque blob, versioned by `REDUCER_SCHEMA_VERSION` — bump it when conversation item shapes
+change). A one-time importer migrates pre-SQLite profiles (`metadata.json`/`transcripts/*.jsonl` →
+`.bak`, kept). Daily rotating `VACUUM INTO` backups under `userData/backups/`. The cold launch list
+and process-free reopen are both served from our stores alone. **Every persistence write is
+best-effort and must never reject the live flow** — on a store failure, synthesize ids and continue.
 
 **Per-Thread live status** (`src/main/thread-status.ts`). Single source of truth for the sidebar's
 `streaming` / `needsAttention` indicators, keyed by durable `threadId` (distinct from `inFlightTurns`,
@@ -157,8 +163,8 @@ agent-controls choreography behind `connection/use-workspace-actions.ts` /
 (`conversation/reducer.ts`); an event-router (`conversation/event-routing.ts`) subscribes once to
 `acp:event`, switches on the ACP method, and dispatches typed actions; per-kind row renderers live
 in `conversation/items/`, the composer (drafts, images, the unified `/`+`@` autocomplete) in
-`conversation/Composer.tsx`. Reopen replays the JSONL transcript through the same reducer
-(`conversation/replay.ts`). Renderer-only UI state (drafts, panel sizes, scroll) stays in
+`conversation/Composer.tsx`. Reopen hydrates tiered (`conversation/replay.ts`): in-memory LRU →
+durable fold snapshot + fold only the entry tail → full fold through the same reducer. Renderer-only UI state (drafts, panel sizes, scroll) stays in
 `localStorage`; durable state goes through IPC.
 
 ## Conventions

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -58,10 +58,11 @@ import {
 import { getShellEnv } from './shell-env'
 import { getAccountWhoami, readKeychainApiKey, readVibeEnvFile } from './auth/whoami'
 import { searchThreads, tokenizeQuery } from './search/search-threads'
-import { proseEntries, type ProseEntry } from './search/transcript-prose'
+import type { ProseEntry } from './search/transcript-prose'
 import { groupThreadsByWorkspace } from './persistence/metadata-store'
 import type { MetadataStoreApi } from './persistence/metadata-store-api'
 import { createMetadataStore } from './persistence/create-metadata-store'
+import { maybeBackupStateDb } from './persistence/state-backup'
 import type { StateDb } from './persistence/sqlite-db'
 import {
   acpEventEntry,
@@ -361,14 +362,15 @@ let terminalManager: TerminalManager | null = null
  * (`createMetadataStore`, ADR-0019) always yields a working store — SQLite when
  * `state.sqlite` opens, the legacy JSON store otherwise — and `load()` degrades
  * to empty state internally (never a throw), so the old `| null` type and its
- * per-handler degraded forks were unreachable. `transcript` nullability IS real
- * (the dir `mkdir` can fail) — the bridge folds that into a silent-no-op tee.
+ * per-handler degraded forks were unreachable. Since #298 `transcript` is
+ * non-null too: it rides the same always-open state database.
  */
 interface MainDeps {
   store: MetadataStoreApi
-  transcript: TranscriptStoreApi | null
-  /** The SQLite engine's handle (ADR-0019); null on the legacy JSON engine. */
-  stateDb: StateDb | null
+  transcript: TranscriptStoreApi
+  /** The one open state database (ADR-0019) — `state.sqlite`, or the loudly-
+   * logged in-memory fallback when it couldn't open (#298). */
+  stateDb: StateDb
   bridge: TranscriptBridge
   /** Null when the attachments dir `mkdir` failed — image persistence no-ops (logged). */
   attachments: AttachmentStore | null
@@ -1102,7 +1104,7 @@ function registerIpc(deps: MainDeps): void {
     await deleteThread({
       threadId,
       store: deps.store,
-      transcript: deps.transcript ?? { delete: () => Promise.resolve() },
+      transcript: deps.transcript,
       attachments: deps.attachments ?? undefined,
       closeSession: bestEffortCloseFor(deps, threadId),
     })
@@ -1136,7 +1138,7 @@ function registerIpc(deps: MainDeps): void {
       await removeWorkspace({
         workspaceId,
         store: deps.store,
-        transcript: deps.transcript ?? { delete: () => Promise.resolve() },
+        transcript: deps.transcript,
         attachments: deps.attachments ?? undefined,
         // When a warm agent hosts this Workspace, stop it via the SAME path the
         // sweep/stop uses: `pool.dispose` (graceful teardown of hosted sessions) plus
@@ -1265,31 +1267,11 @@ function registerIpc(deps: MainDeps): void {
       const snapshot = groupThreadsByWorkspace(deps.store.snapshot())
       let prose: Map<string, ProseEntry[]> | undefined
       const tokens = tokenizeQuery(args.query)
-      if (tokens.length > 0) {
-        if (deps.stateDb && !deps.stateDb.locked) {
-          // SQLite engine (#296): ONE indexed FTS query feeds the same pure
-          // ranking `searchThreads` always ran — the scan-per-query is gone.
-          prose = ftsProseByThread(deps.stateDb.db, tokens)
-        } else if (deps.transcript) {
-          // Legacy JSON engine only (removed with it in #298): the original
-          // read-every-transcript scan, best-effort per thread — a failed read
-          // degrades that thread to title-only matching, never the query.
-          const store = deps.transcript
-          const threads = snapshot.flatMap((ws) => ws.threads)
-          const loaded = await Promise.all(
-            threads.map(async (thread) => {
-              try {
-                return [thread.id, proseEntries(await store.read(thread.id))] as const
-              } catch (err) {
-                console.error(
-                  `[vibe-mistro:search] transcript read failed (${thread.id}): ${String(err)}`,
-                )
-                return [thread.id, [] as ProseEntry[]] as const
-              }
-            }),
-          )
-          prose = new Map(loaded)
-        }
+      if (tokens.length > 0 && !deps.stateDb.locked) {
+        // ONE indexed FTS query (#296) feeds the same pure ranking
+        // `searchThreads` always ran; a locked (newer-build) db degrades to
+        // title-only matching, consistent with its empty stores.
+        prose = ftsProseByThread(deps.stateDb.db, tokens)
       }
       return searchThreads(snapshot, args.query, args.limit, prose)
     },
@@ -1304,7 +1286,6 @@ function registerIpc(deps: MainDeps): void {
       // usable snapshot (legacy engine, first open, version bump, forceFull
       // corruption fallback) degrades to the whole log as the tail. A missing
       // log reads back empty (never throws).
-      if (!deps.transcript) return Promise.resolve({ snapshot: null, tail: [], lastSeq: 0 })
       return deps.transcript.readWithSnapshot(args.threadId, args.reducerVersion, args.forceFull)
     },
   )
@@ -1313,7 +1294,6 @@ function registerIpc(deps: MainDeps): void {
     // Fire-and-forget (ADR-0019, #297): store the renderer's folded view as an
     // OPAQUE blob — main never parses it (ADR-0001). Best-effort like every
     // persistence write; the store refuses regressions and unknown Threads.
-    if (!deps.transcript) return
     if (!args || typeof args.threadId !== 'string' || typeof args.state !== 'string') return
     if (typeof args.reducerVersion !== 'number' || typeof args.lastSeq !== 'number') return
     void deps.transcript.putSnapshot(args)
@@ -1343,15 +1323,19 @@ app.whenReady().then(async () => {
   const { store, stateDb, engine } = await createMetadataStore({ userDataDir: app.getPath('userData') })
   await store.load()
   console.log(`[main] metadata store engine: ${engine}`)
+  stateDbGlobal = stateDb
 
-  // The per-Thread transcript store (ADR-0005/0019). Its engine FOLLOWS the
-  // metadata store's (same `state.sqlite`, never split-brain) via the stateDb
-  // handle; the SQLite path runs the one-time JSONL import (dir renamed to
-  // `transcripts.bak` when fully handled), the legacy path keeps the mkdir —
-  // a failure leaves `transcript` null and teeing becomes a silent no-op
-  // inside the bridge (best-effort — the conversation is fine).
+  // The per-Thread transcript store (ADR-0005/0019): the same `state.sqlite`
+  // as the metadata store (never split-brain), with the one-time JSONL import
+  // on the way (dir renamed to `transcripts.bak` when fully handled). On the
+  // in-memory fallback the import is SKIPPED — imported rows would evaporate
+  // with the session while the rename tombstoned the real files.
   const transcriptsDir = join(app.getPath('userData'), 'transcripts')
-  const { transcript } = await createTranscriptStore({ stateDb, transcriptsDir })
+  const transcript = await createTranscriptStore({
+    stateDb,
+    transcriptsDir,
+    skipImport: engine === 'memory',
+  })
 
 
   // The per-Thread prompt-image attachments dir (sibling of the transcripts —
@@ -1373,6 +1357,15 @@ app.whenReady().then(async () => {
     resolveBySession: (sessionId) => store.findThreadIdBySessionId(sessionId),
   })
   const deps: MainDeps = { store, transcript, bridge, attachments, stateDb }
+
+  // Daily rotating backup of state.sqlite (ADR-0019, #298) — scheduled off the
+  // launch path, best-effort, and never on the non-durable memory fallback
+  // (there is nothing durable to copy).
+  if (engine === 'sqlite') {
+    setTimeout(() => {
+      void maybeBackupStateDb({ stateDb, backupsDir: join(app.getPath('userData'), 'backups') })
+    }, 5_000)
+  }
 
   // Replace Electron's default Dock icon with the brand mark (dev-run parity with
   // a packaged bundle's icon.icns; t3code does the same). Dev-only: a packaged
@@ -1443,7 +1436,24 @@ app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit()
 })
 
+/**
+ * The open state database (ADR-0019), module-level like the pool so the quit
+ * hook below can optimize + close it (closing checkpoints the WAL).
+ */
+let stateDbGlobal: StateDb | null = null
+
 app.on('will-quit', () => {
+  // Persist the query planner's learnings + checkpoint the WAL on the way out
+  // (ADR-0019, #298). Best-effort: a failure here must never block quitting.
+  if (stateDbGlobal) {
+    try {
+      stateDbGlobal.db.exec('PRAGMA optimize')
+    } catch {
+      // already closed / locked — nothing to optimize
+    }
+    stateDbGlobal.close()
+    stateDbGlobal = null
+  }
   // Stop the idle-evict sweep so no timer outlives the app (TB5 #50). The pool's
   // own teardown is `window-all-closed`'s `disposeAll`; this just clears the timer.
   if (sweepTimer) {

--- a/apps/desktop/src/main/persistence/create-metadata-store.test.ts
+++ b/apps/desktop/src/main/persistence/create-metadata-store.test.ts
@@ -3,13 +3,13 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createMetadataStore } from './create-metadata-store'
-import { METADATA_SCHEMA_VERSION, MetadataStore } from './metadata-store'
+import { METADATA_SCHEMA_VERSION } from './metadata-store'
 import { SqliteMetadataStore } from './sqlite-metadata-store'
 
 /**
- * The engine-selection construction seam (ADR-0019): SQLite normally, legacy
- * JSON behind the escape hatch or when the db can't open, with the one-time
- * import wired in. Real temp-dir `userData` layouts, no Electron.
+ * The engine construction seam (ADR-0019, sqlite-only since #298): open,
+ * import, and the loudly-logged in-memory fallback when the file db cannot
+ * open. Real temp-dir `userData` layouts, no Electron.
  */
 
 const root = mkdtempSync(join(tmpdir(), 'vibe-create-store-'))
@@ -23,18 +23,17 @@ function freshUserData(): string {
 }
 
 describe('createMetadataStore', () => {
-  it('selects SQLite, creates state.sqlite, and the store round-trips', async () => {
+  it('opens state.sqlite and the store round-trips', async () => {
     const userDataDir = freshUserData()
     const result = await createMetadataStore({ userDataDir })
 
     expect(result.engine).toBe('sqlite')
     expect(result.store).toBeInstanceOf(SqliteMetadataStore)
-    expect(result.stateDb).not.toBeNull()
     expect(existsSync(join(userDataDir, 'state.sqlite'))).toBe(true)
 
     const ws = await result.store.upsertWorkspace({ dir: '/proj/x' })
     expect(result.store.snapshot().workspaces.map((w) => w.id)).toEqual([ws.id])
-    result.stateDb?.close()
+    result.stateDb.close()
   })
 
   it('imports a legacy metadata.json on first launch and renames it to .bak', async () => {
@@ -52,41 +51,37 @@ describe('createMetadataStore', () => {
 
     const result = await createMetadataStore({ userDataDir })
 
-    expect(result.engine).toBe('sqlite')
     expect(result.store.snapshot().threads[0]).toMatchObject({ id: 't1', title: 'kept' })
     expect(existsSync(join(userDataDir, 'metadata.json'))).toBe(false)
     expect(existsSync(join(userDataDir, 'metadata.json.bak'))).toBe(true)
 
     // Second launch: steady state — no legacy file, data served from SQLite.
-    result.stateDb?.close()
+    result.stateDb.close()
     const again = await createMetadataStore({ userDataDir })
-    expect(again.engine).toBe('sqlite')
     expect(again.store.snapshot().threads.map((t) => t.id)).toEqual(['t1'])
-    again.stateDb?.close()
+    again.stateDb.close()
   })
 
-  it('honors the VIBE_MISTRO_FORCE_JSON escape hatch (legacy engine, no db created)', async () => {
-    const userDataDir = freshUserData()
-    const result = await createMetadataStore({ userDataDir, forceJson: true })
-
-    expect(result.engine).toBe('json')
-    expect(result.store).toBeInstanceOf(MetadataStore)
-    expect(result.stateDb).toBeNull()
-    expect(existsSync(join(userDataDir, 'state.sqlite'))).toBe(false)
-  })
-
-  it('falls back to the legacy JSON store when state.sqlite cannot open', async () => {
+  it('falls back to a NON-DURABLE in-memory db when state.sqlite cannot open', async () => {
     const userDataDir = freshUserData()
     // Occupy the db path with a DIRECTORY so the open throws.
     mkdirSync(join(userDataDir, 'state.sqlite'))
+    // A legacy file that must NOT be imported (its rows would evaporate while
+    // the .bak rename tombstoned the real file).
+    writeFileSync(
+      join(userDataDir, 'metadata.json'),
+      JSON.stringify({ workspaces: [], threads: [] }),
+    )
 
     const result = await createMetadataStore({ userDataDir })
 
-    expect(result.engine).toBe('json')
-    expect(result.store).toBeInstanceOf(MetadataStore)
-    // The legacy store still works for the session.
-    await result.store.load()
+    expect(result.engine).toBe('memory')
+    // The session still works — just non-durable.
     const ws = await result.store.upsertWorkspace({ dir: '/proj/fallback' })
     expect(result.store.snapshot().workspaces.map((w) => w.id)).toEqual([ws.id])
+    // The legacy file was left strictly alone.
+    expect(existsSync(join(userDataDir, 'metadata.json'))).toBe(true)
+    expect(existsSync(join(userDataDir, 'metadata.json.bak'))).toBe(false)
+    result.stateDb.close()
   })
 })

--- a/apps/desktop/src/main/persistence/create-metadata-store.ts
+++ b/apps/desktop/src/main/persistence/create-metadata-store.ts
@@ -1,5 +1,4 @@
 import { join } from 'node:path'
-import { MetadataStore } from './metadata-store'
 import type { MetadataStoreApi } from './metadata-store-api'
 import { importLegacyMetadata } from './import-legacy-metadata'
 import { openStateDb, type StateDb } from './sqlite-db'
@@ -7,66 +6,55 @@ import { SqliteMetadataStore } from './sqlite-metadata-store'
 import { STATE_MIGRATIONS } from './state-migrations'
 
 /**
- * The metadata-store construction seam (ADR-0019): decides which engine this
- * session runs on and performs the one-time legacy import. `index.ts` calls
- * this once at ready and types everything downstream as `MetadataStoreApi`.
+ * The metadata-store construction seam (ADR-0019): open `state.sqlite`, run the
+ * one-time legacy import, hand back the store. `index.ts` calls this once at
+ * ready and types everything downstream as `MetadataStoreApi`.
  *
- * Engine selection, in order:
- * 1. `VIBE_MISTRO_FORCE_JSON=1` → the legacy JSON store (field escape hatch,
- *    removed with the legacy store after the soak release — #298).
- * 2. `state.sqlite` opens → SQLite store. A LOCKED open (db written by a newer
- *    build) still selects SQLite: the store presents empty + read-only and
- *    `isLocked()` drives the same honest upgrade notice the JSON store did.
- * 3. The open THROWS (unreadable path/disk) → legacy JSON store, logged. The
- *    legacy import also falling over ('failed') runs this session on JSON and
- *    retries next launch — the transaction rollback left the db empty.
+ * The legacy JSON engine and its `VIBE_MISTRO_FORCE_JSON` escape hatch were
+ * removed in #298 after the migration soak. The remaining failure fallback is
+ * an IN-MEMORY database (`engine: 'memory'`): if `state.sqlite` cannot open —
+ * a disk so broken the JSON engine would not have fared better — the session
+ * runs non-durable rather than wedging launch, loudly logged. A LOCKED open
+ * (db written by a newer build) still selects the file db: the store presents
+ * empty + read-only and `isLocked()` drives the honest upgrade notice.
  */
 
 export interface CreateMetadataStoreResult {
   store: MetadataStoreApi
-  /** Non-null only when the SQLite engine was selected. */
-  stateDb: StateDb | null
-  engine: 'sqlite' | 'json'
+  stateDb: StateDb
+  engine: 'sqlite' | 'memory'
 }
 
 export interface CreateMetadataStoreDeps {
   userDataDir: string
-  /** Env override (tests pin it; production reads VIBE_MISTRO_FORCE_JSON). */
-  forceJson?: boolean
 }
 
 export async function createMetadataStore(
   deps: CreateMetadataStoreDeps,
 ): Promise<CreateMetadataStoreResult> {
-  const legacyPath = join(deps.userDataDir, 'metadata.json')
-  const forceJson = deps.forceJson ?? process.env.VIBE_MISTRO_FORCE_JSON === '1'
-
-  if (forceJson) {
-    console.log('[create-metadata-store] VIBE_MISTRO_FORCE_JSON=1 — using the legacy JSON store')
-    return jsonStore(legacyPath, null)
-  }
-
   let stateDb: StateDb
+  let engine: CreateMetadataStoreResult['engine'] = 'sqlite'
   try {
-    stateDb = openStateDb({ path: join(deps.userDataDir, 'state.sqlite'), migrations: STATE_MIGRATIONS })
+    stateDb = openStateDb({
+      path: join(deps.userDataDir, 'state.sqlite'),
+      migrations: STATE_MIGRATIONS,
+    })
   } catch (err) {
-    console.error('[create-metadata-store] state.sqlite failed to open — falling back to JSON:', err)
-    return jsonStore(legacyPath, null)
+    console.error(
+      '[create-metadata-store] state.sqlite failed to open — running NON-DURABLE in memory:',
+      err,
+    )
+    stateDb = openStateDb({ path: ':memory:', migrations: STATE_MIGRATIONS })
+    engine = 'memory'
   }
 
   const store = new SqliteMetadataStore({ stateDb })
-  if (!stateDb.locked) {
-    const imported = await importLegacyMetadata({ filePath: legacyPath, store })
-    if (imported === 'failed') {
-      // Rolled back to an empty db; run this session on the legacy JSON store
-      // (the file is still in place) and retry the import next launch.
-      stateDb.close()
-      return jsonStore(legacyPath, null)
-    }
+  if (engine === 'sqlite' && !stateDb.locked) {
+    // Best-effort: a failed import logs, rolls back, and leaves the legacy file
+    // for the next launch's retry — the session proceeds on the (empty) db.
+    // (Never into the memory fallback: importing would rename the legacy file
+    // to .bak while the imported rows evaporate with the session.)
+    await importLegacyMetadata({ filePath: join(deps.userDataDir, 'metadata.json'), store })
   }
-  return { store, stateDb, engine: 'sqlite' }
-}
-
-function jsonStore(legacyPath: string, stateDb: StateDb | null): CreateMetadataStoreResult {
-  return { store: new MetadataStore({ filePath: legacyPath }), stateDb, engine: 'json' }
+  return { store, stateDb, engine }
 }

--- a/apps/desktop/src/main/persistence/create-transcript-store.test.ts
+++ b/apps/desktop/src/main/persistence/create-transcript-store.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, afterAll } from 'vitest'
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
-import { rmSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createTranscriptStore } from './create-transcript-store'
@@ -8,12 +7,12 @@ import { openStateDb } from './sqlite-db'
 import { SqliteMetadataStore } from './sqlite-metadata-store'
 import { SqliteTranscriptStore } from './sqlite-transcript-store'
 import { STATE_MIGRATIONS } from './state-migrations'
-import { TranscriptStore, userPromptEntry } from './transcript'
+import { userPromptEntry } from './transcript'
 
 /**
- * The transcript-store construction seam (ADR-0019): the engine follows the
- * metadata store's stateDb (never split-brain), with the one-time JSONL import
- * wired into the SQLite path.
+ * The transcript-store construction seam (ADR-0019, sqlite-only since #298):
+ * same stateDb as the metadata store, one-time JSONL import on the way, and
+ * the skip-import guard for the in-memory fallback.
  */
 
 const root = mkdtempSync(join(tmpdir(), 'vibe-create-transcript-'))
@@ -27,7 +26,7 @@ function freshDir(): string {
 }
 
 describe('createTranscriptStore', () => {
-  it('selects SQLite when a stateDb is provided and imports legacy JSONL on the way', async () => {
+  it('returns the SQLite store and imports legacy JSONL on the way', async () => {
     const stateDb = openStateDb({ path: ':memory:', migrations: STATE_MIGRATIONS })
     const meta = new SqliteMetadataStore({ stateDb })
     const ws = await meta.upsertWorkspace({ dir: '/proj/a' })
@@ -37,41 +36,45 @@ describe('createTranscriptStore', () => {
     mkdirSync(transcriptsDir)
     writeFileSync(join(transcriptsDir, 't1.jsonl'), JSON.stringify(userPromptEntry('u1', 'legacy')) + '\n')
 
-    const { transcript, engine } = await createTranscriptStore({ stateDb, transcriptsDir })
+    const transcript = await createTranscriptStore({ stateDb, transcriptsDir })
 
-    expect(engine).toBe('sqlite')
     expect(transcript).toBeInstanceOf(SqliteTranscriptStore)
-    expect(await transcript?.read('t1')).toEqual([userPromptEntry('u1', 'legacy')])
+    expect(await transcript.read('t1')).toEqual([userPromptEntry('u1', 'legacy')])
     expect(existsSync(transcriptsDir)).toBe(false)
     expect(existsSync(`${transcriptsDir}.bak`)).toBe(true)
     stateDb.close()
   })
 
-  it('selects the legacy JSONL store when stateDb is null (engines move together)', async () => {
+  it('skipImport leaves the legacy dir strictly alone (the in-memory fallback path)', async () => {
+    const stateDb = openStateDb({ path: ':memory:', migrations: STATE_MIGRATIONS })
     const transcriptsDir = join(freshDir(), 'transcripts')
-    const { transcript, engine } = await createTranscriptStore({ stateDb: null, transcriptsDir })
+    mkdirSync(transcriptsDir)
+    writeFileSync(join(transcriptsDir, 't1.jsonl'), JSON.stringify(userPromptEntry('u1', 'x')) + '\n')
 
-    expect(engine).toBe('json')
-    expect(transcript).toBeInstanceOf(TranscriptStore)
-    expect(existsSync(transcriptsDir)).toBe(true) // legacy path mkdirs its home
+    const transcript = await createTranscriptStore({ stateDb, transcriptsDir, skipImport: true })
+
+    expect(await transcript.read('t1')).toEqual([])
+    expect(existsSync(transcriptsDir)).toBe(true)
+    expect(existsSync(`${transcriptsDir}.bak`)).toBe(false)
+    stateDb.close()
   })
 
   it('skips the import on a LOCKED stateDb (fail-closed) but still serves the store', async () => {
-    const path = join(freshDir(), 'locked.sqlite')
+    const dir = freshDir()
+    const path = join(dir, 'locked.sqlite')
     const raw = openStateDb({ path, migrations: STATE_MIGRATIONS })
     raw.db.exec('PRAGMA user_version = 99')
     raw.close()
     const stateDb = openStateDb({ path, migrations: STATE_MIGRATIONS })
     expect(stateDb.locked).toBe(true)
 
-    const transcriptsDir = join(freshDir(), 'transcripts')
+    const transcriptsDir = join(dir, 'transcripts')
     mkdirSync(transcriptsDir)
     writeFileSync(join(transcriptsDir, 't1.jsonl'), JSON.stringify(userPromptEntry('u1', 'x')) + '\n')
 
-    const { transcript, engine } = await createTranscriptStore({ stateDb, transcriptsDir })
+    const transcript = await createTranscriptStore({ stateDb, transcriptsDir })
 
-    expect(engine).toBe('sqlite')
-    expect(await transcript?.read('t1')).toEqual([]) // locked reads empty
+    expect(await transcript.read('t1')).toEqual([]) // locked reads empty
     expect(existsSync(transcriptsDir)).toBe(true) // nothing imported or renamed
     stateDb.close()
   })

--- a/apps/desktop/src/main/persistence/create-transcript-store.ts
+++ b/apps/desktop/src/main/persistence/create-transcript-store.ts
@@ -1,55 +1,37 @@
-import { mkdir } from 'node:fs/promises'
 import { importLegacyTranscripts } from './import-legacy-transcripts'
 import { SqliteTranscriptStore } from './sqlite-transcript-store'
-import { TranscriptStore } from './transcript'
 import type { TranscriptStoreApi } from './transcript-store-api'
 import type { StateDb } from './sqlite-db'
 
 /**
- * The transcript-store construction seam (ADR-0019). The engine FOLLOWS the
- * metadata store's: `stateDb` is non-null exactly when `createMetadataStore`
- * selected SQLite, so both stores always run on the same engine — never a
- * split-brain where metadata rows and transcript files disagree about where
- * truth lives. Runs the one-time JSONL import (per-file self-gating; the dir
- * renames to `transcripts.bak` when fully handled).
- *
- * The legacy path keeps its existing semantics: mkdir the transcripts dir and
- * return null on failure — teeing then no-ops inside the bridge (best-effort).
+ * The transcript-store construction seam (ADR-0019). The store shares the
+ * metadata store's `stateDb` (same `state.sqlite`, never split-brain) and runs
+ * the one-time JSONL import (per-file self-gating; the legacy dir renames to
+ * `transcripts.bak` when fully handled). The legacy JSONL engine was removed
+ * in #298 — on the in-memory failure fallback this store simply rides the same
+ * non-durable db.
  */
 
-export interface CreateTranscriptStoreResult {
-  transcript: TranscriptStoreApi | null
-  engine: 'sqlite' | 'json'
-}
-
 export interface CreateTranscriptStoreDeps {
-  /** From `createMetadataStore` — non-null selects the SQLite engine. */
-  stateDb: StateDb | null
-  /** The legacy `userData/transcripts` dir (import source / legacy home). */
+  /** From `createMetadataStore` — the one open state database. */
+  stateDb: StateDb
+  /** The legacy `userData/transcripts` dir (import source only). */
   transcriptsDir: string
+  /** Skip the import (the in-memory fallback: imported rows would evaporate
+   * while the rename tombstones the real files). */
+  skipImport?: boolean
 }
 
 export async function createTranscriptStore(
   deps: CreateTranscriptStoreDeps,
-): Promise<CreateTranscriptStoreResult> {
-  if (deps.stateDb) {
-    const store = new SqliteTranscriptStore({ stateDb: deps.stateDb })
-    if (!deps.stateDb.locked) {
-      // Best-effort: a failed import logs and leaves the dir for the next
-      // launch's retry — it must never block the store (or launch) itself.
-      try {
-        await importLegacyTranscripts({ dir: deps.transcriptsDir, store })
-      } catch (err) {
-        console.error('[create-transcript-store] legacy transcript import failed:', err)
-      }
+): Promise<TranscriptStoreApi> {
+  const store = new SqliteTranscriptStore({ stateDb: deps.stateDb })
+  if (!deps.stateDb.locked && !deps.skipImport) {
+    try {
+      await importLegacyTranscripts({ dir: deps.transcriptsDir, store })
+    } catch (err) {
+      console.error('[create-transcript-store] legacy transcript import failed:', err)
     }
-    return { transcript: store, engine: 'sqlite' }
   }
-
-  try {
-    await mkdir(deps.transcriptsDir, { recursive: true })
-    return { transcript: new TranscriptStore({ dir: deps.transcriptsDir }), engine: 'json' }
-  } catch {
-    return { transcript: null, engine: 'json' }
-  }
+  return store
 }

--- a/apps/desktop/src/main/persistence/import-legacy-metadata.ts
+++ b/apps/desktop/src/main/persistence/import-legacy-metadata.ts
@@ -1,5 +1,5 @@
-import { access, rename } from 'node:fs/promises'
-import { MetadataStore } from './metadata-store'
+import { access, readFile, rename } from 'node:fs/promises'
+import { parseLegacyMetadata } from './metadata-store'
 import type { SqliteMetadataStore } from './sqlite-metadata-store'
 
 /**
@@ -11,8 +11,8 @@ import type { SqliteMetadataStore } from './sqlite-metadata-store'
  * - state db non-empty → already imported; only the `.bak` rename is retried
  *   (covers a crash between commit and rename) — records are NEVER merged into
  *   existing data, so a re-run can't clobber newer SQLite rows with stale JSON;
- * - otherwise → parse through the legacy store itself (its envelope handling,
- *   per-record shape guards, and flag normalization for free), insert verbatim
+ * - otherwise → parse via `parseLegacyMetadata` (the removed JSON engine's
+ *   exact envelope handling, shape guards, and flag normalization), insert verbatim
  *   in one transaction, then rename the file to `metadata.json.bak` — kept, not
  *   deleted, as the rollback path.
  *
@@ -35,6 +35,7 @@ export interface ImportLegacyMetadataDeps {
   store: SqliteMetadataStore
   /** fs seams (tests) — default to node:fs/promises. */
   exists?: (path: string) => Promise<boolean>
+  readFileAt?: (path: string) => Promise<string>
   renameFile?: (from: string, to: string) => Promise<void>
 }
 
@@ -42,14 +43,20 @@ export async function importLegacyMetadata(
   deps: ImportLegacyMetadataDeps,
 ): Promise<ImportLegacyMetadataResult> {
   const exists = deps.exists ?? defaultExists
+  const readFileAt = deps.readFileAt ?? ((path: string) => readFile(path, 'utf8'))
   const renameFile = deps.renameFile ?? rename
   const bakPath = `${deps.filePath}.bak`
 
   if (!(await exists(deps.filePath))) return 'skipped-absent'
 
-  const legacy = new MetadataStore({ filePath: deps.filePath })
-  await legacy.load()
-  if (legacy.isLocked()) {
+  let raw: string
+  try {
+    raw = await readFileAt(deps.filePath)
+  } catch {
+    return 'skipped-absent' // raced away between the exists check and the read
+  }
+  const legacy = parseLegacyMetadata(raw)
+  if (legacy.locked) {
     // Written by a newer build than even this one understands — preserve it.
     console.error(`[import-legacy-metadata] ${deps.filePath} is newer than this build; left as-is`)
     return 'skipped-locked'
@@ -68,7 +75,7 @@ export async function importLegacyMetadata(
   }
 
   try {
-    deps.store.importSnapshot(legacy.snapshot())
+    deps.store.importSnapshot(legacy.snapshot)
   } catch (err) {
     console.error(`[import-legacy-metadata] import failed (rolled back):`, err)
     return 'failed'

--- a/apps/desktop/src/main/persistence/metadata-store.test.ts
+++ b/apps/desktop/src/main/persistence/metadata-store.test.ts
@@ -1,227 +1,60 @@
-import { describe, it, expect, afterAll } from 'vitest'
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import { groupThreadsByWorkspace, METADATA_SCHEMA_VERSION, MetadataStore } from './metadata-store'
+import { describe, it, expect } from 'vitest'
+import {
+  groupThreadsByWorkspace,
+  METADATA_SCHEMA_VERSION,
+  parseLegacyMetadata,
+} from './metadata-store'
 
 /**
- * The main-side Workspace/Thread metadata store (ADR-0005 metadata-first lazy
- * reopen). Exercised over a REAL temp-dir JSON file via the injectable fs/path
- * seam, mirroring fs-write.test.ts — no `userData`, no `vibe-acp` spawned.
+ * The engine-independent metadata pieces (#298 — the JSON engine itself is
+ * gone): `parseLegacyMetadata`, the one-time importer's tolerant envelope
+ * reader (behaviors carried verbatim from the removed engine's `load()`), and
+ * the pure `groupThreadsByWorkspace` launch-list shape.
  */
 
-const dir = mkdtempSync(join(tmpdir(), 'vibe-metadata-'))
-afterAll(() => rmSync(dir, { recursive: true, force: true }))
-
-/** A store bound to a fresh JSON file under the shared temp dir. */
-function storeAt(file: string): MetadataStore {
-  return new MetadataStore({ filePath: join(dir, file) })
-}
-
-describe('MetadataStore round-trip', () => {
-  it('persists Workspaces + Threads and reads them back through a new instance', async () => {
-    const file = 'roundtrip.json'
-    const store = storeAt(file)
-    await store.load()
-
-    const ws = await store.upsertWorkspace({ dir: '/proj/alpha', displayName: 'alpha' })
-    await store.upsertThread({ workspaceId: ws.id, sessionId: 'sess-1', title: 'first' })
-
-    // A brand-new instance over the SAME file must read the persisted state back.
-    const reopened = storeAt(file)
-    await reopened.load()
-    const snap = reopened.snapshot()
-
-    expect(snap.workspaces).toHaveLength(1)
-    expect(snap.workspaces[0]).toMatchObject({ dir: '/proj/alpha', displayName: 'alpha' })
-    expect(snap.threads).toHaveLength(1)
-    expect(snap.threads[0]).toMatchObject({ workspaceId: ws.id, sessionId: 'sess-1', title: 'first' })
+describe('parseLegacyMetadata', () => {
+  it('reads a versioned envelope', () => {
+    const { snapshot, locked } = parseLegacyMetadata(
+      JSON.stringify({
+        schemaVersion: METADATA_SCHEMA_VERSION,
+        workspaces: [{ id: 'w1', dir: '/a', displayName: 'a', lastOpenedAt: 5 }],
+        threads: [
+          { id: 't1', workspaceId: 'w1', sessionId: 's', title: 'T', createdAt: 1, lastActiveAt: 2 },
+        ],
+      }),
+    )
+    expect(locked).toBe(false)
+    expect(snapshot.workspaces.map((w) => w.id)).toEqual(['w1'])
+    expect(snapshot.threads[0]).toMatchObject({ id: 't1', sessionId: 's', title: 'T' })
   })
 
-  it("mints a Thread id distinct from its ACP sessionId, and allows a null sessionId", async () => {
-    const store = storeAt('distinct-id.json')
-    await store.load()
-    const ws = await store.upsertWorkspace({ dir: '/proj/beta' })
-
-    const bound = await store.upsertThread({ workspaceId: ws.id, sessionId: 'acp-session-xyz' })
-    expect(bound.id).not.toBe(bound.sessionId)
-    expect(bound.id.length).toBeGreaterThan(0)
-
-    // A Thread can exist before any ACP session is minted (resume cursor null).
-    const cold = await store.upsertThread({ workspaceId: ws.id })
-    expect(cold.sessionId).toBeNull()
-    expect(cold.id).not.toBe(bound.id)
+  it('reads a legacy header-less file (no schemaVersion) as the current version', () => {
+    const { snapshot, locked } = parseLegacyMetadata(
+      JSON.stringify({
+        workspaces: [{ id: 'w1', dir: '/legacy', displayName: 'L', lastOpenedAt: 5 }],
+        threads: [],
+      }),
+    )
+    expect(locked).toBe(false)
+    expect(snapshot.workspaces.map((w) => w.id)).toEqual(['w1'])
   })
 
-  it('upserts a Workspace by dir (no duplicate), refreshing lastOpenedAt and re-ordering', async () => {
-    let clock = 1000
-    const store = new MetadataStore({ filePath: join(dir, 'ws-order.json'), now: () => clock })
-    await store.load()
-
-    const a = await store.upsertWorkspace({ dir: '/proj/a' })
-    clock = 2000
-    await store.upsertWorkspace({ dir: '/proj/b' })
-    clock = 3000
-    // Re-open A: same record (same id), bumped timestamp, now most-recent.
-    const aAgain = await store.upsertWorkspace({ dir: '/proj/a' })
-
-    expect(aAgain.id).toBe(a.id)
-    expect(aAgain.lastOpenedAt).toBe(3000)
-    const dirs = store.snapshot().workspaces.map((w) => w.dir)
-    expect(dirs).toEqual(['/proj/a', '/proj/b']) // most-recent-first, no duplicate
+  it('degrades unparseable JSON to an EMPTY snapshot without locking (no trustworthy version)', () => {
+    const { snapshot, locked } = parseLegacyMetadata('{ this is not: valid json ]')
+    expect(locked).toBe(false)
+    expect(snapshot).toEqual({ workspaces: [], threads: [] })
   })
 
-  it('upserts a Thread by id (no duplicate), refreshing lastActiveAt and re-ordering', async () => {
-    let clock = 1000
-    const store = new MetadataStore({ filePath: join(dir, 'thread-order.json'), now: () => clock })
-    await store.load()
-    const ws = await store.upsertWorkspace({ dir: '/proj/c' })
-
-    clock = 1100
-    const t1 = await store.upsertThread({ workspaceId: ws.id, sessionId: 's1' })
-    clock = 1200
-    const t2 = await store.upsertThread({ workspaceId: ws.id, sessionId: 's2' })
-    clock = 1300
-    // Touch t1 again (e.g. a new turn): bumps lastActiveAt, no second record.
-    const t1Again = await store.upsertThread({ id: t1.id, workspaceId: ws.id, sessionId: 's1b' })
-
-    expect(t1Again.id).toBe(t1.id)
-    expect(t1Again.createdAt).toBe(1100) // creation time preserved
-    expect(t1Again.lastActiveAt).toBe(1300)
-    expect(t1Again.sessionId).toBe('s1b') // resume cursor advanced
-    const ids = store.snapshot().threads.map((t) => t.id)
-    expect(ids).toEqual([t1.id, t2.id]) // t1 now most-recent
+  it('FAILS CLOSED on a newer schemaVersion (the importer leaves the file untouched)', () => {
+    const { snapshot, locked } = parseLegacyMetadata(
+      JSON.stringify({ schemaVersion: METADATA_SCHEMA_VERSION + 99, workspaces: [], threads: [] }),
+    )
+    expect(locked).toBe(true)
+    expect(snapshot).toEqual({ workspaces: [], threads: [] })
   })
 
-  it('touchThread bumps lastActiveAt (a prompt is activity) and re-heads the derived order', async () => {
-    let clock = 1000
-    const store = new MetadataStore({ filePath: join(dir, 'touch-thread.json'), now: () => clock })
-    await store.load()
-    const ws = await store.upsertWorkspace({ dir: '/proj/touch' })
-    clock = 1100
-    const t1 = await store.upsertThread({ workspaceId: ws.id, sessionId: 's1', title: 'old' })
-    clock = 1200
-    const t2 = await store.upsertThread({ workspaceId: ws.id, sessionId: 's2' })
-
-    // Prompting the OLDER thread again (a resume — no upsert runs) touches it.
-    clock = 1300
-    await store.touchThread(t1.id)
-
-    const t1After = store.snapshot().threads.find((t) => t.id === t1.id)
-    expect(t1After?.lastActiveAt).toBe(1300)
-    expect(t1After?.createdAt).toBe(1100) // creation time preserved
-    expect(t1After?.title).toBe('old') // everything else untouched
-    expect(t1After?.sessionId).toBe('s1')
-    // Derived order re-heads: t1 (1300) now ahead of t2 (1200).
-    expect(store.snapshot().threads.map((t) => t.id)).toEqual([t1.id, t2.id])
-    // Survives a reload (persisted, not just in-memory).
-    const reopened = new MetadataStore({ filePath: join(dir, 'touch-thread.json') })
-    await reopened.load()
-    expect(reopened.snapshot().threads.find((t) => t.id === t1.id)?.lastActiveAt).toBe(1300)
-  })
-
-  it('touchThread is a no-op for an unknown id (no record, no disk write)', async () => {
-    const store = storeAt('touch-unknown.json')
-    await store.load()
-    await expect(store.touchThread('nope')).resolves.toBeUndefined()
-    expect(store.snapshot().threads).toEqual([])
-  })
-
-  it('setThreadTitle renames in place: sets title, holds position, does NOT bump lastActiveAt', async () => {
-    let clock = 1000
-    const store = new MetadataStore({ filePath: join(dir, 'set-title.json'), now: () => clock })
-    await store.load()
-    const ws = await store.upsertWorkspace({ dir: '/proj/rename' })
-    clock = 1100
-    const t1 = await store.upsertThread({ workspaceId: ws.id, sessionId: 's1' })
-    clock = 1200
-    const t2 = await store.upsertThread({ workspaceId: ws.id, sessionId: 's2', pinned: true })
-
-    // Rename the OLDER thread; time advances but a title change is not activity.
-    clock = 9999
-    const changed = await store.setThreadTitle(t1.id, 'Renamed thread')
-    expect(changed).toBe(true)
-
-    const t1After = store.snapshot().threads.find((t) => t.id === t1.id)
-    expect(t1After?.title).toBe('Renamed thread')
-    expect(t1After?.lastActiveAt).toBe(1100) // NOT bumped to 9999 — no reorder
-    expect(t1After?.sessionId).toBe('s1') // preserved
-    // Order unchanged: t2 (1200) still ahead of t1 (1100); t2's pin flag intact.
-    expect(store.snapshot().threads.map((t) => t.id)).toEqual([t2.id, t1.id])
-    expect(store.snapshot().threads.find((t) => t.id === t2.id)?.pinned).toBe(true)
-  })
-
-  it('setThreadTitle is a no-op (returns false, no write) for an unknown id or unchanged title', async () => {
-    const writes: string[] = []
-    const store = new MetadataStore({
-      filePath: join(dir, 'set-title-noop.json'),
-      writeFile: async (_p, data) => {
-        writes.push(data)
-      },
-      rename: async () => {},
-    })
-    await store.load()
-    const ws = await store.upsertWorkspace({ dir: '/proj/noop' })
-    const t = await store.upsertThread({ workspaceId: ws.id, title: 'Same' })
-    const writesAfterSetup = writes.length
-
-    expect(await store.setThreadTitle('no-such-thread', 'X')).toBe(false)
-    expect(await store.setThreadTitle(t.id, 'Same')).toBe(false) // unchanged → absorbs the echo
-    expect(writes.length).toBe(writesAfterSetup) // neither no-op wrote to disk
-  })
-
-  it('sets a Thread title by id (auto-title capture) preserving session + createdAt', async () => {
-    // The `session_info_update` path (main's recordThreadTitle) upserts { id, workspaceId,
-    // title } onto an existing bound Thread — the title must land WITHOUT dropping its
-    // sessionId (resume cursor) or resetting createdAt.
-    let clock = 500
-    const store = new MetadataStore({ filePath: join(dir, 'title-set.json'), now: () => clock })
-    await store.load()
-    const ws = await store.upsertWorkspace({ dir: '/proj/title' })
-    clock = 600
-    const t = await store.upsertThread({ workspaceId: ws.id, sessionId: 'sess-x' })
-    expect(t.title).toBeNull() // untitled until the first prompt's auto-title arrives
-
-    clock = 700
-    const titled = await store.upsertThread({ id: t.id, workspaceId: ws.id, title: 'Fix @auth.py bug' })
-
-    expect(titled.id).toBe(t.id)
-    expect(titled.title).toBe('Fix @auth.py bug')
-    expect(titled.sessionId).toBe('sess-x') // resume cursor NOT clobbered by the title upsert
-    expect(titled.createdAt).toBe(600) // creation time preserved
-    // Durable across a reopen.
-    const reopened = new MetadataStore({ filePath: join(dir, 'title-set.json') })
-    await reopened.load()
-    expect(reopened.snapshot().threads.find((x) => x.id === t.id)?.title).toBe('Fix @auth.py bug')
-  })
-
-  it('degrades to an empty index on a missing file (no throw)', async () => {
-    const store = storeAt('does-not-exist.json')
-    await expect(store.load()).resolves.toBeUndefined()
-    expect(store.snapshot()).toEqual({ workspaces: [], threads: [] })
-  })
-
-  it('degrades to an empty index on a corrupt JSON file (no throw)', async () => {
-    const file = join(dir, 'corrupt.json')
-    writeFileSync(file, '{ this is not: valid json ]')
-    const store = new MetadataStore({ filePath: file })
-    await expect(store.load()).resolves.toBeUndefined()
-    expect(store.snapshot()).toEqual({ workspaces: [], threads: [] })
-
-    // Still usable after a corrupt load: the next write overwrites cleanly.
-    const ws = await store.upsertWorkspace({ dir: '/proj/recover' })
-    expect(store.snapshot().workspaces).toHaveLength(1)
-    expect(ws.dir).toBe('/proj/recover')
-  })
-
-  it('degrades a partially-corrupt file to its valid subset (no throw on list)', async () => {
-    // Valid JSON, but a malformed (null) Thread alongside a valid one and a
-    // malformed Workspace alongside a valid one. Without per-record validation
-    // the null record reaches snapshot()/groupThreadsByWorkspace and throws on
-    // `b.lastActiveAt` — narrowing the corrupt-degrades-gracefully guarantee.
-    const file = join(dir, 'partial-corrupt.json')
-    writeFileSync(
-      file,
+  it('drops malformed records, keeping the valid subset (one bad row cannot poison the import)', () => {
+    const { snapshot } = parseLegacyMetadata(
       JSON.stringify({
         workspaces: [
           { id: 'w1', dir: '/ok', displayName: 'ok', lastOpenedAt: 100 },
@@ -234,249 +67,13 @@ describe('MetadataStore round-trip', () => {
         ],
       }),
     )
-    const store = new MetadataStore({ filePath: file })
-    await store.load()
-
-    const snap = store.snapshot()
-    expect(snap.workspaces.map((w) => w.id)).toEqual(['w1'])
-    expect(snap.threads.map((t) => t.id)).toEqual(['t1'])
-    // Listing the valid subset must not throw on the dropped malformed records.
-    expect(() => groupThreadsByWorkspace(snap)).not.toThrow()
-    expect(groupThreadsByWorkspace(snap)[0].threads.map((t) => t.id)).toEqual(['t1'])
-  })
-})
-
-describe('MetadataStore schema versioning (ADR-0005 hardening)', () => {
-  it('persists a versioned envelope: { schemaVersion, workspaces, threads }', async () => {
-    const file = join(dir, 'envelope.json')
-    const store = new MetadataStore({ filePath: file })
-    await store.load()
-    await store.upsertWorkspace({ dir: '/proj/env' })
-
-    const raw = JSON.parse(readFileSync(file, 'utf8'))
-    expect(raw.schemaVersion).toBe(METADATA_SCHEMA_VERSION)
-    expect(raw.workspaces).toHaveLength(1)
-    expect(Array.isArray(raw.threads)).toBe(true)
+    expect(snapshot.workspaces.map((w) => w.id)).toEqual(['w1'])
+    expect(snapshot.threads.map((t) => t.id)).toEqual(['t1'])
+    expect(() => groupThreadsByWorkspace(snapshot)).not.toThrow()
   })
 
-  it('reads a legacy header-less file (no schemaVersion) as the current version', async () => {
-    // Files written before the envelope carry no schemaVersion — they ARE v1.
-    const file = join(dir, 'legacy.json')
-    writeFileSync(
-      file,
-      JSON.stringify({
-        workspaces: [{ id: 'w1', dir: '/legacy', displayName: 'L', lastOpenedAt: 5 }],
-        threads: [
-          { id: 't1', workspaceId: 'w1', sessionId: null, title: null, createdAt: 1, lastActiveAt: 2 },
-        ],
-      }),
-    )
-    const store = new MetadataStore({ filePath: file })
-    await store.load()
-
-    expect(store.isLocked()).toBe(false)
-    expect(store.snapshot().workspaces.map((w) => w.id)).toEqual(['w1'])
-    expect(store.snapshot().threads.map((t) => t.id)).toEqual(['t1'])
-  })
-
-  it('FAILS CLOSED on a newer schemaVersion: loads empty, locks, and never overwrites the file', async () => {
-    // The crux safety property: an older build must not atomically wipe history
-    // written by a newer one (which the pre-versioning degrade-to-empty would).
-    const file = join(dir, 'future.json')
-    const future = JSON.stringify({
-      schemaVersion: METADATA_SCHEMA_VERSION + 99,
-      workspaces: [{ id: 'wFuture', dir: '/future', displayName: 'F', lastOpenedAt: 9, brandNew: true }],
-      threads: [],
-    })
-    writeFileSync(file, future)
-    const store = new MetadataStore({ filePath: file })
-    await store.load()
-
-    // Refused to load the unknown-future shape — but LOCKED, not silently empty.
-    expect(store.isLocked()).toBe(true)
-    expect(store.snapshot()).toEqual({ workspaces: [], threads: [] })
-
-    // A subsequent write is a NO-OP: the newer on-disk file is preserved byte-for-byte.
-    await store.upsertWorkspace({ dir: '/proj/should-not-persist' })
-    expect(readFileSync(file, 'utf8')).toBe(future)
-  })
-})
-
-describe('MetadataStore.deleteThread (TB6 #35)', () => {
-  it('removes a Thread record so it no longer lists, leaving siblings intact', async () => {
-    const file = 'delete-thread.json'
-    const store = storeAt(file)
-    await store.load()
-    const ws = await store.upsertWorkspace({ dir: '/proj/del' })
-    const keep = await store.upsertThread({ workspaceId: ws.id, sessionId: 'keep' })
-    const drop = await store.upsertThread({ workspaceId: ws.id, sessionId: 'drop' })
-
-    await store.deleteThread(drop.id)
-
-    const ids = store.snapshot().threads.map((t) => t.id)
-    expect(ids).toEqual([keep.id]) // only the dropped Thread is gone
-
-    // Durable: a fresh instance over the SAME file must not see the deleted record.
-    const reopened = storeAt(file)
-    await reopened.load()
-    expect(reopened.snapshot().threads.map((t) => t.id)).toEqual([keep.id])
-  })
-
-  it('is a no-op for an unknown id (idempotent, no throw)', async () => {
-    const store = storeAt('delete-unknown.json')
-    await store.load()
-    const ws = await store.upsertWorkspace({ dir: '/proj/del-unknown' })
-    const t = await store.upsertThread({ workspaceId: ws.id })
-
-    await expect(store.deleteThread('no-such-thread')).resolves.toBeUndefined()
-    // Deleting the same Thread twice is also safe (idempotent).
-    await store.deleteThread(t.id)
-    await expect(store.deleteThread(t.id)).resolves.toBeUndefined()
-    expect(store.snapshot().threads).toEqual([])
-  })
-})
-
-describe('MetadataStore.removeWorkspace ("Remove project")', () => {
-  it('removes the Workspace + all its Threads and returns their ids', async () => {
-    const file = 'remove-ws.json'
-    const store = storeAt(file)
-    await store.load()
-    const ws = await store.upsertWorkspace({ dir: '/proj/rm' })
-    const t1 = await store.upsertThread({ workspaceId: ws.id, sessionId: 's1' })
-    const t2 = await store.upsertThread({ workspaceId: ws.id, sessionId: 's2' })
-
-    const removed = await store.removeWorkspace(ws.id)
-
-    expect(removed).toEqual(expect.arrayContaining([t1.id, t2.id]))
-    expect(removed).toHaveLength(2)
-    expect(store.snapshot().workspaces).toEqual([])
-    expect(store.snapshot().threads).toEqual([])
-
-    // Durable: a fresh instance over the SAME file must not see the removed records.
-    const reopened = storeAt(file)
-    await reopened.load()
-    expect(reopened.snapshot().workspaces).toEqual([])
-    expect(reopened.snapshot().threads).toEqual([])
-  })
-
-  it('leaves other Workspaces and their Threads intact', async () => {
-    const store = storeAt('remove-ws-siblings.json')
-    await store.load()
-    const drop = await store.upsertWorkspace({ dir: '/proj/drop' })
-    const keep = await store.upsertWorkspace({ dir: '/proj/keep' })
-    const dropThread = await store.upsertThread({ workspaceId: drop.id })
-    const keepThread = await store.upsertThread({ workspaceId: keep.id })
-
-    const removed = await store.removeWorkspace(drop.id)
-
-    expect(removed).toEqual([dropThread.id])
-    expect(store.snapshot().workspaces.map((w) => w.id)).toEqual([keep.id])
-    expect(store.snapshot().threads.map((t) => t.id)).toEqual([keepThread.id])
-  })
-
-  it('is a no-op for an unknown id — returns [] and writes NOTHING', async () => {
-    const writes: string[] = []
-    const store = new MetadataStore({
-      filePath: join(dir, 'remove-ws-unknown.json'),
-      readFile: async () => {
-        throw new Error('ENOENT')
-      },
-      writeFile: async (path) => {
-        writes.push(`write:${path}`)
-      },
-      rename: async () => {},
-    })
-    await store.load()
-    await store.upsertWorkspace({ dir: '/proj/present' })
-    const writesAfterSetup = writes.length
-
-    await expect(store.removeWorkspace('no-such-workspace')).resolves.toEqual([])
-    expect(writes.length).toBe(writesAfterSetup) // unknown id → no disk write
-  })
-})
-
-describe('MetadataStore.setThreadFlags (#132 pin / #133 archive)', () => {
-  it('patches only the passed flag, leaving the other untouched, and round-trips', async () => {
-    const file = 'flags-roundtrip.json'
-    const store = storeAt(file)
-    await store.load()
-    const ws = await store.upsertWorkspace({ dir: '/proj/flags' })
-    const t = await store.upsertThread({ workspaceId: ws.id, sessionId: 's1' })
-
-    // Pin only: archived stays absent (undefined = false).
-    await store.setThreadFlags(t.id, { pinned: true })
-    let rec = store.snapshot().threads.find((x) => x.id === t.id)
-    expect(rec?.pinned).toBe(true)
-    expect(rec?.archived).toBeUndefined()
-
-    // Archive only: pin is preserved (only the passed field changes).
-    await store.setThreadFlags(t.id, { archived: true })
-    rec = store.snapshot().threads.find((x) => x.id === t.id)
-    expect(rec?.pinned).toBe(true)
-    expect(rec?.archived).toBe(true)
-
-    // Durable across a fresh instance over the SAME file (survives reopen/eviction).
-    const reopened = storeAt(file)
-    await reopened.load()
-    const back = reopened.snapshot().threads.find((x) => x.id === t.id)
-    expect(back?.pinned).toBe(true)
-    expect(back?.archived).toBe(true)
-
-    // Unpin clears just that flag.
-    await reopened.setThreadFlags(t.id, { pinned: false })
-    expect(reopened.snapshot().threads.find((x) => x.id === t.id)?.pinned).toBe(false)
-    expect(reopened.snapshot().threads.find((x) => x.id === t.id)?.archived).toBe(true)
-  })
-
-  it('holds the record list POSITION (a flag toggle is not activity)', async () => {
-    let clock = 1000
-    const store = new MetadataStore({ filePath: join(dir, 'flags-order.json'), now: () => clock })
-    await store.load()
-    const ws = await store.upsertWorkspace({ dir: '/proj/flags-order' })
-    clock = 1100
-    const t1 = await store.upsertThread({ workspaceId: ws.id })
-    clock = 1200
-    const t2 = await store.upsertThread({ workspaceId: ws.id })
-
-    // t2 leads (most recent). Pinning t1 must NOT re-order the stored list.
-    await store.setThreadFlags(t1.id, { pinned: true })
-    expect(store.snapshot().threads.map((t) => t.id)).toEqual([t2.id, t1.id])
-  })
-
-  it('is a no-op for an unknown id (no throw, no write)', async () => {
-    const events: string[] = []
-    const store = new MetadataStore({
-      filePath: join(dir, 'flags-unknown.json'),
-      readFile: async () => {
-        throw new Error('ENOENT')
-      },
-      writeFile: async (path) => {
-        events.push(`write:${path}`)
-      },
-      rename: async () => {},
-    })
-    await store.load()
-    await expect(store.setThreadFlags('no-such-thread', { pinned: true })).resolves.toBeUndefined()
-    expect(events).toEqual([]) // no disk write for an unknown id
-  })
-
-  it('upsertThread PRESERVES pinned/archived across a routine activity re-target', async () => {
-    const store = storeAt('flags-preserve.json')
-    await store.load()
-    const ws = await store.upsertWorkspace({ dir: '/proj/flags-preserve' })
-    const t = await store.upsertThread({ workspaceId: ws.id })
-    await store.setThreadFlags(t.id, { pinned: true, archived: true })
-
-    // A normal activity-upsert (new turn: same id, fresh sessionId) must NOT clear them.
-    const again = await store.upsertThread({ id: t.id, workspaceId: ws.id, sessionId: 's-new' })
-    expect(again.pinned).toBe(true)
-    expect(again.archived).toBe(true)
-  })
-
-  it('coerces a stored non-boolean flag to undefined on load (defensive)', async () => {
-    const file = join(dir, 'flags-coerce.json')
-    writeFileSync(
-      file,
+  it('coerces a stored non-boolean flag to undefined (defensive normalize)', () => {
+    const { snapshot } = parseLegacyMetadata(
       JSON.stringify({
         schemaVersion: METADATA_SCHEMA_VERSION,
         workspaces: [{ id: 'w1', dir: '/c', displayName: 'c', lastOpenedAt: 1 }],
@@ -486,54 +83,9 @@ describe('MetadataStore.setThreadFlags (#132 pin / #133 archive)', () => {
         ],
       }),
     )
-    const store = new MetadataStore({ filePath: file })
-    await store.load()
-    const rec = store.snapshot().threads.find((t) => t.id === 't1')
-    expect(rec?.pinned).toBeUndefined() // non-boolean coerced away (not truthy-pinned)
+    const rec = snapshot.threads[0]
+    expect(rec?.pinned).toBeUndefined()
     expect(rec?.archived).toBe(true)
-  })
-})
-
-describe('MetadataStore atomic persist', () => {
-  it('writes to a temp file then renames it over the target (crash-safe)', async () => {
-    const events: string[] = []
-    const target = join(dir, 'atomic.json')
-    let tmpContent = ''
-    const store = new MetadataStore({
-      filePath: target,
-      readFile: async () => {
-        throw new Error('ENOENT')
-      },
-      writeFile: async (path, data) => {
-        events.push(`write:${path}`)
-        tmpContent = data
-      },
-      rename: async (from, to) => {
-        // The rename must follow the temp write, and the temp must already hold
-        // the full payload — never a half-written target.
-        events.push(`rename:${from}->${to}`)
-        expect(tmpContent).toContain('/proj/atomic')
-      },
-    })
-    await store.load()
-    await store.upsertWorkspace({ dir: '/proj/atomic' })
-
-    expect(events).toEqual([`write:${target}.tmp`, `rename:${target}.tmp->${target}`])
-  })
-})
-
-describe('findThreadIdBySessionId (transcript routing)', () => {
-  it('resolves the minted Thread id from its bound ACP sessionId, else null', async () => {
-    const store = storeAt('session-lookup.json')
-    await store.load()
-    const ws = await store.upsertWorkspace({ dir: '/proj/route' })
-    const bound = await store.upsertThread({ workspaceId: ws.id, sessionId: 'sess-route' })
-    // A Thread with no session yet must not match a null/absent lookup.
-    await store.upsertThread({ workspaceId: ws.id })
-
-    expect(store.findThreadIdBySessionId('sess-route')).toBe(bound.id)
-    expect(store.findThreadIdBySessionId('no-such-session')).toBeNull()
-    expect(store.findThreadIdBySessionId(null)).toBeNull()
   })
 })
 
@@ -553,9 +105,9 @@ describe('groupThreadsByWorkspace (pure)', () => {
       ],
     })
 
-    expect(grouped.map((w) => w.id)).toEqual(['w2', 'w1']) // workspaces most-recent-first
+    expect(grouped.map((w) => w.id)).toEqual(['w2', 'w1'])
     const w1 = grouped.find((w) => w.id === 'w1')
-    expect(w1?.threads.map((t) => t.id)).toEqual(['t2', 't1']) // threads most-recent-first
+    expect(w1?.threads.map((t) => t.id)).toEqual(['t2', 't1'])
     expect(grouped.flatMap((w) => w.threads).map((t) => t.id)).not.toContain('t4')
   })
 })

--- a/apps/desktop/src/main/persistence/metadata-store.ts
+++ b/apps/desktop/src/main/persistence/metadata-store.ts
@@ -1,35 +1,18 @@
-import { readFile, rename, writeFile } from 'node:fs/promises'
-import { randomUUID } from 'node:crypto'
 import type { ThreadMeta, WorkspaceMeta, WorkspaceThreads } from '../../shared/ipc'
 
 /**
- * Main-side persistence of Workspace + Thread METADATA (ADR-0005: vibe owns the
- * transcript; we own a light, metadata-first index so the app can show a cold,
- * read-only Workspace/Thread list on launch with NO `vibe-acp` process spawned).
+ * The metadata RECORD VOCABULARY + legacy-JSON parsing (ADR-0005/0019). The
+ * live store is `SqliteMetadataStore` (the `workspaces`/`threads` tables);
+ * what remains here is engine-independent: the record/input types both engines
+ * of history shared, `groupThreadsByWorkspace` (the cold launch list shape),
+ * and `parseLegacyMetadata` — the tolerant envelope reader the ONE-TIME
+ * importer (`import-legacy-metadata`) still needs for pre-SQLite
+ * `metadata.json` files.
  *
- * Single-writer: only the main process mutates this. The fs/path is an injected
- * seam (deps) so tests run over a temp-dir file without touching real `userData`,
- * mirroring the fs-read/fs-write handlers. A corrupt or missing file degrades to
- * empty state — never a throw — so a bad index can't wedge launch.
- *
- * SEAM CONTRACT (ADR-0005 hardening): this class is the ONLY reader/writer of the
- * metadata file. No other module may derive its path or touch it directly — the
- * `userData` path is single-sourced in `src/main/index.ts` and injected here. Keep
- * it that way so the JSON→SQLite swap (ADR-0005 defers it) stays a drop-in: swap
- * this class's body behind the same public methods + injected `deps`.
- *
- * SCHEMA VERSIONING: the file is a versioned envelope
- * (`{ schemaVersion, workspaces, threads }`). Legacy files predate the envelope and
- * are read as v1. A file whose version is NEWER than this build FAILS CLOSED: we
- * refuse to load it AND refuse to overwrite it (see `load`/`persist`), so an older
- * build can never atomically wipe history written by a newer one.
+ * The legacy JSON `MetadataStore` engine was removed in #298 after the
+ * migration soak; `metadata.json.bak` remains on disk as the rollback path.
  */
 
-/**
- * The record shapes are the cross-boundary `WorkspaceMeta` / `ThreadMeta`
- * (declared in shared/ipc.ts, since the renderer renders them). Aliased here so
- * the store reads naturally.
- */
 export type WorkspaceRecord = WorkspaceMeta
 export type ThreadRecord = ThreadMeta
 
@@ -40,18 +23,14 @@ export interface MetadataSnapshot {
 }
 
 /**
- * The on-disk schema version of the metadata envelope. Bump ONLY on a
- * backward-incompatible layout change, and add a migration branch in `load()`
- * for the older version(s). A file with a HIGHER version than this constant is
- * refused (fail-closed) rather than migrated down.
+ * The on-disk schema version of the LEGACY metadata envelope (the live schema
+ * version is the database's `PRAGMA user_version`, ADR-0019). A legacy file
+ * with a HIGHER version than this fails closed in `parseLegacyMetadata` — the
+ * importer leaves it untouched rather than importing a shape it can't trust.
  */
 export const METADATA_SCHEMA_VERSION = 1
 
-/**
- * The persisted envelope: the flat index wrapped with its `schemaVersion`.
- * `workspaces`/`threads` are typed `unknown` because `load()` must tolerate an
- * arbitrary/corrupt shape before its per-record guards run.
- */
+/** The persisted legacy envelope, tolerated as arbitrary/corrupt shapes. */
 interface PersistedIndex {
   schemaVersion?: number
   workspaces?: unknown
@@ -81,296 +60,42 @@ export interface ThreadInput {
 }
 
 /**
- * The injectable seam: where the JSON lives and how to read/write it, plus the
- * clock and id source. Production wires `node:fs/promises` + `crypto.randomUUID`
- * and a `userData` path; tests pass a temp file (and may pin `now`/`mintId`).
+ * Parse a legacy `metadata.json`'s raw contents (extracted verbatim from the
+ * removed JSON engine's `load()`, so the importer keeps its exact tolerance):
+ * unparseable JSON degrades to an EMPTY snapshot (a torn write or hand-edit has
+ * no trustworthy version — never a lock); a parseable file with a NEWER
+ * `schemaVersion` fails closed (`locked: true`, empty snapshot) so the importer
+ * preserves it untouched; per-record shape guards drop malformed entries so one
+ * bad record can't poison the import; flags normalize to strict booleans.
  */
-export interface MetadataStoreDeps {
-  /** Absolute path to the JSON index file. */
-  filePath: string
-  readFile?: (path: string) => Promise<string>
-  writeFile?: (path: string, data: string) => Promise<void>
-  /** Atomic move of the temp file over the target. Defaults to `fs.rename`. */
-  rename?: (from: string, to: string) => Promise<void>
-  now?: () => number
-  mintId?: () => string
-}
-
-export class MetadataStore {
-  private readonly filePath: string
-  private readonly readFileFn: (path: string) => Promise<string>
-  private readonly writeFileFn: (path: string, data: string) => Promise<void>
-  private readonly renameFn: (from: string, to: string) => Promise<void>
-  private readonly now: () => number
-  private readonly mintId: () => string
-  private state: MetadataSnapshot = { workspaces: [], threads: [] }
-  /**
-   * Set when `load()` saw a file written by a NEWER schema version. While locked,
-   * `persist()` is a no-op so we never overwrite (and thus destroy) data this
-   * build can't safely parse. Exposed via `isLocked()` so the caller can surface
-   * an honest "upgrade to open your data" notice instead of showing empty.
-   */
-  private locked = false
-
-  constructor(deps: MetadataStoreDeps) {
-    this.filePath = deps.filePath
-    this.readFileFn = deps.readFile ?? ((path) => readFile(path, 'utf8'))
-    this.writeFileFn = deps.writeFile ?? ((path, data) => writeFile(path, data, 'utf8'))
-    this.renameFn = deps.rename ?? rename
-    this.now = deps.now ?? Date.now
-    this.mintId = deps.mintId ?? randomUUID
+export function parseLegacyMetadata(raw: string): { snapshot: MetadataSnapshot; locked: boolean } {
+  let parsed: PersistedIndex
+  try {
+    parsed = JSON.parse(raw) as PersistedIndex
+  } catch {
+    return { snapshot: { workspaces: [], threads: [] }, locked: false }
   }
 
-  /**
-   * Read the index into memory. A missing/unparseable file yields empty state;
-   * a parseable-but-partially-malformed file degrades to its VALID subset —
-   * each record is shape-checked so a single bad entry (e.g. a `null` thread)
-   * can't later crash `snapshot()`/`groupThreadsByWorkspace`. Never throws.
-   *
-   * FAIL-CLOSED on a future version: if the file's `schemaVersion` is newer than
-   * this build understands, we DON'T degrade to empty (which would let the next
-   * `persist()` atomically overwrite real data) — we lock the store instead, so
-   * the newer file is preserved untouched until an upgraded build reads it.
-   */
-  async load(): Promise<void> {
-    let raw: string
-    try {
-      raw = await this.readFileFn(this.filePath)
-    } catch {
-      // Missing/unreadable file — the normal first-run case. Start empty; a file
-      // that never existed carries no version, so this is NOT a lock condition.
-      this.state = { workspaces: [], threads: [] }
-      return
-    }
+  const version =
+    typeof parsed.schemaVersion === 'number' ? parsed.schemaVersion : METADATA_SCHEMA_VERSION
+  if (version > METADATA_SCHEMA_VERSION) {
+    return { snapshot: { workspaces: [], threads: [] }, locked: true }
+  }
 
-    let parsed: PersistedIndex
-    try {
-      parsed = JSON.parse(raw) as PersistedIndex
-    } catch {
-      // Unparseable JSON (a torn write or hand-edit) has no trustworthy version.
-      // Degrade to empty as before — locking here would wedge launch forever on
-      // genuine corruption. (Versioned fail-closed applies only to WELL-FORMED
-      // files that declare a newer version.)
-      this.state = { workspaces: [], threads: [] }
-      return
-    }
-
-    // Legacy files predate the envelope and carry no `schemaVersion` — they ARE
-    // v1 by definition, so a missing/non-numeric version reads as the current one.
-    const version =
-      typeof parsed.schemaVersion === 'number' ? parsed.schemaVersion : METADATA_SCHEMA_VERSION
-    if (version > METADATA_SCHEMA_VERSION) {
-      this.locked = true
-      this.state = { workspaces: [], threads: [] }
-      console.error(
-        `[MetadataStore] ${this.filePath} is schemaVersion ${version}; this build supports ` +
-          `${METADATA_SCHEMA_VERSION}. Refusing to load or overwrite it to avoid destroying ` +
-          `data written by a newer version of vibe-mistro. Upgrade to open these Workspaces/Threads.`,
-      )
-      return
-    }
-
-    this.state = {
+  return {
+    locked: false,
+    snapshot: {
       workspaces: (Array.isArray(parsed.workspaces) ? parsed.workspaces : []).filter(
         isWorkspaceRecord,
       ),
       threads: (Array.isArray(parsed.threads) ? parsed.threads : [])
         .filter(isThreadRecord)
         .map(normalizeThreadFlags),
-    }
-  }
-
-  /**
-   * Whether the store is locked because the on-disk file was written by a newer
-   * schema version (see `load`). Callers should surface an honest "upgrade to
-   * open your data" notice rather than presenting the empty state as real.
-   */
-  isLocked(): boolean {
-    return this.locked
-  }
-
-  /**
-   * Upsert the Workspace keyed by `dir` (the natural key): re-opening a known
-   * dir refreshes `lastOpenedAt` (and `displayName`) on the SAME record rather
-   * than duplicating it. Returns the new or updated record.
-   */
-  async upsertWorkspace(input: WorkspaceInput): Promise<WorkspaceRecord> {
-    const existing = this.state.workspaces.find((w) => w.dir === input.dir)
-    const record: WorkspaceRecord = {
-      id: existing?.id ?? this.mintId(),
-      dir: input.dir,
-      displayName: input.displayName ?? existing?.displayName ?? input.dir,
-      lastOpenedAt: input.lastOpenedAt ?? this.now(),
-    }
-    this.state.workspaces = [record, ...this.state.workspaces.filter((w) => w.dir !== input.dir)]
-    await this.persist()
-    return record
-  }
-
-  /**
-   * Add or update a Thread. A matching `id` re-targets the existing Thread —
-   * preserving its `createdAt` while refreshing `lastActiveAt` (and the
-   * `sessionId` resume cursor) — instead of creating a second record. The
-   * per-Thread flags (`pinned`/`archived`, #132/#133) are PRESERVED across a
-   * re-target too, so a routine activity-upsert never clears a pin/archive; they
-   * change only when explicitly passed here or (the primary path) via
-   * `setThreadFlags`.
-   */
-  async upsertThread(input: ThreadInput): Promise<ThreadRecord> {
-    const ts = this.now()
-    const existing = input.id ? this.state.threads.find((t) => t.id === input.id) : undefined
-    const record: ThreadRecord = {
-      id: existing?.id ?? input.id ?? this.mintId(),
-      workspaceId: input.workspaceId,
-      sessionId: input.sessionId ?? existing?.sessionId ?? null,
-      title: input.title ?? existing?.title ?? null,
-      createdAt: input.createdAt ?? existing?.createdAt ?? ts,
-      lastActiveAt: input.lastActiveAt ?? ts,
-      pinned: input.pinned ?? existing?.pinned,
-      archived: input.archived ?? existing?.archived,
-    }
-    this.state.threads = [record, ...this.state.threads.filter((t) => t.id !== record.id)]
-    await this.persist()
-    return record
-  }
-
-  /**
-   * Bump a Thread's `lastActiveAt` to now. A PROMPT is activity, so `runPromptTurn`
-   * touches its Thread once per turn — `upsertThread` only runs on a BIND (draft
-   * mint / re-bind), so a successful resume (`session/load`) or any later prompt on
-   * an already-hosted session never wrote the store, and a continued Thread kept
-   * its old timestamp forever. An unknown id is a no-op with NO disk write. The
-   * in-memory array position is left alone — `snapshot()`/`groupThreadsByWorkspace`
-   * sort by `lastActiveAt`, so the bump re-heads the derived order automatically.
-   */
-  async touchThread(id: string): Promise<void> {
-    const existing = this.state.threads.find((t) => t.id === id)
-    if (!existing) return // unknown id — nothing to touch, no disk write
-    const updated: ThreadRecord = { ...existing, lastActiveAt: this.now() }
-    this.state.threads = this.state.threads.map((t) => (t.id === id ? updated : t))
-    await this.persist()
-  }
-
-  /**
-   * Toggle a Thread's per-Thread flags (#132 pin / #133 archive) on its metadata
-   * record, keyed by minted `id`. Patches ONLY the provided flag(s) — the other is
-   * left untouched — and holds the record's list POSITION (a flag change is not
-   * activity, so it does not re-order like an upsert). An unknown id is a no-op
-   * with NO write. Persisted atomically like the upserts; flags round-trip through
-   * `load`, so a pin/archive survives reopen/eviction (ADR-0005).
-   */
-  async setThreadFlags(id: string, flags: { pinned?: boolean; archived?: boolean }): Promise<void> {
-    const existing = this.state.threads.find((t) => t.id === id)
-    if (!existing) return // unknown id — nothing to patch, no disk write
-    const updated: ThreadRecord = {
-      ...existing,
-      ...(flags.pinned !== undefined ? { pinned: flags.pinned } : {}),
-      ...(flags.archived !== undefined ? { archived: flags.archived } : {}),
-    }
-    this.state.threads = this.state.threads.map((t) => (t.id === id ? updated : t))
-    await this.persist()
-  }
-
-  /**
-   * Set a Thread's title in place (auto-title on first prompt, or a rename). Like
-   * `setThreadFlags`, this HOLDS the record's list position — a title change is not
-   * activity, so unlike `upsertThread` it does NOT bump `lastActiveAt` or re-head the
-   * list. Returns `true` when the title actually changed (so the caller pushes/refreshes
-   * only then): an unknown id or an unchanged title is a no-op with NO disk write — which
-   * also absorbs the `session_info_update` vibe-acp echoes back after our own rename.
-   */
-  async setThreadTitle(id: string, title: string | null): Promise<boolean> {
-    const existing = this.state.threads.find((t) => t.id === id)
-    if (!existing || existing.title === title) return false
-    const updated: ThreadRecord = { ...existing, title }
-    this.state.threads = this.state.threads.map((t) => (t.id === id ? updated : t))
-    await this.persist()
-    return true
-  }
-
-  /**
-   * Remove a Thread record by its minted `id` (TB6 #35). Idempotent: an unknown
-   * id (or an already-deleted Thread) is a no-op — the filter simply matches
-   * nothing — so deleting twice never throws. The JSONL transcript + any live ACP
-   * session are torn down by the caller (best-effort, ADR-0005); this owns only
-   * our metadata record. Persisted atomically like the upserts.
-   */
-  async deleteThread(id: string): Promise<void> {
-    const before = this.state.threads.length
-    this.state.threads = this.state.threads.filter((t) => t.id !== id)
-    // Only rewrite the index when something actually changed — an unknown-id
-    // delete touches no record and needs no disk write.
-    if (this.state.threads.length !== before) await this.persist()
-  }
-
-  /**
-   * Remove a Workspace record AND every Thread under it ("Remove project"). Returns
-   * the removed Thread ids so the caller can drop THEIR JSONL transcripts (best-
-   * effort, ADR-0005) — the store owns only our metadata, not the transcript files.
-   * Idempotent: an unknown id (or an already-removed Workspace with no threads)
-   * matches nothing, returns `[]`, and writes NOTHING — so removing twice never
-   * throws. Persisted atomically like the other mutations, and only when something
-   * actually changed (an unknown-id removal needs no disk write). Files on disk are
-   * never touched here; this is purely our index.
-   */
-  async removeWorkspace(id: string): Promise<string[]> {
-    const removedThreadIds = this.state.threads.filter((t) => t.workspaceId === id).map((t) => t.id)
-    const hadWorkspace = this.state.workspaces.some((w) => w.id === id)
-    // Nothing to do — no record write for an unknown/already-removed Workspace.
-    if (!hadWorkspace && removedThreadIds.length === 0) return []
-    this.state.workspaces = this.state.workspaces.filter((w) => w.id !== id)
-    this.state.threads = this.state.threads.filter((t) => t.workspaceId !== id)
-    await this.persist()
-    return removedThreadIds
-  }
-
-  /**
-   * Resolve a Thread's minted `id` from its bound ACP `sessionId` (TB2 transcript
-   * routing). Events flow keyed by `sessionId`, but the JSONL is keyed by the
-   * minted Thread `id`; this bridges the two. A null/unmatched session is `null`
-   * (a `null`-session Thread never matches), so the caller can skip the tee.
-   */
-  findThreadIdBySessionId(sessionId: string | null | undefined): string | null {
-    if (!sessionId) return null
-    return this.state.threads.find((t) => t.sessionId === sessionId)?.id ?? null
-  }
-
-  /**
-   * The current in-memory index, most-recent-first (Workspaces by
-   * `lastOpenedAt`, Threads by `lastActiveAt`) — the order the renderer lists.
-   */
-  snapshot(): MetadataSnapshot {
-    return {
-      workspaces: [...this.state.workspaces].sort((a, b) => b.lastOpenedAt - a.lastOpenedAt),
-      threads: [...this.state.threads].sort((a, b) => b.lastActiveAt - a.lastActiveAt),
-    }
-  }
-
-  /**
-   * Write the index to a temp file then `rename` it over the target — atomic on
-   * POSIX, so a crash mid-write can't truncate/corrupt the index (a corrupt
-   * index loads empty = silent total data loss). Residual: with a single writer
-   * (main) this is safe; truly-concurrent writers would be last-rename-wins —
-   * revisit if write frequency rises (TB2). No write queue/mutex for now.
-   *
-   * Wraps the state in the versioned envelope. NO-OP while locked: a store that
-   * loaded a newer-version file must never write, so the newer on-disk data is
-   * preserved (in-memory mutations are intentionally non-durable in that state).
-   */
-  private async persist(): Promise<void> {
-    if (this.locked) return
-    const tmp = `${this.filePath}.tmp`
-    const envelope: PersistedIndex = {
-      schemaVersion: METADATA_SCHEMA_VERSION,
-      workspaces: this.state.workspaces,
-      threads: this.state.threads,
-    }
-    await this.writeFileFn(tmp, JSON.stringify(envelope, null, 2))
-    await this.renameFn(tmp, this.filePath)
+    },
   }
 }
 
-/** Well-formed-Workspace guard for `load()` — drops malformed persisted entries. */
+/** Well-formed-Workspace guard for `parseLegacyMetadata` — drops malformed persisted entries. */
 function isWorkspaceRecord(value: unknown): value is WorkspaceRecord {
   const w = value as Record<string, unknown> | null
   return (
@@ -382,7 +107,7 @@ function isWorkspaceRecord(value: unknown): value is WorkspaceRecord {
   )
 }
 
-/** Well-formed-Thread guard for `load()` — drops malformed persisted entries. */
+/** Well-formed-Thread guard for `parseLegacyMetadata` — drops malformed persisted entries. */
 function isThreadRecord(value: unknown): value is ThreadRecord {
   const t = value as Record<string, unknown> | null
   return (

--- a/apps/desktop/src/main/persistence/snapshot-tiering.test.ts
+++ b/apps/desktop/src/main/persistence/snapshot-tiering.test.ts
@@ -7,8 +7,7 @@ import { openStateDb, type StateDb } from './sqlite-db'
 import { SqliteMetadataStore } from './sqlite-metadata-store'
 import { SqliteTranscriptStore } from './sqlite-transcript-store'
 import { STATE_MIGRATIONS } from './state-migrations'
-import { TranscriptStore, turnCompleteEntry, userPromptEntry } from './transcript'
-import type { TranscriptStoreApi } from './transcript-store-api'
+import { turnCompleteEntry, userPromptEntry } from './transcript'
 
 /**
  * The durable fold-snapshot tiering (ADR-0019, #297): `readWithSnapshot` /
@@ -205,28 +204,5 @@ describe('snapshot cleanup + fail-closed', () => {
       store.putSnapshot({ threadId: 't1', reducerVersion: V, lastSeq: 1, state: '{}' }),
     ).resolves.toBeUndefined()
     stateDb.close()
-  })
-})
-
-describe('legacy TranscriptStore behind the same seam', () => {
-  it('readWithSnapshot answers the whole log as the tail with lastSeq 0; putSnapshot no-ops', async () => {
-    const legacyDir = join(dir, 'legacy-jsonl')
-    const { mkdirSync } = await import('node:fs')
-    mkdirSync(legacyDir, { recursive: true })
-    // Typed as the seam interface — the class implementation legitimately
-    // declares fewer parameters (it ignores them), but callers use the API.
-    const store: TranscriptStoreApi = new TranscriptStore({ dir: legacyDir })
-    await store.append('t1', userPromptEntry('u1', 'legacy'))
-
-    const result = await store.readWithSnapshot('t1', V)
-    expect(result).toEqual({
-      snapshot: null,
-      tail: [userPromptEntry('u1', 'legacy')],
-      lastSeq: 0, // the renderer's put policy keys off this — never snapshots
-    })
-    await expect(
-      store.putSnapshot({ threadId: 't1', reducerVersion: V, lastSeq: 5, state: '{}' }),
-    ).resolves.toBeUndefined()
-    expect(await store.readWithSnapshot('t1', V)).toEqual(result) // nothing stored
   })
 })

--- a/apps/desktop/src/main/persistence/state-backup.test.ts
+++ b/apps/desktop/src/main/persistence/state-backup.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, afterAll } from 'vitest'
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { maybeBackupStateDb } from './state-backup'
+import { openStateDb } from './sqlite-db'
+import { SqliteMetadataStore } from './sqlite-metadata-store'
+import { STATE_MIGRATIONS } from './state-migrations'
+
+/**
+ * The rotating VACUUM INTO backup (ADR-0019, #298): freshness gating from the
+ * newest backup's filename, rotation, locked-db refusal, restorability of the
+ * copy, and failure swallowing. Real temp dirs, fake clock.
+ */
+
+const root = mkdtempSync(join(tmpdir(), 'vibe-state-backup-'))
+afterAll(() => rmSync(root, { recursive: true, force: true }))
+
+let seq = 0
+function freshCase(): { backupsDir: string; dbPath: string } {
+  const dir = join(root, `case-${++seq}`)
+  mkdirSync(dir, { recursive: true })
+  return { backupsDir: join(dir, 'backups'), dbPath: join(dir, 'state.sqlite') }
+}
+
+const DAY = 24 * 60 * 60 * 1000
+
+describe('maybeBackupStateDb', () => {
+  it('creates a restorable copy, then skips while it is fresh, then rotates', async () => {
+    const { backupsDir, dbPath } = freshCase()
+    const stateDb = openStateDb({ path: dbPath, migrations: STATE_MIGRATIONS })
+    const meta = new SqliteMetadataStore({ stateDb })
+    const ws = await meta.upsertWorkspace({ dir: '/proj/backed-up' })
+
+    let clock = 1_000_000_000_000
+    const run = () => maybeBackupStateDb({ stateDb, backupsDir, now: () => clock })
+
+    expect(await run()).toBe('created')
+    expect(await run()).toBe('skipped-fresh') // same instant — fresh
+
+    clock += DAY + 1
+    expect(await run()).toBe('created')
+    clock += DAY + 1
+    expect(await run()).toBe('created')
+    clock += DAY + 1
+    expect(await run()).toBe('created')
+
+    // Rotation: only the newest BACKUP_RETAIN (3) remain, newest last lexically.
+    const names = readdirSync(backupsDir).sort()
+    expect(names).toHaveLength(3)
+
+    // Restorability: the newest copy opens as a normal state db with the data.
+    const restored = openStateDb({
+      path: join(backupsDir, names[names.length - 1] as string),
+      migrations: STATE_MIGRATIONS,
+    })
+    const restoredMeta = new SqliteMetadataStore({ stateDb: restored })
+    expect(restoredMeta.snapshot().workspaces.map((w) => w.id)).toEqual([ws.id])
+    restored.close()
+    stateDb.close()
+  })
+
+  it('leaves foreign files in the backups dir alone (no rotation casualties)', async () => {
+    const { backupsDir, dbPath } = freshCase()
+    mkdirSync(backupsDir, { recursive: true })
+    writeFileSync(join(backupsDir, 'README.txt'), 'mine')
+    const stateDb = openStateDb({ path: dbPath, migrations: STATE_MIGRATIONS })
+
+    let clock = 1_000_000_000_000
+    for (let i = 0; i < 5; i++) {
+      await maybeBackupStateDb({ stateDb, backupsDir, now: () => clock })
+      clock += DAY + 1
+    }
+
+    const names = readdirSync(backupsDir)
+    expect(names).toContain('README.txt')
+    expect(names.filter((n) => n.startsWith('state-'))).toHaveLength(3)
+    stateDb.close()
+  })
+
+  it('refuses to copy a LOCKED (newer-build) database', async () => {
+    const { backupsDir, dbPath } = freshCase()
+    const raw = openStateDb({ path: dbPath, migrations: STATE_MIGRATIONS })
+    raw.db.exec('PRAGMA user_version = 99')
+    raw.close()
+    const stateDb = openStateDb({ path: dbPath, migrations: STATE_MIGRATIONS })
+    expect(stateDb.locked).toBe(true)
+
+    expect(await maybeBackupStateDb({ stateDb, backupsDir })).toBe('skipped-locked')
+    stateDb.close()
+  })
+
+  it("returns 'failed' (never throws) when the backups dir cannot be created", async () => {
+    const { backupsDir, dbPath } = freshCase()
+    // Occupy the backups path with a FILE so mkdir fails.
+    writeFileSync(backupsDir, 'not a dir')
+    const stateDb = openStateDb({ path: dbPath, migrations: STATE_MIGRATIONS })
+
+    expect(await maybeBackupStateDb({ stateDb, backupsDir })).toBe('failed')
+    stateDb.close()
+  })
+})

--- a/apps/desktop/src/main/persistence/state-backup.ts
+++ b/apps/desktop/src/main/persistence/state-backup.ts
@@ -1,0 +1,82 @@
+import { mkdir, readdir, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import type { StateDb } from './sqlite-db'
+
+/**
+ * Best-effort rotating backup of `state.sqlite` (ADR-0019, #298). One database
+ * file concentrates what per-Thread JSONL spread out; WAL + transactions make
+ * torn writes rare, and this covers the residual: a daily `VACUUM INTO` copy
+ * under `userData/backups/`, newest {@link BACKUP_RETAIN} kept.
+ *
+ * Runs OFF the hot path (index.ts schedules it a few seconds after ready) and
+ * every failure is logged-and-swallowed — a backup can never affect launch or
+ * a live turn. Freshness is derived from the newest backup's FILENAME
+ * timestamp (no extra bookkeeping state).
+ *
+ * MANUAL RESTORE: quit the app, replace `userData/state.sqlite` with a backup
+ * file (delete any `state.sqlite-wal`/`-shm` next to it), relaunch. History
+ * regresses to the backup's moment; fold snapshots and the FTS index ride
+ * inside the copy, so nothing needs rebuilding.
+ */
+
+export const BACKUP_RETAIN = 3
+export const BACKUP_MIN_AGE_MS = 24 * 60 * 60 * 1000 // daily
+
+const BACKUP_PREFIX = 'state-'
+const BACKUP_SUFFIX = '.sqlite'
+
+export type BackupResult = 'created' | 'skipped-fresh' | 'skipped-locked' | 'failed'
+
+export interface BackupStateDbDeps {
+  stateDb: StateDb
+  /** `userData/backups` in production; a temp dir in tests. */
+  backupsDir: string
+  now?: () => number
+  retain?: number
+  minAgeMs?: number
+}
+
+/** `state-<epoch-ms>.sqlite` — lexical order == chronological order. */
+function backupName(now: number): string {
+  return `${BACKUP_PREFIX}${String(now).padStart(15, '0')}${BACKUP_SUFFIX}`
+}
+
+/** The epoch-ms a backup file encodes, or null for foreign files (left alone). */
+function backupTimestamp(name: string): number | null {
+  if (!name.startsWith(BACKUP_PREFIX) || !name.endsWith(BACKUP_SUFFIX)) return null
+  const stamp = Number(name.slice(BACKUP_PREFIX.length, -BACKUP_SUFFIX.length))
+  return Number.isFinite(stamp) ? stamp : null
+}
+
+export async function maybeBackupStateDb(deps: BackupStateDbDeps): Promise<BackupResult> {
+  const now = deps.now ?? Date.now
+  const retain = deps.retain ?? BACKUP_RETAIN
+  const minAgeMs = deps.minAgeMs ?? BACKUP_MIN_AGE_MS
+  // A locked db is a NEWER build's data — copying it around is not ours to do.
+  if (deps.stateDb.locked) return 'skipped-locked'
+
+  try {
+    await mkdir(deps.backupsDir, { recursive: true })
+    const existing = (await readdir(deps.backupsDir))
+      .map((name) => ({ name, stamp: backupTimestamp(name) }))
+      .filter((f): f is { name: string; stamp: number } => f.stamp !== null)
+      .sort((a, b) => b.stamp - a.stamp)
+
+    const ts = now()
+    if (existing[0] && ts - existing[0].stamp < minAgeMs) return 'skipped-fresh'
+
+    // VACUUM INTO writes a compacted, self-contained copy without blocking the
+    // connection for long; single-quote escaping is the only SQL-literal need.
+    const target = join(deps.backupsDir, backupName(ts))
+    deps.stateDb.db.exec(`VACUUM INTO '${target.replaceAll("'", "''")}'`)
+
+    for (const stale of existing.slice(Math.max(0, retain - 1))) {
+      await rm(join(deps.backupsDir, stale.name), { force: true })
+    }
+    console.log(`[state-backup] wrote ${target}`)
+    return 'created'
+  } catch (err) {
+    console.error('[state-backup] failed (non-fatal):', err)
+    return 'failed'
+  }
+}

--- a/apps/desktop/src/main/persistence/transcript.test.ts
+++ b/apps/desktop/src/main/persistence/transcript.test.ts
@@ -1,7 +1,4 @@
-import { describe, it, expect, afterAll } from 'vitest'
-import { appendFileSync, existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { describe, it, expect } from 'vitest'
 import {
   acpEventEntry,
   agentReboundEntry,
@@ -10,337 +7,108 @@ import {
   sessionIdFromPayload,
   titleFromSessionInfoUpdate,
   TRANSCRIPT_SCHEMA_VERSION,
-  TranscriptStore,
   transcriptVersionOf,
   turnCompleteEntry,
   turnErrorEntry,
   userPromptEntry,
-  type TranscriptEntry,
 } from './transcript'
 
-/** The version-header line every fresh log starts with (see TRANSCRIPT_SCHEMA_VERSION). */
-const HEADER_LINE = `{"t":"__transcript_header","v":${TRANSCRIPT_SCHEMA_VERSION}}`
-
 /**
- * The main-side per-Thread JSONL transcript (ADR-0005: vibe owns agent context,
- * we own the visible history). Exercised over a REAL temp dir via the injectable
- * append/read seam, mirroring metadata-store.test.ts / fs-write.test.ts — no
- * `userData`, no `vibe-acp` spawned.
+ * The engine-independent transcript pieces (#298 — the JSONL engine itself is
+ * gone; the live store's behaviors are pinned in sqlite-transcript-store.test):
+ * the entry builders, the tolerant legacy-JSONL parser the one-time importer
+ * still uses, and the pure payload extractors.
  */
 
-const dir = mkdtempSync(join(tmpdir(), 'vibe-transcript-'))
-afterAll(() => rmSync(dir, { recursive: true, force: true }))
+const HEADER_LINE = `{"t":"__transcript_header","v":${TRANSCRIPT_SCHEMA_VERSION}}`
 
-/** A store writing `<threadId>.jsonl` files into the shared temp dir. */
-function storeAt(): TranscriptStore {
-  return new TranscriptStore({ dir })
-}
-
-describe('TranscriptStore append', () => {
-  it('writes a version header then appends a user-prompt entry to <threadId>.jsonl', async () => {
-    const store = storeAt()
-    await store.append('thread-up', { t: 'user-prompt', id: 'u1', text: 'hello' })
-
-    const raw = readFileSync(join(dir, 'thread-up.jsonl'), 'utf8')
-    // Line 1 is the schema-version header; the conversation entry follows it.
-    expect(raw).toBe(`${HEADER_LINE}\n{"t":"user-prompt","id":"u1","text":"hello"}\n`)
-    // read() skips the header and returns just the conversation entry.
-    expect(await store.read('thread-up')).toEqual([{ t: 'user-prompt', id: 'u1', text: 'hello' }])
-  })
-
-  it('appends acp-event then resolve-permission in order, append-only across turns', async () => {
-    const store = storeAt()
-    const id = 'thread-order'
-
-    // First turn: prompt -> a streamed event -> a permission response.
-    await store.append(id, { t: 'user-prompt', id: 'u1', text: 'go' })
-    await store.append(id, { t: 'acp-event', payload: { method: 'session/update' } })
-    await store.append(id, { t: 'resolve-permission', requestId: 7, optionId: 'allow', name: 'Allow' })
-
-    const afterFirst = readFileSync(join(dir, `${id}.jsonl`), 'utf8')
-
-    // A second turn appends WITHOUT rewriting the earlier lines.
-    await store.append(id, { t: 'user-prompt', id: 'u2', text: 'again' })
-
-    const lines = readFileSync(join(dir, `${id}.jsonl`), 'utf8').trimEnd().split('\n')
-    expect(lines).toEqual([
-      HEADER_LINE, // written once, as line 1, before the first entry
-      '{"t":"user-prompt","id":"u1","text":"go"}',
-      '{"t":"acp-event","payload":{"method":"session/update"}}',
-      '{"t":"resolve-permission","requestId":7,"optionId":"allow","name":"Allow"}',
-      '{"t":"user-prompt","id":"u2","text":"again"}',
-    ])
-    // The first three lines are byte-identical to before the second turn (append-only).
-    expect(readFileSync(join(dir, `${id}.jsonl`), 'utf8').startsWith(afterFirst)).toBe(true)
-  })
-})
-
-describe('TranscriptStore read / parseTranscript', () => {
-  const entries: TranscriptEntry[] = [
-    { t: 'user-prompt', id: 'u1', text: 'hi' },
-    { t: 'acp-event', payload: { method: 'session/update', params: { update: { sessionUpdate: 'agent_message_chunk' } } } },
-    { t: 'resolve-permission', requestId: 'r1', optionId: 'deny', name: 'Deny' },
-  ]
-
-  it('reads a clean log back into the entry array, in order', async () => {
-    const store = storeAt()
-    const id = 'thread-read'
-    for (const entry of entries) await store.append(id, entry)
-
-    expect(await store.read(id)).toEqual(entries)
-  })
-
-  it('returns [] for a Thread with no log yet (never throws)', async () => {
-    expect(await storeAt().read('thread-absent')).toEqual([])
-  })
-
-  it('parseTranscript round-trips clean newline-delimited JSON', () => {
-    const raw = entries.map((e) => JSON.stringify(e)).join('\n') + '\n'
+describe('parseTranscript (the legacy importer reader)', () => {
+  it('round-trips clean newline-delimited JSON, dropping the version header', () => {
+    const entries = [
+      userPromptEntry('u1', 'hello'),
+      acpEventEntry({ method: 'session/update', params: { sessionId: 's' } }),
+      turnCompleteEntry(),
+    ]
+    const raw = [HEADER_LINE, ...entries.map((e) => JSON.stringify(e))].join('\n') + '\n'
     expect(parseTranscript(raw)).toEqual(entries)
   })
 
   it('tolerates a malformed/partial trailing line: parses the valid prefix, no throw', () => {
-    // A crash mid-append leaves the final record torn (no closing brace, no \n).
-    const torn =
-      '{"t":"user-prompt","id":"u1","text":"hi"}\n' +
-      '{"t":"acp-event","payload":{"a":1}}\n' +
-      '{"t":"resolve-permission","requestId":2,"opti'
-
-    expect(() => parseTranscript(torn)).not.toThrow()
-    expect(parseTranscript(torn)).toEqual([
-      { t: 'user-prompt', id: 'u1', text: 'hi' },
-      { t: 'acp-event', payload: { a: 1 } },
-    ])
+    const raw =
+      JSON.stringify(userPromptEntry('u1', 'ok')) + '\n' + '{"t":"acp-event","payload":{ torn'
+    expect(parseTranscript(raw)).toEqual([userPromptEntry('u1', 'ok')])
   })
 
-  it('read() tolerates a torn trailing line written to a real temp file', async () => {
-    const id = 'thread-torn'
-    const store = storeAt()
-    await store.append(id, { t: 'user-prompt', id: 'u1', text: 'hi' })
-    // Simulate a torn write by appending a partial (non-terminated) JSON line.
-    appendFileSync(join(dir, `${id}.jsonl`), '{"t":"acp-event","payl')
-
-    const read = await store.read(id)
-    expect(read).toEqual([{ t: 'user-prompt', id: 'u1', text: 'hi' }])
+  it('drops foreign/garbled-but-parseable JSON lines (unknown tags)', () => {
+    const raw = [
+      '{"t":"not-a-real-tag"}',
+      '"just a string"',
+      JSON.stringify(turnCompleteEntry()),
+    ].join('\n')
+    expect(parseTranscript(raw)).toEqual([turnCompleteEntry()])
   })
 
   it('parses a user-prompt WITH image refs and a legacy one WITHOUT, side by side', () => {
-    // The additive optional `images` needs no schema-version bump: the guard
-    // discriminates on `t` alone, so legacy lines and new lines coexist in one log.
-    const raw =
-      '{"t":"user-prompt","id":"u1","text":"old"}\n' +
-      '{"t":"user-prompt","id":"u2","text":"new","images":[{"file":"a.png","mimeType":"image/png"}]}\n'
-
-    expect(parseTranscript(raw)).toEqual([
-      { t: 'user-prompt', id: 'u1', text: 'old' },
-      { t: 'user-prompt', id: 'u2', text: 'new', images: [{ file: 'a.png', mimeType: 'image/png' }] },
-    ])
-  })
-})
-
-describe('userPromptEntry images', () => {
-  it('carries the refs when given, and omits the field entirely when absent or empty', () => {
-    const refs = [{ file: 'a.png', mimeType: 'image/png' }]
-    expect(userPromptEntry('u1', 'hi', refs)).toEqual({ t: 'user-prompt', id: 'u1', text: 'hi', images: refs })
-    // Legacy byte-identical shape — no `images` key, not even undefined.
-    expect(userPromptEntry('u2', 'hi')).toEqual({ t: 'user-prompt', id: 'u2', text: 'hi' })
-    expect('images' in userPromptEntry('u3', 'hi', [])).toBe(false)
-  })
-})
-
-describe('TranscriptStore schema versioning (ADR-0005 hardening)', () => {
-  it('writes the header exactly once, not before every append', async () => {
-    const store = storeAt()
-    const id = 'thread-header-once'
-    await store.append(id, { t: 'user-prompt', id: 'u1', text: 'a' })
-    await store.append(id, { t: 'user-prompt', id: 'u2', text: 'b' })
-
-    const lines = readFileSync(join(dir, `${id}.jsonl`), 'utf8').trimEnd().split('\n')
-    expect(lines.filter((l) => l === HEADER_LINE)).toHaveLength(1)
-    expect(lines[0]).toBe(HEADER_LINE) // and it's line 1
+    const withImages = userPromptEntry('u1', 'see this', [{ file: 'a.png', mimeType: 'image/png' }])
+    const legacy = { t: 'user-prompt', id: 'u2', text: 'plain' }
+    const parsed = parseTranscript([JSON.stringify(withImages), JSON.stringify(legacy)].join('\n'))
+    expect(parsed[0]).toEqual(withImages)
+    expect(parsed[1]).toEqual(legacy)
   })
 
-  it('does NOT prepend a header to a legacy header-less log (restart-safe)', async () => {
-    // A log written before versioning starts with a real entry, not a header.
-    // Re-opening and appending must leave it header-less (it reads back as v1),
-    // never inject a header into the MIDDLE of the file.
-    const id = 'thread-legacy'
-    const path = join(dir, `${id}.jsonl`)
-    appendFileSync(path, '{"t":"user-prompt","id":"old","text":"pre-versioning"}\n')
-
-    const store = storeAt() // fresh instance: header fast-path set is empty
-    await store.append(id, { t: 'user-prompt', id: 'new', text: 'after upgrade' })
-
-    const lines = readFileSync(path, 'utf8').trimEnd().split('\n')
-    expect(lines).toEqual([
-      '{"t":"user-prompt","id":"old","text":"pre-versioning"}',
-      '{"t":"user-prompt","id":"new","text":"after upgrade"}',
-    ])
-    expect(transcriptVersionOf(readFileSync(path, 'utf8'))).toBe(1)
-  })
-
-  it('transcriptVersionOf reads the header version, or 1 for a legacy log', () => {
-    expect(transcriptVersionOf(`${HEADER_LINE}\n{"t":"turn-complete"}\n`)).toBe(
-      TRANSCRIPT_SCHEMA_VERSION,
-    )
-    expect(transcriptVersionOf('{"t":"user-prompt","id":"u1","text":"hi"}\n')).toBe(1)
+  it('transcriptVersionOf reads the header version, or 1 for a legacy header-less log', () => {
+    expect(transcriptVersionOf(HEADER_LINE + '\n')).toBe(TRANSCRIPT_SCHEMA_VERSION)
+    expect(transcriptVersionOf('{"t":"__transcript_header","v":7}\n')).toBe(7)
+    expect(transcriptVersionOf(JSON.stringify(userPromptEntry('u1', 'x')) + '\n')).toBe(1)
     expect(transcriptVersionOf('')).toBe(1)
-  })
-})
-
-describe('TranscriptStore best-effort', () => {
-  it('append does not propagate when the underlying writer throws', async () => {
-    const store = new TranscriptStore({
-      dir,
-      append: async () => {
-        throw new Error('ENOSPC: no space left on device')
-      },
-    })
-    // The tee must NEVER break the live conversation — a failing append is swallowed.
-    await expect(store.append('thread-fail', { t: 'user-prompt', id: 'u1', text: 'x' })).resolves.toBeUndefined()
-  })
-})
-
-describe('TranscriptStore.delete (TB6 #35)', () => {
-  it('unlinks an existing <threadId>.jsonl so its log is gone', async () => {
-    const store = storeAt()
-    const id = 'thread-delete'
-    await store.append(id, { t: 'user-prompt', id: 'u1', text: 'hi' })
-    expect(existsSync(join(dir, `${id}.jsonl`))).toBe(true)
-
-    await store.delete(id)
-
-    expect(existsSync(join(dir, `${id}.jsonl`))).toBe(false)
-    // And it reads back empty afterwards (no residue for a later same-id Thread).
-    expect(await store.read(id)).toEqual([])
-  })
-
-  it('does not throw when the log is MISSING (never-prompted draft)', async () => {
-    const store = storeAt()
-    // A draft that was never prompted has no JSONL — deleting it must be a no-op.
-    await expect(store.delete('thread-never-written')).resolves.toBeUndefined()
-  })
-
-  it('swallows a non-ENOENT unlink failure (best-effort, never blocks deletion)', async () => {
-    const store = new TranscriptStore({
-      dir,
-      unlink: async () => {
-        throw new Error('EACCES: permission denied')
-      },
-    })
-    await expect(store.delete('thread-unlink-fails')).resolves.toBeUndefined()
   })
 })
 
 describe('entry constructors mirror the reducer inputs', () => {
   it('builds tagged entries matching the ConversationAction shapes', () => {
-    expect(userPromptEntry('u1', 'hi')).toEqual({ t: 'user-prompt', id: 'u1', text: 'hi' })
-    expect(acpEventEntry({ method: 'session/update' })).toEqual({
-      t: 'acp-event',
-      payload: { method: 'session/update' },
-    })
-    expect(resolvePermissionEntry(7, 'allow', 'Allow')).toEqual({
+    expect(userPromptEntry('id-1', 'text')).toEqual({ t: 'user-prompt', id: 'id-1', text: 'text' })
+    expect(acpEventEntry({ x: 1 })).toEqual({ t: 'acp-event', payload: { x: 1 } })
+    expect(turnCompleteEntry()).toEqual({ t: 'turn-complete' })
+    expect(turnErrorEntry('boom')).toEqual({ t: 'turn-error', message: 'boom' })
+    expect(agentReboundEntry()).toEqual({ t: 'agent-rebound' })
+    expect(resolvePermissionEntry(7, 'allow')).toEqual({
       t: 'resolve-permission',
       requestId: 7,
       optionId: 'allow',
-      name: 'Allow',
-    })
-    // Main may not know the chosen option's display name at the chokepoint
-    // (respondPermission carries only requestId + optionId); name is then null.
-    expect(resolvePermissionEntry('r1', 'deny')).toEqual({
-      t: 'resolve-permission',
-      requestId: 'r1',
-      optionId: 'deny',
       name: null,
     })
-    // The agent-rebound notice (TB4 #33) carries no payload — the copy is a
-    // renderer-side constant — and round-trips through parseTranscript.
-    expect(agentReboundEntry()).toEqual({ t: 'agent-rebound' })
-    expect(parseTranscript('{"t":"agent-rebound"}\n')).toEqual([{ t: 'agent-rebound' }])
+  })
+
+  it('userPromptEntry carries image refs when given, omitting the field when absent or empty', () => {
+    const refs = [{ file: 'a.png', mimeType: 'image/png' }]
+    expect(userPromptEntry('u', 't', refs)).toEqual({
+      t: 'user-prompt',
+      id: 'u',
+      text: 't',
+      images: refs,
+    })
+    expect(userPromptEntry('u', 't')).toEqual({ t: 'user-prompt', id: 'u', text: 't' })
+    expect(userPromptEntry('u', 't', [])).toEqual({ t: 'user-prompt', id: 'u', text: 't' })
   })
 })
 
-describe('TranscriptStore serializes concurrent appends (M1)', () => {
-  it('preserves CALL order for fire-and-forget appends even when the writer reorders by timing', async () => {
-    const written: string[] = []
-    let call = 0
-    // A writer whose completion delay DECREASES with call order (first call is
-    // slowest). Without the per-Thread chain these un-awaited writes would land
-    // out of order; serialization forces strict call order.
-    const append = (_path: string, line: string): Promise<void> => {
-      const delay = (10 - call++) * 4
-      return new Promise((resolve) =>
-        setTimeout(() => {
-          written.push(line)
-          resolve()
-        }, delay),
-      )
-    }
-    const store = new TranscriptStore({ dir, append })
-
-    let tail: Promise<void> = Promise.resolve()
-    for (let i = 0; i < 10; i++) {
-      // Fire-and-forget exactly like the production tee — do NOT await each.
-      tail = store.append('thread-serial', { t: 'user-prompt', id: `u${i}`, text: String(i) })
-    }
-    await tail
-
-    // Ignore the one-time version header (not a conversation entry); the
-    // user-prompt entries must land in strict call order.
-    expect(
-      written
-        .map((l) => JSON.parse(l) as { t: string; text?: string })
-        .filter((e) => e.t === 'user-prompt')
-        .map((e) => e.text),
-    ).toEqual(Array.from({ length: 10 }, (_, i) => String(i)))
-  })
-
-  it('preserves order with the real fs writer over a temp dir (mirrors production concurrency)', async () => {
-    const store = storeAt()
-    const id = 'thread-serial-fs'
-
-    let tail: Promise<void> = Promise.resolve()
-    for (let i = 0; i < 20; i++) {
-      tail = store.append(id, { t: 'user-prompt', id: `u${i}`, text: String(i) })
-    }
-    await tail
-
-    const texts = (await store.read(id)).map((e) => (e as { text: string }).text)
-    expect(texts).toEqual(Array.from({ length: 20 }, (_, i) => String(i)))
-  })
-})
-
-describe('turn-outcome entries (S2)', () => {
-  it('constructs turn-complete / turn-error entries mirroring the reducer actions', () => {
-    expect(turnCompleteEntry()).toEqual({ t: 'turn-complete' })
-    expect(turnErrorEntry('boom')).toEqual({ t: 'turn-error', message: 'boom' })
-  })
-
-  it('survives a write+read round-trip (recognized by the reader)', async () => {
-    const store = storeAt()
-    const id = 'thread-outcome'
-    await store.append(id, turnCompleteEntry())
-    await store.append(id, turnErrorEntry('explode'))
-    expect(await store.read(id)).toEqual([{ t: 'turn-complete' }, { t: 'turn-error', message: 'explode' }])
-  })
-  // The fold of these entries through conversationReducer is asserted renderer-side
-  // (src/renderer/src/conversation/reducer.test.ts, "transcript replay contract")
-  // — a main-project test can't import the reducer across the composite boundary.
-})
-
-describe('sessionIdFromPayload (S3 routing)', () => {
+describe('sessionIdFromPayload (routing)', () => {
   it('extracts the sessionId from session/update and session/request_permission payloads', () => {
+    expect(sessionIdFromPayload({ method: 'session/update', params: { sessionId: 'sess-1' } })).toBe(
+      'sess-1',
+    )
     expect(
-      sessionIdFromPayload({ method: 'session/update', params: { sessionId: 's1', update: {} } }),
-    ).toBe('s1')
-    expect(
-      sessionIdFromPayload({ id: 1, method: 'session/request_permission', params: { sessionId: 's2' } }),
-    ).toBe('s2')
+      sessionIdFromPayload({
+        method: 'session/request_permission',
+        id: 3,
+        params: { sessionId: 'sess-2' },
+      }),
+    ).toBe('sess-2')
   })
 
   it('returns null when no string sessionId is present (lifecycle / garbage)', () => {
-    expect(sessionIdFromPayload({ type: 'exit', info: { code: 0 } })).toBeNull()
-    expect(sessionIdFromPayload({ params: { sessionId: 5 } })).toBeNull()
+    expect(sessionIdFromPayload({ type: 'exit', code: 0 })).toBeNull()
+    expect(sessionIdFromPayload({ method: 'session/update', params: { sessionId: 7 } })).toBeNull()
     expect(sessionIdFromPayload(null)).toBeNull()
     expect(sessionIdFromPayload('nope')).toBeNull()
   })
@@ -351,56 +119,31 @@ describe('titleFromSessionInfoUpdate (auto-title capture)', () => {
     expect(
       titleFromSessionInfoUpdate({
         method: 'session/update',
-        params: { sessionId: 's1', update: { sessionUpdate: 'session_info_update', title: 'Refactor @auth.py' } },
+        params: {
+          sessionId: 's',
+          update: { sessionUpdate: 'session_info_update', title: 'Fix the bug' },
+        },
       }),
-    ).toBe('Refactor @auth.py')
+    ).toBe('Fix the bug')
   })
 
-  it('returns null for other session/update kinds and non-title payloads', () => {
-    // A different sessionUpdate discriminant — not a title event.
+  it('returns null for other session/update kinds, blank titles, and non-update payloads', () => {
     expect(
       titleFromSessionInfoUpdate({
         method: 'session/update',
-        params: { sessionId: 's1', update: { sessionUpdate: 'agent_message_chunk', content: {} } },
-      }),
-    ).toBeNull()
-    // Right discriminant but empty/missing/non-string title → skip (no clobber with '').
-    expect(
-      titleFromSessionInfoUpdate({
-        method: 'session/update',
-        params: { sessionId: 's1', update: { sessionUpdate: 'session_info_update', title: '' } },
+        params: {
+          sessionId: 's',
+          update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'x' } },
+        },
       }),
     ).toBeNull()
     expect(
       titleFromSessionInfoUpdate({
         method: 'session/update',
-        params: { sessionId: 's1', update: { sessionUpdate: 'session_info_update', title: 7 } },
+        params: { sessionId: 's', update: { sessionUpdate: 'session_info_update', title: '' } },
       }),
     ).toBeNull()
-    // Wrong method / garbage.
-    expect(titleFromSessionInfoUpdate({ method: 'session/request_permission', params: {} })).toBeNull()
-    expect(titleFromSessionInfoUpdate({ method: 'session/update', params: {} })).toBeNull()
+    expect(titleFromSessionInfoUpdate({ type: 'exit' })).toBeNull()
     expect(titleFromSessionInfoUpdate(null)).toBeNull()
-    expect(titleFromSessionInfoUpdate('nope')).toBeNull()
-  })
-})
-
-/**
- * Permission-response routing under multiplexing (TB5 #34). Several Threads share
- * one agent; a permission response must tee to the Thread it ANSWERS (by its
- * explicit threadId), NOT the agent's last-prompted Thread. This pins the
- * per-threadId contract `respondPermission` now uses (it tees by args.threadId,
- * not the agentId -> threadId map that would misroute after a sibling prompt).
- */
-describe('resolve-permission routing by threadId (TB5 multiplex)', () => {
-  it('tees a resolve-permission entry to the answered Thread, not a sibling', async () => {
-    const store = storeAt()
-    // Thread A has a pending permission; meanwhile sibling B was the last prompted.
-    await store.append('perm-A', resolvePermissionEntry('req-1', 'allow-once'))
-
-    const a = await store.read('perm-A')
-    expect(a).toEqual([{ t: 'resolve-permission', requestId: 'req-1', optionId: 'allow-once', name: null }])
-    // The sibling's log is untouched — the entry did not misroute to B.
-    expect(await store.read('perm-B')).toEqual([])
   })
 })

--- a/apps/desktop/src/main/persistence/transcript.ts
+++ b/apps/desktop/src/main/persistence/transcript.ts
@@ -1,29 +1,22 @@
-import { appendFile, readFile, unlink } from 'node:fs/promises'
-import { join } from 'node:path'
-import type { ReadTranscriptResult, TranscriptEntry, TranscriptImageRef } from '../../shared/ipc'
+import type { TranscriptEntry, TranscriptImageRef } from '../../shared/ipc'
 
 /**
- * The per-Thread visible-conversation transcript we OWN (ADR-0005). The main
- * process tees the conversation INPUTS — the user's prompt, each streamed
- * `session/update` payload, the turn outcome, and permission responses — to an
- * append-only JSONL file (`<Thread id>.jsonl`) as they cross the IPC chokepoints.
- * On reopen (TB3) the log replays through the renderer reducer to rebuild the
- * view with NO `vibe-acp` process. The renderer stays pure (ADR-0001) — it never
- * writes here.
+ * The transcript ENTRY VOCABULARY + legacy-JSONL parsing (ADR-0005/0019). The
+ * live store is `SqliteTranscriptStore` (the `transcript_entries` event log);
+ * what remains here is engine-independent:
  *
- * `TranscriptEntry` (the entry union, mirroring the reducer's `ConversationAction`
- * inputs) lives in `src/shared/ipc.ts` so the renderer replay can name it across
- * the composite project boundary; re-exported here for the main-side writers.
+ *  - the entry builders main's tee chokepoints use (mirroring the reducer's
+ *    `ConversationAction` inputs — `TranscriptEntry` itself lives in shared/ipc
+ *    so the renderer replay can name it);
+ *  - the pure payload extractors (`sessionIdFromPayload`,
+ *    `titleFromSessionInfoUpdate`) used for event routing + auto-title capture;
+ *  - `parseTranscript`/`isTranscriptEntry`/`transcriptVersionOf` — the tolerant
+ *    legacy-JSONL reader the ONE-TIME importer (`import-legacy-transcripts`)
+ *    still needs for pre-SQLite `transcripts/*.jsonl` files (torn trailing
+ *    lines skipped, the version-header line dropped).
  *
- * SEAM CONTRACT (ADR-0005 hardening): this class is the ONLY reader/writer of the
- * transcript files. No other module may build a `<threadId>.jsonl` path or touch
- * that dir — the `userData` transcripts dir is single-sourced in `src/main/index.ts`
- * and injected here. Keep it that way so the JSONL→SQLite swap stays a drop-in.
- *
- * SCHEMA VERSIONING: each log's FIRST line is a version header (see
- * `TRANSCRIPT_SCHEMA_VERSION`), so a future reader/migrator can tell which format
- * a file is in. Legacy logs predate the header and are read as v1. The header is
- * NOT a conversation entry — replay skips it (`isTranscriptEntry` rejects it).
+ * The legacy JSONL `TranscriptStore` engine was removed in #298 after the
+ * migration soak; `.bak` files remain on disk as the rollback path.
  */
 export type { TranscriptEntry }
 
@@ -37,11 +30,6 @@ export const TRANSCRIPT_SCHEMA_VERSION = 1
 /** The header line's discriminator tag. Deliberately outside the entry union so
  * `isTranscriptEntry` drops it and replay never sees it as a conversation event. */
 const TRANSCRIPT_HEADER_TAG = '__transcript_header'
-
-/** The version-header record written as line 1 of a fresh log. */
-function transcriptHeader(): { t: typeof TRANSCRIPT_HEADER_TAG; v: number } {
-  return { t: TRANSCRIPT_HEADER_TAG, v: TRANSCRIPT_SCHEMA_VERSION }
-}
 
 /**
  * The format version of a raw transcript: the `v` from its header line, or `1`
@@ -154,162 +142,6 @@ export function titleFromSessionInfoUpdate(payload: unknown): string | null {
   if ((update as { sessionUpdate?: unknown }).sessionUpdate !== 'session_info_update') return null
   const title = (update as { title?: unknown }).title
   return typeof title === 'string' && title.length > 0 ? title : null
-}
-
-/**
- * The injectable seam: where the logs live and how to append a line. Production
- * wires `node:fs/promises` + a `userData` transcripts dir; tests pass a temp dir
- * (and may stub `append` to simulate a failing disk), mirroring MetadataStore.
- */
-export interface TranscriptDeps {
-  /** Directory holding the `<threadId>.jsonl` files. */
-  dir: string
-  /** Append a line to a file (created if absent). Defaults to `fs.appendFile`. */
-  append?: (path: string, line: string) => Promise<void>
-  /** Read a Thread's whole log. Defaults to `fs.readFile`. */
-  readFile?: (path: string) => Promise<string>
-  /** Remove a Thread's log file (TB6 delete). Defaults to `fs.unlink`. */
-  unlink?: (path: string) => Promise<void>
-}
-
-export class TranscriptStore {
-  private readonly dir: string
-  private readonly appendFn: (path: string, line: string) => Promise<void>
-  private readonly readFileFn: (path: string) => Promise<string>
-  private readonly unlinkFn: (path: string) => Promise<void>
-  /**
-   * One serialized promise chain per Thread (keyed by log path). Each `append`
-   * links onto its Thread's tail SYNCHRONOUSLY (read-then-set with no `await`
-   * between), so appends run in CALL order even when fired concurrently
-   * fire-and-forget — without this, two un-awaited `appendFile`s to the same
-   * file race and land out of order, corrupting replay (e.g. a chunk's text
-   * scrambles, or a `tool_call_update` folds before its `tool_call`).
-   */
-  private readonly tails = new Map<string, Promise<void>>()
-  /**
-   * Threads whose header we've already ensured this session (so we don't re-check
-   * on every append). Cleared on `delete` so a re-created log gets a fresh header.
-   * Restart-safe because `ensureHeader` checks the file's CONTENTS, not this set,
-   * to decide whether to write — the set is only a per-session fast-path.
-   */
-  private readonly headerEnsured = new Set<string>()
-
-  constructor(deps: TranscriptDeps) {
-    this.dir = deps.dir
-    this.appendFn = deps.append ?? ((path, line) => appendFile(path, line, 'utf8'))
-    this.readFileFn = deps.readFile ?? ((path) => readFile(path, 'utf8'))
-    this.unlinkFn = deps.unlink ?? unlink
-  }
-
-  /** Absolute path of a Thread's log. */
-  private pathFor(threadId: string): string {
-    return join(this.dir, `${threadId}.jsonl`)
-  }
-
-  /**
-   * Append one entry as a single JSON line to the Thread's log, serialized after
-   * the Thread's prior appends so call order is preserved. Best-effort by design
-   * (mirrors the guarded metadata writes): each link swallows its own I/O error
-   * — a failed append can't break the live conversation NOR poison the chain for
-   * the entries after it (losing one line beats wedging the turn or the order).
-   */
-  append(threadId: string, entry: TranscriptEntry): Promise<void> {
-    const path = this.pathFor(threadId)
-    const line = `${JSON.stringify(entry)}\n`
-    const prev = this.tails.get(threadId) ?? Promise.resolve()
-    const next = prev
-      // Ensure the version header is line 1 BEFORE this entry, inside the same
-      // serialized chain so it can't race a concurrent append.
-      .then(() => this.ensureHeader(threadId, path))
-      .then(() => this.appendFn(path, line))
-      .catch(() => {
-        // A transcript write failure is non-fatal — the conversation proceeds, and
-        // the chain stays alive (resolved) so later appends still run in order.
-      })
-    this.tails.set(threadId, next)
-    return next
-  }
-
-  /**
-   * Guarantee a fresh log's FIRST line is the version header, exactly once per
-   * file. Restart-safe: it checks the file's CURRENT contents rather than an
-   * in-memory "first append" flag, so after a restart an existing non-empty log
-   * (header, or a legacy header-less v1 log) is left intact and only a brand-new
-   * or empty file gets the header. Self-guarded: a header read/write failure is
-   * swallowed so it can never cost the entry that follows it — a missing header
-   * simply reads back as v1.
-   */
-  private async ensureHeader(threadId: string, path: string): Promise<void> {
-    if (this.headerEnsured.has(threadId)) return
-    this.headerEnsured.add(threadId)
-    try {
-      let existing = ''
-      try {
-        existing = await this.readFileFn(path)
-      } catch {
-        existing = '' // ENOENT — a brand-new log
-      }
-      if (existing.length === 0) {
-        await this.appendFn(path, `${JSON.stringify(transcriptHeader())}\n`)
-      }
-    } catch {
-      // Header write failed — proceed to append the entry regardless. Losing the
-      // header (reads back as v1) must never lose the conversation line.
-    }
-  }
-
-  /**
-   * Read a Thread's log into its entry array (the TB3 replay source). A missing
-   * log yields `[]`; a malformed/partial trailing line is skipped, never fatal.
-   */
-  async read(threadId: string): Promise<TranscriptEntry[]> {
-    let raw: string
-    try {
-      raw = await this.readFileFn(this.pathFor(threadId))
-    } catch {
-      // No log yet (ENOENT) — an unwritten Thread reads back empty.
-      return []
-    }
-    return parseTranscript(raw)
-  }
-
-  /**
-   * The tiered-read seam method (ADR-0019, #297) on the LEGACY engine: JSONL
-   * never snapshots, so this is always the full log as the tail with no
-   * snapshot and a meaningless-by-design `lastSeq: 0` (the renderer's put is
-   * a no-op below, so the horizon is never echoed anywhere).
-   */
-  async readWithSnapshot(threadId: string): Promise<ReadTranscriptResult> {
-    return { snapshot: null, tail: await this.read(threadId), lastSeq: 0 }
-  }
-
-  /** Fold snapshots don't exist on the legacy engine — a documented no-op. */
-  async putSnapshot(): Promise<void> {}
-
-  /**
-   * Delete a Thread's log (TB6 #35). Best-effort by design, mirroring the guarded
-   * appends: a MISSING file (a never-prompted draft has no JSONL) is a no-op, and
-   * ANY unlink failure is swallowed — tearing down our records must never throw,
-   * since the metadata record is already being removed alongside (ADR-0005).
-   *
-   * Dropping the Thread's append-chain tail only stops FUTURE chained appends —
-   * it does NOT cancel an `appendFile` already in flight (which, with flag 'a',
-   * would recreate the file after the unlink) nor a fresh tee arriving on a new
-   * chain. That's acceptable solely because delete is COLD-LIST-ONLY today: no
-   * live agent is streaming appends to a Thread being deleted from the cold list.
-   * This MUST be revisited before wiring delete into the live `ConnectedWorkspace`
-   * thread list — do NOT rely on this tail-drop as a real cancellation guard.
-   */
-  async delete(threadId: string): Promise<void> {
-    this.tails.delete(threadId)
-    // Forget the header fast-path so a re-created log for this id re-writes it.
-    this.headerEnsured.delete(threadId)
-    try {
-      await this.unlinkFn(this.pathFor(threadId))
-    } catch {
-      // No log (ENOENT) or an unremovable file — non-fatal; deletion proceeds.
-    }
-  }
 }
 
 /**

--- a/apps/desktop/src/main/thread-binding.test.ts
+++ b/apps/desktop/src/main/thread-binding.test.ts
@@ -1,10 +1,9 @@
-import { describe, it, expect, afterAll } from 'vitest'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { describe, it, expect } from 'vitest'
 import { randomUUID } from 'node:crypto'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
 import { ensureBoundSession, resolveContinueTarget, type SessionBinder } from './thread-binding'
-import { MetadataStore } from './persistence/metadata-store'
+import { openStateDb } from './persistence/sqlite-db'
+import { SqliteMetadataStore } from './persistence/sqlite-metadata-store'
+import { STATE_MIGRATIONS } from './persistence/state-migrations'
 import { SessionLoadError, WorkspaceAgentError } from './workspace-agent'
 import type { ThreadInfo } from '../shared/ipc'
 
@@ -19,8 +18,12 @@ import type { ThreadInfo } from '../shared/ipc'
  * `session/new` calls) over a REAL temp-dir store — never a live `vibe-acp`.
  */
 
-const dir = mkdtempSync(join(tmpdir(), 'vibe-binding-'))
-afterAll(() => rmSync(dir, { recursive: true, force: true }))
+/** An isolated in-memory metadata store per test (#298 — the JSON engine is gone). */
+function memStore(): SqliteMetadataStore {
+  return new SqliteMetadataStore({
+    stateDb: openStateDb({ path: ':memory:', migrations: STATE_MIGRATIONS }),
+  })
+}
 
 /**
  * A fake binder that mints a fresh sessionId per `openThread` (one per session/new)
@@ -81,7 +84,7 @@ function fakeBinder(opts: {
 
 describe('ensureBoundSession', () => {
   it('persists a renderer-minted draft id on first prompt (nothing before), binds it, and reuses it', async () => {
-    const store = new MetadataStore({ filePath: join(dir, 'bind.json') })
+    const store = memStore()
     await store.load()
     const ws = await store.upsertWorkspace({ dir: '/proj/bind' })
     // #58: the draft is renderer-only — its id is minted in the renderer and NO
@@ -123,7 +126,7 @@ describe('ensureBoundSession', () => {
   })
 
   it('reuses a preopened primary session on first prompt — binds it, NO session/new (ADR-0012)', async () => {
-    const store = new MetadataStore({ filePath: join(dir, 'reuse.json') })
+    const store = memStore()
     await store.load()
     const ws = await store.upsertWorkspace({ dir: '/proj/reuse' })
     const threadId = randomUUID()
@@ -161,7 +164,7 @@ describe('ensureBoundSession', () => {
   })
 
   it('mints a fresh session/new for a draft when NO preopened primary session is supplied', async () => {
-    const store = new MetadataStore({ filePath: join(dir, 'no-preopen.json') })
+    const store = memStore()
     await store.load()
     const ws = await store.upsertWorkspace({ dir: '/proj/no-preopen' })
     const agent = fakeOpener()
@@ -182,7 +185,7 @@ describe('ensureBoundSession', () => {
   })
 
   it('binds two drafts under one agent to two distinct sessions (multi-Thread per Workspace)', async () => {
-    const store = new MetadataStore({ filePath: join(dir, 'multi.json') })
+    const store = memStore()
     await store.load()
     const ws = await store.upsertWorkspace({ dir: '/proj/multi' })
     // Two renderer-minted draft ids, neither persisted until its first prompt (#58).
@@ -211,11 +214,11 @@ describe('ensureBoundSession', () => {
  */
 describe('ensureBoundSession — reopened Thread (TB4 #33)', () => {
   async function reopenedStore(sessionId: string): Promise<{
-    store: MetadataStore
+    store: SqliteMetadataStore
     workspaceId: string
     threadId: string
   }> {
-    const store = new MetadataStore({ filePath: join(dir, `reopen-${randomName()}.json`) })
+    const store = memStore()
     await store.load()
     const ws = await store.upsertWorkspace({ dir: `/proj/${randomName()}` })
     const thread = await store.upsertThread({ workspaceId: ws.id, sessionId })
@@ -297,7 +300,7 @@ describe('ensureBoundSession — reopened Thread (TB4 #33)', () => {
  */
 describe('resolveContinueTarget — continue without opening a Thread (TB4 #33)', () => {
   it('seeds from the existing record without persisting a new Thread, then resumes on first prompt', async () => {
-    const store = new MetadataStore({ filePath: join(dir, `continue-${randomName()}.json`) })
+    const store = memStore()
     await store.load()
     const ws = await store.upsertWorkspace({ dir: '/proj/continue' })
     const existing = await store.upsertThread({ workspaceId: ws.id, sessionId: 'cursor-1', title: 'Earlier' })
@@ -330,7 +333,7 @@ describe('resolveContinueTarget — continue without opening a Thread (TB4 #33)'
   })
 
   it('returns null for an unknown Thread id (caller falls back to opening fresh)', async () => {
-    const store = new MetadataStore({ filePath: join(dir, `continue-miss-${randomName()}.json`) })
+    const store = memStore()
     await store.load()
     expect(resolveContinueTarget(store, 'no-such-thread')).toBeNull()
   })

--- a/docs/adr/0019-sqlite-persistence-node-sqlite-event-log-projections.md
+++ b/docs/adr/0019-sqlite-persistence-node-sqlite-event-log-projections.md
@@ -108,8 +108,16 @@ sub-millisecond. Per-event persistence and conversation loads are a non-issue.
   real Developer-ID releases are unaffected. For local smokes, re-sign without the runtime flag:
   `codesign --force --deep -s - "dist/mac-arm64/Vibe Mistro.app"`.
 - One database file concentrates what per-Thread JSONL spread out. WAL + transactions make torn
-  writes far rarer than torn JSONL lines; slice 6 (#298) decides a `VACUUM INTO` backup for the
-  residual risk.
+  writes far rarer than torn JSONL lines; **decided in #298: a daily rotating `VACUUM INTO` backup**
+  (`state-backup.ts`, newest 3 kept under `userData/backups/`, best-effort off the launch path)
+  covers the residual. Manual restore: quit, replace `state.sqlite` with a backup (drop `-wal`/
+  `-shm`), relaunch — projections ride inside the copy.
+- **Legacy engines removed in #298** (post-soak): the JSON `MetadataStore` / JSONL `TranscriptStore`
+  classes and the `VIBE_MISTRO_FORCE_JSON` escape hatch are gone; the one-time importer (and its
+  tolerant legacy parsers) stays for profiles that skipped the soak releases, and `.bak` files are
+  never touched. The open-failure fallback is now an in-memory database (non-durable session,
+  loudly logged, imports skipped) rather than the JSON engine. `PRAGMA optimize` + close (WAL
+  checkpoint) run at quit.
 - Changing conversation item shapes requires bumping the reducer schema version constant — the
   cost of a stale snapshot is one full re-fold per Thread, lazily.
 - The migration is delivered as slices #294–#298; this ADR is slice #293's output. No persistence


### PR DESCRIPTION
Closes #298 — and with it the SQLite persistence epic (#292): all six slices shipped.

## Soak note, up front

The issue scheduled this slice *after a soak release*; it ships now at the user's direction. The risk profile is acceptable because every rollback path survives: `.bak` files are never touched, the importer stays in-tree permanently for skipped-release profiles, and the net diff **removes 1,555 lines** of legacy engine against 570 added.

## What this does

- **Legacy engines removed**: the JSON `MetadataStore` and JSONL `TranscriptStore` classes and the `VIBE_MISTRO_FORCE_JSON` escape hatch are gone. What survives is exactly what the one-time importer needs — `parseLegacyMetadata` (the removed engine's `load()` extracted verbatim: envelope handling, fail-closed on newer versions, per-record shape guards, flag normalization) and `parseTranscript` + the entry builders/extractors, all still pinned by tests.
- **Failure fallback rethought**: if `state.sqlite` can't open, the session now runs on an **in-memory database** (loudly logged, `engine: 'memory'`) instead of the JSON engine — a disk that broken wouldn't have served JSON either. Imports are *skipped* on the fallback so the `.bak` rename can never tombstone files whose imported rows would evaporate with the session. `MainDeps.transcript`/`stateDb` became non-null, collapsing the null-guard forks.
- **Quit path**: `PRAGMA optimize` + db close (WAL checkpoint) on `will-quit`, best-effort. Verified in the packaged app: after a graceful quit the `-wal`/`-shm` files are gone — checkpointed into the main db.
- **Backup — the ADR's open decision, now decided and implemented**: daily rotating `VACUUM INTO` under `userData/backups/` (newest 3 kept, freshness derived from the filename stamp — no bookkeeping state), scheduled 5s after ready, refused on a locked db, never on the memory fallback. Manual restore path documented in `state-backup.ts` and ADR-0019. Backups are proven **restorable** in tests (a copy opens as a working state db with the data).
- **Search**: the legacy scan branch is deleted — FTS is the only prose path; a locked (newer-build) db degrades to title-only, consistent with its empty stores.
- **Docs swept**: CLAUDE.md's persistence and reopen sections now describe the SQLite architecture (event log + two projections, tiered hydrate, importer, backups); ADR-0019 records the backup decision and removal consequences.

## Tests

1,490 green (net: legacy-engine suites replaced by pure-function tests for the surviving parsers, plus the new backup suite — create/fresh-skip/rotate/foreign-files-untouched/locked-refusal/restorability/mkdir-failure). `thread-binding` tests re-pointed at `:memory:` SQLite stores.

## Packaged verification — all three profile shapes

| profile | result |
|---|---|
| **Fresh** (empty userData) | boots, `engine: sqlite`, db created |
| **Skipped-releases** (full legacy: `metadata.json` + 18 JSONL files) | both imports in one launch — 5 threads + 13 orphans handled, `.bak`s in place |
| **Migrated** (current real-profile copy) | backup file written on schedule; graceful quit checkpoints the WAL away |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QsAPKdeg6ML7Shm1sVYYZ