### PR TITLE
[codex] Structured composer send lifecycle

### DIFF
--- a/apps/desktop/src/renderer/src/conversation/Composer.tsx
+++ b/apps/desktop/src/renderer/src/conversation/Composer.tsx
@@ -37,12 +37,16 @@ import {
   isLongPaste,
   pastedLabel,
   removeContext,
-  serializeForSend,
   type PendingContext,
 } from './pending-contexts'
 import { nextQueueId, type FollowUpQueue } from './follow-up-queue'
 import { useComposerAutocomplete, CompletionPopover } from './use-composer-autocomplete'
 import { createCommandSource, createPathSource } from './composer-sources'
+import {
+  createComposerSendSnapshot,
+  createQueuedFollowUp,
+  restoreFailedSendSnapshot,
+} from './composer-send-lifecycle'
 
 /** Process-local counters for unique pending-image / element / review / paste-chip ids (not Math.random/Date). */
 let imageSeq = 0
@@ -178,6 +182,8 @@ export function Composer({
   // text — a `/` accept stages a skill chip here instead of splicing text in. Same
   // lifecycle as staged images: ephemeral, cleared on send/enqueue, kept on failure.
   const [pendingContexts, setPendingContexts] = useState<PendingContext[]>([])
+  const liveComposerStateRef = useRef({ prompt: draft, contexts: pendingContexts, images: pendingImages })
+  liveComposerStateRef.current = { prompt: draft, contexts: pendingContexts, images: pendingImages }
   const inputRef = useRef<HTMLTextAreaElement>(null)
   // The hidden file picker behind the 📎 button (#100).
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -347,22 +353,18 @@ export function Composer({
   // end); when idle we send immediately, preserving #100's clear-on-success /
   // keep-on-failure UX (a failed send keeps the text + staged images for retry).
   async function send(): Promise<void> {
-    // Flatten the staged context chips into the wire text (#229): the skill chip
-    // becomes the leading `/name` invocation the agent parses server-side.
-    const text = serializeForSend(draft, pendingContexts)
-    const hasContent = text.length > 0 || pendingImages.length > 0
-    if (!hasContent) return
-    const images = pendingImages.map(({ data, mimeType, previewUrl }) => ({
-      data,
-      mimeType,
-      previewUrl,
-    }))
+    const snapshot = createComposerSendSnapshot({
+      prompt: draft,
+      contexts: pendingContexts,
+      images: pendingImages,
+    })
+    if (!snapshot.hasContent) return
     if (followUps.sending) {
       // A turn is live for this Thread (authoritative module latch, not the per-
       // instance reducer snapshot which lags on a remount) — queue it (protocol forbids
       // a concurrent prompt) and clear the composer so the user can compose the next
       // follow-up. It auto-flushes on the next turn end.
-      followUps.enqueue({ id: nextQueueId(), text, images })
+      followUps.enqueue(createQueuedFollowUp(nextQueueId(), snapshot))
       setDraft('')
       clearPersistedDraft()
       setPendingImages([])
@@ -375,23 +377,18 @@ export function Composer({
     // response. The echo is already in the transcript; on a FAILED outcome we RESTORE
     // the payload for retry (#100's keep-on-failure, e.g. switching to a vision model
     // after -31008) — unless the user started composing something new meanwhile.
-    const staged = pendingImages
-    const stagedContexts = pendingContexts
-    const proseBefore = draft
     setPendingImages([])
     setPendingContexts([])
     setDraft('')
     clearPersistedDraft()
-    const ok = await submitPrompt(text, images)
+    const ok = await submitPrompt(snapshot.text, snapshot.images)
     if (!ok) {
       // Restore the PRE-serialize prose + chips (not the flattened wire text), so a
       // retry re-serializes cleanly instead of double-prepending the invocation.
-      setDraft((current) => {
-        if (current.length > 0) return current
-        return proseBefore
-      })
-      setPendingImages((current) => (current.length > 0 ? current : staged))
-      setPendingContexts((current) => (current.length > 0 ? current : stagedContexts))
+      const restored = restoreFailedSendSnapshot(snapshot, liveComposerStateRef.current)
+      setDraft(restored.prompt)
+      setPendingImages(restored.images)
+      setPendingContexts(restored.contexts)
     }
   }
 

--- a/apps/desktop/src/renderer/src/conversation/composer-send-lifecycle.test.ts
+++ b/apps/desktop/src/renderer/src/conversation/composer-send-lifecycle.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createComposerSendSnapshot,
+  createQueuedFollowUp,
+  restoreFailedSendSnapshot,
+} from './composer-send-lifecycle'
+import type { PendingContext } from './pending-contexts'
+
+describe('createComposerSendSnapshot', () => {
+  it('captures an immutable send-ready snapshot from live composer state', () => {
+    const contexts: PendingContext[] = [{ kind: 'file', path: 'src/app.ts' }]
+    const images = [
+      {
+        id: 'img:1',
+        name: 'screen.png',
+        data: 'abc',
+        mimeType: 'image/png',
+        previewUrl: 'data:image/png;base64,abc',
+      },
+    ]
+
+    const snapshot = createComposerSendSnapshot({
+      prompt: 'read this',
+      contexts,
+      images,
+    })
+
+    contexts.push({ kind: 'skill', name: 'teach' })
+    images[0].data = 'mutated'
+
+    expect(snapshot.hasContent).toBe(true)
+    expect(snapshot.text).toBe('read this\n\n<attached_files>\n@src/app.ts\n</attached_files>')
+    expect(snapshot.images).toEqual([
+      {
+        data: 'abc',
+        mimeType: 'image/png',
+        previewUrl: 'data:image/png;base64,abc',
+      },
+    ])
+    expect(snapshot.restore).toEqual({
+      prompt: 'read this',
+      contexts: [{ kind: 'file', path: 'src/app.ts' }],
+      images: [
+        {
+          id: 'img:1',
+          name: 'screen.png',
+          data: 'abc',
+          mimeType: 'image/png',
+          previewUrl: 'data:image/png;base64,abc',
+        },
+      ],
+    })
+  })
+})
+
+describe('restoreFailedSendSnapshot', () => {
+  it('restores the attempted snapshot only when the current composer is still empty', () => {
+    const snapshot = createComposerSendSnapshot({
+      prompt: 'retry this',
+      contexts: [{ kind: 'skill', name: 'teach' }],
+      images: [
+        {
+          id: 'img:1',
+          name: 'screen.png',
+          data: 'abc',
+          mimeType: 'image/png',
+          previewUrl: 'data:image/png;base64,abc',
+        },
+      ],
+    })
+
+    expect(
+      restoreFailedSendSnapshot(snapshot, {
+        prompt: '',
+        contexts: [],
+        images: [],
+      }),
+    ).toEqual(snapshot.restore)
+
+    expect(
+      restoreFailedSendSnapshot(snapshot, {
+        prompt: 'new draft',
+        contexts: [],
+        images: [],
+      }),
+    ).toEqual({
+      prompt: 'new draft',
+      contexts: [],
+      images: [],
+    })
+  })
+})
+
+describe('createQueuedFollowUp', () => {
+  it('stores the send-ready snapshot payload independently from later snapshot mutation', () => {
+    const snapshot = createComposerSendSnapshot({
+      prompt: 'queue this',
+      contexts: [],
+      images: [
+        {
+          id: 'img:1',
+          name: 'screen.png',
+          data: 'abc',
+          mimeType: 'image/png',
+          previewUrl: 'data:image/png;base64,abc',
+        },
+      ],
+    })
+
+    const queued = createQueuedFollowUp('queued:1', snapshot)
+    snapshot.images[0].data = 'mutated'
+
+    expect(queued).toEqual({
+      id: 'queued:1',
+      text: 'queue this',
+      images: [
+        {
+          data: 'abc',
+          mimeType: 'image/png',
+          previewUrl: 'data:image/png;base64,abc',
+        },
+      ],
+    })
+  })
+})

--- a/apps/desktop/src/renderer/src/conversation/composer-send-lifecycle.ts
+++ b/apps/desktop/src/renderer/src/conversation/composer-send-lifecycle.ts
@@ -1,0 +1,84 @@
+import { serializeForSend, type PendingContext } from './pending-contexts'
+import type { QueuedMessage } from './follow-up-queue'
+
+export interface ComposerDraftImage {
+  id: string
+  data: string
+  mimeType: string
+  name: string
+  previewUrl: string
+}
+
+export interface ComposerSendImage {
+  data: string
+  mimeType: string
+  previewUrl: string
+}
+
+export interface ComposerSendSnapshot {
+  hasContent: boolean
+  text: string
+  images: ComposerSendImage[]
+  restore: {
+    prompt: string
+    contexts: PendingContext[]
+    images: ComposerDraftImage[]
+  }
+}
+
+export interface ComposerLiveState {
+  prompt: string
+  contexts: readonly PendingContext[]
+  images: readonly ComposerDraftImage[]
+}
+
+export function createComposerSendSnapshot({
+  prompt,
+  contexts,
+  images,
+}: {
+  prompt: string
+  contexts: readonly PendingContext[]
+  images: readonly ComposerDraftImage[]
+}): ComposerSendSnapshot {
+  const restoreContexts = contexts.map((context) => ({ ...context })) as PendingContext[]
+  const restoreImages = images.map((image) => ({ ...image }))
+  const sendImages = images.map(({ data, mimeType, previewUrl }) => ({ data, mimeType, previewUrl }))
+  const text = serializeForSend(prompt, restoreContexts)
+  return {
+    hasContent: text.length > 0 || sendImages.length > 0,
+    text,
+    images: sendImages,
+    restore: {
+      prompt,
+      contexts: restoreContexts,
+      images: restoreImages,
+    },
+  }
+}
+
+export function restoreFailedSendSnapshot(
+  snapshot: ComposerSendSnapshot,
+  current: ComposerLiveState,
+): ComposerSendSnapshot['restore'] {
+  if (current.prompt.length > 0 || current.contexts.length > 0 || current.images.length > 0) {
+    return {
+      prompt: current.prompt,
+      contexts: [...current.contexts],
+      images: current.images.map((image) => ({ ...image })),
+    }
+  }
+  return {
+    prompt: snapshot.restore.prompt,
+    contexts: snapshot.restore.contexts.map((context) => ({ ...context })) as PendingContext[],
+    images: snapshot.restore.images.map((image) => ({ ...image })),
+  }
+}
+
+export function createQueuedFollowUp(id: string, snapshot: ComposerSendSnapshot): QueuedMessage {
+  return {
+    id,
+    text: snapshot.text,
+    images: snapshot.images.map((image) => ({ ...image })),
+  }
+}


### PR DESCRIPTION
## Summary

- Extract composer send snapshotting into a pure lifecycle module.
- Send and queue immutable send-ready payloads while preserving plain prompt text plus image blocks.
- Restore failed sends from the attempted snapshot only when the current composer remains empty.

## Parent

Implements #307.

## Validation

- bun run --cwd apps/desktop test src/renderer/src/conversation/composer-send-lifecycle.test.ts
- bun run typecheck
- bun run lint
- bun run test
- bun run build