### PR TITLE
Implement start-anchored slash Inline token

### DIFF
--- a/apps/desktop/src/renderer/src/conversation/Composer.tsx
+++ b/apps/desktop/src/renderer/src/conversation/Composer.tsx
@@ -20,7 +20,7 @@ import { AgentControls } from './AgentControls'
 import { Card } from '../ui/card'
 import { IconButton } from '../ui/icon-button'
 import type { AcpCommand } from './reducer'
-import { useComposerDraftText } from './composer-draft-store'
+import { useComposerDraft } from './composer-draft-store'
 import {
   appendText,
   subscribeComposerInsert,
@@ -48,6 +48,7 @@ import {
 } from './composer-send-lifecycle'
 import { ComposerPromptEditor } from './ComposerPromptEditor'
 import type { ComposerEditorHandle } from './composer-editor-handle'
+import { getSlashCommandInlineToken, setSlashCommandInlineToken } from './composer-inline-tokens'
 
 /** Process-local counters for unique pending-image / element / review / paste-chip ids (not Math.random/Date). */
 let imageSeq = 0
@@ -174,17 +175,29 @@ export function Composer({
   // REMOUNTS on a Thread switch — the lazy initializer seeds THAT Thread's stored
   // draft fresh, with no stale carry-over (no re-seed effect needed). Reading here
   // must not write, so we only persist on change/send below.
-  const [draft, setDraft, clearPersistedDraft] = useComposerDraftText(threadId)
+  const [composerDraft, setComposerDraft, clearPersistedDraft] = useComposerDraft(threadId)
+  const draft = composerDraft.prompt
+  const slashCommandToken = getSlashCommandInlineToken(composerDraft.inlineTokens)
   // Images staged in the composer, awaiting send (#100). Renderer-only, ephemeral:
   // this view remounts on a Thread switch (keyed by threadId), so the strip starts
   // empty per Thread. Kept on a failed send so the user can retry / switch model.
   const [pendingImages, setPendingImages] = useState<PendingImage[]>([])
   // Pending-context chips (#229): structured attachments staged BESIDE the draft
-  // text — a `/` accept stages a skill chip here instead of splicing text in. Same
-  // lifecycle as staged images: ephemeral, cleared on send/enqueue, kept on failure.
+  // text. Same lifecycle as staged images: ephemeral, cleared on send/enqueue,
+  // kept on failure. Slash commands live in the structured draft's Inline tokens.
   const [pendingContexts, setPendingContexts] = useState<PendingContext[]>([])
-  const liveComposerStateRef = useRef({ prompt: draft, contexts: pendingContexts, images: pendingImages })
-  liveComposerStateRef.current = { prompt: draft, contexts: pendingContexts, images: pendingImages }
+  const liveComposerStateRef = useRef({
+    prompt: draft,
+    inlineTokens: composerDraft.inlineTokens,
+    contexts: pendingContexts,
+    images: pendingImages,
+  })
+  liveComposerStateRef.current = {
+    prompt: draft,
+    inlineTokens: composerDraft.inlineTokens,
+    contexts: pendingContexts,
+    images: pendingImages,
+  }
   const inputRef = useRef<ComposerEditorHandle>(null)
   // The hidden file picker behind the 📎 button (#100).
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -215,7 +228,17 @@ export function Composer({
   // autocomplete hook calls this when it accepts a completion; the textarea's onChange
   // and the composer-insert subscription use it too.
   function writeDraft(next: string | ((current: string) => string)): void {
-    setDraft(next)
+    setComposerDraft((current) => ({
+      ...current,
+      prompt: typeof next === 'function' ? next(current.prompt) : next,
+    }))
+  }
+
+  function setSlashCommandToken(command: AcpCommand | null): void {
+    setComposerDraft((current) => ({
+      ...current,
+      inlineTokens: setSlashCommandInlineToken(current.inlineTokens, command),
+    }))
   }
 
   // The `/` (#95) and `@` (#190) autocompletes, unified into ONE state machine over two
@@ -228,8 +251,15 @@ export function Composer({
     [pathEntries],
   )
   const sources = useMemo(() => [commandSource, pathSource], [commandSource, pathSource])
-  const autocomplete = useComposerAutocomplete(sources, draft, writeDraft, inputRef, (context) =>
-    setPendingContexts((prev) => addContext(prev, context)),
+  const autocomplete = useComposerAutocomplete(
+    sources,
+    draft,
+    writeDraft,
+    inputRef,
+    (context) => setPendingContexts((prev) => addContext(prev, context)),
+    (token) => {
+      if (token.kind === 'slashCommand') setSlashCommandToken(token)
+    },
   )
 
   // Insert from the Files preview's action (#189): the side panel is a sibling of this
@@ -356,6 +386,7 @@ export function Composer({
   async function send(): Promise<void> {
     const snapshot = createComposerSendSnapshot({
       prompt: draft,
+      inlineTokens: composerDraft.inlineTokens,
       contexts: pendingContexts,
       images: pendingImages,
     })
@@ -366,7 +397,7 @@ export function Composer({
       // a concurrent prompt) and clear the composer so the user can compose the next
       // follow-up. It auto-flushes on the next turn end.
       followUps.enqueue(createQueuedFollowUp(nextQueueId(), snapshot))
-      setDraft('')
+      writeDraft('')
       clearPersistedDraft()
       setPendingImages([])
       setPendingContexts([])
@@ -380,14 +411,18 @@ export function Composer({
     // after -31008) — unless the user started composing something new meanwhile.
     setPendingImages([])
     setPendingContexts([])
-    setDraft('')
+    writeDraft('')
     clearPersistedDraft()
     const ok = await submitPrompt(snapshot.text, snapshot.images)
     if (!ok) {
       // Restore the PRE-serialize prose + chips (not the flattened wire text), so a
       // retry re-serializes cleanly instead of double-prepending the invocation.
       const restored = restoreFailedSendSnapshot(snapshot, liveComposerStateRef.current)
-      setDraft(restored.prompt)
+      setComposerDraft((current) => ({
+        ...current,
+        prompt: restored.prompt,
+        inlineTokens: restored.inlineTokens,
+      }))
       setPendingImages(restored.images)
       setPendingContexts(restored.contexts)
     }
@@ -397,6 +432,14 @@ export function Composer({
     // The autocomplete intercepts nav/accept/Esc while open; when it doesn't handle the
     // key (closed, or a non-nav key), Enter falls through to send.
     if (autocomplete.onKeyDown(e)) return
+    if ((e.key === 'Backspace' || e.key === 'Delete') && slashCommandToken) {
+      const caret = inputRef.current?.getSelectionStart() ?? draft.length
+      if (caret === 0) {
+        e.preventDefault()
+        setSlashCommandToken(null)
+        return
+      }
+    }
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
       void send()
@@ -443,13 +486,31 @@ export function Composer({
             </div>
           )}
 
-          {pendingContexts.length > 0 && (
-            // Pending-context chip row (#229/#230/#231): the structured attachments staged
-            // beside the draft — mirrors the sent-turn chips with a ✕ remove per chip.
+          {(slashCommandToken || pendingContexts.length > 0) && (
+            // Token/chip row (#229/#230/#231/#309): the structured slash command token and
+            // pending attachments staged beside the draft, with a remove action per chip.
             // Removing an ELEMENT chip also removes its paired screenshot (one payload in,
             // one gesture out); removing the thumbnail alone keeps the chip (screenshot is
             // optional context, the pick isn't).
             <div className="mb-3 flex flex-wrap gap-2">
+              {slashCommandToken && (
+                <span
+                  data-inline-token-chip
+                  title={slashCommandToken.description}
+                  className="inline-flex max-w-full items-center gap-1 rounded-md border border-[var(--accent-tint-border)] bg-[var(--accent-tint)] py-0.5 pr-1 pl-1.5 font-mono text-xs leading-none text-accent-text"
+                >
+                  <Sparkles className="size-3 shrink-0" aria-hidden />
+                  <span className="truncate">/{slashCommandToken.name}</span>
+                  <button
+                    type="button"
+                    aria-label={`Remove /${slashCommandToken.name}`}
+                    onClick={() => setSlashCommandToken(null)}
+                    className="inline-flex size-3.5 shrink-0 items-center justify-center rounded-sm text-accent-text outline-none hover:bg-[var(--accent-tint-border)]"
+                  >
+                    <X className="size-3" aria-hidden />
+                  </button>
+                </span>
+              )}
               {pendingContexts.map((context) => (
                 <span
                   key={contextKey(context)}
@@ -606,7 +667,10 @@ export function Composer({
               // A staged chip alone is sendable — it serializes to wire text (a bare
               // /skill, @path block, or pasted_text block) even with an empty draft.
               disabled={
-                draft.trim().length === 0 && pendingImages.length === 0 && pendingContexts.length === 0
+                draft.trim().length === 0 &&
+                composerDraft.inlineTokens.length === 0 &&
+                pendingImages.length === 0 &&
+                pendingContexts.length === 0
               }
               aria-label={followUps.sending ? 'Queue message' : 'Send message'}
               title={followUps.sending ? 'Queue' : 'Send'}

--- a/apps/desktop/src/renderer/src/conversation/command-autocomplete.test.ts
+++ b/apps/desktop/src/renderer/src/conversation/command-autocomplete.test.ts
@@ -48,9 +48,9 @@ describe('getCommandQuery — trigger detection', () => {
     expect(getCommandQuery('/re', 0).active).toBe(false)
   })
 
-  it('activates for a `/`-token at the start of a later line', () => {
+  it('does NOT activate for a `/`-token at the start of a later line', () => {
     // "hello\n/re" — the slash opens the second line (index 6), caret at end.
-    expect(getCommandQuery('hello\n/re', 9)).toEqual({ active: true, query: 're', start: 6 })
+    expect(getCommandQuery('hello\n/re', 9).active).toBe(false)
   })
 
   it('does NOT activate for a non-slash line', () => {

--- a/apps/desktop/src/renderer/src/conversation/command-autocomplete.ts
+++ b/apps/desktop/src/renderer/src/conversation/command-autocomplete.ts
@@ -9,9 +9,9 @@
  * keyboard wiring.
  *
  * Trigger rule: the popover is active only for a `/`-prefixed token at the START
- * of the input (input start, or the start of a line after a newline), with the
- * caret inside or after that token. A closed token — one the caret has moved past
- * a whitespace of — does not qualify, matching a shell's "first word" feel.
+ * of the prompt, with the caret inside or after that token. A closed token — one
+ * the caret has moved past a whitespace of — does not qualify, matching a shell's
+ * "first word" feel.
  */
 
 import type { AcpCommand } from './reducer'
@@ -35,26 +35,24 @@ const NO_TRIGGER: CommandTrigger = { active: false, query: '', start: -1 }
 const TOKEN_WHITESPACE = /\s/
 
 /**
- * Detect a `/`-command trigger at the caret. Active only when the `/` sits at the
- * start of the caret's line (input start or just after a `\n`) and the text from
- * the `/` up to the caret contains no whitespace (the token is still open). Returns
- * the query (text after `/`, up to the caret) and the `/`'s index on a hit.
+ * Detect a `/`-command trigger at the caret. Active only when the `/` sits at index
+ * 0 and the text from the `/` up to the caret contains no whitespace (the token is
+ * still open). Returns the query (text after `/`, up to the caret) and the `/`'s
+ * index on a hit.
  *
  * `caret` is clamped defensively — a caller may hand us a DOM `selectionStart` that
  * a controlled re-render has momentarily desynced from `value`.
  */
 export function getCommandQuery(value: string, caret: number): CommandTrigger {
   const pos = Math.max(0, Math.min(caret, value.length))
-  // Start of the caret's line: one past the last newline at/before the caret, or 0.
-  const lineStart = value.lastIndexOf('\n', pos - 1) + 1
-  // The token must open with a `/` at the line start, and the caret must sit AFTER
+  // The token must open with a `/` at prompt start, and the caret must sit AFTER
   // that `/` (a caret resting on the `/` itself isn't inside the token yet).
-  if (value[lineStart] !== '/' || pos <= lineStart) return NO_TRIGGER
-  const query = value.slice(lineStart + 1, pos)
+  if (value[0] !== '/' || pos <= 0) return NO_TRIGGER
+  const query = value.slice(1, pos)
   // A whitespace before the caret means the token closed — the caret is on a later
   // word (e.g. `/init ` with the caret past the space), so the popover must not show.
   if (TOKEN_WHITESPACE.test(query)) return NO_TRIGGER
-  return { active: true, query, start: lineStart }
+  return { active: true, query, start: 0 }
 }
 
 /**

--- a/apps/desktop/src/renderer/src/conversation/composer-draft-store.test.ts
+++ b/apps/desktop/src/renderer/src/conversation/composer-draft-store.test.ts
@@ -199,6 +199,20 @@ describe('composer draft external store', () => {
     expect(notifications).toBe(1)
     expect(store.getSnapshot('t1').prompt).toBe('two')
   })
+
+  it('returns a referentially stable structured snapshot between writes', () => {
+    const storage = fakeStorage()
+    const store = createComposerDraftStore(storage)
+    store.setDraft('t1', {
+      prompt: 'one',
+      inlineTokens: [{ kind: 'slashCommand', name: 'teach' }],
+      contextAttachments: [],
+      images: [],
+      nonPersistedImageIds: [],
+    })
+
+    expect(store.getSnapshot('t1')).toBe(store.getSnapshot('t1'))
+  })
 })
 
 describe('lazy migration from text-only v1 drafts', () => {

--- a/apps/desktop/src/renderer/src/conversation/composer-draft-store.ts
+++ b/apps/desktop/src/renderer/src/conversation/composer-draft-store.ts
@@ -1,4 +1,5 @@
 import { useCallback, useSyncExternalStore } from 'react'
+import { coerceInlineTokens, type ComposerInlineToken } from './composer-inline-tokens'
 
 /**
  * Per-Thread composer drafts (#60): the unsent text in a Thread's composer, kept
@@ -32,7 +33,7 @@ export interface DraftStorage {
 
 export interface ComposerDraft {
   prompt: string
-  inlineTokens: unknown[]
+  inlineTokens: ComposerInlineToken[]
   contextAttachments: unknown[]
   images: unknown[]
   nonPersistedImageIds: string[]
@@ -48,7 +49,7 @@ interface PersistedComposerDrafts {
 
 const EMPTY_COMPOSER_DRAFT: ComposerDraft = Object.freeze({
   prompt: '',
-  inlineTokens: Object.freeze([]) as unknown as unknown[],
+  inlineTokens: Object.freeze([]) as unknown as ComposerInlineToken[],
   contextAttachments: Object.freeze([]) as unknown as unknown[],
   images: Object.freeze([]) as unknown as unknown[],
   nonPersistedImageIds: Object.freeze([]) as unknown as string[],
@@ -79,7 +80,7 @@ function coerceDraft(value: unknown): ComposerDraft | null {
   const draft = value as Partial<ComposerDraft>
   return {
     prompt: typeof draft.prompt === 'string' ? draft.prompt : '',
-    inlineTokens: Array.isArray(draft.inlineTokens) ? draft.inlineTokens : [],
+    inlineTokens: Array.isArray(draft.inlineTokens) ? coerceInlineTokens(draft.inlineTokens) : [],
     contextAttachments: Array.isArray(draft.contextAttachments) ? draft.contextAttachments : [],
     images: Array.isArray(draft.images) ? draft.images : [],
     nonPersistedImageIds: Array.isArray(draft.nonPersistedImageIds)
@@ -224,8 +225,9 @@ export function setDraft(
   threadId: string,
   text: string,
 ): void {
+  const current = getComposerDraft(storage, threadId)
   setComposerDraft(storage, threadId, {
-    ...emptyComposerDraft(),
+    ...current,
     prompt: text,
   })
 }
@@ -253,8 +255,19 @@ export interface ComposerDraftStore {
 
 export function createComposerDraftStore(storage: DraftStorage | null | undefined): ComposerDraftStore {
   const listeners = new Set<() => void>()
+  const snapshotCache = new Map<string, ComposerDraft>()
   function notify(): void {
     for (const listener of listeners) listener()
+  }
+  function snapshot(threadId: string): ComposerDraft {
+    const cached = snapshotCache.get(threadId)
+    if (cached) return cached
+    const next = getComposerDraft(storage, threadId)
+    snapshotCache.set(threadId, next)
+    return next
+  }
+  function invalidate(threadId: string): void {
+    snapshotCache.delete(threadId)
   }
   return {
     subscribe(listener) {
@@ -264,21 +277,24 @@ export function createComposerDraftStore(storage: DraftStorage | null | undefine
       }
     },
     getSnapshot(threadId) {
-      return getComposerDraft(storage, threadId)
+      return snapshot(threadId)
     },
     getTextSnapshot(threadId) {
-      return getDraft(storage, threadId)
+      return snapshot(threadId).prompt
     },
     setDraft(threadId, draft) {
       setComposerDraft(storage, threadId, draft)
+      invalidate(threadId)
       notify()
     },
     setText(threadId, text) {
       setDraft(storage, threadId, text)
+      invalidate(threadId)
       notify()
     },
     clear(threadId) {
       clearDraft(storage, threadId)
+      invalidate(threadId)
       notify()
     },
   }
@@ -305,4 +321,28 @@ export function useComposerDraftText(
   )
   const clear = useCallback(() => composerDraftStore.clear(threadId), [threadId])
   return [prompt, setText, clear]
+}
+
+export function useComposerDraft(
+  threadId: string,
+): [
+  ComposerDraft,
+  (draft: ComposerDraft | ((current: ComposerDraft) => ComposerDraft)) => void,
+  () => void,
+] {
+  const draft = useSyncExternalStore(composerDraftStore.subscribe, () =>
+    composerDraftStore.getSnapshot(threadId),
+  )
+  const setStructuredDraft = useCallback(
+    (nextDraft: ComposerDraft | ((current: ComposerDraft) => ComposerDraft)) => {
+      const next =
+        typeof nextDraft === 'function'
+          ? nextDraft(composerDraftStore.getSnapshot(threadId))
+          : nextDraft
+      composerDraftStore.setDraft(threadId, next)
+    },
+    [threadId],
+  )
+  const clear = useCallback(() => composerDraftStore.clear(threadId), [threadId])
+  return [draft, setStructuredDraft, clear]
 }

--- a/apps/desktop/src/renderer/src/conversation/composer-inline-tokens.test.ts
+++ b/apps/desktop/src/renderer/src/conversation/composer-inline-tokens.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import {
+  coerceInlineTokens,
+  serializeInlineTokensForSend,
+  setSlashCommandInlineToken,
+} from './composer-inline-tokens'
+
+describe('setSlashCommandInlineToken', () => {
+  it('adds one start-anchored slash command token', () => {
+    expect(setSlashCommandInlineToken([], { name: 'teach', description: 'Teach mode' })).toEqual([
+      { kind: 'slashCommand', name: 'teach', description: 'Teach mode' },
+    ])
+  })
+
+  it('replaces an existing slash command token', () => {
+    expect(
+      setSlashCommandInlineToken([{ kind: 'slashCommand', name: 'teach' }], {
+        name: 'review',
+      }),
+    ).toEqual([{ kind: 'slashCommand', name: 'review', description: undefined }])
+  })
+})
+
+describe('coerceInlineTokens', () => {
+  it('keeps only the first valid slash command token', () => {
+    expect(
+      coerceInlineTokens([
+        { kind: 'slashCommand', name: 'teach' },
+        { kind: 'slashCommand', name: 'review' },
+        { kind: 'slashCommand' },
+        null,
+      ]),
+    ).toEqual([{ kind: 'slashCommand', name: 'teach', description: undefined }])
+  })
+})
+
+describe('serializeInlineTokensForSend', () => {
+  it('emits a bare slash command when the prompt body is empty', () => {
+    expect(serializeInlineTokensForSend('', [{ kind: 'slashCommand', name: 'teach' }])).toBe(
+      '/teach',
+    )
+  })
+
+  it('prepends the slash command exactly once before prompt body text', () => {
+    expect(
+      serializeInlineTokensForSend('explain this', [{ kind: 'slashCommand', name: 'teach' }]),
+    ).toBe('/teach explain this')
+  })
+
+  it('does not duplicate a command already present in prompt text', () => {
+    expect(
+      serializeInlineTokensForSend('/teach explain this', [
+        { kind: 'slashCommand', name: 'teach' },
+      ]),
+    ).toBe('/teach explain this')
+  })
+})

--- a/apps/desktop/src/renderer/src/conversation/composer-inline-tokens.ts
+++ b/apps/desktop/src/renderer/src/conversation/composer-inline-tokens.ts
@@ -1,0 +1,69 @@
+import type { AcpCommand } from './reducer'
+
+export interface SlashCommandInlineToken {
+  kind: 'slashCommand'
+  name: string
+  description?: string
+}
+
+export type ComposerInlineToken = SlashCommandInlineToken
+
+function isSlashCommandInlineToken(value: unknown): value is SlashCommandInlineToken {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+  const token = value as Partial<SlashCommandInlineToken>
+  return token.kind === 'slashCommand' && typeof token.name === 'string' && token.name.length > 0
+}
+
+export function coerceInlineTokens(values: unknown[]): ComposerInlineToken[] {
+  const tokens: ComposerInlineToken[] = []
+  let hasSlashCommand = false
+  for (const value of values) {
+    if (!isSlashCommandInlineToken(value)) continue
+    if (hasSlashCommand) continue
+    hasSlashCommand = true
+    tokens.push({
+      kind: 'slashCommand',
+      name: value.name,
+      description: typeof value.description === 'string' ? value.description : undefined,
+    })
+  }
+  return tokens
+}
+
+export function createSlashCommandInlineToken(command: AcpCommand): SlashCommandInlineToken {
+  return {
+    kind: 'slashCommand',
+    name: command.name,
+    description: command.description,
+  }
+}
+
+export function getSlashCommandInlineToken(
+  tokens: readonly ComposerInlineToken[],
+): SlashCommandInlineToken | null {
+  return tokens.find((token) => token.kind === 'slashCommand') ?? null
+}
+
+export function setSlashCommandInlineToken(
+  tokens: readonly ComposerInlineToken[],
+  command: AcpCommand | null,
+): ComposerInlineToken[] {
+  const rest = tokens.filter((token) => token.kind !== 'slashCommand')
+  return command ? [createSlashCommandInlineToken(command), ...rest] : rest
+}
+
+export function serializeInlineTokensForSend(
+  prompt: string,
+  tokens: readonly ComposerInlineToken[],
+): string {
+  const slash = getSlashCommandInlineToken(tokens)
+  if (!slash) return prompt
+  const commandText = `/${slash.name}`
+  const trimmedPrompt = prompt.trimStart()
+  if (trimmedPrompt.length === 0) return commandText
+  if (trimmedPrompt.toLowerCase().startsWith(`${commandText.toLowerCase()} `)) {
+    return trimmedPrompt
+  }
+  if (trimmedPrompt.toLowerCase() === commandText.toLowerCase()) return trimmedPrompt
+  return `${commandText} ${trimmedPrompt}`
+}

--- a/apps/desktop/src/renderer/src/conversation/composer-send-lifecycle.test.ts
+++ b/apps/desktop/src/renderer/src/conversation/composer-send-lifecycle.test.ts
@@ -21,6 +21,7 @@ describe('createComposerSendSnapshot', () => {
 
     const snapshot = createComposerSendSnapshot({
       prompt: 'read this',
+      inlineTokens: [{ kind: 'slashCommand', name: 'teach' }],
       contexts,
       images,
     })
@@ -29,7 +30,9 @@ describe('createComposerSendSnapshot', () => {
     images[0].data = 'mutated'
 
     expect(snapshot.hasContent).toBe(true)
-    expect(snapshot.text).toBe('read this\n\n<attached_files>\n@src/app.ts\n</attached_files>')
+    expect(snapshot.text).toBe(
+      '/teach read this\n\n<attached_files>\n@src/app.ts\n</attached_files>',
+    )
     expect(snapshot.images).toEqual([
       {
         data: 'abc',
@@ -39,6 +42,7 @@ describe('createComposerSendSnapshot', () => {
     ])
     expect(snapshot.restore).toEqual({
       prompt: 'read this',
+      inlineTokens: [{ kind: 'slashCommand', name: 'teach' }],
       contexts: [{ kind: 'file', path: 'src/app.ts' }],
       images: [
         {
@@ -57,6 +61,7 @@ describe('restoreFailedSendSnapshot', () => {
   it('restores the attempted snapshot only when the current composer is still empty', () => {
     const snapshot = createComposerSendSnapshot({
       prompt: 'retry this',
+      inlineTokens: [{ kind: 'slashCommand', name: 'teach' }],
       contexts: [{ kind: 'skill', name: 'teach' }],
       images: [
         {
@@ -72,6 +77,7 @@ describe('restoreFailedSendSnapshot', () => {
     expect(
       restoreFailedSendSnapshot(snapshot, {
         prompt: '',
+        inlineTokens: [],
         contexts: [],
         images: [],
       }),
@@ -80,11 +86,13 @@ describe('restoreFailedSendSnapshot', () => {
     expect(
       restoreFailedSendSnapshot(snapshot, {
         prompt: 'new draft',
+        inlineTokens: [],
         contexts: [],
         images: [],
       }),
     ).toEqual({
       prompt: 'new draft',
+      inlineTokens: [],
       contexts: [],
       images: [],
     })
@@ -95,6 +103,7 @@ describe('createQueuedFollowUp', () => {
   it('stores the send-ready snapshot payload independently from later snapshot mutation', () => {
     const snapshot = createComposerSendSnapshot({
       prompt: 'queue this',
+      inlineTokens: [],
       contexts: [],
       images: [
         {

--- a/apps/desktop/src/renderer/src/conversation/composer-send-lifecycle.ts
+++ b/apps/desktop/src/renderer/src/conversation/composer-send-lifecycle.ts
@@ -1,5 +1,9 @@
 import { serializeForSend, type PendingContext } from './pending-contexts'
 import type { QueuedMessage } from './follow-up-queue'
+import {
+  serializeInlineTokensForSend,
+  type ComposerInlineToken,
+} from './composer-inline-tokens'
 
 export interface ComposerDraftImage {
   id: string
@@ -21,6 +25,7 @@ export interface ComposerSendSnapshot {
   images: ComposerSendImage[]
   restore: {
     prompt: string
+    inlineTokens: ComposerInlineToken[]
     contexts: PendingContext[]
     images: ComposerDraftImage[]
   }
@@ -28,29 +33,34 @@ export interface ComposerSendSnapshot {
 
 export interface ComposerLiveState {
   prompt: string
+  inlineTokens: readonly ComposerInlineToken[]
   contexts: readonly PendingContext[]
   images: readonly ComposerDraftImage[]
 }
 
 export function createComposerSendSnapshot({
   prompt,
+  inlineTokens,
   contexts,
   images,
 }: {
   prompt: string
+  inlineTokens: readonly ComposerInlineToken[]
   contexts: readonly PendingContext[]
   images: readonly ComposerDraftImage[]
 }): ComposerSendSnapshot {
+  const restoreInlineTokens = inlineTokens.map((token) => ({ ...token })) as ComposerInlineToken[]
   const restoreContexts = contexts.map((context) => ({ ...context })) as PendingContext[]
   const restoreImages = images.map((image) => ({ ...image }))
   const sendImages = images.map(({ data, mimeType, previewUrl }) => ({ data, mimeType, previewUrl }))
-  const text = serializeForSend(prompt, restoreContexts)
+  const text = serializeInlineTokensForSend(serializeForSend(prompt, restoreContexts), restoreInlineTokens)
   return {
     hasContent: text.length > 0 || sendImages.length > 0,
     text,
     images: sendImages,
     restore: {
       prompt,
+      inlineTokens: restoreInlineTokens,
       contexts: restoreContexts,
       images: restoreImages,
     },
@@ -61,15 +71,22 @@ export function restoreFailedSendSnapshot(
   snapshot: ComposerSendSnapshot,
   current: ComposerLiveState,
 ): ComposerSendSnapshot['restore'] {
-  if (current.prompt.length > 0 || current.contexts.length > 0 || current.images.length > 0) {
+  if (
+    current.prompt.length > 0 ||
+    current.inlineTokens.length > 0 ||
+    current.contexts.length > 0 ||
+    current.images.length > 0
+  ) {
     return {
       prompt: current.prompt,
+      inlineTokens: current.inlineTokens.map((token) => ({ ...token })) as ComposerInlineToken[],
       contexts: [...current.contexts],
       images: current.images.map((image) => ({ ...image })),
     }
   }
   return {
     prompt: snapshot.restore.prompt,
+    inlineTokens: snapshot.restore.inlineTokens.map((token) => ({ ...token })) as ComposerInlineToken[],
     contexts: snapshot.restore.contexts.map((context) => ({ ...context })) as PendingContext[],
     images: snapshot.restore.images.map((image) => ({ ...image })),
   }

--- a/apps/desktop/src/renderer/src/conversation/composer-sources.tsx
+++ b/apps/desktop/src/renderer/src/conversation/composer-sources.tsx
@@ -4,6 +4,7 @@ import type { AcpCommand } from './reducer'
 import { filterCommands, getCommandQuery, removeCommandToken } from './command-autocomplete'
 import { applyPath, filterPaths, getPathQuery, removePathToken } from './path-autocomplete'
 import type { CompletionSource } from './use-composer-autocomplete'
+import { createSlashCommandInlineToken } from './composer-inline-tokens'
 
 /**
  * The two concrete completion sources (quality-review slice 4a): thin configs over the pure
@@ -14,10 +15,9 @@ import type { CompletionSource } from './use-composer-autocomplete'
  */
 
 /**
- * The `/` slash-command source (#95): start-anchored, always closes on accept. Accepting
- * stages the skill as a pending-context CHIP (#229) — the trigger token is removed from
- * the text and the chip rides back through `apply`'s `context`; the invocation is
- * re-prepended to the wire text at send. Rows show `/name` + an optional description.
+ * The `/` slash-command source (#95/#309): prompt-start anchored, always closes on accept.
+ * Accepting stages the command as the single structured Inline token; the typed trigger
+ * text is removed from the prompt body and the command is serialized back at send.
  */
 export function createCommandSource(commands: readonly AcpCommand[]): CompletionSource<AcpCommand> {
   return {
@@ -34,7 +34,7 @@ export function createCommandSource(commands: readonly AcpCommand[]): Completion
     rowKey: (command) => command.name,
     apply: (value, start, caret, command) => ({
       ...removeCommandToken(value, start, caret),
-      context: { kind: 'skill', name: command.name, description: command.description },
+      inlineToken: createSlashCommandInlineToken(command),
     }),
     closeOnAccept: () => true,
     renderRow: (command) => (

--- a/apps/desktop/src/renderer/src/conversation/use-composer-autocomplete.tsx
+++ b/apps/desktop/src/renderer/src/conversation/use-composer-autocomplete.tsx
@@ -11,6 +11,7 @@ import { moveSelection } from './command-autocomplete'
 import { resolveAutocomplete, type ActiveTrigger, type Detection } from './autocomplete-machine'
 import type { PendingContext } from './pending-contexts'
 import type { ComposerEditorHandle } from './composer-editor-handle'
+import type { ComposerInlineToken } from './composer-inline-tokens'
 
 /**
  * One completion mechanism for the composer (quality-review slice 4a): the `/` command
@@ -39,14 +40,14 @@ export interface CompletionSource<Row = unknown> {
   /** A stable React key for a row. */
   rowKey(row: Row): string
   /** Splice the accepted row over its `@`/`/` token; return the new value + caret. A source
-   *  whose accept stages a pending-context CHIP (#229) instead of inline text removes the
-   *  token and returns the chip as `context` — the hook hands it to `onContext`. */
+   *  whose accept stages structured data instead of inline text removes the typed token
+   *  and returns either a pending-context chip or an Inline token. */
   apply(
     value: string,
     start: number,
     caret: number,
     row: Row,
-  ): { value: string; caret: number; context?: PendingContext }
+  ): { value: string; caret: number; context?: PendingContext; inlineToken?: ComposerInlineToken }
   /** Whether accepting this row CLOSES the popover. False re-derives the trigger to drill in
    *  (a directory reopens on its new fragment). */
   closeOnAccept(row: Row): boolean
@@ -91,6 +92,7 @@ export function useComposerAutocomplete(
   inputRef: RefObject<ComposerEditorHandle | null>,
   /** Receives the pending-context chip when an accepted row stages one (#229). */
   onContext?: (context: PendingContext) => void,
+  onInlineToken?: (token: ComposerInlineToken) => void,
 ): ComposerAutocomplete {
   const [trigger, setTrigger] = useState<ActiveTrigger | null>(null)
   const [index, setIndex] = useState(0)
@@ -144,6 +146,7 @@ export function useComposerAutocomplete(
     const next = source.apply(value, trigger.start, caret, row)
     setValue(next.value)
     if (next.context) onContext?.(next.context)
+    if (next.inlineToken) onInlineToken?.(next.inlineToken)
     setIndex(0)
     if (source.closeOnAccept(row)) {
       dismissedRef.current[trigger.sourceIndex] = null


### PR DESCRIPTION
## Summary
- store accepted slash commands as the single structured composer Inline token instead of a pending skill chip
- restrict slash autocomplete to absolute prompt start, so later-line and mid-sentence slash text stays ordinary prompt text
- serialize the structured slash token into send/queued follow-up text exactly once and restore it on failed sends

Closes #309

## Validation
- bun run --cwd apps/desktop test src/renderer/src/conversation/command-autocomplete.test.ts src/renderer/src/conversation/composer-inline-tokens.test.ts src/renderer/src/conversation/composer-send-lifecycle.test.ts src/renderer/src/conversation/composer-draft-store.test.ts
- bun run typecheck
- bun run lint
- bun run test
- bun run build

Note: the first parallel lint attempt raced with build and hit a transient missing electron-vite temp config file; rerunning lint by itself passed.