### PR TITLE
Persist context attachments outside the editor

### DIFF
--- a/apps/desktop/src/renderer/src/conversation/Composer.tsx
+++ b/apps/desktop/src/renderer/src/conversation/Composer.tsx
@@ -1,5 +1,6 @@
 import {
   useEffect,
+  useCallback,
   useMemo,
   useRef,
   useState,
@@ -20,7 +21,7 @@ import { AgentControls } from './AgentControls'
 import { Card } from '../ui/card'
 import { IconButton } from '../ui/icon-button'
 import type { AcpCommand } from './reducer'
-import { useComposerDraft } from './composer-draft-store'
+import { useComposerDraft, type ComposerDraftImage } from './composer-draft-store'
 import {
   appendText,
   subscribeComposerInsert,
@@ -112,18 +113,6 @@ function chipTitle(context: PendingContext): string | undefined {
 const IMAGE_ACCEPT = ACCEPTED_IMAGE_TYPES.join(',')
 
 /**
- * An image staged in the composer before send (#100). `data` is BARE base64 (sent
- * to the agent); `previewUrl` is the full data URL (thumbnail + echoed user turn).
- */
-interface PendingImage {
-  id: string
-  data: string
-  mimeType: string
-  name: string
-  previewUrl: string
-}
-
-/**
  * The composer: the Thread's input surface (quality-review slice 4 split from Conversation).
  * Owns its own renderer-only state — the per-Thread persisted draft (#60), the staged images
  * awaiting send (#100), and the unified `/`+`@` autocomplete (#95/#190) — plus the queued
@@ -178,14 +167,8 @@ export function Composer({
   const [composerDraft, setComposerDraft, clearPersistedDraft] = useComposerDraft(threadId)
   const draft = composerDraft.prompt
   const slashCommandToken = getSlashCommandInlineToken(composerDraft.inlineTokens)
-  // Images staged in the composer, awaiting send (#100). Renderer-only, ephemeral:
-  // this view remounts on a Thread switch (keyed by threadId), so the strip starts
-  // empty per Thread. Kept on a failed send so the user can retry / switch model.
-  const [pendingImages, setPendingImages] = useState<PendingImage[]>([])
-  // Pending-context chips (#229): structured attachments staged BESIDE the draft
-  // text. Same lifecycle as staged images: ephemeral, cleared on send/enqueue,
-  // kept on failure. Slash commands live in the structured draft's Inline tokens.
-  const [pendingContexts, setPendingContexts] = useState<PendingContext[]>([])
+  const pendingImages = composerDraft.images
+  const pendingContexts = composerDraft.contextAttachments
   const liveComposerStateRef = useRef({
     prompt: draft,
     inlineTokens: composerDraft.inlineTokens,
@@ -234,6 +217,25 @@ export function Composer({
     }))
   }
 
+  const setPendingContexts = useCallback((
+    next: PendingContext[] | ((current: PendingContext[]) => PendingContext[]),
+  ): void => {
+    setComposerDraft((current) => ({
+      ...current,
+      contextAttachments:
+        typeof next === 'function' ? next(current.contextAttachments) : next,
+    }))
+  }, [setComposerDraft])
+
+  const setPendingImages = useCallback((
+    next: ComposerDraftImage[] | ((current: ComposerDraftImage[]) => ComposerDraftImage[]),
+  ): void => {
+    setComposerDraft((current) => ({
+      ...current,
+      images: typeof next === 'function' ? next(current.images) : next,
+    }))
+  }, [setComposerDraft])
+
   function setSlashCommandToken(command: AcpCommand | null): void {
     setComposerDraft((current) => ({
       ...current,
@@ -264,15 +266,14 @@ export function Composer({
 
   // Insert from the Files preview's action (#189): the side panel is a sibling of this
   // view, so it reaches the composer through the module-level `composer-insert` channel
-  // keyed by threadId. The path stages as a pending-context FILE chip (#230) — same as an
-  // `@` autocomplete accept — and is re-serialized to a plain-text `@path` mention at send
-  // (the agent expands it itself, ADR-0002).
+  // keyed by threadId. The path stages as a prompt-level file chip and is serialized
+  // into the legacy trailing <attached_files> block at send.
   useEffect(() => {
     return subscribeComposerInsert(threadId, (relativePath) => {
       setPendingContexts((prev) => addContext(prev, { kind: 'file', path: relativePath }))
       inputRef.current?.focus()
     })
-  }, [threadId])
+  }, [setPendingContexts, threadId])
 
   // Insert RAW text from the Terminal Surface's "Add to chat" (ADR-0014 slice 4): the
   // terminal is a side-panel sibling, so its selection reaches the composer through the
@@ -293,7 +294,7 @@ export function Composer({
       setPendingImages((prev) => [...prev, { id: `img:${imageSeq++}`, ...image }])
       inputRef.current?.focus()
     })
-  }, [threadId])
+  }, [setPendingImages, threadId])
 
   // Stage a Browser Surface element pick (#224/#231): the ONE payload — element metadata
   // + optional pre-split screenshot — arrives through the module-level channel keyed by
@@ -311,7 +312,7 @@ export function Composer({
       )
       inputRef.current?.focus()
     })
-  }, [threadId])
+  }, [setPendingContexts, setPendingImages, threadId])
 
   // Stage a Review Surface diff comment (#239): file + located line range + note +
   // verbatim diff excerpt arrive through the module-level channel keyed by threadId;
@@ -322,7 +323,7 @@ export function Composer({
       setPendingContexts((prev) => addContext(prev, { kind: 'review', id: `rc:${reviewSeq++}`, ...comment }))
       inputRef.current?.focus()
     })
-  }, [threadId])
+  }, [setPendingContexts, threadId])
 
   // Read a pasted/picked image blob to a data URL (DOM: FileReader lives here, not
   // in the pure module), split it into bare base64 + mime via `parseDataUrl`, and
@@ -397,10 +398,7 @@ export function Composer({
       // a concurrent prompt) and clear the composer so the user can compose the next
       // follow-up. It auto-flushes on the next turn end.
       followUps.enqueue(createQueuedFollowUp(nextQueueId(), snapshot))
-      writeDraft('')
       clearPersistedDraft()
-      setPendingImages([])
-      setPendingContexts([])
       return
     }
     // Idle: send now, clearing the composer OPTIMISTICALLY — `submitPrompt` resolves
@@ -409,9 +407,6 @@ export function Composer({
     // response. The echo is already in the transcript; on a FAILED outcome we RESTORE
     // the payload for retry (#100's keep-on-failure, e.g. switching to a vision model
     // after -31008) — unless the user started composing something new meanwhile.
-    setPendingImages([])
-    setPendingContexts([])
-    writeDraft('')
     clearPersistedDraft()
     const ok = await submitPrompt(snapshot.text, snapshot.images)
     if (!ok) {
@@ -422,9 +417,9 @@ export function Composer({
         ...current,
         prompt: restored.prompt,
         inlineTokens: restored.inlineTokens,
+        contextAttachments: restored.contexts,
+        images: restored.images,
       }))
-      setPendingImages(restored.images)
-      setPendingContexts(restored.contexts)
     }
   }
 

--- a/apps/desktop/src/renderer/src/conversation/composer-draft-store.test.ts
+++ b/apps/desktop/src/renderer/src/conversation/composer-draft-store.test.ts
@@ -52,6 +52,63 @@ describe('getDraft / setDraft round-trip', () => {
     })
   })
 
+  it('round-trips structured context attachments and images', () => {
+    const storage = fakeStorage()
+    setComposerDraft(storage, 't1', {
+      prompt: 'review this',
+      inlineTokens: [],
+      contextAttachments: [
+        {
+          kind: 'review',
+          id: 'rc:1',
+          filePath: 'src/app.ts',
+          startLine: 4,
+          endLine: 6,
+          note: 'check this',
+          excerpt: '+const x = 1',
+        },
+        { kind: 'pasted', id: 'paste:1', text: 'long\npaste' },
+      ],
+      images: [
+        {
+          id: 'img:1',
+          data: 'abc',
+          mimeType: 'image/png',
+          name: 'screen.png',
+          previewUrl: 'data:image/png;base64,abc',
+        },
+      ],
+      nonPersistedImageIds: [],
+    })
+
+    expect(getComposerDraft(storage, 't1')).toEqual({
+      prompt: 'review this',
+      inlineTokens: [],
+      contextAttachments: [
+        {
+          kind: 'review',
+          id: 'rc:1',
+          filePath: 'src/app.ts',
+          startLine: 4,
+          endLine: 6,
+          note: 'check this',
+          excerpt: '+const x = 1',
+        },
+        { kind: 'pasted', id: 'paste:1', text: 'long\npaste' },
+      ],
+      images: [
+        {
+          id: 'img:1',
+          data: 'abc',
+          mimeType: 'image/png',
+          name: 'screen.png',
+          previewUrl: 'data:image/png;base64,abc',
+        },
+      ],
+      nonPersistedImageIds: [],
+    })
+  })
+
   it('stores and reads back a draft keyed by threadId', () => {
     const storage = fakeStorage()
     setDraft(storage, 't1', 'hello world')
@@ -294,6 +351,54 @@ describe('malformed / missing tolerance (never throws into render)', () => {
     const storage = fakeStorage()
     storage.map.set(COMPOSER_DRAFT_STORAGE_KEY, JSON.stringify({ t1: 42 }))
     expect(getDraft(storage, 't1')).toBe('')
+  })
+
+  it('drops malformed context attachments and images from persisted structured drafts', () => {
+    const storage = fakeStorage()
+    storage.map.set(
+      COMPOSER_DRAFT_STORAGE_KEY,
+      JSON.stringify({
+        schemaVersion: 1,
+        drafts: {
+          t1: {
+            prompt: 'keep',
+            inlineTokens: [],
+            contextAttachments: [
+              { kind: 'file', path: 'src/app.ts' },
+              { kind: 'review', id: 'missing-fields' },
+              null,
+            ],
+            images: [
+              {
+                id: 'img:1',
+                data: 'abc',
+                mimeType: 'image/png',
+                name: 'screen.png',
+                previewUrl: 'data:image/png;base64,abc',
+              },
+              { id: 'bad' },
+            ],
+            nonPersistedImageIds: [],
+          },
+        },
+      }),
+    )
+
+    expect(getComposerDraft(storage, 't1')).toEqual({
+      prompt: 'keep',
+      inlineTokens: [],
+      contextAttachments: [{ kind: 'file', path: 'src/app.ts' }],
+      images: [
+        {
+          id: 'img:1',
+          data: 'abc',
+          mimeType: 'image/png',
+          name: 'screen.png',
+          previewUrl: 'data:image/png;base64,abc',
+        },
+      ],
+      nonPersistedImageIds: [],
+    })
   })
 
   it('returns "" for an absent key', () => {

--- a/apps/desktop/src/renderer/src/conversation/composer-draft-store.ts
+++ b/apps/desktop/src/renderer/src/conversation/composer-draft-store.ts
@@ -1,5 +1,6 @@
 import { useCallback, useSyncExternalStore } from 'react'
 import { coerceInlineTokens, type ComposerInlineToken } from './composer-inline-tokens'
+import { coercePendingContexts, type PendingContext } from './pending-contexts'
 
 /**
  * Per-Thread composer drafts (#60): the unsent text in a Thread's composer, kept
@@ -34,9 +35,17 @@ export interface DraftStorage {
 export interface ComposerDraft {
   prompt: string
   inlineTokens: ComposerInlineToken[]
-  contextAttachments: unknown[]
-  images: unknown[]
+  contextAttachments: PendingContext[]
+  images: ComposerDraftImage[]
   nonPersistedImageIds: string[]
+}
+
+export interface ComposerDraftImage {
+  id: string
+  data: string
+  mimeType: string
+  name: string
+  previewUrl: string
 }
 
 /** The persisted shape: a thread id -> structured draft map. */
@@ -50,8 +59,8 @@ interface PersistedComposerDrafts {
 const EMPTY_COMPOSER_DRAFT: ComposerDraft = Object.freeze({
   prompt: '',
   inlineTokens: Object.freeze([]) as unknown as ComposerInlineToken[],
-  contextAttachments: Object.freeze([]) as unknown as unknown[],
-  images: Object.freeze([]) as unknown as unknown[],
+  contextAttachments: Object.freeze([]) as unknown as PendingContext[],
+  images: Object.freeze([]) as unknown as ComposerDraftImage[],
   nonPersistedImageIds: Object.freeze([]) as unknown as string[],
 })
 
@@ -63,6 +72,31 @@ function emptyComposerDraft(): ComposerDraft {
     images: [],
     nonPersistedImageIds: [],
   }
+}
+
+function coerceImages(values: unknown[]): ComposerDraftImage[] {
+  const images: ComposerDraftImage[] = []
+  for (const value of values) {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) continue
+    const image = value as Partial<ComposerDraftImage>
+    if (
+      typeof image.id !== 'string' ||
+      typeof image.data !== 'string' ||
+      typeof image.mimeType !== 'string' ||
+      typeof image.name !== 'string' ||
+      typeof image.previewUrl !== 'string'
+    ) {
+      continue
+    }
+    images.push({
+      id: image.id,
+      data: image.data,
+      mimeType: image.mimeType,
+      name: image.name,
+      previewUrl: image.previewUrl,
+    })
+  }
+  return images
 }
 
 function isEmptyDraft(draft: ComposerDraft): boolean {
@@ -81,8 +115,10 @@ function coerceDraft(value: unknown): ComposerDraft | null {
   return {
     prompt: typeof draft.prompt === 'string' ? draft.prompt : '',
     inlineTokens: Array.isArray(draft.inlineTokens) ? coerceInlineTokens(draft.inlineTokens) : [],
-    contextAttachments: Array.isArray(draft.contextAttachments) ? draft.contextAttachments : [],
-    images: Array.isArray(draft.images) ? draft.images : [],
+    contextAttachments: Array.isArray(draft.contextAttachments)
+      ? coercePendingContexts(draft.contextAttachments)
+      : [],
+    images: Array.isArray(draft.images) ? coerceImages(draft.images) : [],
     nonPersistedImageIds: Array.isArray(draft.nonPersistedImageIds)
       ? draft.nonPersistedImageIds.filter((id): id is string => typeof id === 'string')
       : [],

--- a/apps/desktop/src/renderer/src/conversation/composer-send-lifecycle.ts
+++ b/apps/desktop/src/renderer/src/conversation/composer-send-lifecycle.ts
@@ -4,14 +4,7 @@ import {
   serializeInlineTokensForSend,
   type ComposerInlineToken,
 } from './composer-inline-tokens'
-
-export interface ComposerDraftImage {
-  id: string
-  data: string
-  mimeType: string
-  name: string
-  previewUrl: string
-}
+import type { ComposerDraftImage } from './composer-draft-store'
 
 export interface ComposerSendImage {
   data: string

--- a/apps/desktop/src/renderer/src/conversation/pending-contexts.ts
+++ b/apps/desktop/src/renderer/src/conversation/pending-contexts.ts
@@ -73,6 +73,81 @@ export type PendingContext =
   | ReviewCommentContext
   | PastedTextContext
 
+function stringOrNull(value: unknown): string | null {
+  return typeof value === 'string' ? value : null
+}
+
+function numberOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function coercePendingContext(value: unknown): PendingContext | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null
+  const context = value as Record<string, unknown>
+  switch (context.kind) {
+    case 'skill': {
+      if (typeof context.name !== 'string' || context.name.length === 0) return null
+      return {
+        kind: 'skill',
+        name: context.name,
+        description: typeof context.description === 'string' ? context.description : undefined,
+      }
+    }
+    case 'file':
+      return typeof context.path === 'string' && context.path.length > 0
+        ? { kind: 'file', path: context.path }
+        : null
+    case 'element': {
+      const id = stringOrNull(context.id)
+      const tagName = stringOrNull(context.tagName)
+      const text = stringOrNull(context.text)
+      const pageUrl = stringOrNull(context.pageUrl)
+      if (!id || !tagName || text === null || !pageUrl) return null
+      return {
+        kind: 'element',
+        id,
+        tagName,
+        selector: stringOrNull(context.selector),
+        text,
+        pageUrl,
+        imageId: stringOrNull(context.imageId),
+      }
+    }
+    case 'review': {
+      const id = stringOrNull(context.id)
+      const filePath = stringOrNull(context.filePath)
+      const note = stringOrNull(context.note)
+      const excerpt = stringOrNull(context.excerpt)
+      if (!id || !filePath || note === null || excerpt === null) return null
+      return {
+        kind: 'review',
+        id,
+        filePath,
+        startLine: numberOrNull(context.startLine),
+        endLine: numberOrNull(context.endLine),
+        note,
+        excerpt,
+      }
+    }
+    case 'pasted': {
+      const id = stringOrNull(context.id)
+      const text = stringOrNull(context.text)
+      return id && text !== null ? { kind: 'pasted', id, text } : null
+    }
+    default:
+      return null
+  }
+}
+
+export function coercePendingContexts(values: unknown[]): PendingContext[] {
+  const contexts: PendingContext[] = []
+  for (const value of values) {
+    const context = coercePendingContext(value)
+    if (context) contexts.push(context)
+  }
+  return contexts
+}
+
 /** A paste is compressed into a chip past EITHER bound — enough characters to balloon
  *  the textarea, or enough lines to push the controls off-screen. */
 export const LONG_PASTE_CHARS = 1000


### PR DESCRIPTION
## Summary
- move composer context attachments and staged images into the structured draft store while keeping them outside the Lexical editor
- preserve existing prompt-level send serialization through prose marker blocks and image payload snapshots
- coerce persisted context attachments and images defensively so malformed localStorage cannot break render

Closes #311

## Validation
- bun run --cwd apps/desktop test src/renderer/src/conversation/composer-draft-store.test.ts src/renderer/src/conversation/composer-send-lifecycle.test.ts src/renderer/src/conversation/pending-contexts.test.ts
- bun run typecheck
- bun run lint
- bun run test
- bun run build