### PR TITLE
Insert file and folder completions inline

### DIFF
--- a/apps/desktop/src/renderer/src/conversation/composer-sources.test.ts
+++ b/apps/desktop/src/renderer/src/conversation/composer-sources.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { createPathSource } from './composer-sources'
+import type { FileEntry } from '../../../shared/ipc'
+
+const ENTRIES: FileEntry[] = [
+  { path: 'src/reducer.ts', kind: 'file' },
+  { path: 'src', kind: 'directory' },
+]
+
+describe('createPathSource', () => {
+  it('accepts a file as inline @path text at the trigger position', () => {
+    const source = createPathSource({ entries: ENTRIES, onFirstOpen: () => {} })
+
+    expect(source.apply('see @re now', 4, 7, ENTRIES[0])).toEqual({
+      value: 'see @src/reducer.ts  now',
+      caret: 20,
+    })
+  })
+
+  it('accepts a folder as inline @path/ text at the trigger position', () => {
+    const source = createPathSource({ entries: ENTRIES, onFirstOpen: () => {} })
+
+    expect(source.apply('open @sr next', 5, 8, ENTRIES[1])).toEqual({
+      value: 'open @src/ next',
+      caret: 10,
+    })
+  })
+
+  it('closes the popover for both files and folders once the reference is inserted', () => {
+    const source = createPathSource({ entries: ENTRIES, onFirstOpen: () => {} })
+
+    expect(source.closeOnAccept(ENTRIES[0])).toBe(true)
+    expect(source.closeOnAccept(ENTRIES[1])).toBe(true)
+  })
+})

--- a/apps/desktop/src/renderer/src/conversation/composer-sources.tsx
+++ b/apps/desktop/src/renderer/src/conversation/composer-sources.tsx
@@ -2,7 +2,7 @@ import { File, Folder } from 'lucide-react'
 import type { FileEntry } from '../../../shared/ipc'
 import type { AcpCommand } from './reducer'
 import { filterCommands, getCommandQuery, removeCommandToken } from './command-autocomplete'
-import { applyPath, filterPaths, getPathQuery, removePathToken } from './path-autocomplete'
+import { applyPath, filterPaths, getPathQuery } from './path-autocomplete'
 import type { CompletionSource } from './use-composer-autocomplete'
 import { createSlashCommandInlineToken } from './composer-inline-tokens'
 
