### PR TITLE
[codex] Structured composer draft store

### DIFF
--- a/apps/desktop/src/renderer/src/conversation/Composer.tsx
+++ b/apps/desktop/src/renderer/src/conversation/Composer.tsx
@@ -21,7 +21,7 @@ import { Card } from '../ui/card'
 import { IconButton } from '../ui/icon-button'
 import { Textarea } from '../ui/textarea'
 import type { AcpCommand } from './reducer'
-import { getDraft, setDraft as persistDraft, clearDraft } from './composer-draft-store'
+import { useComposerDraftText } from './composer-draft-store'
 import {
   appendText,
   subscribeComposerInsert,
@@ -169,7 +169,7 @@ export function Composer({
   // REMOUNTS on a Thread switch — the lazy initializer seeds THAT Thread's stored
   // draft fresh, with no stale carry-over (no re-seed effect needed). Reading here
   // must not write, so we only persist on change/send below.
-  const [draft, setDraft] = useState(() => getDraft(window.localStorage, threadId))
+  const [draft, setDraft, clearPersistedDraft] = useComposerDraftText(threadId)
   // Images staged in the composer, awaiting send (#100). Renderer-only, ephemeral:
   // this view remounts on a Thread switch (keyed by threadId), so the strip starts
   // empty per Thread. Kept on a failed send so the user can retry / switch model.
@@ -207,9 +207,8 @@ export function Composer({
   // Write-through: keep React state and the persisted draft (#60) in lockstep. The
   // autocomplete hook calls this when it accepts a completion; the textarea's onChange
   // and the composer-insert subscription use it too.
-  function writeDraft(next: string): void {
+  function writeDraft(next: string | ((current: string) => string)): void {
     setDraft(next)
-    persistDraft(window.localStorage, threadId, next)
   }
 
   // The `/` (#95) and `@` (#190) autocompletes, unified into ONE state machine over two
@@ -243,7 +242,7 @@ export function Composer({
   // same module-level channel keyed by threadId — appended verbatim (no `@`).
   useEffect(() => {
     return subscribeComposerInsertText(threadId, (text) => {
-      writeDraft(appendText(getDraft(window.localStorage, threadId), text))
+      writeDraft((current) => appendText(current, text))
       inputRef.current?.focus()
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -365,7 +364,7 @@ export function Composer({
       // follow-up. It auto-flushes on the next turn end.
       followUps.enqueue({ id: nextQueueId(), text, images })
       setDraft('')
-      clearDraft(window.localStorage, threadId)
+      clearPersistedDraft()
       setPendingImages([])
       setPendingContexts([])
       return
@@ -382,14 +381,13 @@ export function Composer({
     setPendingImages([])
     setPendingContexts([])
     setDraft('')
-    clearDraft(window.localStorage, threadId)
+    clearPersistedDraft()
     const ok = await submitPrompt(text, images)
     if (!ok) {
       // Restore the PRE-serialize prose + chips (not the flattened wire text), so a
       // retry re-serializes cleanly instead of double-prepending the invocation.
       setDraft((current) => {
         if (current.length > 0) return current
-        persistDraft(window.localStorage, threadId, proseBefore)
         return proseBefore
       })
       setPendingImages((current) => (current.length > 0 ? current : staged))

--- a/apps/desktop/src/renderer/src/conversation/composer-draft-store.test.ts
+++ b/apps/desktop/src/renderer/src/conversation/composer-draft-store.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect } from 'vitest'
 import {
   COMPOSER_DRAFT_STORAGE_KEY,
+  LEGACY_COMPOSER_DRAFT_STORAGE_KEY,
   clearDraft,
+  createComposerDraftStore,
+  getComposerDraft,
   getDraft,
+  setComposerDraft,
   setDraft,
   type DraftStorage,
 } from './composer-draft-store'
@@ -30,10 +34,45 @@ function fakeStorage(): DraftStorage & { map: Map<string, string> } {
 }
 
 describe('getDraft / setDraft round-trip', () => {
+  it('stores and reads back a structured draft keyed by threadId', () => {
+    const storage = fakeStorage()
+    setComposerDraft(storage, 't1', {
+      prompt: 'hello world',
+      inlineTokens: [],
+      contextAttachments: [],
+      images: [],
+      nonPersistedImageIds: [],
+    })
+    expect(getComposerDraft(storage, 't1')).toEqual({
+      prompt: 'hello world',
+      inlineTokens: [],
+      contextAttachments: [],
+      images: [],
+      nonPersistedImageIds: [],
+    })
+  })
+
   it('stores and reads back a draft keyed by threadId', () => {
     const storage = fakeStorage()
     setDraft(storage, 't1', 'hello world')
     expect(getDraft(storage, 't1')).toBe('hello world')
+  })
+
+  it('persists structured drafts behind explicit schema metadata', () => {
+    const storage = fakeStorage()
+    setDraft(storage, 't1', 'hello world')
+    expect(JSON.parse(storage.map.get(COMPOSER_DRAFT_STORAGE_KEY) ?? '{}')).toEqual({
+      schemaVersion: 1,
+      drafts: {
+        t1: {
+          prompt: 'hello world',
+          inlineTokens: [],
+          contextAttachments: [],
+          images: [],
+          nonPersistedImageIds: [],
+        },
+      },
+    })
   })
 
   it('returns "" for an absent thread', () => {
@@ -136,6 +175,85 @@ describe('per-Thread isolation', () => {
     setDraft(storage, 't1', '')
     expect(getDraft(storage, 't1')).toBe('')
     expect(getDraft(storage, 't2')).toBe('two')
+  })
+})
+
+describe('composer draft external store', () => {
+  it('notifies subscribers when a Thread draft changes and exposes per-Thread snapshots', () => {
+    const storage = fakeStorage()
+    const store = createComposerDraftStore(storage)
+    let notifications = 0
+    const unsubscribe = store.subscribe(() => {
+      notifications += 1
+    })
+
+    store.setText('t1', 'one')
+
+    expect(notifications).toBe(1)
+    expect(store.getSnapshot('t1').prompt).toBe('one')
+    expect(store.getTextSnapshot('t1')).toBe('one')
+    expect(store.getSnapshot('t2').prompt).toBe('')
+
+    unsubscribe()
+    store.setText('t1', 'two')
+    expect(notifications).toBe(1)
+    expect(store.getSnapshot('t1').prompt).toBe('two')
+  })
+})
+
+describe('lazy migration from text-only v1 drafts', () => {
+  it('migrates text-only drafts to structured drafts and removes the legacy key after writing v2', () => {
+    const storage = fakeStorage()
+    storage.map.set(
+      LEGACY_COMPOSER_DRAFT_STORAGE_KEY,
+      JSON.stringify({
+        t1: 'keep this\n\n<attached_files>\n@src/main.ts\n</attached_files>',
+        t2: 'second',
+      }),
+    )
+
+    expect(getComposerDraft(storage, 't1')).toEqual({
+      prompt: 'keep this\n\n<attached_files>\n@src/main.ts\n</attached_files>',
+      inlineTokens: [],
+      contextAttachments: [],
+      images: [],
+      nonPersistedImageIds: [],
+    })
+    expect(getDraft(storage, 't2')).toBe('second')
+    expect(storage.map.has(LEGACY_COMPOSER_DRAFT_STORAGE_KEY)).toBe(false)
+    expect(JSON.parse(storage.map.get(COMPOSER_DRAFT_STORAGE_KEY) ?? '{}')).toEqual({
+      schemaVersion: 1,
+      drafts: {
+        t1: {
+          prompt: 'keep this\n\n<attached_files>\n@src/main.ts\n</attached_files>',
+          inlineTokens: [],
+          contextAttachments: [],
+          images: [],
+          nonPersistedImageIds: [],
+        },
+        t2: {
+          prompt: 'second',
+          inlineTokens: [],
+          contextAttachments: [],
+          images: [],
+          nonPersistedImageIds: [],
+        },
+      },
+    })
+  })
+
+  it('keeps the legacy key and still returns the text draft when the v2 migration write fails', () => {
+    const storage = fakeStorage()
+    storage.map.set(LEGACY_COMPOSER_DRAFT_STORAGE_KEY, JSON.stringify({ t1: 'local only' }))
+    const originalSetItem = storage.setItem
+    storage.setItem = (key, value) => {
+      if (key === COMPOSER_DRAFT_STORAGE_KEY) throw new Error('quota exceeded')
+      originalSetItem(key, value)
+    }
+
+    expect(getDraft(storage, 't1')).toBe('local only')
+    expect(storage.map.has(LEGACY_COMPOSER_DRAFT_STORAGE_KEY)).toBe(true)
+    expect(storage.map.has(COMPOSER_DRAFT_STORAGE_KEY)).toBe(false)
   })
 })
 

--- a/apps/desktop/src/renderer/src/conversation/composer-draft-store.ts
+++ b/apps/desktop/src/renderer/src/conversation/composer-draft-store.ts
@@ -1,3 +1,5 @@
+import { useCallback, useSyncExternalStore } from 'react'
+
 /**
  * Per-Thread composer drafts (#60): the unsent text in a Thread's composer, kept
  * so it survives any unmount — a cold↔live transition, an agent eviction/re-warm
@@ -14,8 +16,12 @@
  * malformed blob, an absent key, and a quota/security exception.
  */
 
-/** The single localStorage key holding the `threadId -> text` map. */
-export const COMPOSER_DRAFT_STORAGE_KEY = 'vibe-mistro:composer-drafts:v1'
+/** The legacy localStorage key holding the `threadId -> text` map. */
+export const LEGACY_COMPOSER_DRAFT_STORAGE_KEY = 'vibe-mistro:composer-drafts:v1'
+
+/** The versioned localStorage key holding the structured `threadId -> draft` map. */
+export const COMPOSER_DRAFT_STORAGE_KEY = 'vibe-mistro:composer-drafts:v2'
+export const COMPOSER_DRAFT_SCHEMA_VERSION = 1
 
 /** The slice of the Web Storage API we depend on — `window.localStorage` satisfies it. */
 export interface DraftStorage {
@@ -24,8 +30,88 @@ export interface DraftStorage {
   removeItem(key: string): void
 }
 
-/** The persisted shape: a thread id -> unsent text map. */
-type DraftMap = Record<string, string>
+export interface ComposerDraft {
+  prompt: string
+  inlineTokens: unknown[]
+  contextAttachments: unknown[]
+  images: unknown[]
+  nonPersistedImageIds: string[]
+}
+
+/** The persisted shape: a thread id -> structured draft map. */
+type DraftMap = Record<string, ComposerDraft>
+
+interface PersistedComposerDrafts {
+  schemaVersion: typeof COMPOSER_DRAFT_SCHEMA_VERSION
+  drafts: DraftMap
+}
+
+const EMPTY_COMPOSER_DRAFT: ComposerDraft = Object.freeze({
+  prompt: '',
+  inlineTokens: Object.freeze([]) as unknown as unknown[],
+  contextAttachments: Object.freeze([]) as unknown as unknown[],
+  images: Object.freeze([]) as unknown as unknown[],
+  nonPersistedImageIds: Object.freeze([]) as unknown as string[],
+})
+
+function emptyComposerDraft(): ComposerDraft {
+  return {
+    prompt: '',
+    inlineTokens: [],
+    contextAttachments: [],
+    images: [],
+    nonPersistedImageIds: [],
+  }
+}
+
+function isEmptyDraft(draft: ComposerDraft): boolean {
+  return (
+    draft.prompt.trim().length === 0 &&
+    draft.inlineTokens.length === 0 &&
+    draft.contextAttachments.length === 0 &&
+    draft.images.length === 0 &&
+    draft.nonPersistedImageIds.length === 0
+  )
+}
+
+function coerceDraft(value: unknown): ComposerDraft | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null
+  const draft = value as Partial<ComposerDraft>
+  return {
+    prompt: typeof draft.prompt === 'string' ? draft.prompt : '',
+    inlineTokens: Array.isArray(draft.inlineTokens) ? draft.inlineTokens : [],
+    contextAttachments: Array.isArray(draft.contextAttachments) ? draft.contextAttachments : [],
+    images: Array.isArray(draft.images) ? draft.images : [],
+    nonPersistedImageIds: Array.isArray(draft.nonPersistedImageIds)
+      ? draft.nonPersistedImageIds.filter((id): id is string => typeof id === 'string')
+      : [],
+  }
+}
+
+function readLegacyMap(storage: DraftStorage): DraftMap {
+  let raw: string | null
+  try {
+    raw = storage.getItem(LEGACY_COMPOSER_DRAFT_STORAGE_KEY)
+  } catch {
+    return {}
+  }
+  if (raw === null) return {}
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {}
+    const map: DraftMap = {}
+    for (const [threadId, value] of Object.entries(parsed)) {
+      if (typeof value !== 'string') continue
+      map[threadId] = {
+        ...emptyComposerDraft(),
+        prompt: value,
+      }
+    }
+    return map
+  } catch {
+    return {}
+  }
+}
 
 /**
  * Read + parse the draft map, tolerating everything: an unavailable storage, an
@@ -44,7 +130,17 @@ function readMap(storage: DraftStorage | null | undefined): DraftMap {
   try {
     const parsed: unknown = JSON.parse(raw)
     if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {}
-    return parsed as DraftMap
+    const envelope = parsed as Partial<PersistedComposerDrafts>
+    if (envelope.schemaVersion !== COMPOSER_DRAFT_SCHEMA_VERSION) return {}
+    if (typeof envelope.drafts !== 'object' || envelope.drafts === null || Array.isArray(envelope.drafts)) {
+      return {}
+    }
+    const map: DraftMap = {}
+    for (const [threadId, value] of Object.entries(envelope.drafts)) {
+      const draft = coerceDraft(value)
+      if (draft) map[threadId] = draft
+    }
+    return map
   } catch {
     return {}
   }
@@ -55,22 +151,48 @@ function readMap(storage: DraftStorage | null | undefined): DraftMap {
  * the last draft is pruned the whole key is REMOVED (not stored as `'{}'`), so an
  * emptied store leaves no dangling blob behind.
  */
-function writeMap(storage: DraftStorage, map: DraftMap): void {
+function writeMap(storage: DraftStorage, map: DraftMap): boolean {
   try {
     if (Object.keys(map).length === 0) {
       storage.removeItem(COMPOSER_DRAFT_STORAGE_KEY)
-      return
+      return true
     }
-    storage.setItem(COMPOSER_DRAFT_STORAGE_KEY, JSON.stringify(map))
+    storage.setItem(
+      COMPOSER_DRAFT_STORAGE_KEY,
+      JSON.stringify({ schemaVersion: COMPOSER_DRAFT_SCHEMA_VERSION, drafts: map }),
+    )
+    return true
   } catch {
     // Best-effort: a full/blocked storage must never throw from a keystroke.
+    return false
   }
 }
 
+function migrateLegacyMap(storage: DraftStorage): DraftMap {
+  const legacy = readLegacyMap(storage)
+  if (Object.keys(legacy).length === 0) return {}
+  if (!writeMap(storage, legacy)) return legacy
+  try {
+    storage.removeItem(LEGACY_COMPOSER_DRAFT_STORAGE_KEY)
+  } catch {
+    // Best-effort: failing to delete the old key must not break render.
+  }
+  return legacy
+}
+
 /** The stored draft for a Thread, or '' when absent/malformed. Never throws. */
+export function getComposerDraft(
+  storage: DraftStorage | null | undefined,
+  threadId: string,
+): ComposerDraft {
+  const map = readMap(storage)
+  if (threadId in map) return map[threadId]
+  if (!storage) return EMPTY_COMPOSER_DRAFT
+  return migrateLegacyMap(storage)[threadId] ?? EMPTY_COMPOSER_DRAFT
+}
+
 export function getDraft(storage: DraftStorage | null | undefined, threadId: string): string {
-  const text = readMap(storage)[threadId]
-  return typeof text === 'string' ? text : ''
+  return getComposerDraft(storage, threadId).prompt
 }
 
 /**
@@ -80,22 +202,32 @@ export function getDraft(storage: DraftStorage | null | undefined, threadId: str
  * is the only place we trim. A no-op (already-stored value, or pruning an absent
  * entry) skips the write.
  */
-export function setDraft(
+export function setComposerDraft(
   storage: DraftStorage | null | undefined,
   threadId: string,
-  text: string,
+  draft: ComposerDraft,
 ): void {
   if (!storage) return
   const map = readMap(storage)
-  if (text.trim().length === 0) {
+  if (isEmptyDraft(draft)) {
     if (!(threadId in map)) return
     delete map[threadId]
     writeMap(storage, map)
     return
   }
-  if (map[threadId] === text) return
-  map[threadId] = text
+  map[threadId] = draft
   writeMap(storage, map)
+}
+
+export function setDraft(
+  storage: DraftStorage | null | undefined,
+  threadId: string,
+  text: string,
+): void {
+  setComposerDraft(storage, threadId, {
+    ...emptyComposerDraft(),
+    prompt: text,
+  })
 }
 
 /**
@@ -108,4 +240,69 @@ export function clearDraft(storage: DraftStorage | null | undefined, threadId: s
   if (!(threadId in map)) return
   delete map[threadId]
   writeMap(storage, map)
+}
+
+export interface ComposerDraftStore {
+  subscribe(listener: () => void): () => void
+  getSnapshot(threadId: string): ComposerDraft
+  getTextSnapshot(threadId: string): string
+  setDraft(threadId: string, draft: ComposerDraft): void
+  setText(threadId: string, text: string): void
+  clear(threadId: string): void
+}
+
+export function createComposerDraftStore(storage: DraftStorage | null | undefined): ComposerDraftStore {
+  const listeners = new Set<() => void>()
+  function notify(): void {
+    for (const listener of listeners) listener()
+  }
+  return {
+    subscribe(listener) {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    },
+    getSnapshot(threadId) {
+      return getComposerDraft(storage, threadId)
+    },
+    getTextSnapshot(threadId) {
+      return getDraft(storage, threadId)
+    },
+    setDraft(threadId, draft) {
+      setComposerDraft(storage, threadId, draft)
+      notify()
+    },
+    setText(threadId, text) {
+      setDraft(storage, threadId, text)
+      notify()
+    },
+    clear(threadId) {
+      clearDraft(storage, threadId)
+      notify()
+    },
+  }
+}
+
+function resolveWindowStorage(): DraftStorage | null {
+  return typeof window === 'undefined' ? null : window.localStorage
+}
+
+const composerDraftStore = createComposerDraftStore(resolveWindowStorage())
+
+export function useComposerDraftText(
+  threadId: string,
+): [string, (text: string | ((current: string) => string)) => void, () => void] {
+  const prompt = useSyncExternalStore(composerDraftStore.subscribe, () =>
+    composerDraftStore.getTextSnapshot(threadId),
+  )
+  const setText = useCallback(
+    (text: string | ((current: string) => string)) => {
+      const next = typeof text === 'function' ? text(composerDraftStore.getTextSnapshot(threadId)) : text
+      composerDraftStore.setText(threadId, next)
+    },
+    [threadId],
+  )
+  const clear = useCallback(() => composerDraftStore.clear(threadId), [threadId])
+  return [prompt, setText, clear]
 }


### PR DESCRIPTION
## Summary

- Introduce structured v2 composer drafts with schema metadata and legacy v1 text-draft migration.
- Add a targeted useSyncExternalStore composer draft store/hook and wire Composer prompt text through it.
- Cover structured round-trip, per-Thread snapshots, migration success, and migration failure fallback.

## Parent

Implements #306.

## Validation

- bun run --cwd apps/desktop test src/renderer/src/conversation/composer-draft-store.test.ts
- bun run typecheck
- bun run lint
- bun run test
- bun run build