### PR TITLE
feat: add Mistral dark mode

### DIFF
--- a/apps/desktop/e2e/theme.spec.ts
+++ b/apps/desktop/e2e/theme.spec.ts
@@ -1,0 +1,64 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { expect, test } from '@playwright/test'
+import { assertBuilt, launch } from './launch'
+
+test.beforeAll(() => {
+  assertBuilt()
+})
+
+test('dark theme persists and System follows the OS without overriding explicit choices', async () => {
+  const userData = await mkdtemp(join(tmpdir(), 'vibe-mistro-theme-e2e-'))
+  await writeFile(join(userData, 'theme.json'), JSON.stringify({ preference: 'dark' }))
+
+  const first = await launch(userData)
+  try {
+    await expect(first.page.locator('html')).toHaveClass(/\bdark\b/)
+    await expect
+      .poll(
+        () =>
+          first.page.evaluate<string>(
+            "getComputedStyle(document.documentElement).getPropertyValue('--background').trim()",
+          ),
+      )
+      .toBe('#151524')
+
+    await first.page.getByText('Your account').click()
+    await first.page.getByRole('menuitem', { name: 'Settings' }).click()
+    await expect(first.page.getByRole('heading', { name: 'Appearance' })).toBeVisible()
+
+    await first.app.evaluate(({ nativeTheme }) => {
+      nativeTheme.themeSource = 'light'
+    })
+    await first.page.getByRole('button', { name: 'System' }).click()
+    await expect(first.page.locator('html')).not.toHaveClass(/\bdark\b/)
+
+    await first.app.evaluate(({ nativeTheme }) => {
+      nativeTheme.themeSource = 'dark'
+    })
+    await expect(first.page.locator('html')).toHaveClass(/\bdark\b/)
+
+    await first.page.getByRole('button', { name: 'Light' }).click()
+    await expect(first.page.locator('html')).not.toHaveClass(/\bdark\b/)
+    await first.app.evaluate(({ nativeTheme }) => {
+      nativeTheme.themeSource = 'dark'
+    })
+    await expect(first.page.locator('html')).not.toHaveClass(/\bdark\b/)
+
+    await first.page.getByRole('button', { name: 'Dark' }).click()
+    await expect(first.page.locator('html')).toHaveClass(/\bdark\b/)
+    await expect
+      .poll(async () => JSON.parse(await readFile(join(userData, 'theme.json'), 'utf8')).preference)
+      .toBe('dark')
+  } finally {
+    await first.app.close()
+  }
+
+  const relaunched = await launch(userData)
+  try {
+    await expect(relaunched.page.locator('html')).toHaveClass(/\bdark\b/)
+  } finally {
+    await relaunched.app.close()
+  }
+})

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,7 +18,7 @@
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:update": "playwright test --update-snapshots",
-    "lint": "eslint .",
+    "lint": "eslint . && node scripts/check-theme-tokens.mjs",
     "dist": "electron-vite build && electron-builder --mac --arm64 --publish never",
     "dist:unsigned": "CSC_IDENTITY_AUTO_DISCOVERY=false bun run dist",
     "release": "electron-vite build && electron-builder --mac --arm64 --publish always",