@@ -51,11 +51,11 @@ export function createCommandSource(commands: readonly AcpCommand[]): Completion
 }
 
 /**
- * The `@` file-path source (#190): mid-sentence. Accepting a FILE stages it as a
- * pending-context CHIP (#230) — token removed, chip rides back through `apply`'s
- * `context`, the `@path` mention re-serialized at send. Accepting a DIRECTORY keeps
- * today's in-text drill-down (trailing slash re-derives the trigger into it). `onOpen`
- * kicks the lazy `files:list` fetch on first trigger. Rows show a dir/file icon + path.
+ * The `@` file-path source (#190/#310): mid-sentence. Accepting a file or folder
+ * inserts inline `@path` text exactly where the user triggered completion; legacy
+ * pending file chips still exist for side-panel inserts and old transcripts.
+ * `onOpen` kicks the lazy `files:list` fetch on first trigger. Rows show a dir/file
+ * icon + path.
  */
 export function createPathSource({
   entries,
@@ -76,11 +76,8 @@ export function createPathSource({
       return filterPaths(entries, query)
     },
     rowKey: (entry) => entry.path,
-    apply: (value, start, caret, entry) =>
-      entry.kind === 'directory'
-        ? applyPath(value, start, caret, entry)
-        : { ...removePathToken(value, start, caret), context: { kind: 'file', path: entry.path } },
-    closeOnAccept: (entry) => entry.kind !== 'directory',
+    apply: (value, start, caret, entry) => applyPath(value, start, caret, entry),
+    closeOnAccept: () => true,
     onOpen: onFirstOpen,
     renderRow: (entry) => (
       <>

--- a/apps/desktop/src/renderer/src/conversation/path-autocomplete.test.ts
+++ b/apps/desktop/src/renderer/src/conversation/path-autocomplete.test.ts
@@ -4,7 +4,6 @@ import {
   filterPaths,
   getPathQuery,
   moveSelection,
-  removePathToken,
   MAX_PATH_RESULTS,
 } from './path-autocomplete'
 import type { FileEntry } from '../../../shared/ipc'
@@ -156,16 +155,6 @@ describe('applyPath — plain-text insertion transform', () => {
     const out = applyPath('see @sr done', 4, 7, { path: 'src', kind: 'directory' })
     expect(out.value).toBe('see @src/ done')
     expect(out.caret).toBe(9)
-  })
-})
-
-describe('removePathToken — chip-accept transform (#230)', () => {
-  it('removes the `@query` token and rests the caret where it began', () => {
-    expect(removePathToken('@re', 0, 3)).toEqual({ value: '', caret: 0 })
-  })
-
-  it('removes a mid-sentence token, keeping text either side intact', () => {
-    expect(removePathToken('see @re done', 4, 7)).toEqual({ value: 'see  done', caret: 4 })
   })
 })
 

--- a/apps/desktop/src/renderer/src/conversation/path-autocomplete.ts
+++ b/apps/desktop/src/renderer/src/conversation/path-autocomplete.ts
@@ -12,8 +12,7 @@
  *
  * Accepting inserts PLAIN TEXT `@<path>` with NO client-side expansion (ADR-0002): a FILE
  * gets a trailing space (`@path `, token closed, caret past it); a DIRECTORY gets a
- * trailing slash (`@dir/`, no space) so re-deriving the fragment naturally continues into
- * the directory's children. The agent resolves the literal `@path` itself server-side
+ * trailing slash (`@dir/`). The agent resolves the literal `@path` itself server-side
  * (render_path_prompt).
  *
  * Deliberately DOM-free and side-effect-free so it unit-tests as plain data
@@ -127,14 +126,4 @@ export function applyPath(
   const insert = `@${entry.path}${suffix}`
   const nextValue = value.slice(0, start) + insert + value.slice(caret)
   return { value: nextValue, caret: start + insert.length }
-}
-
-/**
- * Remove the `@query` token (from `start` up to `caret`) outright — the chip-accept
- * transform (#230): an accepted FILE becomes a pending-context chip beside the text
- * (a directory still drills down in-text via {@link applyPath}). Text after the caret
- * is kept; the caret rests where the token began.
- */
-export function removePathToken(value: string, start: number, caret: number): PathInsertion {
-  return { value: value.slice(0, start) + value.slice(caret), caret: start }
 }

--- a/apps/desktop/src/renderer/src/conversation/use-composer-autocomplete.tsx
+++ b/apps/desktop/src/renderer/src/conversation/use-composer-autocomplete.tsx
@@ -48,8 +48,8 @@ export interface CompletionSource<Row = unknown> {
     caret: number,
     row: Row,
   ): { value: string; caret: number; context?: PendingContext; inlineToken?: ComposerInlineToken }
-  /** Whether accepting this row CLOSES the popover. False re-derives the trigger to drill in
-   *  (a directory reopens on its new fragment). */
+  /** Whether accepting this row CLOSES the popover. False re-derives the trigger for
+   *  source-specific continuation flows. */
   closeOnAccept(row: Row): boolean
   /** Fired once this source's token becomes active — the lazy `@` listing fetch hooks here. */
   onOpen?(): void
@@ -136,8 +136,8 @@ export function useComposerAutocomplete(
   // Accept a completion: splice the row in over its token, keep the composer value (+ its
   // persisted draft, via `setValue`) in lockstep, then restore focus and drop the caret
   // just past the insertion (rAF, so React's controlled value doesn't stomp the DOM caret).
-  // A source that DOESN'T close on accept (a directory) re-derives the trigger so completion
-  // drills into the new fragment; otherwise the token's latch is cleared and the popover shuts.
+  // A source that DOESN'T close on accept re-derives the trigger for source-specific
+  // continuation flows; otherwise the token's latch is cleared and the popover shuts.
   function accept(row: unknown): void {
     if (!trigger) return
     const source = sources[trigger.sourceIndex]


### PR DESCRIPTION
## Summary
- insert accepted @ file completions inline at the trigger position instead of staging pending file chips
- insert accepted @ folder completions inline and close the popover after accepting the folder reference
- keep legacy attached-files marker parsing untouched for old transcripts and side-panel file chips

Closes #310

## Validation
- bun run --cwd apps/desktop test src/renderer/src/conversation/composer-sources.test.ts src/renderer/src/conversation/path-autocomplete.test.ts src/renderer/src/conversation/pending-contexts.test.ts
- bun run typecheck
- bun run lint
- bun run test
- bun run build