### PR TITLE
Add terminal inline composer tokens

### DIFF
--- a/apps/desktop/src/renderer/src/conversation/Composer.tsx
+++ b/apps/desktop/src/renderer/src/conversation/Composer.tsx
@@ -28,6 +28,7 @@ import {
   subscribeComposerInsertElement,
   subscribeComposerInsertImage,
   subscribeComposerInsertReviewComment,
+  subscribeComposerInsertTerminal,
   subscribeComposerInsertText,
 } from './composer-insert'
 import { ACCEPTED_IMAGE_TYPES, isAcceptedImageType, parseDataUrl } from './image-attach'
@@ -49,13 +50,20 @@ import {
 } from './composer-send-lifecycle'
 import { ComposerPromptEditor } from './ComposerPromptEditor'
 import type { ComposerEditorHandle } from './composer-editor-handle'
-import { getSlashCommandInlineToken, setSlashCommandInlineToken } from './composer-inline-tokens'
+import {
+  createTerminalInlineToken,
+  getSlashCommandInlineToken,
+  insertTerminalInlineTokenAt,
+  pruneInactiveInlineTokens,
+  setSlashCommandInlineToken,
+} from './composer-inline-tokens'
 
 /** Process-local counters for unique pending-image / element / review / paste-chip ids (not Math.random/Date). */
 let imageSeq = 0
 let elementSeq = 0
 let reviewSeq = 0
 let pasteSeq = 0
