### PR TITLE
[codex] Lexical composer editor foundation

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -24,8 +24,10 @@
     "postinstall": "node scripts/fix-node-pty-perms.mjs && node scripts/patch-dev-electron.mjs"
   },
   "dependencies": {
+    "@lexical/react": "^0.46.0",
     "chokidar": "^5.0.0",
     "electron-updater": "^6.6.2",
+    "lexical": "^0.46.0",
     "node-pty": "^1.1.0"
   },
   "devDependencies": {

--- a/apps/desktop/src/renderer/src/conversation/Composer.tsx
+++ b/apps/desktop/src/renderer/src/conversation/Composer.tsx
@@ -19,7 +19,6 @@ import type {
 import { AgentControls } from './AgentControls'
 import { Card } from '../ui/card'
 import { IconButton } from '../ui/icon-button'
-import { Textarea } from '../ui/textarea'
 import type { AcpCommand } from './reducer'
 import { useComposerDraftText } from './composer-draft-store'
 import {
@@ -47,6 +46,8 @@ import {
   createQueuedFollowUp,
   restoreFailedSendSnapshot,
 } from './composer-send-lifecycle'
+import { ComposerPromptEditor } from './ComposerPromptEditor'
+import type { ComposerEditorHandle } from './composer-editor-handle'
 
 /** Process-local counters for unique pending-image / element / review / paste-chip ids (not Math.random/Date). */
 let imageSeq = 0
@@ -184,7 +185,7 @@ export function Composer({
   const [pendingContexts, setPendingContexts] = useState<PendingContext[]>([])
   const liveComposerStateRef = useRef({ prompt: draft, contexts: pendingContexts, images: pendingImages })
   liveComposerStateRef.current = { prompt: draft, contexts: pendingContexts, images: pendingImages }
-  const inputRef = useRef<HTMLTextAreaElement>(null)
+  const inputRef = useRef<ComposerEditorHandle>(null)
   // The hidden file picker behind the 📎 button (#100).
   const fileInputRef = useRef<HTMLInputElement>(null)
   // The shared `files:list` listing (ADR-0013 decision 5), fetched ONCE per composer
@@ -316,7 +317,7 @@ export function Composer({
   // treatment, via our ADR-0017 chips) — the composer stays compact and the full text
   // rides a trailing <pasted_text> block at send. `preventDefault` fires ONLY when we
   // handled the paste ourselves, so a normal short text paste is untouched.
-  function onPaste(e: ClipboardEvent<HTMLTextAreaElement>): void {
+  function onPaste(e: ClipboardEvent<HTMLDivElement>): void {
     let handled = false
     for (const item of e.clipboardData.items) {
       if (item.kind !== 'file' || !isAcceptedImageType(item.type)) continue
@@ -392,7 +393,7 @@ export function Composer({
     }
   }
 
-  function onKeyDown(e: KeyboardEvent<HTMLTextAreaElement>): void {
+  function onKeyDown(e: KeyboardEvent<HTMLDivElement>): void {
     // The autocomplete intercepts nav/accept/Esc while open; when it doesn't handle the
     // key (closed, or a non-nav key), Enter falls through to send.
     if (autocomplete.onKeyDown(e)) return
@@ -519,22 +520,21 @@ export function Composer({
                 onAccept={autocomplete.accept}
               />
             )}
-            <Textarea
+            <ComposerPromptEditor
               ref={inputRef}
               className="min-h-0 resize-none border-0 bg-transparent p-0 text-[17px] leading-normal focus-visible:border-0"
               placeholder={isEmpty ? 'Ask anything…' : 'Ask for follow-up changes'}
               value={draft}
-              onChange={(e) => {
+              onChange={(value, caret) => {
                 // Write-through: keep React state and the persisted draft (#60) in lockstep.
-                writeDraft(e.target.value)
+                writeDraft(value)
                 // Re-derive the `/` (#95) and `@` (#190) triggers from the new value + caret.
-                autocomplete.onInput(e.target.value, e.target.selectionStart)
+                autocomplete.onInput(value, caret)
               }}
               // Caret moves (arrows/click) with no edit also open/close the triggers.
-              onSelect={(e) => autocomplete.onInput(e.currentTarget.value, e.currentTarget.selectionStart)}
+              onSelect={(value, caret) => autocomplete.onInput(value, caret)}
               onKeyDown={onKeyDown}
               onPaste={onPaste}
-              rows={2}
             />
           </div>
 

--- a/apps/desktop/src/renderer/src/conversation/ComposerPromptEditor.tsx
+++ b/apps/desktop/src/renderer/src/conversation/ComposerPromptEditor.tsx
@@ -1,0 +1,171 @@
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  type LexicalEditor,
+} from 'lexical'
+import { LexicalComposer } from '@lexical/react/LexicalComposer'
+import { ContentEditable } from '@lexical/react/LexicalContentEditable'
+import { LexicalErrorBoundary } from '@lexical/react/LexicalErrorBoundary'
+import { PlainTextPlugin } from '@lexical/react/LexicalPlainTextPlugin'
+import { OnChangePlugin } from '@lexical/react/LexicalOnChangePlugin'
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  type ClipboardEvent,
+  type JSX,
+  type KeyboardEvent,
+} from 'react'
+import { cn } from '../lib/utils'
+import type { ComposerEditorHandle } from './composer-editor-handle'
+
+function editorText(editor: LexicalEditor): string {
+  return editor.getEditorState().read(() => $getRoot().getTextContent())
+}
+
+function setEditorText(editor: LexicalEditor, text: string): void {
+  editor.update(() => {
+    const root = $getRoot()
+    root.clear()
+    const paragraph = $createParagraphNode()
+    paragraph.append($createTextNode(text))
+    root.append(paragraph)
+  })
+}
+
+function domSelectionOffset(root: HTMLElement | null): number | null {
+  const selection = window.getSelection()
+  if (!root || !selection || selection.rangeCount === 0) return null
+  const range = selection.getRangeAt(0)
+  if (!root.contains(range.startContainer)) return null
+  const before = range.cloneRange()
+  before.selectNodeContents(root)
+  before.setEnd(range.startContainer, range.startOffset)
+  return before.toString().length
+}
+
+function EditorBridge({
+  value,
+  editorRef,
+}: {
+  value: string
+  editorRef: React.Ref<ComposerEditorHandle>
+}): null {
+  const [editor] = useLexicalComposerContext()
+  const lastExternalValueRef = useRef(value)
+
+  useImperativeHandle(
+    editorRef,
+    () => ({
+      getSelectionStart: () => domSelectionOffset(editor.getRootElement()),
+      focus: () => editor.focus(),
+      setSelectionRange(start) {
+        editor.focus(() => {
+          const selection = window.getSelection()
+          const root = editor.getRootElement()
+          const textNode = root?.firstChild?.firstChild ?? null
+          if (!selection || !textNode) return
+          const range = document.createRange()
+          range.setStart(textNode, Math.min(start, textNode.textContent?.length ?? 0))
+          range.collapse(true)
+          selection.removeAllRanges()
+          selection.addRange(range)
+        })
+      },
+    }),
+    [editor],
+  )
+
+  useEffect(() => {
+    if (value === lastExternalValueRef.current) return
+    if (editorText(editor) === value) {
+      lastExternalValueRef.current = value
+      return
+    }
+    setEditorText(editor, value)
+    lastExternalValueRef.current = value
+  }, [editor, value])
+
+  return null
+}
+
+export interface ComposerPromptEditorProps {
+  value: string
+  placeholder: string
+  disabled?: boolean
+  className?: string
+  onChange: (value: string, caret: number | null) => void
+  onSelect: (value: string, caret: number | null) => void
+  onKeyDown?: (event: KeyboardEvent<HTMLDivElement>) => void
+  onPaste?: (event: ClipboardEvent<HTMLDivElement>) => void
+}
+
+export const ComposerPromptEditor = forwardRef<ComposerEditorHandle, ComposerPromptEditorProps>(
+  function ComposerPromptEditor(
+    { value, placeholder, disabled = false, className, onChange, onSelect, onKeyDown, onPaste },
+    ref,
+  ): JSX.Element {
+    const initialConfig = {
+      namespace: 'ComposerPromptEditor',
+      editable: !disabled,
+      onError(error: Error) {
+        throw error
+      },
+      editorState(editor: LexicalEditor) {
+        setEditorText(editor, value)
+      },
+    }
+
+    return (
+      <LexicalComposer initialConfig={initialConfig}>
+        <div className={cn('relative', disabled && 'pointer-events-none opacity-50')}>
+          <PlainTextPlugin
+            contentEditable={
+              <ContentEditable
+                className={cn(
+                  'min-h-[3rem] w-full resize-none bg-transparent p-0 text-[17px] leading-normal text-text outline-none',
+                  'whitespace-pre-wrap break-words',
+                  className,
+                )}
+                aria-label={placeholder}
+                onKeyDown={onKeyDown}
+                onPaste={onPaste}
+                onSelect={(event) => {
+                  const text = event.currentTarget.textContent ?? ''
+                  onSelect(text, domSelectionOffset(event.currentTarget))
+                }}
+              />
+            }
+            placeholder={
+              <div className="pointer-events-none absolute top-0 left-0 text-[17px] leading-normal text-placeholder">
+                {placeholder}
+              </div>
+            }
+            ErrorBoundary={LexicalErrorBoundary}
+          />
+          <OnChangePlugin
+            onChange={(editorState, editor) => {
+              let text = ''
+              editorState.read(() => {
+                text = $getRoot().getTextContent()
+              })
+              lastValueOnChange(editor, text, onChange)
+            }}
+          />
+          <EditorBridge value={value} editorRef={ref} />
+        </div>
+      </LexicalComposer>
+    )
+  },
+)
+
+function lastValueOnChange(
+  editor: LexicalEditor,
+  text: string,
+  onChange: (value: string, caret: number | null) => void,
+): void {
+  onChange(text, domSelectionOffset(editor.getRootElement()))
+}

--- a/apps/desktop/src/renderer/src/conversation/composer-editor-handle.ts
+++ b/apps/desktop/src/renderer/src/conversation/composer-editor-handle.ts
@@ -1,0 +1,5 @@
+export interface ComposerEditorHandle {
+  getSelectionStart(): number | null
+  focus(): void
+  setSelectionRange(start: number, end: number): void
+}

--- a/apps/desktop/src/renderer/src/conversation/use-composer-autocomplete.tsx
+++ b/apps/desktop/src/renderer/src/conversation/use-composer-autocomplete.tsx
@@ -10,6 +10,7 @@ import { cn } from '../lib/utils'
 import { moveSelection } from './command-autocomplete'
 import { resolveAutocomplete, type ActiveTrigger, type Detection } from './autocomplete-machine'
 import type { PendingContext } from './pending-contexts'
+import type { ComposerEditorHandle } from './composer-editor-handle'
 
 /**
  * One completion mechanism for the composer (quality-review slice 4a): the `/` command
@@ -71,7 +72,7 @@ export interface ComposerAutocomplete {
   onInput(value: string, caret: number | null): void
   /** Popover-open key interception (nav + accept + Esc). Returns true when it handled the
    *  key, so the composer skips Enter's send / Tab's focus move. */
-  onKeyDown(e: KeyboardEvent<HTMLTextAreaElement>): boolean
+  onKeyDown(e: KeyboardEvent<HTMLElement>): boolean
   /** Accept a row (mouse click on a popover row). */
   accept(row: unknown): void
 }
@@ -87,7 +88,7 @@ export function useComposerAutocomplete(
   sources: readonly CompletionSource[],
   value: string,
   setValue: (next: string) => void,
-  inputRef: RefObject<HTMLTextAreaElement | null>,
+  inputRef: RefObject<ComposerEditorHandle | null>,
   /** Receives the pending-context chip when an accepted row stages one (#229). */
   onContext?: (context: PendingContext) => void,
 ): ComposerAutocomplete {
@@ -139,7 +140,7 @@ export function useComposerAutocomplete(
     if (!trigger) return
     const source = sources[trigger.sourceIndex]
     const node = inputRef.current
-    const caret = node ? node.selectionStart : value.length
+    const caret = node?.getSelectionStart() ?? value.length
     const next = source.apply(value, trigger.start, caret, row)
     setValue(next.value)
     if (next.context) onContext?.(next.context)
@@ -158,7 +159,7 @@ export function useComposerAutocomplete(
     })
   }
 
-  function onKeyDown(e: KeyboardEvent<HTMLTextAreaElement>): boolean {
+  function onKeyDown(e: KeyboardEvent<HTMLElement>): boolean {
     // Popover-open key interception: navigation + accept must win over Enter's send and
     // Tab's focus move. When closed, this returns false and every key falls through.
     if (!open || !trigger) return false


### PR DESCRIPTION
## Summary

- Add Lexical dependencies for the desktop renderer.
- Introduce a plain-text Lexical ComposerPromptEditor with a narrow editor handle for focus, selection, and autocomplete integration.
- Replace the composer textarea with the Lexical editor while preserving plain-text draft synchronization, paste handling, submit shortcuts, and slash/at autocomplete entry points.

## Parent

Implements #308.

## Validation

- bun run --cwd apps/desktop test src/renderer/src/conversation/autocomplete-machine.test.ts src/renderer/src/conversation/command-autocomplete.test.ts src/renderer/src/conversation/path-autocomplete.test.ts src/renderer/src/conversation/composer-draft-store.test.ts src/renderer/src/conversation/composer-send-lifecycle.test.ts
- bun run typecheck
- bun run lint
- bun run test
- bun run build

Note: production build emits Rollup PURE annotation warnings from Lexical package output, but completes successfully.