### PR TITLE
Cap unsent image draft persistence

### DIFF
--- a/apps/desktop/src/renderer/src/conversation/Composer.tsx
+++ b/apps/desktop/src/renderer/src/conversation/Composer.tsx
@@ -169,6 +169,10 @@ export function Composer({
   const slashCommandToken = getSlashCommandInlineToken(composerDraft.inlineTokens)
   const pendingImages = composerDraft.images
   const pendingContexts = composerDraft.contextAttachments
+  const nonPersistedImageIds = useMemo(
+    () => new Set(composerDraft.nonPersistedImageIds),
+    [composerDraft.nonPersistedImageIds],
+  )
   const liveComposerStateRef = useRef({
     prompt: draft,
     inlineTokens: composerDraft.inlineTokens,
@@ -546,23 +550,35 @@ export function Composer({
           {pendingImages.length > 0 && (
             // Staged-image strip (#100): thumbnails with a ✕ remove, above the input.
             <div className="mb-3 flex flex-wrap gap-2">
-              {pendingImages.map((img) => (
-                <div key={img.id} className="relative size-14">
-                  <img
-                    className="size-14 rounded-lg border border-border object-cover"
-                    src={img.previewUrl}
-                    alt={img.name}
-                  />
-                  <button
-                    type="button"
-                    aria-label={`Remove ${img.name}`}
-                    onClick={() => removeImage(img.id)}
-                    className="absolute -top-1.5 -right-1.5 inline-flex size-[18px] items-center justify-center rounded-full border border-border bg-panel text-text outline-none"
+              {pendingImages.map((img) => {
+                const sessionOnly = nonPersistedImageIds.has(img.id)
+                return (
+                  <div
+                    key={img.id}
+                    className="relative size-14"
+                    title={sessionOnly ? `${img.name} is current-session-only` : img.name}
                   >
-                    <X className="size-3" aria-hidden />
-                  </button>
-                </div>
-              ))}
+                    <img
+                      className="size-14 rounded-lg border border-border object-cover"
+                      src={img.previewUrl}
+                      alt={img.name}
+                    />
+                    {sessionOnly && (
+                      <span className="absolute bottom-0 left-0 max-w-full rounded-tr-md rounded-bl-lg bg-panel/95 px-1 py-0.5 text-[9px] leading-none text-muted">
+                        Session only
+                      </span>
+                    )}
+                    <button
+                      type="button"
+                      aria-label={`Remove ${img.name}`}
+                      onClick={() => removeImage(img.id)}
+                      className="absolute -top-1.5 -right-1.5 inline-flex size-[18px] items-center justify-center rounded-full border border-border bg-panel text-text outline-none"
+                    >
+                      <X className="size-3" aria-hidden />
+                    </button>
+                  </div>
+                )
+              })}
             </div>
           )}
 

--- a/apps/desktop/src/renderer/src/conversation/composer-draft-store.test.ts
+++ b/apps/desktop/src/renderer/src/conversation/composer-draft-store.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
+  COMPOSER_DRAFT_IMAGE_MAX_COUNT,
+  COMPOSER_DRAFT_IMAGE_MAX_DATA_URL_CHARS,
   COMPOSER_DRAFT_STORAGE_KEY,
   LEGACY_COMPOSER_DRAFT_STORAGE_KEY,
   clearDraft,
@@ -31,6 +33,20 @@ function fakeStorage(): DraftStorage & { map: Map<string, string> } {
       map.delete(k)
     },
   }
+}
+
+function image(id: string, previewUrl = 'data:image/png;base64,AAAA') {
+  return {
+    id,
+    data: previewUrl.slice('data:image/png;base64,'.length),
+    mimeType: 'image/png',
+    name: `${id}.png`,
+    previewUrl,
+  }
+}
+
+function storedDraft(storage: DraftStorage & { map: Map<string, string> }, threadId: string) {
+  return JSON.parse(storage.map.get(COMPOSER_DRAFT_STORAGE_KEY) ?? '{}').drafts?.[threadId]
 }
 
 describe('getDraft / setDraft round-trip', () => {
@@ -107,6 +123,26 @@ describe('getDraft / setDraft round-trip', () => {
       ],
       nonPersistedImageIds: [],
     })
+  })
+
+  it('persists image drafts as data-url records only and restores sendable data from them', () => {
+    const storage = fakeStorage()
+    setComposerDraft(storage, 't1', {
+      prompt: 'look',
+      inlineTokens: [],
+      contextAttachments: [],
+      images: [image('img:1')],
+      nonPersistedImageIds: [],
+    })
+
+    expect(storedDraft(storage, 't1').images).toEqual([
+      {
+        id: 'img:1',
+        name: 'img:1.png',
+        previewUrl: 'data:image/png;base64,AAAA',
+      },
+    ])
+    expect(getComposerDraft(storage, 't1').images).toEqual([image('img:1')])
   })
 
   it('stores and reads back a draft keyed by threadId', () => {
@@ -269,6 +305,50 @@ describe('composer draft external store', () => {
     })
 
     expect(store.getSnapshot('t1')).toBe(store.getSnapshot('t1'))
+  })
+
+  it('keeps over-count images usable in the current session but omits them from storage', () => {
+    const storage = fakeStorage()
+    const store = createComposerDraftStore(storage)
+    const images = Array.from({ length: COMPOSER_DRAFT_IMAGE_MAX_COUNT + 1 }, (_, i) =>
+      image(`img:${i}`),
+    )
+
+    store.setDraft('t1', {
+      prompt: 'look',
+      inlineTokens: [],
+      contextAttachments: [],
+      images,
+      nonPersistedImageIds: [],
+    })
+
+    expect(store.getSnapshot('t1').images).toHaveLength(COMPOSER_DRAFT_IMAGE_MAX_COUNT + 1)
+    expect(store.getSnapshot('t1').nonPersistedImageIds).toEqual([
+      `img:${COMPOSER_DRAFT_IMAGE_MAX_COUNT}`,
+    ])
+    expect(storedDraft(storage, 't1').images).toHaveLength(COMPOSER_DRAFT_IMAGE_MAX_COUNT)
+  })
+
+  it('keeps oversized images usable in the current session but prunes image-only storage', () => {
+    const storage = fakeStorage()
+    const store = createComposerDraftStore(storage)
+    const prefix = 'data:image/png;base64,'
+    const oversized = image(
+      'img:big',
+      `${prefix}${'A'.repeat(COMPOSER_DRAFT_IMAGE_MAX_DATA_URL_CHARS - prefix.length + 1)}`,
+    )
+
+    store.setDraft('t1', {
+      prompt: '',
+      inlineTokens: [],
+      contextAttachments: [],
+      images: [oversized],
+      nonPersistedImageIds: [],
+    })
+
+    expect(store.getSnapshot('t1').images).toEqual([oversized])
+    expect(store.getSnapshot('t1').nonPersistedImageIds).toEqual(['img:big'])
+    expect(storage.map.has(COMPOSER_DRAFT_STORAGE_KEY)).toBe(false)
   })
 })
 

--- a/apps/desktop/src/renderer/src/conversation/composer-draft-store.ts
+++ b/apps/desktop/src/renderer/src/conversation/composer-draft-store.ts
@@ -1,5 +1,6 @@
 import { useCallback, useSyncExternalStore } from 'react'
 import { coerceInlineTokens, type ComposerInlineToken } from './composer-inline-tokens'
+import { parseDataUrl } from './image-attach'
 import { coercePendingContexts, type PendingContext } from './pending-contexts'
 
 /**
@@ -24,6 +25,8 @@ export const LEGACY_COMPOSER_DRAFT_STORAGE_KEY = 'vibe-mistro:composer-drafts:v1
 /** The versioned localStorage key holding the structured `threadId -> draft` map. */
 export const COMPOSER_DRAFT_STORAGE_KEY = 'vibe-mistro:composer-drafts:v2'
 export const COMPOSER_DRAFT_SCHEMA_VERSION = 1
+export const COMPOSER_DRAFT_IMAGE_MAX_COUNT = 4
+export const COMPOSER_DRAFT_IMAGE_MAX_DATA_URL_CHARS = 1_500_000
 
 /** The slice of the Web Storage API we depend on — `window.localStorage` satisfies it. */
 export interface DraftStorage {
@@ -44,6 +47,12 @@ export interface ComposerDraftImage {
   id: string
   data: string
   mimeType: string
+  name: string
+  previewUrl: string
+}
+
+interface PersistedComposerDraftImage {
+  id: string
   name: string
   previewUrl: string
 }
@@ -79,24 +88,63 @@ function coerceImages(values: unknown[]): ComposerDraftImage[] {
   for (const value of values) {
     if (typeof value !== 'object' || value === null || Array.isArray(value)) continue
     const image = value as Partial<ComposerDraftImage>
+    const parsedPreview = typeof image.previewUrl === 'string' ? parseDataUrl(image.previewUrl) : null
     if (
       typeof image.id !== 'string' ||
-      typeof image.data !== 'string' ||
-      typeof image.mimeType !== 'string' ||
       typeof image.name !== 'string' ||
-      typeof image.previewUrl !== 'string'
+      typeof image.previewUrl !== 'string' ||
+      !parsedPreview
     ) {
       continue
     }
     images.push({
       id: image.id,
-      data: image.data,
-      mimeType: image.mimeType,
+      data: parsedPreview.data,
+      mimeType: parsedPreview.mimeType,
       name: image.name,
       previewUrl: image.previewUrl,
     })
   }
   return images
+}
+
+function persistedImageRecords(draft: ComposerDraft): {
+  images: PersistedComposerDraftImage[]
+  nonPersistedImageIds: string[]
+} {
+  const images: PersistedComposerDraftImage[] = []
+  const nonPersistedImageIds: string[] = []
+  for (const image of draft.images) {
+    if (
+      images.length < COMPOSER_DRAFT_IMAGE_MAX_COUNT &&
+      image.previewUrl.length <= COMPOSER_DRAFT_IMAGE_MAX_DATA_URL_CHARS
+    ) {
+      images.push({
+        id: image.id,
+        name: image.name,
+        previewUrl: image.previewUrl,
+      })
+    } else {
+      nonPersistedImageIds.push(image.id)
+    }
+  }
+  return { images, nonPersistedImageIds }
+}
+
+function sessionDraft(draft: ComposerDraft): ComposerDraft {
+  return {
+    ...draft,
+    nonPersistedImageIds: persistedImageRecords(draft).nonPersistedImageIds,
+  }
+}
+
+function persistedDraft(draft: ComposerDraft): ComposerDraft {
+  const persisted = persistedImageRecords(draft)
+  return {
+    ...draft,
+    images: persisted.images as unknown as ComposerDraftImage[],
+    nonPersistedImageIds: [],
+  }
 }
 
 function isEmptyDraft(draft: ComposerDraft): boolean {
@@ -194,9 +242,18 @@ function writeMap(storage: DraftStorage, map: DraftMap): boolean {
       storage.removeItem(COMPOSER_DRAFT_STORAGE_KEY)
       return true
     }
+    const persistedMap: DraftMap = {}
+    for (const [threadId, draft] of Object.entries(map)) {
+      const next = persistedDraft(draft)
+      if (!isEmptyDraft(next)) persistedMap[threadId] = next
+    }
+    if (Object.keys(persistedMap).length === 0) {
+      storage.removeItem(COMPOSER_DRAFT_STORAGE_KEY)
+      return true
+    }
     storage.setItem(
       COMPOSER_DRAFT_STORAGE_KEY,
-      JSON.stringify({ schemaVersion: COMPOSER_DRAFT_SCHEMA_VERSION, drafts: map }),
+      JSON.stringify({ schemaVersion: COMPOSER_DRAFT_SCHEMA_VERSION, drafts: persistedMap }),
     )
     return true
   } catch {
@@ -319,13 +376,18 @@ export function createComposerDraftStore(storage: DraftStorage | null | undefine
       return snapshot(threadId).prompt
     },
     setDraft(threadId, draft) {
-      setComposerDraft(storage, threadId, draft)
-      invalidate(threadId)
+      const next = sessionDraft(draft)
+      setComposerDraft(storage, threadId, next)
+      snapshotCache.set(threadId, next)
       notify()
     },
     setText(threadId, text) {
-      setDraft(storage, threadId, text)
-      invalidate(threadId)
+      const next = {
+        ...snapshot(threadId),
+        prompt: text,
+      }
+      setComposerDraft(storage, threadId, next)
+      snapshotCache.set(threadId, sessionDraft(next))
       notify()
     },
     clear(threadId) {


### PR DESCRIPTION
## Summary
- persist unsent image draft previews as capped data-url records
- keep over-cap images available for the current session and mark them as session-only
- restore persisted image drafts into sendable composer image records

Closes #312

## Validation
- bun run --cwd apps/desktop test src/renderer/src/conversation/composer-draft-store.test.ts
- bun run lint
- bun run test
- bun run build
- bun run typecheck