--- a/apps/desktop/scripts/check-theme-tokens.mjs
+++ b/apps/desktop/scripts/check-theme-tokens.mjs
@@ -1,0 +1,58 @@
+import { readdir, readFile } from 'node:fs/promises'
+import { extname, join, relative } from 'node:path'
+import process from 'node:process'
+
+const SOURCE_ROOT = new URL('../src/renderer/src/', import.meta.url)
+const SOURCE_PATH = SOURCE_ROOT.pathname
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx'])
+const REMOVED_TOKEN_NAMES = [
+  'bg',
+  'panel',
+  'surface',
+  'border-muted',
+  'text',
+  'text-strong',
+  'text-body',
+  'text-secondary',
+  'placeholder',
+  'faint',
+  'accent-text',
+  'accent-emphasis',
+  'on-accent',
+  'ok',
+  'bad',
+]
+const UTILITY_PREFIXES = ['bg', 'text', 'border', 'divide', 'ring', 'from', 'via', 'to']
+const REMOVED_UTILITY = new RegExp(
+  `\\b(?:${UTILITY_PREFIXES.join('|')})-(?:${REMOVED_TOKEN_NAMES.join('|')})(?=$|[\\s/"'\\x60])`,
+  'g',
+)
+
+async function sourceFiles(directory) {
+  const entries = await readdir(directory, { withFileTypes: true })
+  const nested = await Promise.all(
+    entries.map(async (entry) => {
+      const path = join(directory, entry.name)
+      if (entry.isDirectory()) return sourceFiles(path)
+      if (!SOURCE_EXTENSIONS.has(extname(entry.name)) || entry.name.includes('.test.')) return []
+      return [path]
+    }),
+  )
+  return nested.flat()
+}
+
+const violations = []
+for (const filePath of await sourceFiles(SOURCE_PATH)) {
+  const lines = (await readFile(filePath, 'utf8')).split('\n')
+  lines.forEach((line, index) => {
+    for (const match of line.matchAll(REMOVED_UTILITY)) {
+      violations.push(`${relative(SOURCE_PATH, filePath)}:${index + 1}: ${match[0]}`)
+    }
+  })
+}
+
+if (violations.length > 0) {
+  console.error('Removed theme utilities found; use the semantic token layer:')
+  for (const violation of violations) console.error(`  ${violation}`)
+  process.exitCode = 1
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,4 +1,14 @@
-import { app, BrowserWindow, dialog, ipcMain, Menu, nativeImage, shell, type WebContents } from 'electron'
+import {
+  app,
+  BrowserWindow,
+  dialog,
+  ipcMain,
+  Menu,
+  nativeImage,
+  nativeTheme,
+  shell,
+  type WebContents,
+} from 'electron'
 import electronUpdater, { type UpdateInfo } from 'electron-updater'
 import { mkdir } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
@@ -43,6 +53,10 @@ import {
   type ThreadStatusEvent,
   type ThreadTitleEvent,
   type AppUpdateStatusEvent,
+  isThemePreference,
+  type SetThemeArgs,
+  type ThemePreference,
+  type ThemeState,
 } from '../shared/ipc'
 import { detectVibe } from './vibe-detect'
 import { checkVibeUpdate } from './vibe-update'
@@ -102,6 +116,11 @@ import { clampWebviewAttachment } from './browser/webview-clamp'
 import { safeExternalUrl } from './files/safe-external-url'
 import { APP_DISPLAY_NAME, buildMenuTemplate } from './app-menu'
 import { applyPendingThreadControls } from './pending-thread-controls'
+import { resolveTheme, THEME_BACKGROUND } from './theme/resolve-theme'
+import {
+  DEFAULT_THEME_PREFERENCE,
+  ThemePreferenceStore,
+} from './theme/theme-store'
 
 // App identity: rename the app (menu roles, About panel) away from package.json's
 // `vibe-mistro`. Must run before `app.whenReady()`. `app.name` also derives the
@@ -231,6 +250,37 @@ function emitThreadTitle(event: ThreadTitleEvent): void {
 let appUpdateStatus: AppUpdateStatusEvent = APP_UPDATE_INITIAL
 /** Whether startAppUpdater actually armed the updater (packaged / mock-feed runs). */
 let appUpdaterEnabled = false
+
+/**
+ * Main owns theme preference and resolution so the first BrowserWindow can paint
+ * the correct background before its renderer exists. `nativeTheme.themeSource`
+ * is intentionally never changed; system appearance is read, not overridden.
+ */
+let themeState: ThemeState = {
+  preference: DEFAULT_THEME_PREFERENCE,
+  resolved: 'light',
+}
+let themeStore: ThemePreferenceStore | null = null
+
+/** Apply one main-owned transition and broadcast confirmed state to renderers. */
+function applyThemePreference(preference: ThemePreference): ThemeState {
+  const resolved = resolveTheme(preference, nativeTheme.shouldUseDarkColors)
+  const resolvedChanged = resolved !== themeState.resolved
+  const changed = resolvedChanged || preference !== themeState.preference
+  themeState = { preference, resolved }
+
+  if (changed) {
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (resolvedChanged) win.setBackgroundColor(THEME_BACKGROUND[resolved])
+      if (!win.webContents.isDestroyed()) win.webContents.send(IPC.themeStatus, themeState)
+    }
+  }
+  return themeState
+}
+
+function refreshResolvedTheme(): void {
+  applyThemePreference(themeState.preference)
+}
 
 function applyUpdaterEvent(event: UpdaterEvent): void {
   const next = reduceUpdaterEvent(appUpdateStatus, event)
@@ -762,6 +812,7 @@ function createWindow(): void {
     minWidth: 900,
     minHeight: 600,
     show: false,
+    backgroundColor: THEME_BACKGROUND[themeState.resolved],
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
     ...(process.platform === 'darwin' ? {} : { icon: APP_ICON_PNG }),
     webPreferences: {
@@ -775,7 +826,18 @@ function createWindow(): void {
     },
   })
 
-  win.on('ready-to-show', () => win.show())
+  // Theme-ready is the normal reveal path. If renderer startup fails before its
+  // handshake, degrade to a visible diagnostic window instead of staying hidden.
+  win.once('ready-to-show', () => {
+    if (win.isVisible()) return
+    const fallback = setTimeout(() => {
+      if (win.isDestroyed() || win.isVisible()) return
+      console.error('[theme] renderer readiness timed out; showing window fallback')
+      win.show()
+    }, 2_000)
+    win.once('show', () => clearTimeout(fallback))
+    win.once('closed', () => clearTimeout(fallback))
+  })
 
   win.webContents.setWindowOpenHandler(({ url }) => {
     shell.openExternal(url)
@@ -842,6 +904,21 @@ function registerIpc(deps: MainDeps): void {
   )
 
   ipcMain.handle(IPC.appUpdateGetStatus, (): AppUpdateStatusEvent => appUpdateStatus)
+
+  ipcMain.handle(IPC.themeGet, (): ThemeState => themeState)
+
+  ipcMain.handle(IPC.themeSet, (_event, args: SetThemeArgs): ThemeState => {
+    if (!isThemePreference(args?.preference)) return themeState
+    const next = applyThemePreference(args.preference)
+    void themeStore?.save(next.preference)
+    return next
+  })
+
+  // The renderer applies the confirmed root theme before mounting. Showing only
+  // after that handshake prevents a persisted dark preference flashing light.
+  ipcMain.on(IPC.themeReady, (event) => {
+    BrowserWindow.fromWebContents(event.sender)?.show()
+  })
 
   ipcMain.on(IPC.appUpdateRestart, () => {
     // Only meaningful once a download is ready; a stray send is a no-op rather
@@ -1435,6 +1512,13 @@ app.whenReady().then(async () => {
 
   registerIpc(deps)
   startAppUpdater()
+
+  // Load before the first BrowserWindow so its pre-renderer paint matches the
+  // persisted preference. The store tolerates missing or malformed data.
+  themeStore = new ThemePreferenceStore(app.getPath('userData'))
+  applyThemePreference(await themeStore.load())
+  nativeTheme.on('updated', refreshResolvedTheme)
+
   createWindow()
 
   // The periodic sweep (TB5 #50): release any agent untouched past IDLE_EVICT_MS,

--- a/apps/desktop/src/main/theme/resolve-theme.test.ts
+++ b/apps/desktop/src/main/theme/resolve-theme.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { resolveTheme, THEME_BACKGROUND } from './resolve-theme'
+
+describe('resolveTheme', () => {
+  it('keeps explicit preferences independent of the OS', () => {
+    expect(resolveTheme('light', true)).toBe('light')
+    expect(resolveTheme('light', false)).toBe('light')
+    expect(resolveTheme('dark', true)).toBe('dark')
+    expect(resolveTheme('dark', false)).toBe('dark')
+  })
+
+  it('resolves system through the OS preference', () => {
+    expect(resolveTheme('system', true)).toBe('dark')
+    expect(resolveTheme('system', false)).toBe('light')
+  })
+})
+
+describe('THEME_BACKGROUND', () => {
+  it('provides paintable colours for both resolved themes', () => {
+    expect(THEME_BACKGROUND.light).toMatch(/^#[0-9a-f]{6}$/i)
+    expect(THEME_BACKGROUND.dark).toMatch(/^#[0-9a-f]{6}$/i)
+  })
+})

--- a/apps/desktop/src/main/theme/resolve-theme.ts
+++ b/apps/desktop/src/main/theme/resolve-theme.ts
@@ -1,0 +1,19 @@
+import type { ResolvedTheme, ThemePreference } from '../../shared/ipc'
+
+/** Resolve `system` through Electron's current OS appearance. */
+export function resolveTheme(
+  preference: ThemePreference,
+  systemPrefersDark: boolean,
+): ResolvedTheme {
+  if (preference === 'system') return systemPrefersDark ? 'dark' : 'light'
+  return preference
+}
+
+/**
+ * BrowserWindow paints this colour before and behind the renderer. Keep these
+ * literals aligned with the light and dark `--background` tokens in styles.css.
+ */
+export const THEME_BACKGROUND: Record<ResolvedTheme, string> = {
+  light: '#fbfaf8',
+  dark: '#151524',
+}

--- a/apps/desktop/src/main/theme/theme-store.test.ts
+++ b/apps/desktop/src/main/theme/theme-store.test.ts
@@ -1,0 +1,101 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  DEFAULT_THEME_PREFERENCE,
+  parseThemeFile,
+  ThemePreferenceStore,
+  themePath,
+} from './theme-store'
+
+describe('parseThemeFile', () => {
+  it('reads valid preferences', () => {
+    expect(parseThemeFile('{"preference":"light"}')).toBe('light')
+    expect(parseThemeFile('{"preference":"dark"}')).toBe('dark')
+    expect(parseThemeFile('{"preference":"system"}')).toBe('system')
+  })
+
+  it('defaults malformed or invalid data to light', () => {
+    expect(DEFAULT_THEME_PREFERENCE).toBe('light')
+    expect(parseThemeFile('not json')).toBe('light')
+    expect(parseThemeFile('null')).toBe('light')
+    expect(parseThemeFile('[]')).toBe('light')
+    expect(parseThemeFile('{"preference":"solarized"}')).toBe('light')
+    expect(parseThemeFile('{}')).toBe('light')
+  })
+})
+
+describe('ThemePreferenceStore', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'vibe-mistro-theme-'))
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('loads light when no preference is persisted', async () => {
+    expect(await new ThemePreferenceStore(dir).load()).toBe('light')
+  })
+
+  it('round-trips a preference', async () => {
+    const store = new ThemePreferenceStore(dir)
+    await store.save('dark')
+    expect(await store.load()).toBe('dark')
+    expect(JSON.parse(await readFile(themePath(dir), 'utf8'))).toEqual({ preference: 'dark' })
+  })
+
+  it('loads light from a corrupt preference file', async () => {
+    await writeFile(themePath(dir), '{{{', 'utf8')
+    expect(await new ThemePreferenceStore(dir).load()).toBe('light')
+  })
+
+  it('logs and resolves when persistence fails', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    await expect(new ThemePreferenceStore(join(dir, 'missing')).save('dark')).resolves.toBeUndefined()
+    expect(error).toHaveBeenCalledOnce()
+  })
+
+  it('serializes rapid saves so the latest confirmed preference wins', async () => {
+    const releases: Array<() => void> = []
+    const persisted: string[] = []
+    const store = new ThemePreferenceStore(dir, {
+      read: async () => persisted.at(-1) ?? '',
+      write: async (_path, contents) => {
+        await new Promise<void>((resolve) => releases.push(resolve))
+        persisted.push(contents)
+      },
+    })
+
+    const dark = store.save('dark')
+    await vi.waitFor(() => expect(releases).toHaveLength(1))
+    const light = store.save('light')
+    await Promise.resolve()
+    expect(releases).toHaveLength(1)
+
+    releases[0]?.()
+    await dark
+    await vi.waitFor(() => expect(releases).toHaveLength(2))
+    releases[1]?.()
+    await light
+
+    expect(persisted.map(parseThemeFile)).toEqual(['dark', 'light'])
+    expect(await store.load()).toBe('light')
+  })
+
+  it('logs non-missing read failures while still defaulting to light', async () => {
+    const failure = new Error('permission denied')
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const store = new ThemePreferenceStore(dir, {
+      read: () => Promise.reject(failure),
+      write: () => Promise.resolve(),
+    })
+
+    await expect(store.load()).resolves.toBe('light')
+    expect(error).toHaveBeenCalledWith('[theme] failed to read preference:', failure)
+  })
+})

--- a/apps/desktop/src/main/theme/theme-store.ts
+++ b/apps/desktop/src/main/theme/theme-store.ts
@@ -1,0 +1,76 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { isThemePreference, type ThemePreference } from '../../shared/ipc'
+
+export const THEME_FILENAME = 'theme.json'
+export const DEFAULT_THEME_PREFERENCE: ThemePreference = 'light'
+
+export function themePath(userDataDir: string): string {
+  return join(userDataDir, THEME_FILENAME)
+}
+
+export interface ThemeFileAccess {
+  read: (filePath: string) => Promise<string>
+  write: (filePath: string, contents: string) => Promise<void>
+}
+
+const NODE_THEME_FILE_ACCESS: ThemeFileAccess = {
+  read: (filePath) => readFile(filePath, 'utf8'),
+  write: async (filePath, contents) => {
+    await writeFile(filePath, contents, 'utf8')
+  },
+}
+
+function isMissingFile(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT'
+}
+
+/** Parse a persisted theme file tolerantly; malformed data uses the default. */
+export function parseThemeFile(raw: string): ThemePreference {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return DEFAULT_THEME_PREFERENCE
+  }
+  if (!parsed || typeof parsed !== 'object') return DEFAULT_THEME_PREFERENCE
+  const preference = (parsed as Record<string, unknown>).preference
+  return isThemePreference(preference) ? preference : DEFAULT_THEME_PREFERENCE
+}
+
+/**
+ * Small, early-loading persistence seam independent of the state database.
+ * Theme writes are best-effort so a disk failure never blocks a live theme flip.
+ */
+export class ThemePreferenceStore {
+  private readonly filePath: string
+  private saveTail: Promise<void> = Promise.resolve()
+
+  constructor(
+    userDataDir: string,
+    private readonly fileAccess: ThemeFileAccess = NODE_THEME_FILE_ACCESS,
+  ) {
+    this.filePath = themePath(userDataDir)
+  }
+
+  async load(): Promise<ThemePreference> {
+    try {
+      return parseThemeFile(await this.fileAccess.read(this.filePath))
+    } catch (error) {
+      if (!isMissingFile(error)) console.error('[theme] failed to read preference:', error)
+      return DEFAULT_THEME_PREFERENCE
+    }
+  }
+
+  save(preference: ThemePreference): Promise<void> {
+    // IPC transitions can arrive faster than filesystem writes. A per-store tail
+    // preserves click order so the last confirmed preference is also last on disk.
+    const pending = this.saveTail.then(() =>
+      this.fileAccess.write(this.filePath, `${JSON.stringify({ preference }, null, 2)}\n`),
+    )
+    this.saveTail = pending.catch((error: unknown) => {
+      console.error('[theme] failed to persist preference:', error)
+    })
+    return this.saveTail
+  }
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -83,6 +83,8 @@ import {
   type CheckVibeUpdateArgs,
   type VibeUpdateResult,
   type AppUpdateStatusEvent,
+  type SetThemeArgs,
+  type ThemeState,
 } from '../shared/ipc'
 
 /**
@@ -106,6 +108,9 @@ const api = {
   getAppUpdateStatus: (): Promise<AppUpdateStatusEvent> =>
     ipcRenderer.invoke(IPC.appUpdateGetStatus),
   appUpdateRestart: (): void => ipcRenderer.send(IPC.appUpdateRestart),
+  getTheme: (): Promise<ThemeState> => ipcRenderer.invoke(IPC.themeGet),
+  setTheme: (args: SetThemeArgs): Promise<ThemeState> => ipcRenderer.invoke(IPC.themeSet, args),
+  themeReady: (): void => ipcRenderer.send(IPC.themeReady),
   openWorkspaceDialog: (): Promise<string | null> => ipcRenderer.invoke(IPC.openWorkspaceDialog),
   startThread: (args: StartThreadArgs): Promise<StartThreadResult> =>
     ipcRenderer.invoke(IPC.startThread, args),
@@ -202,6 +207,7 @@ const api = {
   onAgentEvicted: subscribe<AgentEvictedEvent>(IPC.agentEvicted),
   onMenuAction: subscribe<MenuActionEvent>(IPC.menuAction),
   onAppUpdateStatus: subscribe<AppUpdateStatusEvent>(IPC.appUpdateStatus),
+  onThemeStatus: subscribe<ThemeState>(IPC.themeStatus),
   onGitStatus: subscribe<GitStatusEvent>(IPC.gitStatus),
   onGitActionProgress: subscribe<GitActionProgressEvent>(IPC.gitActionProgress),
 }

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -973,7 +973,7 @@ export function App(): JSX.Element {
   const isMac = navigator.userAgent.includes('Macintosh')
 
   return (
-    <div className="flex h-screen flex-col bg-bg text-text">
+    <div className="flex h-screen flex-col bg-background text-foreground">
       {/* Window chrome (#113): a draggable top bar. Back/forward walk the nav history
           (nav-history.ts); the top-right layout controls are live. The bar stays
           `-webkit-app-region: drag` so the window moves; every interactive control
@@ -1024,7 +1024,7 @@ export function App(): JSX.Element {
             part of the window's drag region like the rest of the bar. */}
         <div className="ml-2 flex items-center gap-2">
           <Logo size={20} />
-          <span className="text-[13.5px] font-semibold tracking-tight text-text-strong">
+          <span className="text-[13.5px] font-semibold tracking-tight text-foreground">
             Vibe Mistro
           </span>
         </div>
@@ -1049,7 +1049,7 @@ export function App(): JSX.Element {
             }
             aria-pressed={activePanel.isOpen}
             disabled={!selectedWs}
-            className={activePanel.isOpen ? 'bg-accent/15 text-accent-text' : undefined}
+            className={activePanel.isOpen ? 'bg-primary/15 text-primary' : undefined}
             onClick={() => {
               if (selectedWs) toggleWorkspacePanelVisibility(selectedWs)
             }}
@@ -1070,7 +1070,7 @@ export function App(): JSX.Element {
             }
             aria-pressed={terminalRevealed}
             disabled={!selectedWs}
-            className={terminalRevealed ? 'bg-accent/15 text-accent-text' : undefined}
+            className={terminalRevealed ? 'bg-primary/15 text-primary' : undefined}
             onClick={() => {
               if (selectedWs) toggleWorkspaceTerminalSurface(selectedWs)
             }}

--- a/apps/desktop/src/renderer/src/auth/SignInPanel.tsx
+++ b/apps/desktop/src/renderer/src/auth/SignInPanel.tsx
@@ -109,7 +109,7 @@ export function SignInPanel({
     return (
       <SignInCard>
         <SignInLoading label="Signing in…" />
-        <p className="text-[13px] leading-relaxed text-muted">
+        <p className="text-[13px] leading-relaxed text-muted-foreground">
           Complete sign-in in your browser, then return here.
         </p>
         <Button variant="outline" size="sm" className="self-start" onClick={cancel}>
@@ -132,11 +132,11 @@ export function SignInPanel({
   // re-running the browser flow (#79) — for an out-of-band `vibe` CLI sign-in.
   return (
     <SignInCard>
-      <div className="text-sm font-semibold text-text-strong">Not signed in to Mistral Vibe</div>
+      <div className="text-sm font-semibold text-foreground">Not signed in to Mistral Vibe</div>
       {view.kind === 'sign-in' && view.description && (
-        <p className="text-[13px] leading-relaxed text-muted">{view.description}</p>
+        <p className="text-[13px] leading-relaxed text-muted-foreground">{view.description}</p>
       )}
-      {view.kind === 'error' && <p className="text-[13px] leading-relaxed text-bad">{view.message}</p>}
+      {view.kind === 'error' && <p className="text-[13px] leading-relaxed text-destructive">{view.message}</p>}
       <div className="flex flex-wrap items-center gap-2">
         <Button variant="default" onClick={() => void signIn(view.methodId)}>
           {view.kind === 'error' ? `Retry — ${view.methodName}` : view.methodName}
@@ -168,7 +168,7 @@ function SignInCard({ children }: { children: ReactNode }): JSX.Element {
  * checking / signing-out / opening). Copy is unchanged; only the look. */
 function SignInLoading({ label }: { label: string }): JSX.Element {
   return (
-    <div className="flex items-center gap-2.5 text-sm font-semibold text-text-strong">
+    <div className="flex items-center gap-2.5 text-sm font-semibold text-foreground">
       {/* Spinner is decorative here — the visible label carries the accessible name,
           so hide the spinner's own role=img to avoid a double screen-reader announce. */}
       <span aria-hidden className="inline-flex">

--- a/apps/desktop/src/renderer/src/conversation/AgentControls.tsx
+++ b/apps/desktop/src/renderer/src/conversation/AgentControls.tsx
@@ -109,20 +109,20 @@ function AgentControl({
         aria-label={label}
         title={label}
         className={cn(
-          'inline-flex min-w-0 items-center gap-1.5 rounded-lg px-1.5 py-1 text-sm text-text-body outline-none transition-colors @max-[480px]:gap-1',
-          'hover:text-accent-text',
-          'disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:text-text-body',
+          'inline-flex min-w-0 items-center gap-1.5 rounded-lg px-1.5 py-1 text-sm text-foreground outline-none transition-colors @max-[480px]:gap-1',
+          'hover:text-primary',
+          'disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:text-foreground',
           '[&_svg]:pointer-events-none [&_svg]:shrink-0',
         )}
       >
-        {Icon && <Icon className="size-4 text-muted" aria-hidden />}
+        {Icon && <Icon className="size-4 text-muted-foreground" aria-hidden />}
         {/* truncate (not wrap): a long model id like "devstral-small" must never
             line-break inside the chip; in a tight column it ellipsizes instead. Below
             480px of composer width the label HIDES entirely — an empty truncated span
             would still cost two flex gaps between icon and chevron — leaving a clean
             icon+chevron chip (the trigger's title/aria-label still name it). */}
         <span className="min-w-0 truncate font-medium @max-[480px]:hidden">{currentLabel}</span>
-        <ChevronDown className="size-3.5 text-faint" aria-hidden />
+        <ChevronDown className="size-3.5 text-muted-foreground" aria-hidden />
       </MenuTrigger>
       <MenuContent align="start">
         {options.map((o) => (

--- a/apps/desktop/src/renderer/src/conversation/Composer.tsx
+++ b/apps/desktop/src/renderer/src/conversation/Composer.tsx
@@ -545,7 +545,7 @@ export function Composer({
       <Card
         className={cn(
           'gap-0 p-0 shadow-xs transition-colors',
-          isDraggingFiles && 'border-accent bg-[var(--accent-tint)]',
+          isDraggingFiles && 'border-primary bg-primary/10',
         )}
         onDragEnter={onDragEnter}
         onDragOver={onDragOver}
@@ -562,14 +562,14 @@ export function Composer({
               {followUps.queued.map((m) => (
                 <div
                   key={m.id}
-                  className="flex items-center gap-2 rounded-lg border border-border bg-panel px-2 py-1"
+                  className="flex items-center gap-2 rounded-lg border border-border bg-card px-2 py-1"
                 >
-                  <span className="min-w-0 flex-1 truncate text-[13px] text-text">
+                  <span className="min-w-0 flex-1 truncate text-[13px] text-foreground">
                     {m.text
                       ? m.text
                       : `📎 ${m.images.length} image${m.images.length === 1 ? '' : 's'}`}
                     {m.text && m.images.length > 0 && (
-                      <span className="text-muted"> 📎 {m.images.length}</span>
+                      <span className="text-muted-foreground"> 📎 {m.images.length}</span>
                     )}
                   </span>
                   <IconButton
@@ -595,7 +595,7 @@ export function Composer({
                 <span
                   data-inline-token-chip
                   title={slashCommandToken.description}
-                  className="inline-flex max-w-full items-center gap-1 rounded-md border border-[var(--accent-tint-border)] bg-[var(--accent-tint)] py-0.5 pr-1 pl-1.5 font-mono text-xs leading-none text-accent-text"
+                  className="inline-flex max-w-full items-center gap-1 rounded-md border border-primary/30 bg-primary/10 py-0.5 pr-1 pl-1.5 font-mono text-xs leading-none text-primary"
                 >
                   <Sparkles className="size-3 shrink-0" aria-hidden />
                   <span className="truncate">/{slashCommandToken.name}</span>
@@ -603,7 +603,7 @@ export function Composer({
                     type="button"
                     aria-label={`Remove /${slashCommandToken.name}`}
                     onClick={() => setSlashCommandToken(null)}
-                    className="inline-flex size-3.5 shrink-0 items-center justify-center rounded-sm text-accent-text outline-none hover:bg-[var(--accent-tint-border)]"
+                    className="inline-flex size-3.5 shrink-0 items-center justify-center rounded-sm text-primary outline-none hover:bg-primary/30"
                   >
                     <X className="size-3" aria-hidden />
                   </button>
@@ -614,7 +614,7 @@ export function Composer({
                   key={contextKey(context)}
                   data-pending-context-chip
                   title={pendingContextChipTitle(context)}
-                  className="inline-flex max-w-full items-center gap-1 rounded-md border border-[var(--accent-tint-border)] bg-[var(--accent-tint)] py-0.5 pr-1 pl-1.5 font-mono text-xs leading-none text-accent-text"
+                  className="inline-flex max-w-full items-center gap-1 rounded-md border border-primary/30 bg-primary/10 py-0.5 pr-1 pl-1.5 font-mono text-xs leading-none text-primary"
                 >
                   {context.kind === 'skill' ? (
                     <Sparkles className="size-3 shrink-0" aria-hidden />
@@ -637,7 +637,7 @@ export function Composer({
                         removeImage(context.imageId)
                       }
                     }}
-                    className="inline-flex size-3.5 shrink-0 items-center justify-center rounded-sm text-accent-text outline-none hover:bg-[var(--accent-tint-border)]"
+                    className="inline-flex size-3.5 shrink-0 items-center justify-center rounded-sm text-primary outline-none hover:bg-primary/30"
                   >
                     <X className="size-3" aria-hidden />
                   </button>
@@ -663,7 +663,7 @@ export function Composer({
                       alt={img.name}
                     />
                     {sessionOnly && (
-                      <span className="absolute bottom-0 left-0 max-w-full rounded-tr-md rounded-bl-lg bg-panel/95 px-1 py-0.5 text-[9px] leading-none text-muted">
+                      <span className="absolute bottom-0 left-0 max-w-full rounded-tr-md rounded-bl-lg bg-card/95 px-1 py-0.5 text-[9px] leading-none text-muted-foreground">
                         Session only
                       </span>
                     )}
@@ -671,7 +671,7 @@ export function Composer({
                       type="button"
                       aria-label={`Remove ${img.name}`}
                       onClick={() => removeImage(img.id)}
-                      className="absolute -top-1.5 -right-1.5 inline-flex size-[18px] items-center justify-center rounded-full border border-border bg-panel text-text outline-none"
+                      className="absolute -top-1.5 -right-1.5 inline-flex size-[18px] items-center justify-center rounded-full border border-border bg-card text-foreground outline-none"
                     >
                       <X className="size-3" aria-hidden />
                     </button>
@@ -682,7 +682,7 @@ export function Composer({
           )}
 
           {draftPersistenceError && (
-            <p role="status" className="mb-3 text-xs text-bad">
+            <p role="status" className="mb-3 text-xs text-destructive">
               Draft changes are available now but could not be saved for the next app launch.
             </p>
           )}
@@ -795,7 +795,7 @@ export function Composer({
               }
               aria-label={followUps.sending ? 'Queue message' : 'Send message'}
               title={followUps.sending ? 'Queue' : 'Send'}
-              className="inline-flex size-9 shrink-0 items-center justify-center rounded-full text-white shadow-[0_1px_2px_var(--accent-shadow)] outline-none transition-opacity [background:var(--accent-grad-action)] hover:opacity-90 disabled:cursor-default disabled:opacity-40 @max-[560px]:size-8"
+              className="inline-flex size-9 shrink-0 items-center justify-center rounded-full shadow-[0_1px_2px_var(--cta-shadow)] outline-none transition-opacity [background:var(--accent-grad-action)] [color:var(--cta-foreground)] hover:opacity-90 disabled:cursor-default disabled:opacity-40 @max-[560px]:size-8"
             >
               <ArrowUp className="size-5 @max-[560px]:size-4" aria-hidden />
             </button>

--- a/apps/desktop/src/renderer/src/conversation/ComposerPromptEditor.tsx
+++ b/apps/desktop/src/renderer/src/conversation/ComposerPromptEditor.tsx
@@ -180,7 +180,7 @@ export const ComposerPromptEditor = forwardRef<ComposerEditorHandle, ComposerPro
             contentEditable={
               <ContentEditable
                 className={cn(
-                  'min-h-[3rem] w-full resize-none bg-transparent p-0 text-[17px] leading-normal text-text outline-none',
+                  'min-h-[3rem] w-full resize-none bg-transparent p-0 text-[17px] leading-normal text-foreground outline-none',
                   'whitespace-pre-wrap break-words',
                   className,
                 )}
@@ -194,7 +194,7 @@ export const ComposerPromptEditor = forwardRef<ComposerEditorHandle, ComposerPro
               />
             }
             placeholder={
-              <div className="pointer-events-none absolute top-0 left-0 text-[17px] leading-normal text-placeholder">
+              <div className="pointer-events-none absolute top-0 left-0 text-[17px] leading-normal text-muted-foreground">
                 {placeholder}
               </div>
             }

--- a/apps/desktop/src/renderer/src/conversation/FileChip.tsx
+++ b/apps/desktop/src/renderer/src/conversation/FileChip.tsx
@@ -30,13 +30,13 @@ export function FileChip({
   const position = link.line ? `L${link.line}${link.column ? `:C${link.column}` : ''}` : null
   const inner = (
     <>
-      <File className="size-3.5 shrink-0 text-accent-text" aria-hidden />
+      <File className="size-3.5 shrink-0 text-primary" aria-hidden />
       <span>{label}</span>
-      {position && <span className="text-muted">{position}</span>}
+      {position && <span className="text-muted-foreground">{position}</span>}
     </>
   )
   const chipClass = cn(
-    'inline-flex items-center gap-1 rounded-md border border-[var(--accent-tint-border)] bg-[var(--accent-tint)] px-1.5 py-0.5 align-text-bottom font-mono text-[0.85em] leading-none text-accent-text',
+    'inline-flex items-center gap-1 rounded-md border border-primary/30 bg-primary/10 px-1.5 py-0.5 align-text-bottom font-mono text-[0.85em] leading-none text-primary',
     className,
   )
 
@@ -49,7 +49,7 @@ export function FileChip({
         onClick={() => openFile(link)}
         className={cn(
           chipClass,
-          'cursor-pointer outline-none transition-colors hover:bg-[var(--accent-tint-border)] focus-visible:ring-2 focus-visible:ring-accent/40',
+          'cursor-pointer outline-none transition-colors hover:bg-primary/30 focus-visible:ring-2 focus-visible:ring-primary/40',
         )}
       >
         {inner}

--- a/apps/desktop/src/renderer/src/conversation/MessageScroller.tsx
+++ b/apps/desktop/src/renderer/src/conversation/MessageScroller.tsx
@@ -46,7 +46,7 @@ export function MessageScroller({
           type="button"
           onClick={() => void scrollToBottom()}
           aria-label="Scroll to latest"
-          className="absolute bottom-2 left-1/2 inline-flex size-8 -translate-x-1/2 items-center justify-center rounded-full border border-border bg-panel text-muted shadow-md outline-none transition-colors hover:text-text"
+          className="absolute bottom-2 left-1/2 inline-flex size-8 -translate-x-1/2 items-center justify-center rounded-full border border-border bg-card text-muted-foreground shadow-md outline-none transition-colors hover:text-foreground"
         >
           <ArrowDown className="size-4" aria-hidden />
         </button>

--- a/apps/desktop/src/renderer/src/conversation/Response.tsx
+++ b/apps/desktop/src/renderer/src/conversation/Response.tsx
@@ -101,7 +101,7 @@ export function Response({ text, className }: { text: string; className?: string
       inlineCode: ({ className: codeClassName, children }) => (
         <code
           className={cn(
-            'rounded-md border border-border bg-[var(--accent-tint)] px-1.5 py-0.5 font-mono text-[0.85em]',
+            'rounded-md border border-border bg-primary/10 px-1.5 py-0.5 font-mono text-[0.85em]',
             codeClassName,
           )}
         >
@@ -121,7 +121,7 @@ export function Response({ text, className }: { text: string; className?: string
             href={href}
             target="_blank"
             rel="noreferrer noopener"
-            className={cn('font-medium text-accent-text underline', linkClassName)}
+            className={cn('font-medium text-primary underline', linkClassName)}
           >
             {children}
           </a>

--- a/apps/desktop/src/renderer/src/conversation/composer-sources.tsx
+++ b/apps/desktop/src/renderer/src/conversation/composer-sources.tsx
@@ -39,11 +39,11 @@ export function createCommandSource(commands: readonly AcpCommand[]): Completion
     closeOnAccept: () => true,
     renderRow: (command) => (
       <>
-        <span className="text-[13px] font-semibold whitespace-nowrap text-accent-text">
+        <span className="text-[13px] font-semibold whitespace-nowrap text-primary">
           /{command.name}
         </span>
         {command.description && (
-          <span className="truncate text-xs text-muted">{command.description}</span>
+          <span className="truncate text-xs text-muted-foreground">{command.description}</span>
         )}
       </>
     ),
@@ -82,11 +82,11 @@ export function createPathSource({
     renderRow: (entry) => (
       <>
         {entry.kind === 'directory' ? (
-          <Folder className="size-3.5 shrink-0 text-muted" aria-hidden />
+          <Folder className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
         ) : (
-          <File className="size-3.5 shrink-0 text-muted" aria-hidden />
+          <File className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
         )}
-        <span className="truncate text-[13px] text-text-body">
+        <span className="truncate text-[13px] text-foreground">
           {entry.path}
           {entry.kind === 'directory' && '/'}
         </span>

--- a/apps/desktop/src/renderer/src/conversation/items/PermissionRow.tsx
+++ b/apps/desktop/src/renderer/src/conversation/items/PermissionRow.tsx
@@ -15,13 +15,13 @@ export function PermissionRow({ item }: { item: PermissionItem }): JSX.Element {
   // settled "You chose: …" state is unchanged; the wiring (`onPermission`, `item.options`,
   // `chosenName`) is behaviour-identical to the retired BEM version.
   return (
-    <div className="flex flex-col gap-2.5 rounded-lg border border-[var(--accent-tint-border)] bg-[var(--accent-tint)] p-3">
-      <div className="flex items-center gap-1.5 text-[13px] font-semibold text-accent-text">
+    <div className="flex flex-col gap-2.5 rounded-lg border border-primary/30 bg-primary/10 p-3">
+      <div className="flex items-center gap-1.5 text-[13px] font-semibold text-primary">
         <ShieldAlert className="size-4 shrink-0" aria-hidden />
         <span>Permission request{item.toolCallId ? ` · ${item.toolCallId}` : ''}</span>
       </div>
       {item.chosenName ? (
-        <div className="flex items-center gap-1.5 text-[13px] text-muted">
+        <div className="flex items-center gap-1.5 text-[13px] text-muted-foreground">
           <Check className="size-3.5 shrink-0" aria-hidden />
           <span>You chose: {item.chosenName}</span>
         </div>

--- a/apps/desktop/src/renderer/src/conversation/items/ReasoningRow.tsx
+++ b/apps/desktop/src/renderer/src/conversation/items/ReasoningRow.tsx
@@ -20,7 +20,7 @@ export function ReasoningRow({ item, index }: { item: ReasoningItem; index: numb
       open={open}
       onOpenChange={setOpen}
       toggleZone="header"
-      headerClassName="flex items-center gap-1.5 rounded-md px-0.5 py-0.5 text-[12px] text-muted outline-none transition-colors hover:bg-accent/10 focus-visible:bg-accent/10"
+      headerClassName="flex items-center gap-1.5 rounded-md px-0.5 py-0.5 text-[12px] text-muted-foreground outline-none transition-colors hover:bg-primary/10 focus-visible:bg-primary/10"
       header={
         <>
           <Brain className="size-3.5 shrink-0" aria-hidden />
@@ -30,7 +30,7 @@ export function ReasoningRow({ item, index }: { item: ReasoningItem; index: numb
       }
     >
       <Response
-        className="mt-1 ms-2 border-s border-border ps-3 text-[13px] leading-relaxed text-muted"
+        className="mt-1 ms-2 border-s border-border ps-3 text-[13px] leading-relaxed text-muted-foreground"
         text={item.text}
       />
     </FoldableRow>

--- a/apps/desktop/src/renderer/src/conversation/items/ToolRow.tsx
+++ b/apps/desktop/src/renderer/src/conversation/items/ToolRow.tsx
@@ -60,10 +60,10 @@ function ToolKindIcon({ name, className }: { name: ToolIconName; className?: str
  *  live, a muted check when completed, a destructive X on failure, a neutral static dot
  *  when a non-terminal status settled after the turn ended (#164). */
 const TOOL_STATUS_GLYPHS: Record<ToolStatusGlyphName, { icon: LucideIcon; className: string }> = {
-  check: { icon: Check, className: 'size-4 text-muted' },
-  x: { icon: X, className: 'size-4 text-bad' },
-  spinner: { icon: Loader2, className: 'size-4 animate-spin text-muted' },
-  dot: { icon: Circle, className: 'size-2 fill-muted text-muted opacity-60' },
+  check: { icon: Check, className: 'size-4 text-muted-foreground' },
+  x: { icon: X, className: 'size-4 text-destructive' },
+  spinner: { icon: Loader2, className: 'size-4 animate-spin text-muted-foreground' },
+  dot: { icon: Circle, className: 'size-2 fill-muted text-muted-foreground opacity-60' },
 }
 
 function ToolStatusGlyph({ glyph }: { glyph: ToolStatusGlyphName }): JSX.Element {
@@ -104,20 +104,20 @@ function GenericToolRow({ item, index }: { item: ToolItem; index: number }): JSX
       toggleZone="container"
       className={cn(
         'flex flex-col rounded-md px-0.5 py-0.5 transition-colors',
-        canExpand && 'cursor-pointer hover:bg-accent/10 focus-visible:bg-accent/10 outline-none',
+        canExpand && 'cursor-pointer hover:bg-primary/10 focus-visible:bg-primary/10 outline-none',
       )}
       headerClassName="flex items-center gap-1.5 select-none"
       header={
         <>
-          <span className="flex size-5 shrink-0 items-center justify-center text-muted">
+          <span className="flex size-5 shrink-0 items-center justify-center text-muted-foreground">
             <ToolKindIcon name={toolKindIcon(item.toolKind)} className="size-3.5 shrink-0 stroke-[1.8]" />
           </span>
           <p className="flex min-w-0 flex-1 items-baseline gap-1.5 text-[13px] leading-5">
-            <span className="min-w-0 shrink truncate font-medium text-text-body">{heading}</span>
-            {preview && <span className="min-w-0 flex-1 truncate text-muted">{preview}</span>}
+            <span className="min-w-0 shrink truncate font-medium text-foreground">{heading}</span>
+            {preview && <span className="min-w-0 flex-1 truncate text-muted-foreground">{preview}</span>}
           </p>
           <span className="flex shrink-0 items-center gap-px">
-            {canExpand && <FoldChevron open={expanded} className="text-muted" />}
+            {canExpand && <FoldChevron open={expanded} className="text-muted-foreground" />}
             <span className="flex size-4 shrink-0 items-center justify-center">
               <ToolStatusGlyph glyph={status.glyph} />
             </span>
@@ -171,17 +171,17 @@ function FileChangeToolRow({
   return (
     <section
       data-file-change-card
-      className="overflow-hidden rounded-lg border border-border bg-surface/80 shadow-[0_1px_0_rgba(24,20,16,0.03)]"
+      className="overflow-hidden rounded-lg border border-border bg-secondary/80 shadow-[0_1px_0_var(--subtle-edge-shadow)]"
     >
-      <div className="flex items-center gap-2 border-b border-border-muted bg-sidebar/55 px-2.5 py-2">
-        <span className="flex size-6 shrink-0 items-center justify-center rounded-md border border-border bg-bg text-accent-text">
+      <div className="flex items-center gap-2 border-b border-border bg-sidebar/55 px-2.5 py-2">
+        <span className="flex size-6 shrink-0 items-center justify-center rounded-md border border-border bg-background text-primary">
           <FileDiff className="size-3.5" aria-hidden />
         </span>
         <div className="min-w-0 flex-1">
-          <p className="text-[12px] font-semibold tracking-[0.01em] text-text-strong">{fileChangeHeading(changes)}</p>
-          <p className="flex items-center gap-1.5 font-mono text-[10px] tabular-nums text-muted">
-            {stats.additions > 0 ? <span className="text-ok">+{stats.additions}</span> : null}
-            {stats.deletions > 0 ? <span className="text-bad">−{stats.deletions}</span> : null}
+          <p className="text-[12px] font-semibold tracking-[0.01em] text-foreground">{fileChangeHeading(changes)}</p>
+          <p className="flex items-center gap-1.5 font-mono text-[10px] tabular-nums text-muted-foreground">
+            {stats.additions > 0 ? <span className="text-success">+{stats.additions}</span> : null}
+            {stats.deletions > 0 ? <span className="text-destructive">−{stats.deletions}</span> : null}
             {stats.additions === 0 && stats.deletions === 0 ? <span>No text changes</span> : null}
           </p>
         </div>
@@ -189,7 +189,7 @@ function FileChangeToolRow({
           type="button"
           aria-expanded={expanded}
           onClick={() => setExpanded((open) => !open)}
-          className="inline-flex shrink-0 items-center gap-1 rounded-md px-1.5 py-1 text-[11px] font-medium text-muted outline-none transition-colors hover:bg-accent/10 hover:text-text-strong focus-visible:bg-accent/10"
+          className="inline-flex shrink-0 items-center gap-1 rounded-md px-1.5 py-1 text-[11px] font-medium text-muted-foreground outline-none transition-colors hover:bg-primary/10 hover:text-foreground focus-visible:bg-primary/10"
         >
           {expanded ? 'Hide changes' : 'View changes'}
           <FoldChevron open={expanded} />
@@ -199,7 +199,7 @@ function FileChangeToolRow({
         </span>
       </div>
 
-      <div className="divide-y divide-border-muted">
+      <div className="divide-y divide-border">
         {changes.map((change, changeIndex) => (
           <FileChangeRow
             key={`${change.path}:${changeIndex}`}
@@ -212,14 +212,14 @@ function FileChangeToolRow({
       </div>
 
       {expanded ? (
-        <div className="border-t border-border bg-bg px-2.5 py-2.5">
+        <div className="border-t border-border bg-background px-2.5 py-2.5">
           <div className="space-y-3">
             {changes.map((change, changeIndex) => (
               <FileChangePreview key={`${change.path}:preview:${changeIndex}`} change={change} />
             ))}
           </div>
           {failureDetail ? (
-            <pre className="mt-2 max-h-32 overflow-auto rounded-md border border-[var(--bad-tint-border)] bg-[var(--bad-tint)] p-2 font-mono text-[10px] whitespace-pre-wrap text-bad">
+            <pre className="mt-2 max-h-32 overflow-auto rounded-md border border-destructive/35 bg-destructive/10 p-2 font-mono text-[10px] whitespace-pre-wrap text-destructive">
               {failureDetail}
             </pre>
           ) : null}
@@ -247,16 +247,16 @@ function FileChangeRow({
   const canOpenLocalFile = actionsEnabled && change.kind !== 'deleted'
   const pathContent = (
     <>
-      <Icon className="size-3.5 shrink-0 text-accent-text" aria-hidden />
-      <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-text" title={change.path}>
+      <Icon className="size-3.5 shrink-0 text-primary" aria-hidden />
+      <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-foreground" title={change.path}>
         {change.path}
       </span>
       <span
         className={cn(
           'shrink-0 rounded-sm px-1.5 py-0.5 text-[9px] font-semibold tracking-[0.06em] uppercase',
-          change.kind === 'created' && 'bg-ok/10 text-ok',
-          change.kind === 'edited' && 'bg-[var(--accent-tint)] text-accent-text',
-          change.kind === 'deleted' && 'bg-bad/10 text-bad',
+          change.kind === 'created' && 'bg-success/10 text-success',
+          change.kind === 'edited' && 'bg-primary/10 text-primary',
+          change.kind === 'deleted' && 'bg-destructive/10 text-destructive',
         )}
       >
         {label}
@@ -272,7 +272,7 @@ function FileChangeRow({
           disabled={!canOpenLocalFile}
           onClick={() => onOpen(change.path)}
           aria-label={`Open ${change.path}`}
-          className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-1 py-1 text-left outline-none transition-colors hover:bg-accent/10 focus-visible:bg-accent/10 disabled:cursor-default disabled:opacity-65"
+          className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-1 py-1 text-left outline-none transition-colors hover:bg-primary/10 focus-visible:bg-primary/10 disabled:cursor-default disabled:opacity-65"
         >
           {pathContent}
         </button>
@@ -286,7 +286,7 @@ function FileChangeRow({
           onClick={() => onOpen(change.path)}
           title="Open file preview"
           aria-label={`Open ${basename(change.path)} in file preview`}
-          className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted opacity-60 outline-none transition-all hover:bg-accent/10 hover:text-text-strong focus-visible:bg-accent/10 focus-visible:opacity-100 disabled:opacity-25 group-hover:opacity-100"
+          className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-60 outline-none transition-all hover:bg-primary/10 hover:text-foreground focus-visible:bg-primary/10 focus-visible:opacity-100 disabled:opacity-25 group-hover:opacity-100"
         >
           <PanelRightOpen className="size-3.5" aria-hidden />
         </button>
@@ -298,7 +298,7 @@ function FileChangeRow({
           onClick={() => onReveal(change.path)}
           title="Reveal in Finder"
           aria-label={`Reveal ${basename(change.path)} in Finder`}
-          className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted opacity-60 outline-none transition-all hover:bg-accent/10 hover:text-text-strong focus-visible:bg-accent/10 focus-visible:opacity-100 disabled:opacity-25 group-hover:opacity-100"
+          className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-60 outline-none transition-all hover:bg-primary/10 hover:text-foreground focus-visible:bg-primary/10 focus-visible:opacity-100 disabled:opacity-25 group-hover:opacity-100"
         >
           <FolderOpen className="size-3.5" aria-hidden />
         </button>
@@ -312,14 +312,14 @@ function FileChangePreview({ change }: { change: FileChange }): JSX.Element {
   const newPreview = changeLinePreview(change.newText)
   return (
     <div>
-      <p className="mb-1.5 truncate font-mono text-[10px] font-medium text-muted" title={change.path}>
+      <p className="mb-1.5 truncate font-mono text-[10px] font-medium text-muted-foreground" title={change.path}>
         {change.path}
       </p>
-      <div className="max-h-72 overflow-auto rounded-md border border-border-muted bg-sidebar/35 font-mono text-[10.5px] leading-[1.55]">
+      <div className="max-h-72 overflow-auto rounded-md border border-border bg-sidebar/35 font-mono text-[10.5px] leading-[1.55]">
         <ChangeLines marker="−" preview={oldPreview} tone="deletion" />
         <ChangeLines marker="+" preview={newPreview} tone="addition" />
         {oldPreview.lines.length === 0 && newPreview.lines.length === 0 ? (
-          <p className="px-3 py-2 text-muted">No textual replacement to preview.</p>
+          <p className="px-3 py-2 text-muted-foreground">No textual replacement to preview.</p>
         ) : null}
       </div>
     </div>
@@ -338,21 +338,21 @@ function ChangeLines({
   if (preview.lines.length === 0) return null
   const addition = tone === 'addition'
   return (
-    <div className={addition ? 'bg-ok/10' : 'bg-bad/10'}>
+    <div className={addition ? 'bg-success/10' : 'bg-destructive/10'}>
       {preview.lines.map((line, lineIndex) => (
         <div
           key={lineIndex}
           className={cn(
-            'grid min-w-max grid-cols-[24px_1fr] border-b border-border-muted/60 last:border-b-0',
-            addition ? 'text-text' : 'text-text-body',
+            'grid min-w-max grid-cols-[24px_1fr] border-b border-border/60 last:border-b-0',
+            addition ? 'text-foreground' : 'text-foreground',
           )}
         >
-          <span className={cn('select-none px-1.5 text-center', addition ? 'text-ok' : 'text-bad')}>{marker}</span>
+          <span className={cn('select-none px-1.5 text-center', addition ? 'text-success' : 'text-destructive')}>{marker}</span>
           <code className="pe-3 whitespace-pre">{line || ' '}</code>
         </div>
       ))}
       {preview.hiddenLineCount > 0 ? (
-        <p className="border-t border-border-muted px-3 py-1 text-muted">
+        <p className="border-t border-border px-3 py-1 text-muted-foreground">
           {preview.hiddenLineCount.toLocaleString()} more lines not shown
         </p>
       ) : null}

--- a/apps/desktop/src/renderer/src/conversation/items/message-rows.tsx
+++ b/apps/desktop/src/renderer/src/conversation/items/message-rows.tsx
@@ -41,7 +41,7 @@ export function UserRow({ item, selectable }: { item: UserItem; selectable: bool
             <span
               data-command-chip
               title={command.description}
-              className="inline-flex items-center gap-1 rounded-md border border-[var(--accent-tint-border)] bg-[var(--accent-tint)] px-1.5 py-0.5 font-mono text-xs leading-none text-accent-text"
+              className="inline-flex items-center gap-1 rounded-md border border-primary/30 bg-primary/10 px-1.5 py-0.5 font-mono text-xs leading-none text-primary"
             >
               <Sparkles className="size-3 shrink-0" aria-hidden />/{command.name}
             </span>
@@ -51,7 +51,7 @@ export function UserRow({ item, selectable }: { item: UserItem; selectable: bool
               key={file.path}
               data-file-chip
               title={file.path}
-              className="inline-flex max-w-full items-center gap-1 rounded-md border border-[var(--accent-tint-border)] bg-[var(--accent-tint)] px-1.5 py-0.5 font-mono text-xs leading-none text-accent-text"
+              className="inline-flex max-w-full items-center gap-1 rounded-md border border-primary/30 bg-primary/10 px-1.5 py-0.5 font-mono text-xs leading-none text-primary"
             >
               <File className="size-3 shrink-0" aria-hidden />
               <span className="truncate">{file.path}</span>
@@ -64,7 +64,7 @@ export function UserRow({ item, selectable }: { item: UserItem; selectable: bool
               title={[`<${element.tagName}>`, element.selector ?? '', element.text, element.pageUrl]
                 .filter((line) => line.length > 0)
                 .join('\n')}
-              className="inline-flex max-w-full items-center gap-1 rounded-md border border-[var(--accent-tint-border)] bg-[var(--accent-tint)] px-1.5 py-0.5 font-mono text-xs leading-none text-accent-text"
+              className="inline-flex max-w-full items-center gap-1 rounded-md border border-primary/30 bg-primary/10 px-1.5 py-0.5 font-mono text-xs leading-none text-primary"
             >
               <MousePointerClick className="size-3 shrink-0" aria-hidden />
               <span className="truncate">{element.selector ?? `<${element.tagName}>`}</span>
@@ -77,7 +77,7 @@ export function UserRow({ item, selectable }: { item: UserItem; selectable: bool
               key={review.id}
               data-review-chip
               title={[review.note, '', review.excerpt].join('\n')}
-              className="inline-flex max-w-full items-center gap-1 rounded-md border border-[var(--accent-tint-border)] bg-[var(--accent-tint)] px-1.5 py-0.5 font-mono text-xs leading-none text-accent-text"
+              className="inline-flex max-w-full items-center gap-1 rounded-md border border-primary/30 bg-primary/10 px-1.5 py-0.5 font-mono text-xs leading-none text-primary"
             >
               <MessageSquareText className="size-3 shrink-0" aria-hidden />
               <span className="truncate">
@@ -97,7 +97,7 @@ export function UserRow({ item, selectable }: { item: UserItem; selectable: bool
               key={paste.id}
               data-pasted-chip
               title={paste.text.length > 400 ? `${paste.text.slice(0, 400)}…` : paste.text}
-              className="inline-flex max-w-full items-center gap-1 rounded-md border border-[var(--accent-tint-border)] bg-[var(--accent-tint)] px-1.5 py-0.5 font-mono text-xs leading-none text-accent-text"
+              className="inline-flex max-w-full items-center gap-1 rounded-md border border-primary/30 bg-primary/10 px-1.5 py-0.5 font-mono text-xs leading-none text-primary"
             >
               <Clipboard className="size-3 shrink-0" aria-hidden />
               <span className="truncate">{pastedLabel(paste)}</span>
@@ -110,7 +110,7 @@ export function UserRow({ item, selectable }: { item: UserItem; selectable: bool
               key={selection.id}
               data-message-selection-chip
               title={pendingContextChipTitle(selection)}
-              className="inline-flex max-w-full items-center gap-1 rounded-md border border-[var(--accent-tint-border)] bg-[var(--accent-tint)] px-1.5 py-0.5 font-mono text-xs leading-none text-accent-text"
+              className="inline-flex max-w-full items-center gap-1 rounded-md border border-primary/30 bg-primary/10 px-1.5 py-0.5 font-mono text-xs leading-none text-primary"
             >
               <MessageSquareText className="size-3 shrink-0" aria-hidden />
               <span className="truncate">{pendingContextChipLabel(selection)}</span>
@@ -124,7 +124,7 @@ export function UserRow({ item, selectable }: { item: UserItem; selectable: bool
           data-message-selection-content={selectable ? '' : undefined}
           data-message-id={selectable ? item.id : undefined}
           data-message-role={selectable ? 'user' : undefined}
-          className="max-w-[80%] rounded-2xl border border-border bg-surface px-3.5 py-2.5 text-[15px] leading-relaxed break-words whitespace-pre-wrap text-text-body"
+          className="max-w-[80%] rounded-2xl border border-border bg-secondary px-3.5 py-2.5 text-[15px] leading-relaxed break-words whitespace-pre-wrap text-foreground"
         >
           {item.images && item.images.length > 0 && (
             <div className="mb-2 flex flex-wrap justify-end gap-2">
@@ -172,7 +172,7 @@ export function AssistantRow({
         data-message-role={selectable ? 'agent' : undefined}
         className="contents"
       >
-        <Response className="text-text-body" text={item.text} />
+        <Response className="text-foreground" text={item.text} />
       </div>
       {/* Actions bar (#116): a hover-reveal row under the answer, holding the Copy
           control (clipboard + anchored toast). Hidden while the answer streams (a
@@ -239,7 +239,7 @@ function MessageCopyButton({ text }: { text: string }): JSX.Element {
           render={
             <IconButton
               size="icon-xs"
-              className="text-muted hover:text-text"
+              className="text-muted-foreground hover:text-foreground"
               aria-label="Copy message"
               disabled={feedback === 'copied'}
               onClick={onCopy}
@@ -247,7 +247,7 @@ function MessageCopyButton({ text }: { text: string }): JSX.Element {
           }
         >
           {feedback === 'copied' ? (
-            <Check className="size-3.5 text-accent-text" aria-hidden />
+            <Check className="size-3.5 text-primary" aria-hidden />
           ) : (
             <Copy className="size-3.5" aria-hidden />
           )}

--- a/apps/desktop/src/renderer/src/conversation/message-selection-toolbar.tsx
+++ b/apps/desktop/src/renderer/src/conversation/message-selection-toolbar.tsx
@@ -129,7 +129,7 @@ export function MessageSelectionToolbar({
             aria-label="Message selection actions"
             initialFocus={false}
             finalFocus={false}
-            className="rounded-md border border-border bg-panel p-1 shadow-lg outline-none"
+            className="rounded-md border border-border bg-card p-1 shadow-lg outline-none"
           >
             <Button
               type="button"

--- a/apps/desktop/src/renderer/src/conversation/use-composer-autocomplete.tsx
+++ b/apps/desktop/src/renderer/src/conversation/use-composer-autocomplete.tsx
@@ -215,7 +215,7 @@ export function CompletionPopover({
 }): JSX.Element {
   return (
     <ul
-      className="absolute right-0 bottom-full left-0 z-10 mb-2 max-h-56 list-none overflow-y-auto rounded-xl border border-border bg-panel p-1 shadow-lg"
+      className="absolute right-0 bottom-full left-0 z-10 mb-2 max-h-56 list-none overflow-y-auto rounded-xl border border-border bg-card p-1 shadow-lg"
       role="listbox"
       aria-label={source.label}
     >
@@ -225,7 +225,7 @@ export function CompletionPopover({
           ref={i === activeIndex ? activeRowRef : null}
           role="option"
           aria-selected={i === activeIndex}
-          className={cn(source.rowClassName, i === activeIndex && 'bg-[var(--accent-tint)]')}
+          className={cn(source.rowClassName, i === activeIndex && 'bg-primary/10')}
           // mousedown (not click) so we accept BEFORE the textarea blurs.
           onMouseDown={(e) => {
             e.preventDefault()

--- a/apps/desktop/src/renderer/src/conversation/use-jump-to-item.ts
+++ b/apps/desktop/src/renderer/src/conversation/use-jump-to-item.ts
@@ -41,7 +41,7 @@ export function useJumpToItem(
         // Animations API, so no stylesheet coupling; cleans itself up on finish.
         el.animate(
           [
-            { backgroundColor: 'color-mix(in srgb, var(--accent) 18%, transparent)' },
+            { backgroundColor: 'color-mix(in srgb, var(--primary) 18%, transparent)' },
             { backgroundColor: 'transparent' },
           ],
           { duration: 1600, easing: 'ease-out' },

--- a/apps/desktop/src/renderer/src/editors/OpenInEditorButton.tsx
+++ b/apps/desktop/src/renderer/src/editors/OpenInEditorButton.tsx
@@ -57,7 +57,7 @@ export function OpenInEditorButton({
   return (
     <div className="flex items-center gap-1.5">
       {error && (
-        <span role="status" className="text-xs text-bad">
+        <span role="status" className="text-xs text-destructive">
           {error}
         </span>
       )}

--- a/apps/desktop/src/renderer/src/git/AllFilesDiffView.tsx
+++ b/apps/desktop/src/renderer/src/git/AllFilesDiffView.tsx
@@ -91,18 +91,18 @@ export function AllFilesDiffView({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <div className="flex items-center gap-1.5 border-b border-border-muted px-3 py-2">
+      <div className="flex items-center gap-1.5 border-b border-border px-3 py-2">
         <Button
           type="button"
           variant="ghost"
           size="xs"
           onClick={onBack}
-          className="-ml-1 shrink-0 text-muted hover:text-accent-text"
+          className="-ml-1 shrink-0 text-muted-foreground hover:text-primary"
         >
           <ArrowLeft className="size-3.5" aria-hidden />
           <span>Changes</span>
         </Button>
-        <span className="min-w-0 flex-1 truncate text-[13px] text-text">
+        <span className="min-w-0 flex-1 truncate text-[13px] text-foreground">
           All changes · {files.length} {files.length === 1 ? 'file' : 'files'}
         </span>
       </div>
@@ -113,7 +113,7 @@ export function AllFilesDiffView({
       {result?.truncated && <DiffTruncationBanner />}
 
       {loading && !result ? (
-        <p className="px-3 py-3 text-[13px] text-muted">Loading diff…</p>
+        <p className="px-3 py-3 text-[13px] text-muted-foreground">Loading diff…</p>
       ) : (
         // Review comments (#239): select lines in any file → inline note editor → a
         // pending-context chip in the active Thread's composer.

--- a/apps/desktop/src/renderer/src/git/BranchDiffView.tsx
+++ b/apps/desktop/src/renderer/src/git/BranchDiffView.tsx
@@ -83,7 +83,7 @@ export function BranchDiffView({
 
   if (currentBranch === null) {
     return (
-      <p className="px-3 py-3 text-[13px] text-muted">
+      <p className="px-3 py-3 text-[13px] text-muted-foreground">
         Branch changes needs a checked-out branch — HEAD is currently detached.
       </p>
     )
@@ -95,17 +95,17 @@ export function BranchDiffView({
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       {/* The compare row: head → base picker. */}
-      <div className="flex items-center gap-1.5 border-b border-border-muted px-3 py-2 text-[13px]">
-        <span className="min-w-0 shrink truncate font-medium text-text" title={currentBranch}>
+      <div className="flex items-center gap-1.5 border-b border-border px-3 py-2 text-[13px]">
+        <span className="min-w-0 shrink truncate font-medium text-foreground" title={currentBranch}>
           {currentBranch}
         </span>
-        <ArrowRight className="size-3.5 shrink-0 text-muted" aria-hidden />
+        <ArrowRight className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
         <Menu>
           <MenuTrigger
             render={
               <button
                 type="button"
-                className="min-w-0 flex-1 truncate rounded-md border border-border px-2 py-1 text-left text-[13px] text-text transition-colors hover:bg-accent/10"
+                className="min-w-0 flex-1 truncate rounded-md border border-border px-2 py-1 text-left text-[13px] text-foreground transition-colors hover:bg-primary/10"
                 title="Choose the base ref to compare against"
               />
             }
@@ -125,17 +125,17 @@ export function BranchDiffView({
             </div>
             <MenuItem onClick={() => onBaseRefChange(null)}>
               <span className="min-w-0 flex-1 truncate">Automatic (default branch)</span>
-              {baseRef === null && <Check className="size-3.5 shrink-0 text-accent-text" aria-hidden />}
+              {baseRef === null && <Check className="size-3.5 shrink-0 text-primary" aria-hidden />}
             </MenuItem>
             <MenuSeparator />
             {filtered.map((b) => (
               <MenuItem key={b.name} onClick={() => onBaseRefChange(b.name)}>
                 <span className="min-w-0 flex-1 truncate">{b.name}</span>
-                {b.isRemote && <span className="shrink-0 text-[10px] text-faint">remote</span>}
-                {baseRef === b.name && <Check className="size-3.5 shrink-0 text-accent-text" aria-hidden />}
+                {b.isRemote && <span className="shrink-0 text-[10px] text-muted-foreground">remote</span>}
+                {baseRef === b.name && <Check className="size-3.5 shrink-0 text-primary" aria-hidden />}
               </MenuItem>
             ))}
-            {filtered.length === 0 && <p className="px-2 py-1.5 text-[12px] text-muted">No matching refs.</p>}
+            {filtered.length === 0 && <p className="px-2 py-1.5 text-[12px] text-muted-foreground">No matching refs.</p>}
           </MenuContent>
         </Menu>
       </div>
@@ -147,14 +147,14 @@ export function BranchDiffView({
 
       {/* Review comments work in BOTH scopes (#239): whatever the diff shows is quotable. */}
       {loading && !result ? (
-        <p className="px-3 py-3 text-[13px] text-muted">Loading branch diff…</p>
+        <p className="px-3 py-3 text-[13px] text-muted-foreground">Loading branch diff…</p>
       ) : result && !result.ok ? (
         // Friendly copy, raw git reason preserved in the tooltip (never a crash).
-        <p className="px-3 py-3 text-[13px] text-muted" title={result.error} role="alert">
+        <p className="px-3 py-3 text-[13px] text-muted-foreground" title={result.error} role="alert">
           Can’t compare against {baseRef ?? 'the default branch'} — pick another base ref.
         </p>
       ) : result && result.files.length === 0 ? (
-        <p className="px-3 py-3 text-[13px] text-muted">
+        <p className="px-3 py-3 text-[13px] text-muted-foreground">
           No changes against {result.baseRef}
           {prefs.ignoreWhitespace ? ' (whitespace-only changes hidden)' : ''}.
         </p>

--- a/apps/desktop/src/renderer/src/git/BranchMenu.tsx
+++ b/apps/desktop/src/renderer/src/git/BranchMenu.tsx
@@ -95,7 +95,7 @@ export function BranchMenu({
 
   return (
     <>
-      <div className="flex items-center gap-1.5 border-b border-border-muted px-3 py-2 text-[13px] text-muted">
+      <div className="flex items-center gap-1.5 border-b border-border px-3 py-2 text-[13px] text-muted-foreground">
         <Menu
           onOpenChange={(open) => {
             if (open) void loadBranches()
@@ -106,30 +106,30 @@ export function BranchMenu({
             title={busy ? 'Agent is working…' : branch}
             className={cn(
               'flex min-w-0 flex-1 items-center gap-1.5 rounded-md px-2 py-1 text-left transition-colors',
-              'hover:bg-accent/10 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent',
+              'hover:bg-primary/10 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent',
             )}
           >
             <GitBranch size={14} aria-hidden className="shrink-0" />
-            <span className="min-w-0 flex-1 truncate font-medium text-text">{branch}</span>
+            <span className="min-w-0 flex-1 truncate font-medium text-foreground">{branch}</span>
             <ChevronDown size={13} aria-hidden className="shrink-0" />
           </MenuTrigger>
           <MenuContent align="start" className="max-h-80 min-w-48 overflow-y-auto">
             {loading ? (
-              <div className="px-3 py-1.5 text-sm text-muted">Loading…</div>
+              <div className="px-3 py-1.5 text-sm text-muted-foreground">Loading…</div>
             ) : listError ? (
-              <div className="px-3 py-1.5 text-sm text-bad">{listError}</div>
+              <div className="px-3 py-1.5 text-sm text-destructive">{listError}</div>
             ) : branches && branches.length > 0 ? (
               branches.map((b) => (
                 <MenuItem key={b.name} onClick={() => void checkout(b.name)} disabled={b.current}>
                   <Check size={13} aria-hidden className={cn('shrink-0', b.current ? 'opacity-100' : 'opacity-0')} />
                   <span className="min-w-0 flex-1 truncate">{b.name}</span>
-                  {b.isRemote && <span className="shrink-0 text-[10px] uppercase text-muted">remote</span>}
+                  {b.isRemote && <span className="shrink-0 text-[10px] uppercase text-muted-foreground">remote</span>}
                 </MenuItem>
               ))
             ) : (
-              <div className="px-3 py-1.5 text-sm text-muted">No branches.</div>
+              <div className="px-3 py-1.5 text-sm text-muted-foreground">No branches.</div>
             )}
-            <MenuSeparator className="my-1 h-px bg-border-muted" />
+            <MenuSeparator className="my-1 h-px bg-border" />
             <MenuItem onClick={() => setCreating(true)}>
               <span className="w-3 shrink-0" aria-hidden />
               Create branch…
@@ -146,7 +146,7 @@ export function BranchMenu({
       </div>
 
       {creating && (
-        <div className="flex items-center gap-1.5 border-b border-border-muted px-3 py-2">
+        <div className="flex items-center gap-1.5 border-b border-border px-3 py-2">
           <Input
             autoFocus
             aria-label="New branch name"
@@ -179,7 +179,7 @@ export function BranchMenu({
       )}
 
       {opError && (
-        <p className="border-b border-border-muted px-3 py-2 text-[11px] text-bad" role="alert">
+        <p className="border-b border-border px-3 py-2 text-[11px] text-destructive" role="alert">
           {opError}
         </p>
       )}

--- a/apps/desktop/src/renderer/src/git/ChangesPanel.tsx
+++ b/apps/desktop/src/renderer/src/git/ChangesPanel.tsx
@@ -191,9 +191,9 @@ export function ChangesPanel({
   // must never strand the user with no way back to the card stack.
   if (!status || !status.isRepo) {
     return (
-      <aside className="flex min-h-0 flex-1 flex-col text-text">
+      <aside className="flex min-h-0 flex-1 flex-col text-foreground">
         <ReviewHeader onCollapse={onCollapse} onRefresh={refresh} />
-        <p className="px-3 py-3 text-[13px] text-muted">
+        <p className="px-3 py-3 text-[13px] text-muted-foreground">
           {!status ? 'Loading changes…' : 'Not a Git repository.'}
         </p>
       </aside>
@@ -363,7 +363,7 @@ export function ChangesPanel({
   // view each render, so sections track the list and churn drives its refetch.
   if (isActive && selectedPath !== null && view.files.length > 0) {
     return (
-      <aside className="flex min-h-0 flex-1 flex-col text-text">
+      <aside className="flex min-h-0 flex-1 flex-col text-foreground">
         <DiffWorkerProvider>
           <AllFilesDiffView
             workspaceDir={workspaceDir}
@@ -380,15 +380,15 @@ export function ChangesPanel({
   return (
     // The SHELL (SurfacePanel) owns the panel's width + border-l chrome now; this fills
     // it and scrolls internally — the shell column is viewport-height, not <main>-scrolled.
-    <aside className="flex min-h-0 flex-1 flex-col overflow-y-auto text-text">
+    <aside className="flex min-h-0 flex-1 flex-col overflow-y-auto text-foreground">
       <ReviewHeader count={view.fileCount} onCollapse={onCollapse} onRefresh={refresh} />
 
       {/* Environment (#119) — a STATIC placeholder gesturing at the mockup's fuller
           "Environment / Local / Sources" side-panel (styled chrome, non-functional,
           like the sidebar's Search/Scheduled/Plugins "Soon" rows). Not wired to
           anything; the live git surface begins at the branch header below. */}
-      <div className="border-b border-border-muted px-3 py-2.5">
-        <p className="mb-1 px-1 text-[11px] font-medium text-faint">Environment</p>
+      <div className="border-b border-border px-3 py-2.5">
+        <p className="mb-1 px-1 text-[11px] font-medium text-muted-foreground">Environment</p>
         <div className="flex flex-col gap-0.5">
           <EnvPlaceholder icon={<Monitor className="size-4" aria-hidden />}>Local</EnvPlaceholder>
           <EnvPlaceholder icon={<Boxes className="size-4" aria-hidden />}>Sources</EnvPlaceholder>
@@ -416,7 +416,7 @@ export function ChangesPanel({
       {/* Diff scope (#237): Working tree (live) vs Branch changes (`base...HEAD`, on
           demand) — persisted per Workspace. Branch scope swaps the list + commit area
           for the read-only range view; review keeps working after commits land. */}
-      <div className="flex items-center border-b border-border-muted px-3 py-2 text-[13px]">
+      <div className="flex items-center border-b border-border px-3 py-2 text-[13px]">
         <div className="flex overflow-hidden rounded-md border border-border">
           <button
             type="button"
@@ -424,8 +424,8 @@ export function ChangesPanel({
             onClick={() => updateDiffScope({ scope: 'working' })}
             className={
               diffScope.scope === 'working'
-                ? 'bg-accent/10 px-2.5 py-1 text-accent-text'
-                : 'px-2.5 py-1 text-muted transition-colors hover:text-accent-text'
+                ? 'bg-primary/10 px-2.5 py-1 text-primary'
+                : 'px-2.5 py-1 text-muted-foreground transition-colors hover:text-primary'
             }
           >
             Working tree
@@ -436,8 +436,8 @@ export function ChangesPanel({
             onClick={() => updateDiffScope({ scope: 'branch' })}
             className={
               diffScope.scope === 'branch'
-                ? 'bg-accent/10 px-2.5 py-1 text-accent-text'
-                : 'px-2.5 py-1 text-muted transition-colors hover:text-accent-text'
+                ? 'bg-primary/10 px-2.5 py-1 text-primary'
+                : 'px-2.5 py-1 text-muted-foreground transition-colors hover:text-primary'
             }
           >
             Branch changes
@@ -457,7 +457,7 @@ export function ChangesPanel({
           />
         </DiffWorkerProvider>
       ) : view.files.length === 0 ? (
-        <p className="px-3 py-3 text-[13px] text-muted">No changes — working tree clean.</p>
+        <p className="px-3 py-3 text-[13px] text-muted-foreground">No changes — working tree clean.</p>
       ) : (
         <ul className="flex flex-col gap-0.5 py-1.5">
           {view.files.map((file) => (
@@ -493,7 +493,7 @@ export function ChangesPanel({
           push / Push / Pull / View PR; the rest in the attached menu). Disabled while a
           turn streams (`busy`) or an action runs. git's reason surfaces inline. */}
       {diffScope.scope === 'working' && (view.files.length > 0 || quickAction.primary !== null) && (
-        <div className="flex flex-col gap-2 border-t border-border-muted px-3 py-2.5">
+        <div className="flex flex-col gap-2 border-t border-border px-3 py-2.5">
           {view.files.length > 0 && (
             <Textarea
               value={message}
@@ -510,7 +510,7 @@ export function ChangesPanel({
               }}
             />
           )}
-          {busy && <p className="text-[11px] text-muted">Agent is working…</p>}
+          {busy && <p className="text-[11px] text-muted-foreground">Agent is working…</p>}
           <QuickActions
             view={quickAction}
             commitCount={selectedPaths.length}
@@ -529,7 +529,7 @@ export function ChangesPanel({
                 setRevertTarget('all')
               }}
               disabled={busy || reverting}
-              className="self-start text-[11px] text-muted transition-colors hover:text-bad disabled:opacity-50"
+              className="self-start text-[11px] text-muted-foreground transition-colors hover:text-destructive disabled:opacity-50"
             >
               Revert all changes…
             </button>
@@ -561,7 +561,7 @@ export function ChangesPanel({
             </DialogDescription>
           </DialogHeader>
           {revertError && (
-            <p className="text-[11px] text-bad" role="alert">
+            <p className="text-[11px] text-destructive" role="alert">
               {revertError}
             </p>
           )}
@@ -597,7 +597,7 @@ export function ChangesPanel({
             </DialogDescription>
           </DialogHeader>
           <div className="flex flex-col gap-1.5">
-            <label htmlFor="guard-branch-name" className="text-[11px] font-medium text-muted">
+            <label htmlFor="guard-branch-name" className="text-[11px] font-medium text-muted-foreground">
               New branch name
             </label>
             <Input
@@ -608,7 +608,7 @@ export function ChangesPanel({
               className="text-[13px]"
             />
             {guardError && (
-              <p className="text-[11px] text-bad" role="alert">
+              <p className="text-[11px] text-destructive" role="alert">
                 {guardError}
               </p>
             )}
@@ -666,23 +666,23 @@ function ReviewHeader({
   onRefresh: () => void
 }): JSX.Element {
   return (
-    <div className="flex items-center gap-2 border-b border-border-muted px-3 py-2.5">
+    <div className="flex items-center gap-2 border-b border-border px-3 py-2.5">
       <button
         type="button"
         onClick={onCollapse}
         title="Collapse"
         aria-label="Collapse Review panel"
-        className="flex min-w-0 flex-1 items-center gap-1.5 rounded-md text-left text-sm font-semibold text-text-strong"
+        className="flex min-w-0 flex-1 items-center gap-1.5 rounded-md text-left text-sm font-semibold text-foreground"
       >
-        <PanelRightClose size={15} aria-hidden className="shrink-0 text-muted" />
+        <PanelRightClose size={15} aria-hidden className="shrink-0 text-muted-foreground" />
         <span>Changes</span>
         {count !== undefined && count > 0 && (
-          <Badge variant="outline" className="ml-0.5 rounded-full px-1.5 py-0 text-[11px] tabular-nums text-muted">
+          <Badge variant="outline" className="ml-0.5 rounded-full px-1.5 py-0 text-[11px] tabular-nums text-muted-foreground">
             {count}
           </Badge>
         )}
       </button>
-      <IconButton size="icon-sm" onClick={onRefresh} title="Refresh" aria-label="Refresh git status" className="text-muted">
+      <IconButton size="icon-sm" onClick={onRefresh} title="Refresh" aria-label="Refresh git status" className="text-muted-foreground">
         <RefreshCw className="size-3.5" aria-hidden />
       </IconButton>
     </div>
@@ -698,11 +698,11 @@ function EnvPlaceholder({ icon, children }: { icon: JSX.Element; children: strin
   return (
     <div
       title="Coming soon"
-      className="flex cursor-default items-center gap-2 rounded-md px-2 py-1 text-[13px] text-muted opacity-70"
+      className="flex cursor-default items-center gap-2 rounded-md px-2 py-1 text-[13px] text-muted-foreground opacity-70"
     >
-      <span className="shrink-0 text-muted">{icon}</span>
+      <span className="shrink-0 text-muted-foreground">{icon}</span>
       <span className="min-w-0 flex-1 truncate">{children}</span>
-      <span className="shrink-0 text-[10px] font-medium text-faint">Soon</span>
+      <span className="shrink-0 text-[10px] font-medium text-muted-foreground">Soon</span>
     </div>
   )
 }

--- a/apps/desktop/src/renderer/src/git/DiffWorkerProvider.tsx
+++ b/apps/desktop/src/renderer/src/git/DiffWorkerProvider.tsx
@@ -1,6 +1,8 @@
-import { useMemo, type JSX, type ReactNode } from 'react'
-import { WorkerPoolContextProvider } from '@pierre/diffs/react'
+import { useEffect, useMemo, type JSX, type ReactNode } from 'react'
+import { useWorkerPool, WorkerPoolContextProvider } from '@pierre/diffs/react'
 import DiffsWorker from '@pierre/diffs/worker/worker.js?worker'
+import { getResolvedTheme, useResolvedTheme } from '../shell/resolved-theme-store'
+import { pierreThemeOptions } from './pierre-theme'
 
 /**
  * Mounts `@pierre/diffs`' web-worker pool around the diff viewer (#85, ADR-0008). The
@@ -13,12 +15,9 @@ import DiffsWorker from '@pierre/diffs/worker/worker.js?worker'
  * that news one up. Pool size is derived from `hardwareConcurrency`, clamped to 2-6 so a
  * many-core machine doesn't spawn a wasteful fleet and a single-core one still gets two.
  *
- * Brand is light-mode (CONTEXT.md), so we pin @pierre's `pierre-light` highlighter theme
- * and skip t3code's theme-sync effect entirely — there is no dark mode to follow. If a
- * dark mode ever lands, push the new theme at runtime via `useWorkerPool().setRenderOptions`
- * (verified against `WorkerPoolManager` in `node_modules/@pierre/diffs`) instead of
- * recreating the pool — `setRenderOptions` only re-registers the theme, it does not evict
- * the parsed-AST caches below, so a theme switch never triggers a re-parse.
+ * Theme: CSS cannot reach the worker highlighter. Initialize the singleton from the
+ * current resolved app theme, then push live flips through `setRenderOptions` rather
+ * than recreating the pool. Re-registering the theme preserves the parsed-AST caches.
  *
  * Scale tuning (#389, PRD #387): `totalASTLRUCacheSize` bounds the pool's own parsed-file/
  * parsed-diff LRU caches (keyed by the `cacheKey` callers attach — see `patch-cache-key.ts`),
@@ -28,14 +27,25 @@ import DiffsWorker from '@pierre/diffs/worker/worker.js?worker'
  * `WorkerPoolOptions`/`WorkerRenderingOptions` in `node_modules/@pierre/diffs/dist/worker/types.d.ts`.
  */
 
-/** @pierre's bundled light theme — matches the brand's light-mode surfaces. */
-const DIFF_THEME = 'pierre-light'
-
 /** Parsed-AST LRU entries kept across BOTH the file and diff caches (#389). */
 const AST_LRU_CACHE_SIZE = 240
 
 /** Lines longer than this render unhighlighted instead of hanging the tokenizer (#389). */
 const TOKENIZE_MAX_LINE_LENGTH = 1000
+
+/** Push a resolved-theme flip into the already-live singleton worker pool. */
+function DiffThemeSync(): null {
+  const pool = useWorkerPool()
+  const resolved = useResolvedTheme()
+
+  useEffect(() => {
+    void pool
+      ?.setRenderOptions({ theme: pierreThemeOptions(resolved).theme })
+      .catch((error: unknown) => console.error('[theme] failed to update diff workers:', error))
+  }, [pool, resolved])
+
+  return null
+}
 
 export function DiffWorkerProvider({ children }: { children?: ReactNode }): JSX.Element {
   // Clamp pool size to 2-6 from half the core count (mirrors t3code's heuristic): a
@@ -48,8 +58,12 @@ export function DiffWorkerProvider({ children }: { children?: ReactNode }): JSX.
   return (
     <WorkerPoolContextProvider
       poolOptions={{ workerFactory: () => new DiffsWorker(), poolSize, totalASTLRUCacheSize: AST_LRU_CACHE_SIZE }}
-      highlighterOptions={{ theme: DIFF_THEME, tokenizeMaxLineLength: TOKENIZE_MAX_LINE_LENGTH }}
+      highlighterOptions={{
+        theme: pierreThemeOptions(getResolvedTheme()).theme,
+        tokenizeMaxLineLength: TOKENIZE_MAX_LINE_LENGTH,
+      }}
     >
+      <DiffThemeSync />
       {children}
     </WorkerPoolContextProvider>
   )

--- a/apps/desktop/src/renderer/src/git/FileRow.tsx
+++ b/apps/desktop/src/renderer/src/git/FileRow.tsx
@@ -27,7 +27,7 @@ export function FileRow({
   onRevert?: () => void
 }): JSX.Element {
   return (
-    <li className="group mx-2 flex items-center gap-1 rounded-md transition-colors hover:bg-accent/10">
+    <li className="group mx-2 flex items-center gap-1 rounded-md transition-colors hover:bg-primary/10">
       <input
         type="checkbox"
         checked={checked}
@@ -54,9 +54,9 @@ export function FileRow({
         </span>
         {(file.insertions > 0 || file.deletions > 0) && (
           <span className="shrink-0 tabular-nums text-[11px]">
-            {file.insertions > 0 && <span className="text-ok">+{file.insertions}</span>}
+            {file.insertions > 0 && <span className="text-success">+{file.insertions}</span>}
             {file.insertions > 0 && file.deletions > 0 && ' '}
-            {file.deletions > 0 && <span className="text-bad">−{file.deletions}</span>}
+            {file.deletions > 0 && <span className="text-destructive">−{file.deletions}</span>}
           </span>
         )}
       </button>
@@ -68,7 +68,7 @@ export function FileRow({
             file.untracked ? `Delete ${file.path} (untracked)` : `Revert changes to ${file.path}`
           }
           title={file.untracked ? 'Delete file (untracked)…' : 'Revert changes…'}
-          className="mr-1.5 inline-flex size-5 shrink-0 items-center justify-center rounded-sm text-muted opacity-0 transition-opacity group-hover:opacity-100 hover:text-bad focus-visible:opacity-100"
+          className="mr-1.5 inline-flex size-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 hover:text-destructive focus-visible:opacity-100"
         >
           <Undo2 className="size-3.5" aria-hidden />
         </button>

--- a/apps/desktop/src/renderer/src/git/PrSection.tsx
+++ b/apps/desktop/src/renderer/src/git/PrSection.tsx
@@ -105,12 +105,12 @@ export function PrSection({
   // Detached HEAD / before the first fetch: render nothing (no PR surface).
   if (detached || result === null) return null
   if (result === 'loading') {
-    return <p className="border-b border-border-muted px-3 py-1.5 text-[11px] text-muted">Checking pull request…</p>
+    return <p className="border-b border-border px-3 py-1.5 text-[11px] text-muted-foreground">Checking pull request…</p>
   }
   // gh missing / not authed / an unexpected gh failure: a subtle hint, not a crash.
   if (!result.ok) {
     return (
-      <p className="border-b border-border-muted px-3 py-1.5 text-[11px] text-muted" title={result.error}>
+      <p className="border-b border-border px-3 py-1.5 text-[11px] text-muted-foreground" title={result.error}>
         {result.error}
       </p>
     )
@@ -123,11 +123,11 @@ export function PrSection({
   if (isDefault) return null
 
   return (
-    <div className="border-b border-border-muted px-3 py-2">
+    <div className="border-b border-border px-3 py-2">
       {!hasUpstream ? (
         // The push gate: `gh pr create` non-interactively can't prompt to push an
         // unpushed branch, and we never push on the user's behalf — so guide them first.
-        <p className="text-[11px] text-muted">Push your branch to GitHub to open a pull request.</p>
+        <p className="text-[11px] text-muted-foreground">Push your branch to GitHub to open a pull request.</p>
       ) : !creating ? (
         <Button
           type="button"
@@ -142,7 +142,7 @@ export function PrSection({
           }}
           disabled={busy}
           title={busy ? 'Agent is working…' : 'Create a pull request for this branch'}
-          className="-mx-2 text-muted hover:text-accent-text"
+          className="-mx-2 text-muted-foreground hover:text-primary"
         >
           <GitPullRequest className="size-3.5" aria-hidden />
           Create PR
@@ -168,11 +168,11 @@ export function PrSection({
             className="min-h-16 resize-y text-[13px]"
           />
           {createError && (
-            <p className="text-[11px] text-bad" role="alert">
+            <p className="text-[11px] text-destructive" role="alert">
               {createError}
             </p>
           )}
-          {busy && <p className="text-[11px] text-muted">Agent is working…</p>}
+          {busy && <p className="text-[11px] text-muted-foreground">Agent is working…</p>}
           <div className="flex items-center gap-2">
             <Button
               type="button"
@@ -191,7 +191,7 @@ export function PrSection({
                 setCreateError(null)
               }}
               disabled={submitting}
-              className="text-muted hover:text-accent-text"
+              className="text-muted-foreground hover:text-primary"
             >
               Cancel
             </Button>
@@ -205,9 +205,9 @@ export function PrSection({
 /** A PR's chip accent by gh state — open reads positive, merged accent, closed negative. */
 function prStateClass(state: string): string {
   const s = state.toUpperCase()
-  if (s === 'MERGED') return 'text-accent-text'
-  if (s === 'CLOSED') return 'text-bad'
-  return 'text-ok' // OPEN (and any unknown) reads as live.
+  if (s === 'MERGED') return 'text-primary'
+  if (s === 'CLOSED') return 'text-destructive'
+  return 'text-success' // OPEN (and any unknown) reads as live.
 }
 
 /**
@@ -218,17 +218,17 @@ function prStateClass(state: string): string {
  */
 function PrChip({ pr }: { pr: GhPr }): JSX.Element {
   return (
-    <div className="border-b border-border-muted px-3 py-2">
+    <div className="border-b border-border px-3 py-2">
       <a
         href={pr.url}
         target="_blank"
         rel="noreferrer"
         title={`#${pr.number} · ${pr.title} (${pr.state})`}
-        className="flex items-center gap-1.5 rounded-md px-2 py-1 text-[13px] transition-colors hover:bg-accent/10"
+        className="flex items-center gap-1.5 rounded-md px-2 py-1 text-[13px] transition-colors hover:bg-primary/10"
       >
         <GitPullRequest className={cn('size-3.5 shrink-0', prStateClass(pr.state))} aria-hidden />
         <span className={cn('shrink-0 font-medium tabular-nums', prStateClass(pr.state))}>#{pr.number}</span>
-        <span className="min-w-0 flex-1 truncate text-text">{pr.title}</span>
+        <span className="min-w-0 flex-1 truncate text-foreground">{pr.title}</span>
       </a>
     </div>
   )

--- a/apps/desktop/src/renderer/src/git/QuickActions.tsx
+++ b/apps/desktop/src/renderer/src/git/QuickActions.tsx
@@ -33,7 +33,7 @@ export function QuickActions({
   return (
     <div className="flex flex-col gap-2">
       {error && (
-        <p className="text-[11px] text-bad" role="alert">
+        <p className="text-[11px] text-destructive" role="alert">
           {error}
         </p>
       )}

--- a/apps/desktop/src/renderer/src/git/ReviewDiffViewer.tsx
+++ b/apps/desktop/src/renderer/src/git/ReviewDiffViewer.tsx
@@ -18,6 +18,8 @@ import { buildPatchCacheKey } from './patch-cache-key'
 import { buildReviewDiffItemModels, type ReviewDiffFileMeta } from './diff-viewer-items'
 import { emitComposerInsertReviewComment } from '../conversation/composer-insert'
 import { locateRangeInPatch } from './review-comment'
+import { useResolvedTheme } from '../shell/resolved-theme-store'
+import { pierreThemeOptions } from './pierre-theme'
 
 /**
  * The ONE virtualized Review viewer (#388, PRD #387). Both scopes — the working-tree
@@ -43,9 +45,6 @@ import { locateRangeInPatch } from './review-comment'
 interface ReviewDraftMeta {
   kind: 'review-draft'
 }
-
-/** @pierre's light theme — matches the brand's light-mode surfaces (`DiffWorkerProvider`). */
-const DIFF_THEME = 'pierre-light'
 
 /** Which annotation side a range anchors to (the library's own convention). */
 function annotationSide(range: SelectedLineRange): 'additions' | 'deletions' {
@@ -75,6 +74,8 @@ export function ReviewDiffViewer({
   const [note, setNote] = useState('')
   const viewerRef = useRef<CodeViewHandle<ReviewDraftMeta>>(null)
   const scrolledRef = useRef(false)
+  const resolvedTheme = useResolvedTheme()
+  const diffTheme = pierreThemeOptions(resolvedTheme)
 
   // Parse each file's patch to `FileDiffMetadata`, memoized by `diffHash` across
   // refetches — an unchanged file keeps its parse (PRD #387: reuse parsed state).
@@ -186,8 +187,8 @@ export function ReviewDiffViewer({
       options={{
         diffStyle: prefs.diffStyle,
         overflow: prefs.wrap ? 'wrap' : 'scroll',
-        theme: DIFF_THEME,
-        themeType: 'light',
+        theme: diffTheme.theme,
+        themeType: diffTheme.themeType,
         stickyHeaders: true,
         // A drag opens the note editor; block a new selection while one is open.
         enableLineSelection: threadId !== null && !hasOpenDraft,
@@ -209,34 +210,34 @@ export function ReviewDiffViewer({
             className="flex w-full items-center gap-1.5 bg-background px-3 py-1.5 text-left"
           >
             {isCollapsed ? (
-              <ChevronRight className="size-3.5 shrink-0 text-muted" aria-hidden />
+              <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
             ) : (
-              <ChevronDown className="size-3.5 shrink-0 text-muted" aria-hidden />
+              <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
             )}
             {meta && (
               <span className={cn('w-3 shrink-0 text-center text-[11px] font-semibold', glyphClass(meta.glyph))}>
                 {meta.glyph}
               </span>
             )}
-            <span className="min-w-0 flex-1 truncate text-[13px] text-text" dir="rtl" title={path}>
+            <span className="min-w-0 flex-1 truncate text-[13px] text-foreground" dir="rtl" title={path}>
               {path}
             </span>
             {truncated && (
-              <span className="shrink-0 text-[11px] text-muted" title="Diff truncated — file too large">
+              <span className="shrink-0 text-[11px] text-muted-foreground" title="Diff truncated — file too large">
                 truncated
               </span>
             )}
             {meta && (
               <span className="shrink-0 text-[11px] tabular-nums">
-                {meta.insertions > 0 && <span className="text-ok">+{meta.insertions}</span>}{' '}
-                {meta.deletions > 0 && <span className="text-bad">−{meta.deletions}</span>}
+                {meta.insertions > 0 && <span className="text-success">+{meta.insertions}</span>}{' '}
+                {meta.deletions > 0 && <span className="text-destructive">−{meta.deletions}</span>}
               </span>
             )}
           </button>
         )
       }}
       renderAnnotation={() => (
-        <div className="flex w-full max-w-md flex-col gap-1.5 border-y border-border bg-surface p-2">
+        <div className="flex w-full max-w-md flex-col gap-1.5 border-y border-border bg-secondary p-2">
           <Textarea
             autoFocus
             aria-label={`Review comment on ${draft?.path ?? ''}`}
@@ -256,7 +257,7 @@ export function ReviewDiffViewer({
             }}
           />
           <div className="flex items-center justify-end gap-1.5">
-            <Button type="button" variant="ghost" size="xs" onClick={cancelDraft} className="text-muted">
+            <Button type="button" variant="ghost" size="xs" onClick={cancelDraft} className="text-muted-foreground">
               Cancel
             </Button>
             <Button type="button" size="xs" onClick={submitDraft} disabled={note.trim().length === 0}>

--- a/apps/desktop/src/renderer/src/git/diff-view-chrome.tsx
+++ b/apps/desktop/src/renderer/src/git/diff-view-chrome.tsx
@@ -21,7 +21,7 @@ import type { DiffPrefs } from './diff-prefs-store'
  */
 export function DiffTruncationBanner(): JSX.Element {
   return (
-    <p role="alert" className="border-b border-border-muted bg-accent/5 px-3 py-2 text-[13px] text-muted">
+    <p role="alert" className="border-b border-border bg-primary/5 px-3 py-2 text-[13px] text-muted-foreground">
       Diff truncated — this change is too large to show in full. Some later files are omitted.
     </p>
   )
@@ -36,7 +36,7 @@ export function DiffToggles({
   onChange: (patch: Partial<DiffPrefs>) => void
 }): JSX.Element {
   return (
-    <div className="flex items-center gap-2 border-b border-border-muted px-3 py-2 text-[13px]">
+    <div className="flex items-center gap-2 border-b border-border px-3 py-2 text-[13px]">
       <div className="flex overflow-hidden rounded-md border border-border">
         <ToggleButton active={prefs.diffStyle === 'unified'} onClick={() => onChange({ diffStyle: 'unified' })}>
           Stacked
@@ -52,7 +52,7 @@ export function DiffToggles({
         title={prefs.wrap ? 'Scroll long lines' : 'Wrap long lines'}
         className={cn(
           'shrink-0 rounded-md border border-border px-2.5 py-1 transition-colors',
-          prefs.wrap ? 'bg-accent/10 text-accent-text' : 'text-muted hover:text-accent-text',
+          prefs.wrap ? 'bg-primary/10 text-primary' : 'text-muted-foreground hover:text-primary',
         )}
       >
         Wrap
@@ -64,7 +64,7 @@ export function DiffToggles({
         title={prefs.ignoreWhitespace ? 'Show whitespace changes' : 'Hide whitespace changes'}
         className={cn(
           'ml-auto shrink-0 rounded-md border border-border px-2.5 py-1 transition-colors',
-          prefs.ignoreWhitespace ? 'bg-accent/10 text-accent-text' : 'text-muted hover:text-accent-text',
+          prefs.ignoreWhitespace ? 'bg-primary/10 text-primary' : 'text-muted-foreground hover:text-primary',
         )}
       >
         Ignore whitespace
@@ -90,7 +90,7 @@ function ToggleButton({
       aria-pressed={active}
       className={cn(
         'px-2.5 py-1 transition-colors',
-        active ? 'bg-accent/10 text-accent-text' : 'text-muted hover:text-accent-text',
+        active ? 'bg-primary/10 text-primary' : 'text-muted-foreground hover:text-primary',
       )}
     >
       {children}

--- a/apps/desktop/src/renderer/src/git/pierre-theme.test.ts
+++ b/apps/desktop/src/renderer/src/git/pierre-theme.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+import { pierreThemeOptions } from './pierre-theme'
+
+describe('pierreThemeOptions', () => {
+  it('maps both resolved app themes to @pierre/diffs bundled themes', () => {
+    expect(pierreThemeOptions('light')).toEqual({ theme: 'pierre-light', themeType: 'light' })
+    expect(pierreThemeOptions('dark')).toEqual({ theme: 'pierre-dark', themeType: 'dark' })
+  })
+})

--- a/apps/desktop/src/renderer/src/git/pierre-theme.ts
+++ b/apps/desktop/src/renderer/src/git/pierre-theme.ts
@@ -1,0 +1,17 @@
+import type { ResolvedTheme } from '../../../shared/ipc'
+
+/** Keep every @pierre/diffs consumer on the same bundled theme vocabulary. */
+const PIERRE_THEMES: Record<ResolvedTheme, string> = {
+  light: 'pierre-light',
+  dark: 'pierre-dark',
+}
+
+export interface PierreThemeOptions {
+  theme: string
+  themeType: ResolvedTheme
+}
+
+/** Options shared by the worker highlighter, Review viewer, and file preview. */
+export function pierreThemeOptions(resolved: ResolvedTheme): PierreThemeOptions {
+  return { theme: PIERRE_THEMES[resolved], themeType: resolved }
+}

--- a/apps/desktop/src/renderer/src/git/status-view.test.ts
+++ b/apps/desktop/src/renderer/src/git/status-view.test.ts
@@ -25,12 +25,12 @@ describe('fileGlyph', () => {
 
 describe('glyphClass', () => {
   it('accents added/untracked positive, deleted negative, else neutral', () => {
-    expect(glyphClass('A')).toBe('text-ok')
-    expect(glyphClass('U')).toBe('text-ok')
-    expect(glyphClass('D')).toBe('text-bad')
-    expect(glyphClass('M')).toBe('text-accent-text')
-    expect(glyphClass('R')).toBe('text-accent-text')
-    expect(glyphClass('C')).toBe('text-accent-text')
+    expect(glyphClass('A')).toBe('text-success')
+    expect(glyphClass('U')).toBe('text-success')
+    expect(glyphClass('D')).toBe('text-destructive')
+    expect(glyphClass('M')).toBe('text-primary')
+    expect(glyphClass('R')).toBe('text-primary')
+    expect(glyphClass('C')).toBe('text-primary')
   })
 })
 

--- a/apps/desktop/src/renderer/src/git/status-view.ts
+++ b/apps/desktop/src/renderer/src/git/status-view.ts
@@ -44,9 +44,9 @@ export function fileGlyph(file: GitFile): { glyph: string; label: string } {
 
 /** A glyph's accent: added/untracked read positive, deleted negative, else neutral. */
 export function glyphClass(glyph: string): string {
-  if (glyph === 'A' || glyph === 'U') return 'text-ok'
-  if (glyph === 'D') return 'text-bad'
-  return 'text-accent-text'
+  if (glyph === 'A' || glyph === 'U') return 'text-success'
+  if (glyph === 'D') return 'text-destructive'
+  return 'text-primary'
 }
 
 /** Sort rank by glyph so like-changes group together; ties break on path. */

--- a/apps/desktop/src/renderer/src/lib/utils.test.ts
+++ b/apps/desktop/src/renderer/src/lib/utils.test.ts
@@ -15,12 +15,12 @@ describe('cn', () => {
 
   it('keeps the conditional class when the condition is true', () => {
     const active = true
-    expect(cn('text-muted', active && 'text-accent-text')).toBe('text-accent-text')
+    expect(cn('text-muted-foreground', active && 'text-primary')).toBe('text-primary')
   })
 
   it('drops the conditional class (and the base wins) when the condition is false', () => {
     const active = false
-    expect(cn('text-muted', active && 'text-accent-text')).toBe('text-muted')
+    expect(cn('text-muted-foreground', active && 'text-primary')).toBe('text-muted-foreground')
   })
 
   it('drops falsy inputs (false / null / undefined / empty)', () => {

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -1,14 +1,29 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { App } from './App'
+import { startThemeSync } from './shell/theme-sync'
 // Geist (Vercel) — bundled offline via @fontsource-variable, before styles.css so the
 // @font-face rules (and their bundled woff2) are registered when the tokens reference them.
 import '@fontsource-variable/geist'
 import '@fontsource-variable/geist-mono'
 import './styles.css'
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-)
+async function mountApp(): Promise<void> {
+  // Resolve and apply main's confirmed theme while the BrowserWindow is hidden.
+  // The subscription is armed before the read, so a concurrent OS update wins.
+  const stopThemeSync = await startThemeSync(window.api)
+  window.addEventListener('beforeunload', stopThemeSync, { once: true })
+
+  ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+  )
+
+  // Let React commit the themed shell before asking main to reveal the window.
+  requestAnimationFrame(() => window.api.themeReady())
+}
+
+void mountApp().catch((error: unknown) => {
+  console.error('[app] failed to mount:', error)
+})

--- a/apps/desktop/src/renderer/src/search/SearchPalette.tsx
+++ b/apps/desktop/src/renderer/src/search/SearchPalette.tsx
@@ -96,22 +96,22 @@ export function SearchPalette({
                   onMouseDown={(event) => event.preventDefault()}
                   onClick={() => selectHit(hit)}
                 >
-                  <MessageSquare className="size-4 shrink-0 text-muted" aria-hidden />
+                  <MessageSquare className="size-4 shrink-0 text-muted-foreground" aria-hidden />
                   <span className="flex min-w-0 flex-1 flex-col">
                     <span className="flex min-w-0 items-center gap-1.5">
-                      <span className="truncate text-text-strong">{hit.title ?? 'Untitled'}</span>
+                      <span className="truncate text-foreground">{hit.title ?? 'Untitled'}</span>
                       {hit.archived && (
                         <Badge variant="outline" className="shrink-0 px-1.5 py-0 text-[10px]">
                           Archived
                         </Badge>
                       )}
                     </span>
-                    <span className="truncate text-[11px] text-faint">
+                    <span className="truncate text-[11px] text-muted-foreground">
                       {hit.workspaceName}
-                      {hit.snippet && <span className="text-muted"> · {hit.snippet}</span>}
+                      {hit.snippet && <span className="text-muted-foreground"> · {hit.snippet}</span>}
                     </span>
                   </span>
-                  <span className="flex shrink-0 flex-col items-end text-[11px] tabular-nums text-faint">
+                  <span className="flex shrink-0 flex-col items-end text-[11px] tabular-nums text-muted-foreground">
                     <span>{formatRelativeTime(hit.lastActiveAt, Date.now())}</span>
                     {typeof hit.hitCount === 'number' && hit.hitCount > 1 && (
                       <span>{hit.hitCount} matches</span>

--- a/apps/desktop/src/renderer/src/settings/Environment.tsx
+++ b/apps/desktop/src/renderer/src/settings/Environment.tsx
@@ -19,7 +19,7 @@ export function Environment({
   const updateStatus = describeUpdateStatus(update)
   return (
     <div className="flex flex-col gap-2.5 rounded-[9px] border border-border p-3">
-      <div className="flex items-center justify-between text-[13px] font-semibold text-text-strong">
+      <div className="flex items-center justify-between text-[13px] font-semibold text-foreground">
         <span>Environment</span>
         <Button variant="ghost" size="xs" onClick={onRecheck} disabled={loading}>
           {loading ? 'Checking…' : 'Re-check'}
@@ -40,7 +40,7 @@ export function Environment({
             </li>
           )}
           {update?.updateAvailable && (
-            <li className="text-[13px] leading-normal text-faint">
+            <li className="text-[13px] leading-normal text-muted-foreground">
               Update with <CodeText text="uv tool upgrade mistral-vibe" /> (or{' '}
               <CodeText text="brew upgrade mistral-vibe" />), then Re-check.
             </li>

--- a/apps/desktop/src/renderer/src/settings/SettingsView.tsx
+++ b/apps/desktop/src/renderer/src/settings/SettingsView.tsx
@@ -7,6 +7,7 @@ import { useAccountPlan } from '../auth/use-account-plan'
 import { Button } from '../ui/button'
 import { IconButton } from '../ui/icon-button'
 import { Environment } from './Environment'
+import { ThemeControl } from './ThemeControl'
 
 /** The selected Workspace's connected agent + its advertised auth, for the Account section. */
 export interface AccountInfo {
@@ -45,10 +46,10 @@ export function SettingsView({
         <IconButton aria-label="Back" title="Back" onClick={onClose}>
           <ArrowLeft className="size-4" aria-hidden />
         </IconButton>
-        <h1 className="text-[19px] font-semibold tracking-tight text-text-strong">Settings</h1>
+        <h1 className="text-[19px] font-semibold tracking-tight text-foreground">Settings</h1>
       </div>
       <section className="flex flex-col gap-2">
-        <h2 className="text-[13px] font-semibold text-faint">Account</h2>
+        <h2 className="text-[13px] font-semibold text-muted-foreground">Account</h2>
         <AccountSettings
           // Key by agentId so the auth reducer's seed resets per connection — a new
           // agent can't inherit the prior session's sign-out gate/in-flight state.
@@ -58,7 +59,14 @@ export function SettingsView({
         />
       </section>
       <section className="flex flex-col gap-2">
-        <h2 className="text-[13px] font-semibold text-faint">Environment</h2>
+        <h2 className="text-[13px] font-semibold text-muted-foreground">Appearance</h2>
+        <p className="text-[13px] text-muted-foreground">
+          Light, dark, or follow your OS appearance.
+        </p>
+        <ThemeControl />
+      </section>
+      <section className="flex flex-col gap-2">
+        <h2 className="text-[13px] font-semibold text-muted-foreground">Environment</h2>
         <Environment detect={detect} loading={loading} onRecheck={onRecheck} />
       </section>
     </div>
@@ -104,7 +112,7 @@ function AccountSettings({
 
   if (!account) {
     return (
-      <div className="rounded-[9px] border border-border p-3 text-[13px] text-muted">
+      <div className="rounded-[9px] border border-border p-3 text-[13px] text-muted-foreground">
         Not connected — open a project to manage your session.
       </div>
     )
@@ -114,14 +122,14 @@ function AccountSettings({
   return (
     <div className="flex flex-col gap-2.5 rounded-[9px] border border-border p-3">
       <div className="flex items-center gap-2 text-[13px]">
-        {!signingOut && <span className="size-[7px] shrink-0 rounded-full bg-ok" aria-hidden />}
-        <span className="font-semibold text-text-strong">
+        {!signingOut && <span className="size-[7px] shrink-0 rounded-full bg-success" aria-hidden />}
+        <span className="font-semibold text-foreground">
           {signingOut ? 'Signing out…' : 'Signed in to Mistral Vibe'}
         </span>
         {view.kind === 'signed-in' && view.identity && (
-          <span className="text-muted">{view.identity}</span>
+          <span className="text-muted-foreground">{view.identity}</span>
         )}
-        {!signingOut && plan && <span className="text-muted">{plan}</span>}
+        {!signingOut && plan && <span className="text-muted-foreground">{plan}</span>}
         <span className="flex-1" />
         {view.kind === 'signed-in' && view.signOutAvailable && (
           <Button variant="outline" size="sm" onClick={() => void signOut()}>
@@ -130,7 +138,7 @@ function AccountSettings({
         )}
       </div>
       {view.kind === 'signed-in' && view.error && (
-        <div className="text-[13px] text-bad">{view.error}</div>
+        <div className="text-[13px] text-destructive">{view.error}</div>
       )}
     </div>
   )

--- a/apps/desktop/src/renderer/src/settings/ThemeControl.tsx
+++ b/apps/desktop/src/renderer/src/settings/ThemeControl.tsx
@@ -1,0 +1,61 @@
+import { useState, type JSX } from 'react'
+import { THEME_PREFERENCES, type ThemePreference } from '../../../shared/ipc'
+import { cn } from '../lib/utils'
+import { useThemeState } from '../shell/resolved-theme-store'
+
+const LABELS: Record<ThemePreference, string> = {
+  light: 'Light',
+  dark: 'Dark',
+  system: 'System',
+}
+
+const TITLES: Record<ThemePreference, string> = {
+  light: 'Always light',
+  dark: 'Always dark',
+  system: 'Follow the OS appearance',
+}
+
+/** Theme selection rendered only from main-confirmed state, never optimistic state. */
+export function ThemeControl(): JSX.Element {
+  const { preference } = useThemeState()
+  const [error, setError] = useState<string | null>(null)
+
+  async function selectTheme(next: ThemePreference): Promise<void> {
+    setError(null)
+    try {
+      await window.api.setTheme({ preference: next })
+    } catch (cause) {
+      console.error('[theme] failed to set preference:', cause)
+      setError('Could not change the theme. Try again.')
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-start gap-1.5">
+      <div
+        className="flex overflow-hidden rounded-lg border border-border"
+        role="group"
+        aria-label="Theme"
+      >
+        {THEME_PREFERENCES.map((option) => (
+          <button
+            key={option}
+            type="button"
+            onClick={() => void selectTheme(option)}
+            aria-pressed={preference === option}
+            title={TITLES[option]}
+            className={cn(
+              'px-2.5 py-1 text-[13px] transition-colors',
+              preference === option
+                ? 'bg-primary/10 text-primary'
+                : 'text-muted-foreground hover:text-primary',
+            )}
+          >
+            {LABELS[option]}
+          </button>
+        ))}
+      </div>
+      {error ? <p className="text-[12px] text-destructive" role="alert">{error}</p> : null}
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/shell/EmptyState.tsx
+++ b/apps/desktop/src/renderer/src/shell/EmptyState.tsx
@@ -37,7 +37,7 @@ export function EmptyState({
   if (state === 'needs-install') {
     return (
       <div className="flex max-w-[460px] flex-col items-start gap-3">
-        <div className="text-[15px] font-semibold text-text-strong">
+        <div className="text-[15px] font-semibold text-foreground">
           Install Mistral Vibe to get started
         </div>
         {/* Same canonical copy as the spawn-error hint + the persistent banner
@@ -59,8 +59,8 @@ export function EmptyState({
     return (
       <div className="mx-auto flex h-full max-w-[830px] flex-col items-center justify-center gap-6 text-center">
         <Logo size={52} />
-        <h1 className="text-[37px] font-semibold tracking-[-0.6px] text-text-strong">
-          Open a <span className="text-accent-emphasis">project</span> to begin
+        <h1 className="text-[37px] font-semibold tracking-[-0.6px] text-foreground">
+          Open a <span className="text-primary">project</span> to begin
         </h1>
         <p className="hint">
           Each project runs its own Mistral Vibe agent — open one to start your first thread.
@@ -68,13 +68,13 @@ export function EmptyState({
         <Button size="lg" onClick={onOpenProject} disabled={opening}>
           {opening ? 'Connecting…' : 'Open project'}
         </Button>
-        <div className="mt-2 w-full max-w-[500px] rounded-lg border border-border bg-surface px-4 py-3.5 text-left">
-          <div className="text-[13px] font-semibold text-text-strong">New to Mistral Vibe?</div>
-          <ol className="mt-2 flex flex-col gap-2 text-[13px] text-text-secondary">
+        <div className="mt-2 w-full max-w-[500px] rounded-lg border border-border bg-secondary px-4 py-3.5 text-left">
+          <div className="text-[13px] font-semibold text-foreground">New to Mistral Vibe?</div>
+          <ol className="mt-2 flex flex-col gap-2 text-[13px] text-muted-foreground">
             <li className="flex flex-col gap-1">
               <span>1. Install the CLI:</span>
               <span className="flex items-center gap-1.5 rounded-md border border-border bg-sidebar py-0.5 pr-0.5 pl-2">
-                <code className="min-w-0 flex-1 truncate font-mono text-[12px] text-text">
+                <code className="min-w-0 flex-1 truncate font-mono text-[12px] text-foreground">
                   {INSTALL_COMMAND}
                 </code>
                 <CopyCommandButton text={INSTALL_COMMAND} />
@@ -85,7 +85,7 @@ export function EmptyState({
             </li>
           </ol>
           <a
-            className="mt-2 inline-block text-[12px] text-accent-text underline-offset-2 hover:underline"
+            className="mt-2 inline-block text-[12px] text-primary underline-offset-2 hover:underline"
             href={INSTALL_DOCS_URL}
             target="_blank"
             rel="noreferrer"
@@ -102,9 +102,9 @@ export function EmptyState({
   return (
     <div className="mx-auto flex h-full max-w-[830px] flex-col items-center justify-center gap-6 text-center">
       <Logo size={52} />
-      <h1 className="text-[37px] font-semibold tracking-[-0.6px] text-text-strong">
+      <h1 className="text-[37px] font-semibold tracking-[-0.6px] text-foreground">
         {headline.lead}
-        {headline.name && <span className="text-accent-emphasis">{headline.name}</span>}
+        {headline.name && <span className="text-primary">{headline.name}</span>}
         {headline.tail}
       </h1>
       <p className="hint">
@@ -156,7 +156,7 @@ function CopyCommandButton({ text }: { text: string }): JSX.Element {
       title={feedback === 'failed' ? 'Failed to copy' : 'Copy'}
     >
       {feedback === 'copied' ? (
-        <Check className="size-3.5 text-ok" aria-hidden />
+        <Check className="size-3.5 text-success" aria-hidden />
       ) : (
         <Copy className="size-3.5" aria-hidden />
       )}

--- a/apps/desktop/src/renderer/src/shell/InstallBanner.tsx
+++ b/apps/desktop/src/renderer/src/shell/InstallBanner.tsx
@@ -23,9 +23,9 @@ export function InstallBanner({
   return (
     <div
       role="alert"
-      className="flex flex-none items-center gap-2.5 border-b border-[var(--bad-tint-border)] bg-[var(--bad-tint)] px-4 py-1.5 text-[13px] text-text"
+      className="flex flex-none items-center gap-2.5 border-b border-destructive/35 bg-destructive/10 px-4 py-1.5 text-[13px] text-foreground"
     >
-      <TriangleAlert className="size-4 flex-none text-bad" aria-hidden />
+      <TriangleAlert className="size-4 flex-none text-destructive" aria-hidden />
       <span className="min-w-0 flex-1">
         <CodeText text={message} />{' '}
         <a className="underline" href={INSTALL_DOCS_URL} target="_blank" rel="noreferrer">

--- a/apps/desktop/src/renderer/src/shell/Outlet.tsx
+++ b/apps/desktop/src/renderer/src/shell/Outlet.tsx
@@ -28,8 +28,8 @@ export function TransientOutlet({
       return (
         <div className="mx-auto mt-14 flex max-w-[420px] flex-col items-center gap-2 text-center">
           <span className="dot dot--pending" aria-hidden />
-          <div className="text-sm font-semibold text-text-strong">Connecting…</div>
-          <div className="text-[13px] leading-relaxed text-muted">
+          <div className="text-sm font-semibold text-foreground">Connecting…</div>
+          <div className="text-[13px] leading-relaxed text-muted-foreground">
             Launching <code>vibe-acp</code> in <code>{connect.workspaceDir}</code> and running the
             ACP handshake.
           </div>

--- a/apps/desktop/src/renderer/src/shell/Shell.tsx
+++ b/apps/desktop/src/renderer/src/shell/Shell.tsx
@@ -196,8 +196,8 @@ export function Shell({
             onDoubleClick={resetWidth}
             className={cn(
               'absolute -left-1 top-0 h-full w-2 cursor-col-resize [-webkit-app-region:no-drag]',
-              'after:absolute after:inset-y-0 after:left-1 after:w-px after:bg-transparent after:transition-colors after:content-[""] hover:after:bg-accent/40',
-              dragging && 'after:bg-accent/60',
+              'after:absolute after:inset-y-0 after:left-1 after:w-px after:bg-transparent after:transition-colors after:content-[""] hover:after:bg-primary/40',
+              dragging && 'after:bg-primary/60',
             )}
           />
         </div>
@@ -238,7 +238,7 @@ function PrimaryNav({
         type="button"
         onClick={onNewThread}
         disabled={busy}
-        className="flex w-full items-center gap-2.5 rounded-lg bg-[var(--accent-fill)] px-3 py-2 text-left text-[14px] font-semibold text-accent-text outline-none transition-[filter] hover:brightness-[0.98] disabled:pointer-events-none disabled:opacity-50"
+        className="flex w-full items-center gap-2.5 rounded-lg bg-primary/15 px-3 py-2 text-left text-[14px] font-semibold text-primary outline-none transition-[filter] hover:brightness-[0.98] disabled:pointer-events-none disabled:opacity-50"
       >
         <SquarePen className="size-[18px]" aria-hidden />
         New chat
@@ -246,7 +246,7 @@ function PrimaryNav({
       <NavItem onClick={onOpenSearch}>
         <Search className="size-[18px]" aria-hidden />
         <span className="flex-1">Search</span>
-        <span className="text-[11px] font-medium text-faint">⌘K</span>
+        <span className="text-[11px] font-medium text-muted-foreground">⌘K</span>
       </NavItem>
       <NavItem onClick={onOpenSkills}>
         <Sparkles className="size-[18px]" aria-hidden />
@@ -270,7 +270,7 @@ function AccountChip({ onOpenSettings }: { onOpenSettings: () => void }): JSX.El
   const plan = planLabel(useAccountPlan())
   return (
     <Menu>
-      <MenuTrigger className="flex items-center gap-2.5 rounded-[9px] px-2 py-2 text-left outline-none transition-colors hover:bg-accent/10 focus-visible:bg-accent/10 data-[popup-open]:bg-accent/10">
+      <MenuTrigger className="flex items-center gap-2.5 rounded-[9px] px-2 py-2 text-left outline-none transition-colors hover:bg-primary/10 focus-visible:bg-primary/10 data-[popup-open]:bg-primary/10">
         {/* static avatar/name — Vibe exposes no identity to fill them with (ADR-0003). */}
         <span
           aria-hidden
@@ -280,12 +280,12 @@ function AccountChip({ onOpenSettings }: { onOpenSettings: () => void }): JSX.El
           V
         </span>
         <span className="flex min-w-0 flex-1 flex-col">
-          <span className="truncate text-[14px] font-semibold text-text-strong">Your account</span>
-          <span className="truncate text-[12px] text-faint">
+          <span className="truncate text-[14px] font-semibold text-foreground">Your account</span>
+          <span className="truncate text-[12px] text-muted-foreground">
             {plan ? `Mistral Vibe · ${plan}` : 'Mistral Vibe'}
           </span>
         </span>
-        <ChevronDown className="size-4 shrink-0 text-muted" aria-hidden />
+        <ChevronDown className="size-4 shrink-0 text-muted-foreground" aria-hidden />
       </MenuTrigger>
       <MenuContent align="start" className="min-w-[200px]">
         <MenuItem onClick={onOpenSettings}>

--- a/apps/desktop/src/renderer/src/shell/UpdateReadyChip.tsx
+++ b/apps/desktop/src/renderer/src/shell/UpdateReadyChip.tsx
@@ -39,9 +39,9 @@ export function UpdateReadyChip(): JSX.Element | null {
       onClick={() => window.api.appUpdateRestart()}
       title="Restart to apply the update (it also installs on quit)"
     >
-      <RefreshCw className="size-3.5 flex-none text-accent-text" aria-hidden />
+      <RefreshCw className="size-3.5 flex-none text-primary" aria-hidden />
       <span className="min-w-0 flex-1 truncate text-left">{label}</span>
-      <span className="flex-none text-muted">Restart</span>
+      <span className="flex-none text-muted-foreground">Restart</span>
     </Button>
   )
 }

--- a/apps/desktop/src/renderer/src/shell/resolved-theme-store.test.ts
+++ b/apps/desktop/src/renderer/src/shell/resolved-theme-store.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  getResolvedTheme,
+  getThemeState,
+  setThemeState,
+  subscribeThemeState,
+} from './resolved-theme-store'
+
+afterEach(() => setThemeState({ preference: 'light', resolved: 'light' }))
+
+describe('resolved-theme-store', () => {
+  it('defaults to light', () => {
+    expect(getThemeState()).toEqual({ preference: 'light', resolved: 'light' })
+    expect(getResolvedTheme()).toBe('light')
+  })
+
+  it('notifies for resolved and preference-only changes', () => {
+    const listener = vi.fn()
+    const unsubscribe = subscribeThemeState(listener)
+    setThemeState({ preference: 'dark', resolved: 'dark' })
+    setThemeState({ preference: 'system', resolved: 'dark' })
+    expect(listener).toHaveBeenCalledTimes(2)
+    unsubscribe()
+  })
+
+  it('does not notify for a repeated state or after unsubscribe', () => {
+    const listener = vi.fn()
+    const unsubscribe = subscribeThemeState(listener)
+    setThemeState({ preference: 'light', resolved: 'light' })
+    unsubscribe()
+    setThemeState({ preference: 'dark', resolved: 'dark' })
+    expect(listener).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/renderer/src/shell/resolved-theme-store.ts
+++ b/apps/desktop/src/renderer/src/shell/resolved-theme-store.ts
@@ -1,0 +1,35 @@
+import { useSyncExternalStore } from 'react'
+import type { ResolvedTheme, ThemeState } from '../../../shared/ipc'
+
+let currentState: ThemeState = { preference: 'light', resolved: 'light' }
+const listeners = new Set<() => void>()
+
+export function getThemeState(): ThemeState {
+  return currentState
+}
+
+export function getResolvedTheme(): ResolvedTheme {
+  return currentState.resolved
+}
+
+export function subscribeThemeState(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+/** Main-to-renderer write path; repeated states do not rerender subscribers. */
+export function setThemeState(state: ThemeState): void {
+  if (state.preference === currentState.preference && state.resolved === currentState.resolved) return
+  currentState = state
+  for (const listener of listeners) listener()
+}
+
+export function useThemeState(): ThemeState {
+  return useSyncExternalStore(subscribeThemeState, getThemeState)
+}
+
+export function useResolvedTheme(): ResolvedTheme {
+  return useSyncExternalStore(subscribeThemeState, getResolvedTheme)
+}

--- a/apps/desktop/src/renderer/src/shell/theme-sync.test.ts
+++ b/apps/desktop/src/renderer/src/shell/theme-sync.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ThemeState } from '../../../shared/ipc'
+import { getThemeState, setThemeState } from './resolved-theme-store'
+import { startThemeSync } from './theme-sync'
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((fulfill) => {
+    resolve = fulfill
+  })
+  return { promise, resolve }
+}
+
+afterEach(() => {
+  setThemeState({ preference: 'light', resolved: 'light' })
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('startThemeSync', () => {
+  it('subscribes before reading and does not let a stale read replace a push', async () => {
+    const pending = deferred<ThemeState>()
+    const listeners: Array<(state: ThemeState) => void> = []
+    const toggle = vi.fn()
+    vi.stubGlobal('document', { documentElement: { classList: { toggle } } })
+
+    const unsubscribe = vi.fn()
+    const stopPending = startThemeSync({
+      getTheme: () => pending.promise,
+      onThemeStatus: (next) => {
+        listeners.push(next)
+        return unsubscribe
+      },
+    })
+
+    expect(listeners).toHaveLength(1)
+    listeners[0]?.({ preference: 'dark', resolved: 'dark' })
+    pending.resolve({ preference: 'light', resolved: 'light' })
+    const stop = await stopPending
+
+    expect(getThemeState()).toEqual({ preference: 'dark', resolved: 'dark' })
+    expect(toggle).toHaveBeenCalledOnce()
+    expect(toggle).toHaveBeenCalledWith('dark', true)
+    stop()
+    expect(unsubscribe).toHaveBeenCalledOnce()
+  })
+
+  it('logs a failed initial read without producing an unhandled rejection', async () => {
+    const toggle = vi.fn()
+    vi.stubGlobal('document', { documentElement: { classList: { toggle } } })
+    const error = new Error('theme IPC unavailable')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const stop = await startThemeSync({
+      getTheme: () => Promise.reject(error),
+      onThemeStatus: () => vi.fn(),
+    })
+
+    expect(consoleError).toHaveBeenCalledWith('[theme] failed to read initial state:', error)
+    expect(getThemeState()).toEqual({ preference: 'light', resolved: 'light' })
+    expect(toggle).not.toHaveBeenCalled()
+    stop()
+  })
+})

--- a/apps/desktop/src/renderer/src/shell/theme-sync.ts
+++ b/apps/desktop/src/renderer/src/shell/theme-sync.ts
@@ -1,0 +1,27 @@
+import type { ThemeState } from '../../../shared/ipc'
+import { setThemeState } from './resolved-theme-store'
+
+/** Apply main's resolved state to the document and renderer theme store. */
+export function applyThemeState(state: ThemeState): void {
+  document.documentElement.classList.toggle('dark', state.resolved === 'dark')
+  setThemeState(state)
+}
+
+/** Subscribe before reading so a concurrent push cannot be reverted by a stale snapshot. */
+export async function startThemeSync(api: {
+  getTheme: () => Promise<ThemeState>
+  onThemeStatus: (listener: (state: ThemeState) => void) => () => void
+}): Promise<() => void> {
+  let pushed = false
+  const unsubscribe = api.onThemeStatus((state) => {
+    pushed = true
+    applyThemeState(state)
+  })
+  try {
+    const state = await api.getTheme()
+    if (!pushed) applyThemeState(state)
+  } catch (error: unknown) {
+    console.error('[theme] failed to read initial state:', error)
+  }
+  return unsubscribe
+}

--- a/apps/desktop/src/renderer/src/shell/workspace-nav/index.tsx
+++ b/apps/desktop/src/renderer/src/shell/workspace-nav/index.tsx
@@ -169,7 +169,7 @@ export function WorkspaceNav({
           the display-only sort order. The + stays available even with zero Workspaces,
           so the first project can still be opened from here. */}
       <div className="flex items-center justify-between px-3 py-1.5">
-        <span className="text-[13px] font-medium text-faint">Projects</span>
+        <span className="text-[13px] font-medium text-muted-foreground">Projects</span>
         <div className="flex items-center gap-0.5">
           <IconButton
             size="icon-xs"
@@ -188,7 +188,7 @@ export function WorkspaceNav({
             <MenuTrigger
               aria-label="Project list options"
               title="Project list options"
-              className="inline-flex size-6 items-center justify-center rounded-sm text-muted outline-none transition-colors hover:bg-accent/10 hover:text-text focus-visible:bg-accent/10 data-[popup-open]:bg-accent/10"
+              className="inline-flex size-6 items-center justify-center rounded-sm text-muted-foreground outline-none transition-colors hover:bg-primary/10 hover:text-foreground focus-visible:bg-primary/10 data-[popup-open]:bg-primary/10"
             >
               <Ellipsis className="size-4" aria-hidden />
             </MenuTrigger>
@@ -206,7 +206,7 @@ export function WorkspaceNav({
       </div>
 
       {workspaces.length === 0 ? (
-        <p className="px-3 py-1 text-[13px] leading-relaxed text-muted">
+        <p className="px-3 py-1 text-[13px] leading-relaxed text-muted-foreground">
           No workspaces yet. Open a project to begin.
         </p>
       ) : (
@@ -304,16 +304,16 @@ function ProjectRow({
     <Collapsible open={open} onOpenChange={(next) => onToggleOpen(workspace.id, next)}>
       {/* Header row: the fold trigger + a SIBLING ＋ (outside the trigger button, so
           clicking ＋ starts a thread rather than toggling the fold). */}
-      <div className="group/proj flex items-center gap-0.5 rounded-md pr-1 transition-colors hover:bg-accent/10">
-        <CollapsibleTrigger className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-3 py-[7px] text-left text-[14px] text-text-body outline-none focus-visible:bg-accent/10">
+      <div className="group/proj flex items-center gap-0.5 rounded-md pr-1 transition-colors hover:bg-primary/10">
+        <CollapsibleTrigger className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-3 py-[7px] text-left text-[14px] text-foreground outline-none focus-visible:bg-primary/10">
           <ChevronDown
             className={cn(
-              'size-4 shrink-0 text-muted transition-transform',
+              'size-4 shrink-0 text-muted-foreground transition-transform',
               !open && '-rotate-90',
             )}
             aria-hidden
           />
-          <Folder className="size-4 shrink-0 text-muted" aria-hidden />
+          <Folder className="size-4 shrink-0 text-muted-foreground" aria-hidden />
           <span className="flex-1 truncate" title={workspace.dir}>
             {workspace.displayName}
           </span>
@@ -351,12 +351,12 @@ function ProjectRow({
           <MenuTrigger
             aria-label={`${workspace.displayName} project actions`}
             title="Project actions"
-            className="inline-flex size-6 shrink-0 items-center justify-center rounded-sm text-muted opacity-0 outline-none transition-opacity hover:bg-accent/10 hover:text-text focus-visible:opacity-100 group-hover/proj:opacity-100 data-[popup-open]:opacity-100"
+            className="inline-flex size-6 shrink-0 items-center justify-center rounded-sm text-muted-foreground opacity-0 outline-none transition-opacity hover:bg-primary/10 hover:text-foreground focus-visible:opacity-100 group-hover/proj:opacity-100 data-[popup-open]:opacity-100"
           >
             <MoreVertical className="size-3.5" aria-hidden />
           </MenuTrigger>
           <MenuContent>
-            <MenuItem className="text-bad" onClick={() => setConfirmRemoveOpen(true)}>
+            <MenuItem className="text-destructive" onClick={() => setConfirmRemoveOpen(true)}>
               <Trash2 className="size-3.5" aria-hidden />
               Remove project
             </MenuItem>
@@ -414,12 +414,12 @@ function ProjectRow({
               <button
                 type="button"
                 onClick={() => setExpandedThreads((e) => !e)}
-                className="flex items-center gap-2 px-3 py-1 pl-[42px] text-left text-[13px] text-accent-text outline-none hover:underline"
+                className="flex items-center gap-2 px-3 py-1 pl-[42px] text-left text-[13px] text-primary outline-none hover:underline"
               >
                 <span>{expandedThreads ? 'Show less' : `Show more (${hiddenCount})`}</span>
                 {!expandedThreads && hiddenNeedsAttention && (
                   <span
-                    className="size-1.5 shrink-0 rounded-full bg-bad"
+                    className="size-1.5 shrink-0 rounded-full bg-destructive"
                     role="img"
                     aria-label="A hidden thread needs your attention"
                     title="A hidden thread needs your attention"
@@ -429,7 +429,7 @@ function ProjectRow({
             )}
           </ul>
         ) : archivedRows.length === 0 ? (
-          <div className="px-3 py-1 pl-[42px] text-[13px] text-muted">No threads yet</div>
+          <div className="px-3 py-1 pl-[42px] text-[13px] text-muted-foreground">No threads yet</div>
         ) : null}
 
         {/* Archived section (#133): a collapsible "Archived (N)" fold at the BOTTOM,
@@ -477,12 +477,12 @@ function ArchivedSection({
   const [open, setOpen] = useState(false)
   return (
     <Collapsible open={open} onOpenChange={setOpen} className="mt-0.5">
-      <CollapsibleTrigger className="flex w-full items-center gap-2 rounded-md px-3 py-1 pl-[26px] text-left text-[13px] text-faint outline-none transition-colors hover:bg-accent/10 focus-visible:bg-accent/10">
+      <CollapsibleTrigger className="flex w-full items-center gap-2 rounded-md px-3 py-1 pl-[26px] text-left text-[13px] text-muted-foreground outline-none transition-colors hover:bg-primary/10 focus-visible:bg-primary/10">
         <ChevronDown
-          className={cn('size-3.5 shrink-0 text-muted transition-transform', !open && '-rotate-90')}
+          className={cn('size-3.5 shrink-0 text-muted-foreground transition-transform', !open && '-rotate-90')}
           aria-hidden
         />
-        <Archive className="size-3.5 shrink-0 text-muted" aria-hidden />
+        <Archive className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
         <span className="flex-1 truncate">Archived ({rows.length})</span>
       </CollapsibleTrigger>
       <CollapsibleContent>
@@ -561,7 +561,7 @@ function NavThread({
           <span
             className={
               row.live
-                ? 'size-[7px] shrink-0 rounded-full bg-ok'
+                ? 'size-[7px] shrink-0 rounded-full bg-success'
                 : 'size-[7px] shrink-0 rounded-full bg-border'
             }
             aria-hidden
@@ -576,7 +576,7 @@ function NavThread({
               else if (e.key === 'Escape') cancelRename()
             }}
             onBlur={(e) => submitRename(e.currentTarget.value)}
-            className="min-w-0 flex-1 rounded-[3px] bg-transparent px-1 text-[13.5px] text-text outline-none ring-1 ring-accent"
+            className="min-w-0 flex-1 rounded-[3px] bg-transparent px-1 text-[13.5px] text-foreground outline-none ring-1 ring-primary"
           />
         </div>
       </li>
@@ -596,12 +596,12 @@ function NavThread({
         <span
           className={
             row.live
-              ? 'size-[7px] shrink-0 rounded-full bg-ok'
+              ? 'size-[7px] shrink-0 rounded-full bg-success'
               : 'size-[7px] shrink-0 rounded-full bg-border'
           }
           aria-hidden
         />
-        {pinned && <Pin className="size-3 shrink-0 text-muted" aria-label="Pinned" />}
+        {pinned && <Pin className="size-3 shrink-0 text-muted-foreground" aria-label="Pinned" />}
         <span className="flex-1 truncate">{threadLabel(row)}</span>
         {row.streaming && <LogoSnakeSpinner size={15} label="Streaming" />}
         {row.needsAttention && (
@@ -612,7 +612,7 @@ function NavThread({
         {/* Hidden on hover so the kebab (absolute, right-1) takes this spot instead of
             drawing ON TOP of the time; `invisible` keeps the space so nothing reflows. */}
         {timestamp && (
-          <span className="shrink-0 text-[13px] text-faint group-hover/thread:invisible">
+          <span className="shrink-0 text-[13px] text-muted-foreground group-hover/thread:invisible">
             {timestamp}
           </span>
         )}
@@ -624,7 +624,7 @@ function NavThread({
         <MenuTrigger
           aria-label="Thread actions"
           title="Thread actions"
-          className="absolute top-1/2 right-1 inline-flex size-6 -translate-y-1/2 items-center justify-center rounded-sm text-muted opacity-0 outline-none transition-opacity hover:bg-accent/10 hover:text-text focus-visible:opacity-100 group-hover/thread:opacity-100 data-[popup-open]:opacity-100"
+          className="absolute top-1/2 right-1 inline-flex size-6 -translate-y-1/2 items-center justify-center rounded-sm text-muted-foreground opacity-0 outline-none transition-opacity hover:bg-primary/10 hover:text-foreground focus-visible:opacity-100 group-hover/thread:opacity-100 data-[popup-open]:opacity-100"
         >
           <MoreVertical className="size-3.5" aria-hidden />
         </MenuTrigger>
@@ -646,7 +646,7 @@ function NavThread({
             {archived ? 'Unarchive' : 'Archive'}
           </MenuItem>
           {deletable && (
-            <MenuItem className="text-bad" onClick={() => void actions.deleteThread(row.thread)}>
+            <MenuItem className="text-destructive" onClick={() => void actions.deleteThread(row.thread)}>
               <Trash2 className="size-3.5" aria-hidden />
               Delete
             </MenuItem>

--- a/apps/desktop/src/renderer/src/side-panel/BrowserSurface.tsx
+++ b/apps/desktop/src/renderer/src/side-panel/BrowserSurface.tsx
@@ -151,8 +151,10 @@ export function BrowserSurface({
     if (!view || !activeThreadId || picking) return
     setPicking(true)
     try {
-      const accent = getComputedStyle(document.documentElement).getPropertyValue('--accent').trim() || '#e8833a'
-      const raw: unknown = await view.executeJavaScript(buildPickerScript({ accent }), true)
+      const tokens = getComputedStyle(document.documentElement)
+      const accent = tokens.getPropertyValue('--primary').trim() || '#c65420'
+      const accentForeground = tokens.getPropertyValue('--primary-foreground').trim() || '#ffffff'
+      const raw: unknown = await view.executeJavaScript(buildPickerScript({ accent, accentForeground }), true)
       const picked = coercePickedElement(raw)
       if (!picked) return // cancelled (Esc/nav) or a malformed return — nothing to send
       // Screenshot AFTER the picker overlay is gone (the injected script tore it down
@@ -250,7 +252,7 @@ export function BrowserSurface({
   if (initialUrl === null) return <BrowserEmptyState onOpenUrl={openUrl} />
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col bg-panel">
+    <div className="flex min-h-0 flex-1 flex-col bg-card">
       <div className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-1">
         <BrowserAction label="Back" onClick={goBack} disabled={!canGoBack}>
           <ArrowLeft aria-hidden />
@@ -271,14 +273,14 @@ export function BrowserSurface({
             autoCapitalize="off"
             autoCorrect="off"
             className={cn(
-              'w-full rounded-md border border-transparent bg-accent/5 px-2.5 py-1 pr-7 text-xs text-text',
-              'placeholder:text-faint focus:outline-none focus-visible:border-accent/60 focus-visible:bg-surface',
+              'w-full rounded-md border border-transparent bg-primary/5 px-2.5 py-1 pr-7 text-xs text-foreground',
+              'placeholder:text-muted-foreground focus:outline-none focus-visible:border-primary/60 focus-visible:bg-secondary',
             )}
           />
           {load.status === 'loading' && (
             <Loader2
               aria-label="Loading"
-              className="pointer-events-none absolute right-2 top-1/2 size-3.5 -translate-y-1/2 animate-spin text-muted"
+              className="pointer-events-none absolute right-2 top-1/2 size-3.5 -translate-y-1/2 animate-spin text-muted-foreground"
             />
           )}
         </form>
@@ -306,7 +308,7 @@ export function BrowserSurface({
       </div>
       {/* Page title strip (surface chrome) — only when the guest reports one. */}
       {title && (
-        <div className="shrink-0 truncate border-b border-border px-3 py-1 text-[11px] text-muted" title={title}>
+        <div className="shrink-0 truncate border-b border-border px-3 py-1 text-[11px] text-muted-foreground" title={title}>
           {title}
         </div>
       )}
@@ -319,7 +321,7 @@ export function BrowserSurface({
           partition={deriveBrowserPartition(workspaceDir)}
           webpreferences={buildWebviewPreferencesAttribute()}
           useragent={stripElectronUserAgent(navigator.userAgent)}
-          className="size-full bg-white"
+          className="size-full bg-background"
         />
         {load.status === 'failed' && <UnreachableOverlay url={load.url} onRetry={retry} />}
       </div>
@@ -356,10 +358,10 @@ function BrowserEmptyState({ onOpenUrl }: { onOpenUrl: (url: string) => void }):
   }
 
   return (
-    <div className="flex min-h-0 flex-1 items-center justify-center overflow-y-auto bg-panel p-6">
+    <div className="flex min-h-0 flex-1 items-center justify-center overflow-y-auto bg-card p-6">
       <div className="w-full max-w-sm text-center">
-        <h3 className="text-sm font-medium text-text-strong">Preview a dev server</h3>
-        <p className="mt-1 text-xs leading-relaxed text-muted">
+        <h3 className="text-sm font-medium text-foreground">Preview a dev server</h3>
+        <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
           Enter the URL of a local dev server — or any http(s) page.
         </p>
         <form onSubmit={submit}>
@@ -373,14 +375,14 @@ function BrowserEmptyState({ onOpenUrl }: { onOpenUrl: (url: string) => void }):
             autoCapitalize="off"
             autoCorrect="off"
             className={cn(
-              'mt-4 w-full rounded-md border border-border bg-surface px-3 py-1.5 text-[13px] text-text',
-              'placeholder:text-faint focus:outline-none focus-visible:border-accent/60',
+              'mt-4 w-full rounded-md border border-border bg-secondary px-3 py-1.5 text-[13px] text-foreground',
+              'placeholder:text-muted-foreground focus:outline-none focus-visible:border-primary/60',
             )}
           />
         </form>
         <div className="mt-5">
           <div className="mb-2 flex items-center justify-between">
-            <span className="text-[11px] font-medium uppercase tracking-wide text-faint">
+            <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
               Running locally
             </span>
             <button
@@ -388,7 +390,7 @@ function BrowserEmptyState({ onOpenUrl }: { onOpenUrl: (url: string) => void }):
               onClick={discover}
               aria-label="Refresh dev servers"
               title="Refresh"
-              className="flex size-5 items-center justify-center rounded text-muted outline-none transition-colors hover:bg-accent/10 hover:text-text-strong focus-visible:bg-accent/10 [&_svg]:size-3"
+              className="flex size-5 items-center justify-center rounded text-muted-foreground outline-none transition-colors hover:bg-primary/10 hover:text-foreground focus-visible:bg-primary/10 [&_svg]:size-3"
             >
               <RefreshCw aria-hidden className={scanning ? 'animate-spin' : undefined} />
             </button>
@@ -400,17 +402,17 @@ function BrowserEmptyState({ onOpenUrl }: { onOpenUrl: (url: string) => void }):
                   <button
                     type="button"
                     onClick={() => onOpenUrl(server.url)}
-                    className="flex w-full items-center gap-2 rounded-md border border-border bg-surface px-2.5 py-1.5 text-left text-xs outline-none transition-colors hover:bg-accent/10 focus-visible:border-accent/60 [&_svg]:size-3.5 [&_svg]:shrink-0 [&_svg]:text-muted"
+                    className="flex w-full items-center gap-2 rounded-md border border-border bg-secondary px-2.5 py-1.5 text-left text-xs outline-none transition-colors hover:bg-primary/10 focus-visible:border-primary/60 [&_svg]:size-3.5 [&_svg]:shrink-0 [&_svg]:text-muted-foreground"
                   >
                     <Globe aria-hidden />
-                    <span className="min-w-0 flex-1 truncate text-text">localhost:{server.port}</span>
-                    <span className="shrink-0 text-faint">{server.processName}</span>
+                    <span className="min-w-0 flex-1 truncate text-foreground">localhost:{server.port}</span>
+                    <span className="shrink-0 text-muted-foreground">{server.processName}</span>
                   </button>
                 </li>
               ))}
             </ul>
           ) : (
-            <p className="text-xs text-faint">
+            <p className="text-xs text-muted-foreground">
               {scanning ? 'Scanning…' : 'No dev servers detected.'}
             </p>
           )}
@@ -423,19 +425,19 @@ function BrowserEmptyState({ onOpenUrl }: { onOpenUrl: (url: string) => void }):
 /** The "can't reach this page" state over a failed guest, with a one-click Retry. */
 function UnreachableOverlay({ url, onRetry }: { url: string; onRetry: () => void }): JSX.Element {
   return (
-    <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-panel p-6 text-center">
-      <TriangleAlert aria-hidden className="size-6 text-muted" />
+    <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-card p-6 text-center">
+      <TriangleAlert aria-hidden className="size-6 text-muted-foreground" />
       <div>
-        <p className="text-sm font-medium text-text-strong">Can’t reach this page</p>
-        <p className="mt-1 max-w-xs truncate text-xs text-muted" title={url}>
+        <p className="text-sm font-medium text-foreground">Can’t reach this page</p>
+        <p className="mt-1 max-w-xs truncate text-xs text-muted-foreground" title={url}>
           {url}
         </p>
-        <p className="mt-1 text-xs text-muted">The dev server may be starting or stopped.</p>
+        <p className="mt-1 text-xs text-muted-foreground">The dev server may be starting or stopped.</p>
       </div>
       <button
         type="button"
         onClick={onRetry}
-        className="rounded-md border border-border bg-surface px-3 py-1 text-xs font-medium text-text outline-none transition-colors hover:bg-accent/10 focus-visible:border-accent/60"
+        className="rounded-md border border-border bg-secondary px-3 py-1 text-xs font-medium text-foreground outline-none transition-colors hover:bg-primary/10 focus-visible:border-primary/60"
       >
         Retry
       </button>
@@ -489,10 +491,10 @@ function BrowserAction({
       title={label}
       className={cn(
         'flex size-6 shrink-0 items-center justify-center rounded outline-none transition-colors',
-        'hover:bg-accent/10 hover:text-text-strong focus-visible:bg-accent/10',
+        'hover:bg-primary/10 hover:text-foreground focus-visible:bg-primary/10',
         'disabled:pointer-events-none disabled:opacity-40',
         '[&_svg]:size-3.5 [&_svg]:shrink-0',
-        active ? 'bg-accent/15 text-accent-text' : 'text-muted',
+        active ? 'bg-primary/15 text-primary' : 'text-muted-foreground',
       )}
     >
       {children}

--- a/apps/desktop/src/renderer/src/side-panel/FilePreview.tsx
+++ b/apps/desktop/src/renderer/src/side-panel/FilePreview.tsx
@@ -5,6 +5,8 @@ import type { FilesReadResult } from '../../../shared/ipc'
 import { cn } from '../lib/utils'
 import { emitComposerInsert } from '../conversation/composer-insert'
 import { DiffWorkerProvider } from '../git/DiffWorkerProvider'
+import { pierreThemeOptions } from '../git/pierre-theme'
+import { useResolvedTheme } from '../shell/resolved-theme-store'
 import { breadcrumbSegments } from './breadcrumb-segments'
 
 /**
@@ -20,9 +22,6 @@ import { breadcrumbSegments } from './breadcrumb-segments'
  * existing worker pool/theme dependency. This is strictly READ-ONLY: it only ever calls
  * `files:read` / `revealPath`, never any write path.
  */
-
-/** The diff panel's theme (`DiffWorkerProvider`'s `DIFF_THEME`) — reused so the preview matches it. */
-const PREVIEW_THEME = 'pierre-light'
 
 export function FilePreview({
   agentId,
@@ -60,17 +59,17 @@ export function FilePreview({
   const crumbs = breadcrumbSegments(relativePath)
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col text-text">
-      <div className="flex items-center gap-2 border-b border-border-muted px-3 py-2">
+    <div className="flex min-h-0 flex-1 flex-col text-foreground">
+      <div className="flex items-center gap-2 border-b border-border px-3 py-2">
         {/* Read-only, non-interactive breadcrumb of the file's path. */}
-        <nav aria-label="File path" className="flex min-w-0 flex-1 items-center gap-1 text-[11px] text-muted">
+        <nav aria-label="File path" className="flex min-w-0 flex-1 items-center gap-1 text-[11px] text-muted-foreground">
           {crumbs.map((crumb, index) => (
             <span key={index} className="flex min-w-0 items-center gap-1">
-              {index > 0 && <span className="text-faint">/</span>}
+              {index > 0 && <span className="text-muted-foreground">/</span>}
               <span
                 className={cn(
                   'truncate',
-                  index === crumbs.length - 1 && !crumb.ellipsis && 'text-text-strong',
+                  index === crumbs.length - 1 && !crumb.ellipsis && 'text-foreground',
                 )}
               >
                 {crumb.label}
@@ -83,7 +82,7 @@ export function FilePreview({
           onClick={() => void window.api.revealPath({ agentId, path: relativePath })}
           title="Reveal in Finder"
           aria-label="Reveal in Finder"
-          className="shrink-0 rounded-md p-1 text-muted outline-none transition-colors hover:bg-accent/10 hover:text-text-strong focus-visible:bg-accent/10"
+          className="shrink-0 rounded-md p-1 text-muted-foreground outline-none transition-colors hover:bg-primary/10 hover:text-foreground focus-visible:bg-primary/10"
         >
           <FolderOpen size={14} aria-hidden />
         </button>
@@ -95,7 +94,7 @@ export function FilePreview({
           disabled={!activeThreadId}
           title="Insert @path into composer"
           aria-label="Insert @path into composer"
-          className="shrink-0 rounded-md p-1 text-muted outline-none transition-colors hover:bg-accent/10 hover:text-text-strong focus-visible:bg-accent/10 disabled:opacity-40"
+          className="shrink-0 rounded-md p-1 text-muted-foreground outline-none transition-colors hover:bg-primary/10 hover:text-foreground focus-visible:bg-primary/10 disabled:opacity-40"
         >
           <AtSign size={14} aria-hidden />
         </button>
@@ -114,6 +113,9 @@ function PreviewBody({
   result: FilesReadResult | null
   relativePath: string
 }): JSX.Element {
+  const resolvedTheme = useResolvedTheme()
+  const previewTheme = pierreThemeOptions(resolvedTheme)
+
   if (result === null) return <Notice>Loading…</Notice>
   switch (result.kind) {
     case 'binary':
@@ -134,8 +136,8 @@ function PreviewBody({
               options={{
                 disableFileHeader: true,
                 overflow: 'scroll',
-                theme: PREVIEW_THEME,
-                themeType: 'light',
+                theme: previewTheme.theme,
+                themeType: previewTheme.themeType,
               }}
               className="min-h-full text-[12.5px]"
             />
@@ -148,7 +150,7 @@ function PreviewBody({
 /** A centered muted message for the non-text (and loading) states. */
 function Notice({ children }: { children: React.ReactNode }): JSX.Element {
   return (
-    <div className="flex flex-1 items-center justify-center px-6 py-10 text-center text-[13px] text-muted">
+    <div className="flex flex-1 items-center justify-center px-6 py-10 text-center text-[13px] text-muted-foreground">
       {children}
     </div>
   )

--- a/apps/desktop/src/renderer/src/side-panel/FilesSurface.tsx
+++ b/apps/desktop/src/renderer/src/side-panel/FilesSurface.tsx
@@ -20,17 +20,13 @@ import { indexEntryKinds, selectedFilePath, toTreePaths } from './tree-paths'
 /** Map the tree's shadow-DOM theme onto our tokens (styles.css). */
 const TREE_UNSAFE_CSS = `
   :host {
-    /* The widget's defaults use CSS light-dark() (e.g. --trees-input-bg =
-       light-dark(#f8f8f8, #070707)); with no color-scheme pinned it followed the OS, so on a
-       dark-mode Mac the search field rendered near-black. vibe-mistro is a light-only app, so
-       pin the light branch here (scoped to the widget's shadow root) and paint the search
-       input on our warm inset surface to match the panel. */
-    color-scheme: light;
+    /* color-scheme inherits through the host from the app root, so the widget's
+       light-dark() internals follow Vibe Mistro's resolved theme rather than the OS. */
     --trees-input-bg-override: var(--sidebar);
     --trees-bg-override: transparent;
-    --trees-selected-bg-override: var(--accent-tint);
-    --trees-hover-bg-override: color-mix(in srgb, var(--accent) 8%, transparent);
-    --trees-border-color-override: var(--border-muted);
+    --trees-selected-bg-override: color-mix(in srgb, var(--primary) 12%, transparent);
+    --trees-hover-bg-override: color-mix(in srgb, var(--primary) 8%, transparent);
+    --trees-border-color-override: var(--border);
     --trees-font-family-override: inherit;
     --trees-font-size-override: 12.5px;
   }
@@ -131,20 +127,20 @@ export function FilesSurface({
       // virtualized and measures its scroll container, so a content-height (≈0) container renders
       // ZERO rows (the header/search still show). `flex-1` fills the column's height; `min-h-0`
       // lets it shrink below content so the inner tree can scroll. (Matches t3code's FileBrowserPanel.)
-      className="flex min-h-0 flex-1 flex-col text-text"
+      className="flex min-h-0 flex-1 flex-col text-foreground"
     >
-      <div className="flex items-center gap-2 border-b border-border-muted px-3 py-2.5">
+      <div className="flex items-center gap-2 border-b border-border px-3 py-2.5">
         <button
           type="button"
           onClick={onCollapse}
           title="Collapse"
           aria-label="Collapse Files panel"
-          className="flex items-center gap-1.5 rounded-md text-left text-sm font-semibold text-text-strong"
+          className="flex items-center gap-1.5 rounded-md text-left text-sm font-semibold text-foreground"
         >
-          <PanelRightClose size={15} aria-hidden className="shrink-0 text-muted" />
+          <PanelRightClose size={15} aria-hidden className="shrink-0 text-muted-foreground" />
           <span>Files</span>
         </button>
-        <span className="min-w-0 flex-1 truncate text-[11px] text-faint" aria-live="polite">
+        <span className="min-w-0 flex-1 truncate text-[11px] text-muted-foreground" aria-live="polite">
           {statusText}
           {data?.truncated ? ' · partial' : ''}
         </span>
@@ -153,7 +149,7 @@ export function FilesSurface({
           onClick={() => model.openSearch()}
           title="Search files"
           aria-label="Search files"
-          className="rounded-md p-1 text-muted outline-none transition-colors hover:bg-accent/10 hover:text-text-strong focus-visible:bg-accent/10"
+          className="rounded-md p-1 text-muted-foreground outline-none transition-colors hover:bg-primary/10 hover:text-foreground focus-visible:bg-primary/10"
         >
           <Search size={14} aria-hidden />
         </button>
@@ -163,14 +159,14 @@ export function FilesSurface({
           disabled={loading}
           title="Refresh files"
           aria-label="Refresh files"
-          className="rounded-md p-1 text-muted outline-none transition-colors hover:bg-accent/10 hover:text-text-strong focus-visible:bg-accent/10 disabled:opacity-50"
+          className="rounded-md p-1 text-muted-foreground outline-none transition-colors hover:bg-primary/10 hover:text-foreground focus-visible:bg-primary/10 disabled:opacity-50"
         >
           <RefreshCw size={14} aria-hidden className={cn(loading && 'animate-spin')} />
         </button>
       </div>
 
       {error ? (
-        <div className="flex flex-1 items-center justify-center px-6 py-10 text-center text-[13px] text-muted">
+        <div className="flex flex-1 items-center justify-center px-6 py-10 text-center text-[13px] text-muted-foreground">
           {error}
         </div>
       ) : (
@@ -178,7 +174,7 @@ export function FilesSurface({
           model={model}
           aria-label="Workspace files"
           className="min-h-0 flex-1 overflow-hidden"
-          style={{ ['--trees-fg-override' as string]: 'var(--text)' }}
+          style={{ ['--trees-fg-override' as string]: 'var(--foreground)' }}
         />
       )}
     </aside>

--- a/apps/desktop/src/renderer/src/side-panel/SurfacePanel.tsx
+++ b/apps/desktop/src/renderer/src/side-panel/SurfacePanel.tsx
@@ -302,7 +302,7 @@ function PanelBody({
       aria-label="Side panel"
       style={inline ? { width } : undefined}
       className={cn(
-        'relative flex h-full min-h-0 flex-col bg-panel text-text',
+        'relative flex h-full min-h-0 flex-col bg-card text-foreground',
         inline ? 'shrink-0 self-stretch border-l border-border' : 'w-full',
         dragging && 'select-none',
       )}
@@ -319,8 +319,8 @@ function PanelBody({
           onDoubleClick={resetWidth}
           className={cn(
             'absolute inset-y-0 -left-1 z-20 w-2 cursor-col-resize select-none [-webkit-app-region:no-drag]',
-            'after:absolute after:inset-y-0 after:left-1 after:w-px after:bg-transparent after:transition-colors after:content-[""] hover:after:bg-accent/40',
-            dragging && 'after:bg-accent/60',
+            'after:absolute after:inset-y-0 after:left-1 after:w-px after:bg-transparent after:transition-colors after:content-[""] hover:after:bg-primary/40',
+            dragging && 'after:bg-primary/60',
           )}
         />
       )}
@@ -489,7 +489,7 @@ function SurfaceTabStrip({
     <div
       role="tablist"
       aria-label="Open surfaces"
-      className="flex w-full shrink-0 items-center gap-1 overflow-x-auto border-b border-border bg-panel px-2 py-1.5"
+      className="flex w-full shrink-0 items-center gap-1 overflow-x-auto border-b border-border bg-card px-2 py-1.5"
     >
       {surfaces.map((surface, index) => {
         const active = surface.id === activeSurfaceId
@@ -506,8 +506,8 @@ function SurfaceTabStrip({
                 'group flex h-7 min-w-0 max-w-40 shrink-0 items-center gap-1.5 rounded-md pl-2 pr-1 text-[13px] transition-colors',
                 '[&_svg]:size-3.5 [&_svg]:shrink-0',
                 active
-                  ? 'bg-accent/15 text-text-strong'
-                  : 'text-muted hover:bg-accent/10 hover:text-text',
+                  ? 'bg-primary/15 text-foreground'
+                  : 'text-muted-foreground hover:bg-primary/10 hover:text-foreground',
               )}
             >
               <button
@@ -537,7 +537,7 @@ function SurfaceTabStrip({
                 aria-label={`Close ${label}`}
                 title={`Close ${label}`}
                 className={cn(
-                  'flex size-4 shrink-0 items-center justify-center rounded outline-none hover:bg-accent/20',
+                  'flex size-4 shrink-0 items-center justify-center rounded outline-none hover:bg-primary/20',
                   active ? 'opacity-100' : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100',
                 )}
               >
@@ -565,7 +565,7 @@ function SurfaceTabStrip({
       <Menu>
         <MenuTrigger
           aria-label="Open a surface"
-          className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted outline-none transition-colors hover:bg-accent/10 hover:text-text-strong focus-visible:bg-accent/10"
+          className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-primary/10 hover:text-foreground focus-visible:bg-primary/10"
         >
           <Plus className="size-4" aria-hidden />
         </MenuTrigger>
@@ -578,10 +578,10 @@ function SurfaceTabStrip({
               disabled={!enabled}
               onClick={enabled ? () => onOpen(card.target) : undefined}
             >
-              <span className="flex items-center gap-2 [&_svg]:size-4 [&_svg]:shrink-0 [&_svg]:text-muted">
+              <span className="flex items-center gap-2 [&_svg]:size-4 [&_svg]:shrink-0 [&_svg]:text-muted-foreground">
                 {card.icon}
                 {card.label}
-                {!card.live && <span className="text-[11px] font-medium text-faint">Soon</span>}
+                {!card.live && <span className="text-[11px] font-medium text-muted-foreground">Soon</span>}
               </span>
             </MenuItem>
             )
@@ -664,8 +664,8 @@ function LauncherGrid({
     <div className="flex min-h-0 flex-1 items-center justify-center overflow-y-auto p-6">
       <div className="w-full max-w-xl">
         <div className="mb-5 text-center">
-          <h3 className="text-sm font-medium text-text-strong">Open a surface</h3>
-          <p className="mt-1 text-xs text-muted">Choose what to show in the side panel.</p>
+          <h3 className="text-sm font-medium text-foreground">Open a surface</h3>
+          <p className="mt-1 text-xs text-muted-foreground">Choose what to show in the side panel.</p>
         </div>
         <div className="grid grid-cols-2 gap-2">
           {CARDS.map((card) => (
@@ -696,22 +696,22 @@ function LauncherCard({ card, onClick }: { card: CardDef; onClick?: () => void }
       aria-disabled={inert || undefined}
       title={inert ? 'Coming soon' : card.label}
       className={cn(
-        'flex min-h-28 w-full flex-col items-start rounded-lg border border-border bg-surface p-4 text-left outline-none transition-colors',
-        '[&_svg]:size-5 [&_svg]:shrink-0 [&_svg]:text-muted',
+        'flex min-h-28 w-full flex-col items-start rounded-lg border border-border bg-secondary p-4 text-left outline-none transition-colors',
+        '[&_svg]:size-5 [&_svg]:shrink-0 [&_svg]:text-muted-foreground',
         inert
           ? 'cursor-default opacity-50'
-          : 'hover:bg-accent/10 focus-visible:bg-accent/10 [&_svg]:hover:text-text-strong',
+          : 'hover:bg-primary/10 focus-visible:bg-primary/10 [&_svg]:hover:text-foreground',
       )}
     >
       <span className="mb-3">{card.icon}</span>
       <span className="flex w-full items-center gap-2">
-        <span className="min-w-0 flex-1 truncate text-sm font-medium text-text">{card.label}</span>
+        <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">{card.label}</span>
         {card.hint && (
-          <kbd className="shrink-0 rounded-md text-[11px] font-medium tabular-nums text-faint">{card.hint}</kbd>
+          <kbd className="shrink-0 rounded-md text-[11px] font-medium tabular-nums text-muted-foreground">{card.hint}</kbd>
         )}
-        {inert && <span className="shrink-0 text-[11px] font-medium text-faint">Soon</span>}
+        {inert && <span className="shrink-0 text-[11px] font-medium text-muted-foreground">Soon</span>}
       </span>
-      <span className="mt-1 text-xs leading-relaxed text-muted">{card.description}</span>
+      <span className="mt-1 text-xs leading-relaxed text-muted-foreground">{card.description}</span>
     </button>
   )
 }

--- a/apps/desktop/src/renderer/src/side-panel/TerminalSurface.tsx
+++ b/apps/desktop/src/renderer/src/side-panel/TerminalSurface.tsx
@@ -184,7 +184,7 @@ export function TerminalSurface({
   }
 
   return (
-    <div className="relative flex min-h-0 flex-1 flex-col bg-panel">
+    <div className="relative flex min-h-0 flex-1 flex-col bg-card">
       <div className="flex shrink-0 items-center justify-end gap-1 border-b border-border px-2 py-1">
         <TerminalAction
           label="Add selection to chat"
@@ -205,8 +205,8 @@ export function TerminalSurface({
         className="min-h-0 flex-1 px-2 py-1.5 [background:var(--terminal-background)] [color:var(--terminal-foreground)]"
       />
       {openError && (
-        <div className="absolute inset-0 flex items-center justify-center bg-panel p-6">
-          <p className="max-w-sm text-center text-xs leading-relaxed text-muted">{openError}</p>
+        <div className="absolute inset-0 flex items-center justify-center bg-card p-6">
+          <p className="max-w-sm text-center text-xs leading-relaxed text-muted-foreground">{openError}</p>
         </div>
       )}
     </div>
@@ -239,8 +239,8 @@ function TerminalAction({
       aria-label={label}
       title={label}
       className={cn(
-        'flex size-6 items-center justify-center rounded text-muted outline-none transition-colors',
-        'hover:bg-accent/10 hover:text-text-strong focus-visible:bg-accent/10',
+        'flex size-6 items-center justify-center rounded text-muted-foreground outline-none transition-colors',
+        'hover:bg-primary/10 hover:text-foreground focus-visible:bg-primary/10',
         'disabled:pointer-events-none disabled:opacity-40',
         '[&_svg]:size-3.5 [&_svg]:shrink-0',
       )}

--- a/apps/desktop/src/renderer/src/side-panel/browser-picker.test.ts
+++ b/apps/desktop/src/renderer/src/side-panel/browser-picker.test.ts
@@ -96,18 +96,19 @@ describe('formatScreenshotAnnotation', () => {
 
 describe('buildPickerScript', () => {
   it('produces a single IIFE expression that resolves a Promise', () => {
-    const script = buildPickerScript({ accent: '#ff8800' })
+    const script = buildPickerScript({ accent: '#ff8800', accentForeground: '#111111' })
     expect(script.trimStart().startsWith('(')).toBe(true)
     expect(script).toContain('new Promise')
   })
 
   it('embeds the accent color as a safely-quoted string', () => {
-    const script = buildPickerScript({ accent: '#ff8800' })
+    const script = buildPickerScript({ accent: '#ff8800', accentForeground: '#111111' })
     expect(script).toContain(JSON.stringify('#ff8800'))
+    expect(script).toContain(JSON.stringify('#111111'))
   })
 
   it('wires the load-bearing picker mechanics (hover, capture-phase click, Esc)', () => {
-    const script = buildPickerScript({ accent: '#ff8800' })
+    const script = buildPickerScript({ accent: '#ff8800', accentForeground: '#111111' })
     expect(script).toContain('elementsFromPoint')
     expect(script).toContain('getBoundingClientRect')
     expect(script).toContain('preventDefault')
@@ -117,10 +118,11 @@ describe('buildPickerScript', () => {
   })
 
   it('is resistant to a hostile accent value (JSON-encoded, quote escaped)', () => {
-    const script = buildPickerScript({ accent: '";alert(1)//' })
+    const script = buildPickerScript({ accent: '";alert(1)//', accentForeground: "';alert(2)//" })
     // JSON-encoding embeds the value as an escaped string literal — the `"` becomes `\"`,
     // so it can't break out of the string context into executable code.
     expect(script).toContain(JSON.stringify('";alert(1)//'))
+    expect(script).toContain(JSON.stringify("';alert(2)//"))
     expect(script).toContain('\\"') // the double-quote is backslash-escaped, not raw
   })
 })

--- a/apps/desktop/src/renderer/src/side-panel/browser-picker.ts
+++ b/apps/desktop/src/renderer/src/side-panel/browser-picker.ts
@@ -76,11 +76,13 @@ export function coercePickedElement(raw: unknown): PickedElement | null {
  * script runs only in a real browser world — unit tests cover its SHAPE, not its behavior (the
  * app-driving verification exercises the behavior).
  */
-export function buildPickerScript(config: { accent: string }): string {
+export function buildPickerScript(config: { accent: string; accentForeground: string }): string {
   const accent = JSON.stringify(config.accent)
+  const accentForeground = JSON.stringify(config.accentForeground)
   const marker = JSON.stringify('data-vibe-pick-ui')
   return `(() => {
   const ACCENT = ${accent};
+  const ACCENT_FOREGROUND = ${accentForeground};
   const MARKER = ${marker};
   return new Promise((resolve) => {
     const box = document.createElement('div');
@@ -88,7 +90,7 @@ export function buildPickerScript(config: { accent: string }): string {
     Object.assign(box.style, { position: 'fixed', zIndex: '2147483646', pointerEvents: 'none', boxSizing: 'border-box', border: '2px solid ' + ACCENT, background: ACCENT + '22', borderRadius: '2px', display: 'none' });
     const label = document.createElement('div');
     label.setAttribute(MARKER, '');
-    Object.assign(label.style, { position: 'fixed', zIndex: '2147483647', pointerEvents: 'none', background: ACCENT, color: '#fff', font: '11px/1.5 ui-monospace, monospace', padding: '1px 5px', borderRadius: '3px', display: 'none', maxWidth: '60vw', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' });
+    Object.assign(label.style, { position: 'fixed', zIndex: '2147483647', pointerEvents: 'none', background: ACCENT, color: ACCENT_FOREGROUND, font: '11px/1.5 ui-monospace, monospace', padding: '1px 5px', borderRadius: '3px', display: 'none', maxWidth: '60vw', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' });
     document.body.appendChild(box);
     document.body.appendChild(label);
     document.body.style.cursor = 'crosshair';

--- a/apps/desktop/src/renderer/src/skills/SkillsView.tsx
+++ b/apps/desktop/src/renderer/src/skills/SkillsView.tsx
@@ -63,21 +63,21 @@ export function SkillsView({
         <IconButton aria-label="Back" title="Back" onClick={onClose}>
           <ArrowLeft className="size-4" aria-hidden />
         </IconButton>
-        <h1 className="text-[19px] font-semibold tracking-tight text-text-strong">Skills</h1>
+        <h1 className="text-[19px] font-semibold tracking-tight text-foreground">Skills</h1>
       </div>
-      <p className="text-[13px] text-muted">
+      <p className="text-[13px] text-muted-foreground">
         The agent skills installed on this machine — invoked with <code>/name</code> in the
         composer. Project skills{workspaceName ? ` (${workspaceName})` : ''} shadow global ones
         of the same name. Click a skill to read its instructions.
       </p>
 
       {skills === null ? (
-        <div className="rounded-[9px] border border-border p-3 text-[13px] text-muted">
+        <div className="rounded-[9px] border border-border p-3 text-[13px] text-muted-foreground">
           Scanning skill folders…
         </div>
       ) : skills.length === 0 ? (
-        <div className="flex flex-col gap-2 rounded-[9px] border border-border p-4 text-[13px] text-muted">
-          <span className="flex items-center gap-2 font-semibold text-text-strong">
+        <div className="flex flex-col gap-2 rounded-[9px] border border-border p-4 text-[13px] text-muted-foreground">
+          <span className="flex items-center gap-2 font-semibold text-foreground">
             <Sparkles className="size-4" aria-hidden />
             No skills installed
           </span>
@@ -95,7 +95,7 @@ export function SkillsView({
             // buttons are invalid HTML); the row's hover wash lives on the <li>.
             <li
               key={skill.name}
-              className="flex items-start gap-3 rounded-[9px] border border-border p-3 transition-colors hover:bg-accent/10 focus-within:bg-accent/10"
+              className="flex items-start gap-3 rounded-[9px] border border-border p-3 transition-colors hover:bg-primary/10 focus-within:bg-primary/10"
             >
               <button
                 type="button"
@@ -103,11 +103,11 @@ export function SkillsView({
                 aria-label={`Open /${skill.name}`}
                 className="flex min-w-0 flex-1 cursor-pointer items-start gap-3 text-left outline-none"
               >
-                <Sparkles className="mt-0.5 size-4 shrink-0 text-muted" aria-hidden />
+                <Sparkles className="mt-0.5 size-4 shrink-0 text-muted-foreground" aria-hidden />
                 <span className="flex min-w-0 flex-1 flex-col gap-0.5">
                   <SkillHeading skill={skill} />
-                  <span className="text-[13px] text-muted">{skill.description}</span>
-                  <span className="truncate text-[11px] text-faint">{skill.path}</span>
+                  <span className="text-[13px] text-muted-foreground">{skill.description}</span>
+                  <span className="truncate text-[11px] text-muted-foreground">{skill.path}</span>
                 </span>
               </button>
               <RevealButton skill={skill} workspaceDir={workspaceDir} />
@@ -154,26 +154,26 @@ function SkillPreview({
         <IconButton aria-label="Back to skills" title="Back to skills" onClick={onBack}>
           <ArrowLeft className="size-4" aria-hidden />
         </IconButton>
-        <h1 className="min-w-0 truncate text-[19px] font-semibold tracking-tight text-text-strong">
+        <h1 className="min-w-0 truncate text-[19px] font-semibold tracking-tight text-foreground">
           /{skill.name}
         </h1>
         <SkillBadges skill={skill} />
         <span className="flex-1" />
         <RevealButton skill={skill} workspaceDir={workspaceDir} />
       </div>
-      <p className="text-[13px] text-muted">{skill.description}</p>
-      <p className="truncate text-[11px] text-faint">{skill.path}</p>
+      <p className="text-[13px] text-muted-foreground">{skill.description}</p>
+      <p className="truncate text-[11px] text-muted-foreground">{skill.path}</p>
 
       {markdown === undefined ? (
-        <div className="rounded-[9px] border border-border p-3 text-[13px] text-muted">
+        <div className="rounded-[9px] border border-border p-3 text-[13px] text-muted-foreground">
           Reading SKILL.md…
         </div>
       ) : markdown === null ? (
-        <div className="rounded-[9px] border border-border p-3 text-[13px] text-muted">
+        <div className="rounded-[9px] border border-border p-3 text-[13px] text-muted-foreground">
           Couldn’t read this skill’s file — it may have moved. Reveal it to inspect on disk.
         </div>
       ) : markdown === '' ? (
-        <div className="rounded-[9px] border border-border p-3 text-[13px] text-muted">
+        <div className="rounded-[9px] border border-border p-3 text-[13px] text-muted-foreground">
           This skill has no instructions beyond its frontmatter.
         </div>
       ) : (
@@ -188,7 +188,7 @@ function SkillPreview({
 function SkillHeading({ skill }: { skill: SkillInfo }): JSX.Element {
   return (
     <span className="flex min-w-0 items-center gap-1.5">
-      <span className="truncate text-[13px] font-semibold text-text-strong">/{skill.name}</span>
+      <span className="truncate text-[13px] font-semibold text-foreground">/{skill.name}</span>
       <SkillBadges skill={skill} />
     </span>
   )
@@ -204,7 +204,7 @@ function SkillBadges({ skill }: { skill: SkillInfo }): JSX.Element {
         {skill.scope === 'project' ? 'Project' : 'Global'}
       </Badge>
       {!skill.userInvocable && (
-        <Badge variant="outline" className="shrink-0 px-1.5 py-0 text-[10px] text-muted">
+        <Badge variant="outline" className="shrink-0 px-1.5 py-0 text-[10px] text-muted-foreground">
           not invocable
         </Badge>
       )}

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1,80 +1,70 @@
 @import 'tailwindcss';
 @import './typeset.css';
 
-/* Scan streamdown's dist (#114) so Tailwind emits the utility classes it bakes into
-   its rendered markdown JSX — node_modules isn't scanned by default. Its classes are
-   themed onto our tokens via the semantic mappings appended to `@theme inline` below. */
+/* Scan streamdown's dist so Tailwind emits the utility classes embedded in its JSX. */
 @source '../../../node_modules/streamdown/dist';
 
+/* Theme state is expressed by a class on the document root. */
+@custom-variant dark (&:is(.dark *));
+
+@utility cta-brand {
+  background-image: var(--cta-gradient);
+}
+
 :root {
-  /* Mistral light-mode brand tokens — final-design values (docs/design-tokens.md).
-     Warm neutral ramp · softer gradient-forward orange · rounded.
-     Orange = fills / borders / gradients. --accent-text = orange TEXT (AA-safe). */
-  --bg: #fbfaf8;
+  color-scheme: light;
+  font-family: var(--font-sans);
+
+  /* Warm-neutral shell: semantic roles, not component-specific colours. */
+  --background: #fbfaf8;
+  --foreground: #1c1c1c;
+  --card: #ffffff;
+  --card-foreground: #20201e;
+  --popover: #ffffff;
+  --popover-foreground: #20201e;
+  --primary: #c4521d;
+  --primary-foreground: #ffffff;
+  --secondary: #f5f1ec;
+  --secondary-foreground: #33302c;
+  --muted: #f0ebe5;
+  --muted-foreground: #6b645d;
+  --accent: #ece4da;
+  --accent-foreground: #3d3128;
+  --destructive: #b42318;
+  --destructive-foreground: #ffffff;
+  --success: #1a7f37;
+  --success-foreground: #ffffff;
+  --highlight: #f8e6a0;
+  --highlight-foreground: #33270d;
+  --border: #e6ddd3;
+  --input: #ddd2c7;
+  --ring: #c4521d;
   --sidebar: #f5f3ef;
-  --surface: #fdfcfb;
-  --panel: #ffffff;
-  --border: #ecdfd3;
-  --border-muted: #eae3da;
+  --sidebar-foreground: #292623;
+  --sidebar-border: #e6ddd3;
 
-  --text: #1c1c1c;
-  --text-strong: #20201e;
-  --text-body: #33302c;
-  --text-secondary: #524d47;
-  --muted: #6b645d;
-  --placeholder: #a89f95;
-  --faint: #a79f96;
+  /* Warm Mistral identity. Primary is the accessible solid action; the flame
+     gradient is reserved for the composer CTA and brand artwork. */
+  --cta-gradient: linear-gradient(160deg, #e9793f, #c94f1d);
+  --cta-foreground: #ffffff;
+  --cta-shadow: rgb(200 90 30 / 0.3);
+  --accent-grad-logo: linear-gradient(#f6c445 0%, #ef8a3c 50%, #e2452a 100%);
+  --accent-grad-action: linear-gradient(160deg, #ee9b5b, #d65e28);
+  --accent-grad-avatar: linear-gradient(160deg, #ef9f5f, #d86632);
+  --shell-paint-from: #f4f0eb;
+  --shell-paint-to: #ebe5df;
+  --shell-paint: linear-gradient(160deg, var(--shell-paint-from), var(--shell-paint-to));
+  --shell-shadow-ambient: rgb(65 43 27 / 0.12);
+  --subtle-edge-shadow: rgb(65 43 27 / 0.04);
 
-  /* Terminal palette (docs/design-tokens.md). The app shell is light, while the
-     terminal intentionally keeps a familiar dark canvas with readable default
-     input and an explicit ANSI palette. */
+  /* Terminal deliberately stays dark in both app themes. */
   --terminal-background: #1c1b1a;
   --terminal-foreground: #d8d2ca;
   --terminal-green: #7fb56b;
   --terminal-blue: #6ba0d6;
   --terminal-gray: #a49c93;
 
-  --accent: #df6f38;
-  --accent-text: #cf6a3a;
-  --accent-emphasis: #e07a3e;
-  --accent-grad: linear-gradient(160deg, #ee9b5b, #df6f38);
-  --accent-grad-logo: linear-gradient(#f6c445 0%, #ef8a3c 50%, #e2452a 100%);
-  --accent-grad-action: linear-gradient(160deg, #ee9b5b, #df6f38);
-  --accent-grad-avatar: linear-gradient(160deg, #ef9f5f, #e07640);
-  /* Ink on the SOLID soft-orange fill (`.btn`, filled menu highlight, git
-     primary buttons). A warm near-black — white on the softer orange is only
-     ~3.25:1 (fails AA), whereas dark ink clears ~5:1 and matches the prior
-     behaviour. The prototype's white on-orange is the send *icon* on the
-     saturated `--accent-grad-action`, wired later (#117) with white directly. */
-  --on-accent: #241a12;
-
-  --active-bg: #ece4da;
-  --accent-shadow: rgba(200, 90, 30, 0.3);
-  /* The one SOLID filled tint (New-chat pill, #113) — distinct from the subtle
-     --accent-tint hover rgba below; do not use this for hover surfaces. */
-  --accent-fill: #f8e0cf;
-
-  --ok: #1a7f37;
-  --bad: #b42318;
-
-  /* Semantic tints (token-layer rgba; never raw rgba in component rules).
-     --accent-tint stays a SUBTLE low-alpha wash (hover/surface backgrounds across
-     ~10 existing rules) re-hued to the new soft orange — NOT the doc's solid
-     peach, which lives in --accent-fill above. */
-  --accent-tint: rgba(207, 106, 58, 0.08);
-  --accent-tint-border: rgba(207, 106, 58, 0.3);
-  --ok-tint: rgba(26, 127, 55, 0.1);
-  --ok-tint-border: rgba(26, 127, 55, 0.35);
-  --bad-tint: rgba(180, 35, 24, 0.08);
-  --bad-tint-border: rgba(180, 35, 24, 0.35);
-
-  /* Radius scale (reverses the old --radius: 0). Component-specific radii
-     (sm/md/pill/card/full) are bridged via @theme below; --radius is the
-     plain default the many hand-written `var(--radius)` rules resolve to. */
   --radius: 9px;
-
-  /* Type scale (docs/design-tokens.md §Typography). Token layer only — later
-     slices wire these into component rules; existing rules are untouched. */
   --fs-hero: 37px;
   --fs-workspace-title: 20px;
   --fs-composer-placeholder: 17px;
@@ -84,61 +74,76 @@
   --fs-section-header: 13px;
   --fs-timestamp: 13px;
   --fs-code: 13px;
-
-  /* Spacing scale (docs/design-tokens.md §Spacing scale): 2·4·6·8·10·12·14·16·
-     18·20·22·24·40·42·44 (micro 2–12; macro 14–24; hero 40–44). Tailwind v4's
-     generated --spacing (4px-based) already covers this range via `p-*`/`gap-*`
-     utilities — intentionally NOT redefining a parallel spacing var scheme here. */
-
-  font-family: var(--font-sans);
 }
 
-/* Bridge the brand tokens into Tailwind v4's theme so utilities resolve to the
-   SAME variables (the tokens above stay the single source of truth — `@theme
-   inline` emits `var(--…)` references rather than copying values). This makes
-   `bg-accent`, `text-accent-text`, `border-border`, `text-muted`, etc. paint in
-   brand colours. */
-@theme inline {
-  --color-bg: var(--bg);
-  --color-sidebar: var(--sidebar);
-  --color-panel: var(--panel);
-  --color-surface: var(--surface);
-  --color-border: var(--border);
-  --color-border-muted: var(--border-muted);
-  --color-text: var(--text);
-  --color-text-strong: var(--text-strong);
-  --color-text-body: var(--text-body);
-  --color-text-secondary: var(--text-secondary);
-  --color-muted: var(--muted);
-  --color-placeholder: var(--placeholder);
-  --color-faint: var(--faint);
-  --color-accent: var(--accent);
-  --color-accent-text: var(--accent-text);
-  --color-accent-emphasis: var(--accent-emphasis);
-  --color-on-accent: var(--on-accent);
-  --color-ok: var(--ok);
-  --color-bad: var(--bad);
+.dark {
+  color-scheme: dark;
+  /* Mistral's midnight system: values mirror the live mistral.ai dark palette. */
+  --background: #151524;
+  --foreground: oklch(92% 0.004 286.32);
+  --card: #242433;
+  --card-foreground: oklch(92% 0.004 286.32);
+  --popover: #343446;
+  --popover-foreground: oklch(96.7% 0.001 286.375);
+  --primary: #ff5229;
+  --primary-foreground: #151524;
+  --secondary: #242433;
+  --secondary-foreground: oklch(87.1% 0.006 286.286);
+  --muted: #343446;
+  --muted-foreground: oklch(70.5% 0.015 286.067);
+  --accent: #343446;
+  --accent-foreground: oklch(92% 0.004 286.32);
+  --destructive: #f66c60;
+  --destructive-foreground: #151524;
+  --success: #44ba82;
+  --success-foreground: #151524;
+  --highlight: #933800;
+  --highlight-foreground: #ffe8a2;
+  --border: #31313a;
+  --input: #474754;
+  --ring: #ff5229;
+  --sidebar: #151524;
+  --sidebar-foreground: oklch(92% 0.004 286.32);
+  --sidebar-border: #31313a;
+  --cta-gradient: linear-gradient(160deg, #ff8204, #ff5229);
+  --cta-foreground: #151524;
+  --cta-shadow: rgb(0 0 0 / 0.45);
+  --accent-grad-action: linear-gradient(160deg, #ff8204, #ff5229);
+  --accent-grad-avatar: linear-gradient(160deg, #ff8204, #ff5229);
+  --shell-paint-from: #242433;
+  --shell-paint-to: #151524;
+  --shell-shadow-ambient: rgb(0 0 0 / 0.55);
+  --subtle-edge-shadow: rgb(0 0 0 / 0.35);
+}
 
-  /* Streamdown's shadcn semantic tokens → our brand tokens (#114, spike #112). Its
-     rendered markdown styles with `text-primary` (links), `text-foreground`,
-     `text-muted-foreground`, `font-mono`, etc.; map them here so it paints in brand
-     colours. `--color-border` / `--color-sidebar` already exist above (code-block
-     container = `bg-sidebar`). NOTE the `muted` collision (spike caveat): our
-     `--color-muted` is a TEXT grey, so streamdown's `bg-muted` inline-code default is
-     overridden in the `Response` `inlineCode` component (→ `--accent-tint`), NOT here. */
-  --color-primary: var(--accent-text);
-  --color-primary-foreground: var(--on-accent);
-  --color-foreground: var(--text);
-  --color-background: var(--bg);
-  --color-muted-foreground: var(--muted);
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-border: var(--sidebar-border);
   --font-mono: 'SF Mono', ui-monospace, 'Menlo', monospace;
 }
 
-/* Radius scale (docs/design-tokens.md §Radius) — reverses the old all-zero
-   pin so `rounded-*` utilities produce real corners. Declared as plain @theme
-   (not @theme inline) so these are literal px values, never a var(--radius-md)
-   self-reference against the :root token of the same name (TRAP 1: that
-   collision silently resolves to invalid → border-radius falls back to 0). */
 @theme {
   /* Fonts — Geist (Vercel), bundled OFFLINE via @fontsource-variable (imported in
      main.tsx; variable weight 100–900). Defined in `@theme` so `font-sans`/`font-mono`
@@ -165,12 +170,12 @@
 
 body {
   margin: 0;
-  background: var(--bg);
-  color: var(--text);
+  background: var(--background);
+  color: var(--foreground);
 }
 
 .card {
-  background: var(--panel);
+  background: var(--card);
   border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 16px;
@@ -185,8 +190,8 @@ body {
 }
 
 .btn {
-  background: var(--accent-grad);
-  color: var(--on-accent);
+  background: var(--cta-gradient);
+  color: var(--primary-foreground);
   border: none;
   border-radius: var(--radius);
   padding: 6px 12px;
@@ -220,11 +225,11 @@ body {
 }
 
 .status__value {
-  color: var(--muted);
+  color: var(--muted-foreground);
 }
 
 .status__error {
-  color: var(--bad);
+  color: var(--destructive);
   font-size: 13px;
   line-height: 1.4;
   margin-top: 4px;
@@ -238,15 +243,15 @@ body {
 }
 
 .dot--ok {
-  background: var(--ok);
+  background: var(--success);
 }
 
 .dot--bad {
-  background: var(--bad);
+  background: var(--destructive);
 }
 
 .dot--pending {
-  background: var(--accent);
+  background: var(--primary);
   animation: pulse 1.2s ease-in-out infinite;
 }
 
@@ -326,12 +331,12 @@ body {
   .vm-shimmer {
     animation: none;
     background: none;
-    color: var(--accent-text);
+    color: var(--primary);
   }
 }
 
 .hint {
-  color: var(--muted);
+  color: var(--muted-foreground);
   font-size: 13px;
   line-height: 1.5;
 }
@@ -344,9 +349,9 @@ body {
 
 /* The read-only reopened-Thread view (TB3): a muted variant of the live conv. */
 .conv--cold .badge {
-  background: var(--accent-tint);
-  color: var(--accent-text);
-  border-color: var(--accent-tint-border);
+  background: color-mix(in srgb, var(--primary) 10%, transparent);
+  color: var(--primary);
+  border-color: color-mix(in srgb, var(--primary) 30%, transparent);
 }
 
 .thread {
@@ -367,9 +372,9 @@ body {
 }
 
 .badge {
-  background: var(--ok-tint);
-  color: var(--ok);
-  border: 1px solid var(--ok-tint-border);
+  background: color-mix(in srgb, var(--success) 10%, transparent);
+  color: var(--success);
+  border: 1px solid color-mix(in srgb, var(--success) 35%, transparent);
   border-radius: var(--radius);
   padding: 2px 10px;
   font-size: 11px;
@@ -384,7 +389,7 @@ body {
 }
 
 .chips__label {
-  color: var(--muted);
+  color: var(--muted-foreground);
   width: 56px;
   flex-shrink: 0;
 }
@@ -400,17 +405,17 @@ body {
   border-radius: var(--radius);
   padding: 2px 8px;
   font-size: 12px;
-  color: var(--muted);
+  color: var(--muted-foreground);
 }
 
 .chip--active {
-  border-color: var(--accent);
-  color: var(--accent-text);
+  border-color: var(--primary);
+  color: var(--primary);
 }
 
 .alert {
-  border: 1px solid var(--bad-tint-border);
-  background: var(--bad-tint);
+  border: 1px solid color-mix(in srgb, var(--destructive) 35%, transparent);
+  background: color-mix(in srgb, var(--destructive) 10%, transparent);
   border-radius: var(--radius);
   padding: 12px;
   display: flex;
@@ -419,7 +424,7 @@ body {
 }
 
 .alert__title {
-  color: var(--bad);
+  color: var(--destructive);
   font-weight: 600;
   font-size: 13px;
 }
@@ -430,7 +435,7 @@ body {
 }
 
 .alert__hint {
-  color: var(--muted);
+  color: var(--muted-foreground);
   font-size: 12px;
   line-height: 1.4;
 }
@@ -476,14 +481,14 @@ body {
   padding: 8px 12px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  background: var(--accent-tint);
+  background: color-mix(in srgb, var(--primary) 10%, transparent);
   font-size: 12px;
   line-height: 1.4;
-  color: var(--muted);
+  color: var(--muted-foreground);
 }
 
 .notice__icon {
-  color: var(--accent-text);
+  color: var(--primary);
   font-weight: 600;
 }
 
@@ -495,13 +500,13 @@ body {
   display: flex;
   gap: 16px;
   font-size: 12px;
-  color: var(--muted);
+  color: var(--muted-foreground);
   padding-bottom: 4px;
   border-bottom: 1px solid var(--border);
 }
 
 .usage strong {
-  color: var(--text);
+  color: var(--foreground);
   font-weight: 600;
 }
 
@@ -532,7 +537,7 @@ body {
 .fallback__summary {
   cursor: pointer;
   font-size: 12px;
-  color: var(--muted);
+  color: var(--muted-foreground);
   user-select: none;
 }
 
@@ -545,7 +550,7 @@ body {
 .fallback__body {
   margin: 6px 0 0;
   font-size: 11px;
-  color: var(--muted);
+  color: var(--muted-foreground);
   white-space: pre-wrap;
   word-break: break-word;
 }
@@ -558,21 +563,21 @@ body {
 
 .btn--ghost {
   background: transparent;
-  color: var(--muted);
+  color: var(--muted-foreground);
   border: 1px solid var(--border);
 }
 
 /* Interrupt (#103): an outline action distinct from the primary Send. */
 .btn--stop {
   background: transparent;
-  color: var(--text);
+  color: var(--foreground);
   border: 1px solid var(--border);
 }
 
 .recover {
   align-self: flex-start;
   background: transparent;
-  color: var(--muted);
+  color: var(--muted-foreground);
   border: 1px dashed var(--border);
   border-radius: var(--radius);
   padding: 4px 10px;
@@ -581,6 +586,6 @@ body {
 }
 
 .recover:hover {
-  color: var(--text);
-  border-color: var(--accent);
+  color: var(--foreground);
+  border-color: var(--primary);
 }

--- a/apps/desktop/src/renderer/src/typeset.css
+++ b/apps/desktop/src/renderer/src/typeset.css
@@ -164,12 +164,8 @@
       font-weight: 600;
     }
     &:where(mark) {
-      background-color: color-mix(
-        in oklab,
-        oklch(0.86 0.17 95) 40%,
-        transparent
-      );
-      color: inherit;
+      background-color: var(--highlight);
+      color: var(--highlight-foreground);
       padding: 0.05em 0.15em;
       border-radius: 0.2em;
     }

--- a/apps/desktop/src/renderer/src/ui/avatar.tsx
+++ b/apps/desktop/src/renderer/src/ui/avatar.tsx
@@ -41,7 +41,7 @@ export function AvatarFallback({
     <BaseAvatar.Fallback
       data-slot="avatar-fallback"
       className={cn(
-        'flex size-full items-center justify-center text-sm text-on-accent',
+        'flex size-full items-center justify-center text-sm text-primary-foreground',
         className,
       )}
       {...props}

--- a/apps/desktop/src/renderer/src/ui/badge.tsx
+++ b/apps/desktop/src/renderer/src/ui/badge.tsx
@@ -16,11 +16,11 @@ export const badgeVariants = cva(
   {
     variants: {
       variant: {
-        default: 'bg-accent text-on-accent',
-        accent: 'bg-accent/10 text-accent-text',
-        destructive: 'bg-bad/10 text-bad',
-        ok: 'bg-ok/10 text-ok',
-        outline: 'border border-border text-text',
+        default: 'bg-primary text-primary-foreground',
+        accent: 'bg-primary/10 text-primary',
+        destructive: 'bg-destructive/10 text-destructive',
+        ok: 'bg-success/10 text-success',
+        outline: 'border border-border text-foreground',
       },
     },
     defaultVariants: {

--- a/apps/desktop/src/renderer/src/ui/button.tsx
+++ b/apps/desktop/src/renderer/src/ui/button.tsx
@@ -6,25 +6,25 @@ import { cn } from '../lib/utils'
 /**
  * The CVA exemplar for the kit. Structure lifted from shadcn's base-ui `button.tsx`;
  * the semantic `cn-button-variant-*` theme tokens it ships are swapped for real
- * Tailwind utility strings resolved through OUR tokens (`bg-accent`, `text-on-accent`,
+ * Tailwind utility strings resolved through OUR tokens (`bg-primary`, `text-primary-foreground`,
  * `border-border`, …). Radii come from the new rounded scale (#110): text buttons
- * `rounded-md` (10px), icon buttons `rounded-sm` (7px). `text-on-accent` is the warm
+ * `rounded-md` (10px), icon buttons `rounded-sm` (7px). `text-primary-foreground` is the warm
  * dark ink (AA-safe on the softer orange), NOT white.
  */
 export const buttonVariants = cva(
-  'inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors outline-none select-none disabled:pointer-events-none disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-accent/40 [&_svg]:pointer-events-none [&_svg]:shrink-0',
+  'inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors outline-none select-none disabled:pointer-events-none disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-primary/40 [&_svg]:pointer-events-none [&_svg]:shrink-0',
   {
     variants: {
       variant: {
-        default: 'bg-accent text-on-accent hover:bg-accent/90',
-        outline: 'border border-border bg-transparent text-text hover:bg-accent/10',
-        secondary: 'border border-border bg-surface text-text hover:bg-accent/10',
-        ghost: 'text-text hover:bg-accent/10',
-        destructive: 'bg-bad text-white hover:bg-bad/90',
-        link: 'text-accent-text underline-offset-4 hover:underline',
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        outline: 'border border-border bg-transparent text-foreground hover:bg-primary/10',
+        secondary: 'border border-border bg-secondary text-foreground hover:bg-primary/10',
+        ghost: 'text-foreground hover:bg-primary/10',
+        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        link: 'text-primary underline-offset-4 hover:underline',
         // Interrupt action (#103) — an outline distinct from the primary Send;
         // mirrors the existing `.btn--stop` (transparent bg, muted border).
-        stop: 'border border-border bg-transparent text-text hover:bg-accent/10',
+        stop: 'border border-border bg-transparent text-foreground hover:bg-primary/10',
       },
       size: {
         default: 'h-9 px-4 py-2',

--- a/apps/desktop/src/renderer/src/ui/card.tsx
+++ b/apps/desktop/src/renderer/src/ui/card.tsx
@@ -11,7 +11,7 @@ export function Card({ className, ...props }: ComponentProps<'div'>): JSX.Elemen
     <div
       data-slot="card"
       className={cn(
-        'flex flex-col gap-4 rounded-2xl border border-border bg-surface p-6 text-text shadow-sm',
+        'flex flex-col gap-4 rounded-2xl border border-border bg-secondary p-6 text-foreground shadow-sm',
         className,
       )}
       {...props}
@@ -27,7 +27,7 @@ export function CardTitle({ className, ...props }: ComponentProps<'div'>): JSX.E
   return (
     <div
       data-slot="card-title"
-      className={cn('font-semibold text-text-strong', className)}
+      className={cn('font-semibold text-foreground', className)}
       {...props}
     />
   )
@@ -35,7 +35,7 @@ export function CardTitle({ className, ...props }: ComponentProps<'div'>): JSX.E
 
 export function CardDescription({ className, ...props }: ComponentProps<'div'>): JSX.Element {
   return (
-    <div data-slot="card-description" className={cn('text-sm text-muted', className)} {...props} />
+    <div data-slot="card-description" className={cn('text-sm text-muted-foreground', className)} {...props} />
   )
 }
 

--- a/apps/desktop/src/renderer/src/ui/chip.tsx
+++ b/apps/desktop/src/renderer/src/ui/chip.tsx
@@ -20,9 +20,9 @@ export function Chip({
       data-slot="chip"
       data-active={active || undefined}
       className={cn(
-        'inline-flex items-center gap-1.5 rounded-lg px-1.5 py-0.5 text-sm text-muted transition-colors',
+        'inline-flex items-center gap-1.5 rounded-lg px-1.5 py-0.5 text-sm text-muted-foreground transition-colors',
         '[&_svg]:pointer-events-none [&_svg]:shrink-0',
-        active && 'text-accent-text',
+        active && 'text-primary',
         className,
       )}
       {...props}

--- a/apps/desktop/src/renderer/src/ui/command.tsx
+++ b/apps/desktop/src/renderer/src/ui/command.tsx
@@ -36,7 +36,7 @@ export function CommandDialogPopup({
         <BaseDialog.Popup
           data-slot="command-dialog-popup"
           className={cn(
-            'pointer-events-auto flex max-h-[min(28rem,70vh)] w-full max-w-xl flex-col overflow-hidden rounded-2xl border border-border bg-panel text-text shadow-lg outline-none',
+            'pointer-events-auto flex max-h-[min(28rem,70vh)] w-full max-w-xl flex-col overflow-hidden rounded-2xl border border-border bg-card text-foreground shadow-lg outline-none',
             className,
           )}
           {...props}
@@ -75,11 +75,11 @@ export function CommandInput({
 }: ComponentProps<typeof BaseAutocomplete.Input>): JSX.Element {
   return (
     <div className="flex items-center gap-2.5 border-b border-border px-3.5 py-3">
-      <Search className="size-4 shrink-0 text-muted" aria-hidden />
+      <Search className="size-4 shrink-0 text-muted-foreground" aria-hidden />
       <BaseAutocomplete.Input
         data-slot="command-input"
         className={cn(
-          'w-full bg-transparent text-[14px] text-text outline-none placeholder:text-faint',
+          'w-full bg-transparent text-[14px] text-foreground outline-none placeholder:text-muted-foreground',
           className,
         )}
         {...props}
@@ -117,7 +117,7 @@ export function CommandEmpty({
   return (
     <BaseAutocomplete.Empty
       data-slot="command-empty"
-      className={cn('not-empty:py-10 text-center text-[13px] text-muted', className)}
+      className={cn('not-empty:py-10 text-center text-[13px] text-muted-foreground', className)}
       {...props}
     />
   )
@@ -132,7 +132,7 @@ export function CommandItem({
     <BaseAutocomplete.Item
       data-slot="command-item"
       className={cn(
-        'flex cursor-pointer select-none items-center gap-2.5 rounded-[9px] px-2.5 py-2 text-[13px] outline-none data-[highlighted]:bg-accent/10',
+        'flex cursor-pointer select-none items-center gap-2.5 rounded-[9px] px-2.5 py-2 text-[13px] outline-none data-[highlighted]:bg-primary/10',
         className,
       )}
       {...props}
@@ -145,7 +145,7 @@ export function CommandFooter({ children }: { children: ReactNode }): JSX.Elemen
   return (
     <div
       data-slot="command-footer"
-      className="flex items-center gap-3 border-t border-border px-3.5 py-2 text-[11px] text-faint"
+      className="flex items-center gap-3 border-t border-border px-3.5 py-2 text-[11px] text-muted-foreground"
     >
       {children}
     </div>

--- a/apps/desktop/src/renderer/src/ui/dialog.tsx
+++ b/apps/desktop/src/renderer/src/ui/dialog.tsx
@@ -42,7 +42,7 @@ export function DialogContent({
       <BaseDialog.Popup
         data-slot="dialog-content"
         className={cn(
-          'fixed top-1/2 left-1/2 z-50 w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-border bg-panel p-6 text-text shadow-lg outline-none',
+          'fixed top-1/2 left-1/2 z-50 w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-border bg-card p-6 text-foreground shadow-lg outline-none',
           className,
         )}
         {...props}
@@ -90,7 +90,7 @@ export function DialogTitle({
   return (
     <BaseDialog.Title
       data-slot="dialog-title"
-      className={cn('text-base font-semibold text-text-strong', className)}
+      className={cn('text-base font-semibold text-foreground', className)}
       {...props}
     />
   )
@@ -103,7 +103,7 @@ export function DialogDescription({
   return (
     <BaseDialog.Description
       data-slot="dialog-description"
-      className={cn('text-sm text-muted', className)}
+      className={cn('text-sm text-muted-foreground', className)}
       {...props}
     />
   )

--- a/apps/desktop/src/renderer/src/ui/input.tsx
+++ b/apps/desktop/src/renderer/src/ui/input.tsx
@@ -15,8 +15,8 @@ export function Input({
     <BaseInput
       data-slot="input"
       className={cn(
-        'flex h-9 w-full min-w-0 rounded-md border border-border bg-bg px-3 py-1 text-sm text-text outline-none transition-colors',
-        'placeholder:text-placeholder focus-visible:border-accent',
+        'flex h-9 w-full min-w-0 rounded-md border border-border bg-background px-3 py-1 text-sm text-foreground outline-none transition-colors',
+        'placeholder:text-muted-foreground focus-visible:border-primary',
         'disabled:pointer-events-none disabled:opacity-50',
         className,
       )}

--- a/apps/desktop/src/renderer/src/ui/menu-styles.ts
+++ b/apps/desktop/src/renderer/src/ui/menu-styles.ts
@@ -12,7 +12,7 @@
  * width, padding, `z-50`, overflow — stays local at the call site.
  */
 export const menuSurfaceClass =
-  'rounded-md border border-border bg-panel text-sm text-text shadow-md outline-none'
+  'rounded-md border border-border bg-card text-sm text-foreground shadow-md outline-none'
 
 /**
  * The highlight-row ITEM tokens shared by MenuItem / MenuRadioItem / ContextMenuItem:
@@ -21,4 +21,4 @@ export const menuSurfaceClass =
  * local there.
  */
 export const menuItemClass =
-  'flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 outline-none data-[highlighted]:bg-accent data-[highlighted]:text-on-accent'
+  'flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 outline-none data-[highlighted]:bg-primary data-[highlighted]:text-primary-foreground'

--- a/apps/desktop/src/renderer/src/ui/nav-item.tsx
+++ b/apps/desktop/src/renderer/src/ui/nav-item.tsx
@@ -20,10 +20,10 @@ export function NavItem({
       data-slot="nav-item"
       data-active={active || undefined}
       className={cn(
-        'flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-left text-[14px] text-text-body outline-none transition-colors',
-        '[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:text-muted',
-        'hover:bg-accent/10 focus-visible:bg-accent/10',
-        active && 'bg-accent/15 font-semibold text-text-strong [&_svg]:text-text-strong',
+        'flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-left text-[14px] text-foreground outline-none transition-colors',
+        '[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:text-muted-foreground',
+        'hover:bg-primary/10 focus-visible:bg-primary/10',
+        active && 'bg-primary/15 font-semibold text-foreground [&_svg]:text-foreground',
         className,
       )}
       {...props}

--- a/apps/desktop/src/renderer/src/ui/panel.tsx
+++ b/apps/desktop/src/renderer/src/ui/panel.tsx
@@ -11,7 +11,7 @@ export function Panel({ className, ...props }: ComponentProps<'div'>): JSX.Eleme
     <div
       data-slot="panel"
       className={cn(
-        'flex h-full min-h-0 flex-col border-l border-border bg-panel text-text',
+        'flex h-full min-h-0 flex-col border-l border-border bg-card text-foreground',
         className,
       )}
       {...props}
@@ -24,7 +24,7 @@ export function PanelHeader({ className, ...props }: ComponentProps<'div'>): JSX
     <div
       data-slot="panel-header"
       className={cn(
-        'flex flex-none items-center gap-2 border-b border-border-muted px-4 py-3',
+        'flex flex-none items-center gap-2 border-b border-border px-4 py-3',
         className,
       )}
       {...props}
@@ -36,7 +36,7 @@ export function PanelTitle({ className, ...props }: ComponentProps<'div'>): JSX.
   return (
     <div
       data-slot="panel-title"
-      className={cn('flex-1 text-sm font-semibold text-text-strong', className)}
+      className={cn('flex-1 text-sm font-semibold text-foreground', className)}
       {...props}
     />
   )

--- a/apps/desktop/src/renderer/src/ui/popover.tsx
+++ b/apps/desktop/src/renderer/src/ui/popover.tsx
@@ -50,7 +50,7 @@ export function PopoverTitle({
   return (
     <BasePopover.Title
       data-slot="popover-title"
-      className={cn('text-sm font-semibold text-text-strong', className)}
+      className={cn('text-sm font-semibold text-foreground', className)}
       {...props}
     />
   )
@@ -63,7 +63,7 @@ export function PopoverDescription({
   return (
     <BasePopover.Description
       data-slot="popover-description"
-      className={cn('text-sm text-muted', className)}
+      className={cn('text-sm text-muted-foreground', className)}
       {...props}
     />
   )

--- a/apps/desktop/src/renderer/src/ui/select.tsx
+++ b/apps/desktop/src/renderer/src/ui/select.tsx
@@ -23,15 +23,15 @@ export function SelectTrigger({
     <BaseSelect.Trigger
       data-slot="select-trigger"
       className={cn(
-        'flex h-9 w-fit items-center justify-between gap-2 rounded-md border border-border bg-surface px-3 text-sm text-text outline-none transition-colors',
-        'hover:bg-accent/10 focus-visible:border-accent disabled:pointer-events-none disabled:opacity-50',
+        'flex h-9 w-fit items-center justify-between gap-2 rounded-md border border-border bg-secondary px-3 text-sm text-foreground outline-none transition-colors',
+        'hover:bg-primary/10 focus-visible:border-primary disabled:pointer-events-none disabled:opacity-50',
         '[&_svg]:pointer-events-none [&_svg]:shrink-0',
         className,
       )}
       {...props}
     >
       {children}
-      <BaseSelect.Icon render={<ChevronDown className="size-4 text-muted" />} />
+      <BaseSelect.Icon render={<ChevronDown className="size-4 text-muted-foreground" />} />
     </BaseSelect.Trigger>
   )
 }
@@ -86,7 +86,7 @@ export function SelectItem({
       data-slot="select-item"
       className={cn(
         'relative flex cursor-default items-center gap-2 py-1.5 pr-8 pl-3 outline-none select-none',
-        'data-[highlighted]:bg-accent data-[highlighted]:text-on-accent',
+        'data-[highlighted]:bg-primary data-[highlighted]:text-primary-foreground',
         'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
         '[&_svg]:pointer-events-none [&_svg]:shrink-0',
         className,
@@ -108,7 +108,7 @@ export function SelectGroupLabel({
   return (
     <BaseSelect.GroupLabel
       data-slot="select-label"
-      className={cn('px-3 py-1.5 text-xs text-muted', className)}
+      className={cn('px-3 py-1.5 text-xs text-muted-foreground', className)}
       {...props}
     />
   )

--- a/apps/desktop/src/renderer/src/ui/sheet.tsx
+++ b/apps/desktop/src/renderer/src/ui/sheet.tsx
@@ -13,7 +13,7 @@ import { cn } from '../lib/utils'
  * `Dialog.Viewport` (the flex container that pins the popup to an edge), so the structure
  * mirrors t3code's — Portal → Backdrop → Viewport → Popup — rather than needing a fallback.
  * We drop t3code's shadcn colour tokens (`bg-popover`, `bg-background/60`) for ours
- * (`bg-panel`, `bg-black/40`), and keep only the parts we use (no header/footer/title
+ * (`bg-card`, `bg-black/40`), and keep only the parts we use (no header/footer/title
  * helpers — the panel brings its own chrome).
  */
 export const Sheet = BaseDialog.Root
@@ -50,7 +50,7 @@ export function SheetPopup({
           data-slot="sheet-popup"
           className={cn(
             'relative flex h-full min-h-0 w-[min(42vw,28rem)] min-w-80 max-w-[28rem] flex-col overflow-hidden',
-            'border-l border-border bg-panel text-text shadow-lg outline-none',
+            'border-l border-border bg-card text-foreground shadow-lg outline-none',
             'transition-[opacity,translate] duration-200 ease-in-out',
             'data-ending-style:translate-x-8 data-ending-style:opacity-0',
             'data-starting-style:translate-x-8 data-starting-style:opacity-0',

--- a/apps/desktop/src/renderer/src/ui/textarea.tsx
+++ b/apps/desktop/src/renderer/src/ui/textarea.tsx
@@ -14,8 +14,8 @@ export function Textarea({
     <textarea
       data-slot="textarea"
       className={cn(
-        'flex field-sizing-content min-h-16 w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-text outline-none transition-colors',
-        'placeholder:text-placeholder focus-visible:border-accent',
+        'flex field-sizing-content min-h-16 w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground outline-none transition-colors',
+        'placeholder:text-muted-foreground focus-visible:border-primary',
         'disabled:pointer-events-none disabled:opacity-50',
         className,
       )}

--- a/apps/desktop/src/renderer/src/ui/tooltip.tsx
+++ b/apps/desktop/src/renderer/src/ui/tooltip.tsx
@@ -43,7 +43,7 @@ export function TooltipContent({
         <BaseTooltip.Popup
           data-slot="tooltip-content"
           className={cn(
-            'z-50 w-fit max-w-xs rounded-sm bg-text px-2 py-1 text-xs text-bg shadow-md',
+            'z-50 w-fit max-w-xs rounded-sm bg-foreground px-2 py-1 text-xs text-background shadow-md',
             className,
           )}
           {...props}

--- a/apps/desktop/src/shared/ipc/index.ts
+++ b/apps/desktop/src/shared/ipc/index.ts
@@ -21,6 +21,7 @@ import { browserChannels } from './browser'
 import { searchChannels } from './search'
 import { skillsChannels } from './skills'
 import { appUpdateChannels } from './app-update'
+import { themeChannels } from './theme'
 
 /**
  * The one typed channel map. ONE exported object — the channel names are the wire
@@ -40,6 +41,7 @@ export const IPC = {
   ...searchChannels,
   ...skillsChannels,
   ...appUpdateChannels,
+  ...themeChannels,
 } as const
 
 export * from './core'
@@ -54,3 +56,4 @@ export * from './browser'
 export * from './search'
 export * from './skills'
 export * from './app-update'
+export * from './theme'

--- a/apps/desktop/src/shared/ipc/theme.test.ts
+++ b/apps/desktop/src/shared/ipc/theme.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { isThemePreference, THEME_PREFERENCES } from './theme'
+
+describe('isThemePreference', () => {
+  it('accepts every theme preference', () => {
+    for (const preference of THEME_PREFERENCES) expect(isThemePreference(preference)).toBe(true)
+  })
+
+  it('rejects values outside the theme vocabulary', () => {
+    expect(isThemePreference('solarized')).toBe(false)
+    expect(isThemePreference('')).toBe(false)
+    expect(isThemePreference(undefined)).toBe(false)
+    expect(isThemePreference(null)).toBe(false)
+    expect(isThemePreference(42)).toBe(false)
+    expect(isThemePreference({ preference: 'dark' })).toBe(false)
+  })
+})

--- a/apps/desktop/src/shared/ipc/theme.ts
+++ b/apps/desktop/src/shared/ipc/theme.ts
@@ -1,0 +1,32 @@
+/** Theme channels merged into the shared IPC contract. */
+export const themeChannels = {
+  /** Renderer -> main: read the main-owned theme state. */
+  themeGet: 'theme:get',
+  /** Renderer -> main: persist and apply a theme preference. */
+  themeSet: 'theme:set',
+  /** Main -> renderer: theme state changed. */
+  themeStatus: 'theme:status',
+  /** Renderer -> main: the themed app shell is ready to become visible. */
+  themeReady: 'theme:ready',
+} as const
+
+export const THEME_PREFERENCES = ['light', 'dark', 'system'] as const
+
+/** The persisted preference. `system` follows Electron's native theme. */
+export type ThemePreference = (typeof THEME_PREFERENCES)[number]
+
+/** Guard renderer input at the untyped IPC boundary. */
+export function isThemePreference(value: unknown): value is ThemePreference {
+  return (THEME_PREFERENCES as readonly unknown[]).includes(value)
+}
+
+export interface SetThemeArgs {
+  preference: ThemePreference
+}
+
+export type ResolvedTheme = 'light' | 'dark'
+
+export interface ThemeState {
+  preference: ThemePreference
+  resolved: ResolvedTheme
+}


### PR DESCRIPTION
## Summary

- add persisted Light, Dark, and System appearance preferences in Settings
- resolve the theme in Electron main before creating the first window and reveal only after the renderer applies it
- migrate desktop UI paint values to semantic light/dark tokens using Mistral's live midnight palette (`#151524`)
- update Pierre diff workers/views, file previews/tree, browser chrome, and native color-scheme behavior
- serialize preference writes and add a lint guard against removed theme utilities

## Why

The desktop app previously supported only a light appearance. This adds the dark-theme option requested by external user feedback while keeping cold launch, live OS changes, and embedded rendering surfaces consistent.

Closes #412.

## User impact

Users can choose Light, Dark, or System from Settings. The preference persists across relaunches; System follows live OS appearance changes, while explicit choices remain stable.

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run test` — 154 files, 1,675 tests
- `bun run --cwd apps/desktop test:e2e e2e/theme.spec.ts`
- independent standards and specification reviews completed with no remaining findings