+let terminalSeq = 0
 
 /** A review chip's compact line-range suffix, e.g. `:10-12` / `:7` — empty when unlocated. */
 function reviewRange(context: { startLine: number | null; endLine: number | null }): string {
@@ -215,10 +223,14 @@ export function Composer({
   // autocomplete hook calls this when it accepts a completion; the textarea's onChange
   // and the composer-insert subscription use it too.
   function writeDraft(next: string | ((current: string) => string)): void {
-    setComposerDraft((current) => ({
-      ...current,
-      prompt: typeof next === 'function' ? next(current.prompt) : next,
-    }))
+    setComposerDraft((current) => {
+      const prompt = typeof next === 'function' ? next(current.prompt) : next
+      return {
+        ...current,
+        prompt,
+        inlineTokens: pruneInactiveInlineTokens(prompt, current.inlineTokens),
+      }
+    })
   }
 
   const setPendingContexts = useCallback((
@@ -279,9 +291,8 @@ export function Composer({
     })
   }, [setPendingContexts, threadId])
 
-  // Insert RAW text from the Terminal Surface's "Add to chat" (ADR-0014 slice 4): the
-  // terminal is a side-panel sibling, so its selection reaches the composer through the
-  // same module-level channel keyed by threadId — appended verbatim (no `@`).
+  // Insert raw text annotations from sibling surfaces that still use plain text (for
+  // example Browser Surface screenshot notes), keyed by Thread id.
   useEffect(() => {
     return subscribeComposerInsertText(threadId, (text) => {
       writeDraft((current) => appendText(current, text))
@@ -289,6 +300,36 @@ export function Composer({
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [threadId])
+
+  // Insert a Terminal selection as a positional Inline token (#313): the visible
+  // reference lands at the current caret, while the full terminal output stays in
+  // structured draft metadata and serializes as supporting context at send.
+  useEffect(() => {
+    return subscribeComposerInsertTerminal(threadId, ({ source, output }) => {
+      const token = createTerminalInlineToken({
+        id: `terminal:${terminalSeq++}`,
+        source,
+        output,
+      })
+      let nextCaret: number | null = null
+      setComposerDraft((current) => {
+        const caret = inputRef.current?.getSelectionStart() ?? current.prompt.length
+        const inserted = insertTerminalInlineTokenAt(current.prompt, caret, token)
+        nextCaret = inserted.caret
+        return {
+          ...current,
+          prompt: inserted.value,
+          inlineTokens: [...pruneInactiveInlineTokens(inserted.value, current.inlineTokens), token],
+        }
+      })
+      requestAnimationFrame(() => {
+        const input = inputRef.current
+        if (!input || nextCaret === null) return
+        input.focus()
+        input.setSelectionRange(nextCaret, nextCaret)
+      })
+    })
+  }, [setComposerDraft, threadId])
 
   // Stage a STANDALONE image from the Browser Surface (#226 page screenshot): a plain
   // attachment with no structured pick behind it — arrives pre-split through the

--- a/apps/desktop/src/renderer/src/conversation/composer-draft-store.test.ts
+++ b/apps/desktop/src/renderer/src/conversation/composer-draft-store.test.ts
@@ -145,6 +145,35 @@ describe('getDraft / setDraft round-trip', () => {
     expect(getComposerDraft(storage, 't1').images).toEqual([image('img:1')])
   })
 
+  it('persists terminal inline tokens with their supporting output', () => {
+    const storage = fakeStorage()
+    setComposerDraft(storage, 't1', {
+      prompt: 'inspect [terminal:term-1:1]',
+      inlineTokens: [
+        {
+          kind: 'terminal',
+          id: 'terminal:1',
+          source: 'term-1',
+          reference: '[terminal:term-1:1]',
+          output: 'error: boom',
+        },
+      ],
+      contextAttachments: [],
+      images: [],
+      nonPersistedImageIds: [],
+    })
+
+    expect(getComposerDraft(storage, 't1').inlineTokens).toEqual([
+      {
+        kind: 'terminal',
+        id: 'terminal:1',
+        source: 'term-1',
+        reference: '[terminal:term-1:1]',
+        output: 'error: boom',
+      },
+    ])
+  })
+
   it('stores and reads back a draft keyed by threadId', () => {
     const storage = fakeStorage()
     setDraft(storage, 't1', 'hello world')

--- a/apps/desktop/src/renderer/src/conversation/composer-inline-tokens.test.ts
+++ b/apps/desktop/src/renderer/src/conversation/composer-inline-tokens.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   coerceInlineTokens,
+  createTerminalInlineToken,
+  insertTerminalInlineTokenAt,
   serializeInlineTokensForSend,
   setSlashCommandInlineToken,
 } from './composer-inline-tokens'
@@ -32,6 +34,57 @@ describe('coerceInlineTokens', () => {
       ]),
     ).toEqual([{ kind: 'slashCommand', name: 'teach', description: undefined }])
   })
+
+  it('keeps valid terminal tokens with their supporting output', () => {
+    expect(
+      coerceInlineTokens([
+        {
+          kind: 'terminal',
+          id: 'terminal:1',
+          source: 'term-1',
+          reference: '[terminal:term-1:1]',
+          output: 'error: boom',
+        },
+        { kind: 'terminal', id: 'terminal:bad', source: '', reference: '[terminal]', output: 'x' },
+      ]),
+    ).toEqual([
+      {
+        kind: 'terminal',
+        id: 'terminal:1',
+        source: 'term-1',
+        reference: '[terminal:term-1:1]',
+        output: 'error: boom',
+      },
+    ])
+  })
+})
+
+describe('insertTerminalInlineTokenAt', () => {
+  it('inserts the visible terminal reference at the caret', () => {
+    const token = createTerminalInlineToken({
+      id: 'terminal:7',
+      source: 'term-1',
+      output: 'Traceback\n  line 1',
+    })
+
+    expect(insertTerminalInlineTokenAt('check  please', 6, token)).toEqual({
+      value: 'check [terminal:term-1:7] please',
+      caret: 25,
+    })
+  })
+
+  it('adds word-boundary spacing when inserting inside prose', () => {
+    const token = createTerminalInlineToken({
+      id: 'terminal:2',
+      source: 'term-2',
+      output: 'error',
+    })
+
+    expect(insertTerminalInlineTokenAt('lookhere', 4, token)).toEqual({
+      value: 'look [terminal:term-2:2] here',
+      caret: 25,
+    })
+  })
 })
 
 describe('serializeInlineTokensForSend', () => {
@@ -53,5 +106,40 @@ describe('serializeInlineTokensForSend', () => {
         { kind: 'slashCommand', name: 'teach' },
       ]),
     ).toBe('/teach explain this')
+  })
+
+  it('appends terminal supporting context for visible terminal references', () => {
+    expect(
+      serializeInlineTokensForSend('inspect [terminal:term-1:3]', [
+        {
+          kind: 'terminal',
+          id: 'terminal:3',
+          source: 'term-1',
+          reference: '[terminal:term-1:3]',
+          output: 'error: boom\nat app.ts:4',
+        },
+      ]),
+    ).toBe(
+      'inspect [terminal:term-1:3]\n\n' +
+        '<terminal_context>\n' +
+        'Terminal output for [terminal:term-1:3] from term-1:\n' +
+        'error: boom\n' +
+        'at app.ts:4\n' +
+        '</terminal_context>',
+    )
+  })
+
+  it('does not send terminal supporting context after the visible reference is removed', () => {
+    expect(
+      serializeInlineTokensForSend('inspect this', [
+        {
+          kind: 'terminal',
+          id: 'terminal:3',
+          source: 'term-1',
+          reference: '[terminal:term-1:3]',
+          output: 'error: boom',
+        },
+      ]),
+    ).toBe('inspect this')
   })
 })

--- a/apps/desktop/src/renderer/src/conversation/composer-inline-tokens.ts
+++ b/apps/desktop/src/renderer/src/conversation/composer-inline-tokens.ts
@@ -6,7 +6,18 @@ export interface SlashCommandInlineToken {
   description?: string
 }
 
-export type ComposerInlineToken = SlashCommandInlineToken
+export interface TerminalInlineToken {
+  kind: 'terminal'
+  id: string
+  source: string
+  reference: string
+  output: string
+}
+
+export type ComposerInlineToken = SlashCommandInlineToken | TerminalInlineToken
+
+const TERMINAL_CONTEXT_OPEN = '<terminal_context>'
+const TERMINAL_CONTEXT_CLOSE = '</terminal_context>'
 
 function isSlashCommandInlineToken(value: unknown): value is SlashCommandInlineToken {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
@@ -14,18 +25,45 @@ function isSlashCommandInlineToken(value: unknown): value is SlashCommandInlineT
   return token.kind === 'slashCommand' && typeof token.name === 'string' && token.name.length > 0
 }
 
+function isTerminalInlineToken(value: unknown): value is TerminalInlineToken {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+  const token = value as Partial<TerminalInlineToken>
+  return (
+    token.kind === 'terminal' &&
+    typeof token.id === 'string' &&
+    token.id.length > 0 &&
+    typeof token.source === 'string' &&
+    token.source.length > 0 &&
+    typeof token.reference === 'string' &&
+    token.reference.length > 0 &&
+    typeof token.output === 'string' &&
+    token.output.length > 0
+  )
+}
+
 export function coerceInlineTokens(values: unknown[]): ComposerInlineToken[] {
   const tokens: ComposerInlineToken[] = []
   let hasSlashCommand = false
   for (const value of values) {
-    if (!isSlashCommandInlineToken(value)) continue
-    if (hasSlashCommand) continue
-    hasSlashCommand = true
-    tokens.push({
-      kind: 'slashCommand',
-      name: value.name,
-      description: typeof value.description === 'string' ? value.description : undefined,
-    })
+    if (isSlashCommandInlineToken(value)) {
+      if (hasSlashCommand) continue
+      hasSlashCommand = true
+      tokens.push({
+        kind: 'slashCommand',
+        name: value.name,
+        description: typeof value.description === 'string' ? value.description : undefined,
+      })
+      continue
+    }
+    if (isTerminalInlineToken(value)) {
+      tokens.push({
+        kind: 'terminal',
+        id: value.id,
+        source: value.source,
+        reference: value.reference,
+        output: value.output,
+      })
+    }
   }
   return tokens
 }
@@ -52,18 +90,76 @@ export function setSlashCommandInlineToken(
   return command ? [createSlashCommandInlineToken(command), ...rest] : rest
 }
 
+export function createTerminalInlineToken({
+  id,
+  source,
+  output,
+}: {
+  id: string
+  source: string
+  output: string
+}): TerminalInlineToken {
+  const suffix = id.startsWith('terminal:') ? id.slice('terminal:'.length) : id
+  return {
+    kind: 'terminal',
+    id,
+    source,
+    reference: `[terminal:${source}:${suffix}]`,
+    output,
+  }
+}
+
+export function insertTerminalInlineTokenAt(
+  prompt: string,
+  caret: number,
+  token: TerminalInlineToken,
+): { value: string; caret: number } {
+  const start = Math.max(0, Math.min(caret, prompt.length))
+  const before = prompt.slice(0, start)
+  const after = prompt.slice(start)
+  const prefix = before.length > 0 && !/\s$/.test(before) ? ' ' : ''
+  const suffix = after.length > 0 && !/^\s/.test(after) ? ' ' : ''
+  const insert = `${prefix}${token.reference}${suffix}`
+  return {
+    value: `${before}${insert}${after}`,
+    caret: before.length + prefix.length + token.reference.length + suffix.length,
+  }
+}
+
+export function pruneInactiveInlineTokens(
+  prompt: string,
+  tokens: readonly ComposerInlineToken[],
+): ComposerInlineToken[] {
+  return tokens.filter((token) => token.kind !== 'terminal' || prompt.includes(token.reference))
+}
+
+function serializeTerminalContext(prompt: string, tokens: readonly ComposerInlineToken[]): string[] {
+  const lines: string[] = []
+  for (const token of tokens) {
+    if (token.kind !== 'terminal' || !prompt.includes(token.reference)) continue
+    lines.push(`Terminal output for ${token.reference} from ${token.source}:`)
+    lines.push(...token.output.split('\n'))
+  }
+  return lines.length > 0 ? [TERMINAL_CONTEXT_OPEN, ...lines, TERMINAL_CONTEXT_CLOSE] : []
+}
+
 export function serializeInlineTokensForSend(
   prompt: string,
   tokens: readonly ComposerInlineToken[],
 ): string {
   const slash = getSlashCommandInlineToken(tokens)
-  if (!slash) return prompt
+  const terminalContext = serializeTerminalContext(prompt, tokens).join('\n')
+  if (!slash) return [prompt, terminalContext].filter((part) => part.length > 0).join('\n\n')
   const commandText = `/${slash.name}`
   const trimmedPrompt = prompt.trimStart()
-  if (trimmedPrompt.length === 0) return commandText
-  if (trimmedPrompt.toLowerCase().startsWith(`${commandText.toLowerCase()} `)) {
-    return trimmedPrompt
+  if (trimmedPrompt.length === 0) {
+    return [commandText, terminalContext].filter((part) => part.length > 0).join('\n\n')
   }
-  if (trimmedPrompt.toLowerCase() === commandText.toLowerCase()) return trimmedPrompt
-  return `${commandText} ${trimmedPrompt}`
+  if (trimmedPrompt.toLowerCase().startsWith(`${commandText.toLowerCase()} `)) {
+    return [trimmedPrompt, terminalContext].filter((part) => part.length > 0).join('\n\n')
+  }
+  if (trimmedPrompt.toLowerCase() === commandText.toLowerCase()) {
+    return [trimmedPrompt, terminalContext].filter((part) => part.length > 0).join('\n\n')
+  }
+  return [`${commandText} ${trimmedPrompt}`, terminalContext].filter((part) => part.length > 0).join('\n\n')
 }

--- a/apps/desktop/src/renderer/src/conversation/composer-insert.test.ts
+++ b/apps/desktop/src/renderer/src/conversation/composer-insert.test.ts
@@ -4,10 +4,12 @@ import {
   emitComposerInsert,
   emitComposerInsertElement,
   emitComposerInsertImage,
+  emitComposerInsertTerminal,
   emitComposerInsertText,
   subscribeComposerInsert,
   subscribeComposerInsertElement,
   subscribeComposerInsertImage,
+  subscribeComposerInsertTerminal,
   subscribeComposerInsertText,
   type ComposerInsertElement,
   type ComposerInsertImage,
@@ -70,12 +72,12 @@ describe('composer-insert ELEMENT channel (#231 pick-to-chat)', () => {
   })
 })
 
-describe('appendText (Terminal "Add to chat")', () => {
+describe('appendText (raw composer annotations)', () => {
   it('inserts verbatim into an empty draft — no `@`, no forced trailing space', () => {
     expect(appendText('', 'error: boom')).toBe('error: boom')
   })
 
-  it('separates from prior draft with a newline (terminal selections are often multi-line)', () => {
+  it('separates from prior draft with a newline', () => {
     expect(appendText('look at this', 'Traceback\n  line 1')).toBe('look at this\nTraceback\n  line 1')
   })
 
@@ -106,6 +108,33 @@ describe('composer-insert TEXT channel (raw)', () => {
     const off = subscribeComposerInsertText('thread-a', listener)
     off()
     emitComposerInsertText('thread-a', 'x')
+    expect(listener).not.toHaveBeenCalled()
+  })
+})
+
+describe('composer-insert TERMINAL channel', () => {
+  it('delivers structured terminal selection context to the Thread subscriber', () => {
+    const terminal = vi.fn()
+    const text = vi.fn()
+    const offTerminal = subscribeComposerInsertTerminal('thread-a', terminal)
+    const offText = subscribeComposerInsertText('thread-a', text)
+
+    emitComposerInsertTerminal('thread-a', { source: 'term-1', output: 'error: boom' })
+    expect(terminal).toHaveBeenCalledWith({ source: 'term-1', output: 'error: boom' })
+    expect(text).not.toHaveBeenCalled()
+
+    offTerminal()
+    offText()
+  })
+
+  it('is a no-op with no subscriber, and stops after unsubscribe', () => {
+    expect(() =>
+      emitComposerInsertTerminal('nobody', { source: 'term-1', output: 'x' }),
+    ).not.toThrow()
+    const listener = vi.fn()
+    const off = subscribeComposerInsertTerminal('thread-a', listener)
+    off()
+    emitComposerInsertTerminal('thread-a', { source: 'term-1', output: 'x' })
     expect(listener).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/renderer/src/conversation/composer-insert.ts
+++ b/apps/desktop/src/renderer/src/conversation/composer-insert.ts
@@ -42,6 +42,13 @@ type ElementListener = (payload: ComposerInsertElement) => void
 
 type ImageListener = (image: ComposerInsertImage) => void
 
+export interface ComposerInsertTerminal {
+  source: string
+  output: string
+}
+
+type TerminalListener = (payload: ComposerInsertTerminal) => void
+
 /**
  * A Review Surface diff comment to stage in a Thread's composer (#239): the file, the
  * located new-file line range (null when the selection couldn't be mapped), the user's
@@ -62,6 +69,7 @@ const textListenersByThread = new Map<string, Set<InsertListener>>()
 const imageListenersByThread = new Map<string, Set<ImageListener>>()
 const elementListenersByThread = new Map<string, Set<ElementListener>>()
 const reviewListenersByThread = new Map<string, Set<ReviewCommentListener>>()
+const terminalListenersByThread = new Map<string, Set<TerminalListener>>()
 
 /** Subscribe a Thread's composer to review-comment payloads (#239); returns an unsubscribe. */
 export function subscribeComposerInsertReviewComment(
@@ -170,11 +178,10 @@ export function emitComposerInsert(threadId: string, relativePath: string): void
 }
 
 /**
- * Append RAW text to `draft` (the Terminal Surface's "Add to chat", ADR-0014 slice 4):
- * no `@` prefix, no chip, no forced trailing space — the selection is inserted verbatim
- * (deliberately NOT a pending-context chip, #230). A newline separates it from prior draft content
- * (terminal selections are often multi-line), unless the draft is empty or already ends
- * in whitespace. Pure — the composer writes state + persisted draft together with the result.
+ * Append RAW text to `draft` for sibling surfaces that still send plain annotations:
+ * no `@` prefix, no chip, no forced trailing space. A newline separates it from prior
+ * draft content unless the draft is empty or already ends in whitespace. Pure — the
+ * composer writes state + persisted draft together with the result.
  */
 export function appendText(draft: string, text: string): string {
   if (draft.length === 0) return text
@@ -205,3 +212,31 @@ export function emitComposerInsertText(threadId: string, text: string): void {
   for (const listener of set) listener(text)
 }
 
+/** Subscribe a Thread's composer to Terminal selection context payloads; returns an unsubscribe. */
+export function subscribeComposerInsertTerminal(
+  threadId: string,
+  listener: TerminalListener,
+): () => void {
+  let set = terminalListenersByThread.get(threadId)
+  if (!set) {
+    set = new Set()
+    terminalListenersByThread.set(threadId, set)
+  }
+  set.add(listener)
+  return () => {
+    const current = terminalListenersByThread.get(threadId)
+    if (!current) return
+    current.delete(listener)
+    if (current.size === 0) terminalListenersByThread.delete(threadId)
+  }
+}
+
+/** Request the given Thread's composer insert a positional Terminal Inline token. */
+export function emitComposerInsertTerminal(
+  threadId: string,
+  payload: ComposerInsertTerminal,
+): void {
+  const set = terminalListenersByThread.get(threadId)
+  if (!set) return
+  for (const listener of set) listener(payload)
+}

--- a/apps/desktop/src/renderer/src/conversation/composer-send-lifecycle.test.ts
+++ b/apps/desktop/src/renderer/src/conversation/composer-send-lifecycle.test.ts
@@ -55,6 +55,45 @@ describe('createComposerSendSnapshot', () => {
       ],
     })
   })
+
+  it('serializes terminal inline tokens into supporting context and restore metadata', () => {
+    const snapshot = createComposerSendSnapshot({
+      prompt: 'inspect [terminal:term-1:4]',
+      inlineTokens: [
+        {
+          kind: 'terminal',
+          id: 'terminal:4',
+          source: 'term-1',
+          reference: '[terminal:term-1:4]',
+          output: 'error: boom',
+        },
+      ],
+      contexts: [],
+      images: [],
+    })
+
+    expect(snapshot).toMatchObject({
+      hasContent: true,
+      text:
+        'inspect [terminal:term-1:4]\n\n' +
+        '<terminal_context>\n' +
+        'Terminal output for [terminal:term-1:4] from term-1:\n' +
+        'error: boom\n' +
+        '</terminal_context>',
+      restore: {
+        prompt: 'inspect [terminal:term-1:4]',
+        inlineTokens: [
+          {
+            kind: 'terminal',
+            id: 'terminal:4',
+            source: 'term-1',
+            reference: '[terminal:term-1:4]',
+            output: 'error: boom',
+          },
+        ],
+      },
+    })
+  })
 })
 
 describe('restoreFailedSendSnapshot', () => {

--- a/apps/desktop/src/renderer/src/side-panel/TerminalSurface.tsx
+++ b/apps/desktop/src/renderer/src/side-panel/TerminalSurface.tsx
@@ -5,7 +5,7 @@ import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import '@xterm/xterm/css/xterm.css'
 import { cn } from '../lib/utils'
-import { emitComposerInsertText } from '../conversation/composer-insert'
+import { emitComposerInsertTerminal } from '../conversation/composer-insert'
 
 /**
  * The Terminal Surface (ADR-0014): an xterm.js view over the Workspace's shell
@@ -174,12 +174,12 @@ export function TerminalSurface({
       })
   }
 
-  // Add to chat: append the current selection to the active Thread's composer draft
-  // (raw text, no `@`). A no-op with no selection or no mounted composer.
+  // Add to chat: insert a positional Terminal Inline token into the active Thread's
+  // composer while carrying the full selection as supporting context.
   function onAddToChat(): void {
     const selection = terminalRef.current?.getSelection()
     if (!selection || !activeThreadId) return
-    emitComposerInsertText(activeThreadId, selection)
+    emitComposerInsertTerminal(activeThreadId, { source: terminalId, output: selection })
   }
 
   return (


### PR DESCRIPTION
## Summary
- insert Terminal selections as positional composer Inline tokens at the current caret
- store the visible terminal reference plus full selected output in structured drafts
- serialize active terminal references into a trailing <terminal_context> block and prune removed references

Closes #313

## Validation
- bun run --cwd apps/desktop test src/renderer/src/conversation/composer-inline-tokens.test.ts src/renderer/src/conversation/composer-insert.test.ts src/renderer/src/conversation/composer-draft-store.test.ts src/renderer/src/conversation/composer-send-lifecycle.test.ts
- bun run lint
- bun run typecheck
- bun run test
- bun run build