### PR TITLE
feat: add wide mode toggle for conversation column width

### DIFF
--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { App } from './App'
 import { startThemeSync } from './shell/theme-sync'
+import { initWideMode } from './shell/wide-mode-store'
 // Geist (Vercel) — bundled offline via @fontsource-variable, before styles.css so the
 // @font-face rules (and their bundled woff2) are registered when the tokens reference them.
 import '@fontsource-variable/geist'
@@ -9,6 +10,10 @@ import '@fontsource-variable/geist-mono'
 import './styles.css'
 
 async function mountApp(): Promise<void> {
+  // Seed the wide-mode preference from localStorage before first paint so the
+  // --conv-measure-max CSS variable is correct when React commits the shell.
+  initWideMode(window.localStorage)
+
   // Resolve and apply main's confirmed theme while the BrowserWindow is hidden.
   // The subscription is armed before the read, so a concurrent OS update wins.
   const stopThemeSync = await startThemeSync(window.api)

--- a/apps/desktop/src/renderer/src/settings/SettingsView.tsx
+++ b/apps/desktop/src/renderer/src/settings/SettingsView.tsx
@@ -65,9 +65,7 @@ export function SettingsView({
           Light, dark, or follow your OS appearance.
         </p>
         <ThemeControl />
-      </section>
-      <section className="flex flex-col gap-2">
-        <h2 className="text-[13px] font-semibold text-muted-foreground">Conversation width</h2>
+        <h3 className="pt-1 text-[13px] font-semibold text-muted-foreground">Conversation width</h3>
         <p className="text-[13px] text-muted-foreground">
           Standard caps the transcript at 830px; Wide lets it use the full outlet.
         </p>

--- a/apps/desktop/src/renderer/src/settings/SettingsView.tsx
+++ b/apps/desktop/src/renderer/src/settings/SettingsView.tsx
@@ -8,6 +8,7 @@ import { Button } from '../ui/button'
 import { IconButton } from '../ui/icon-button'
 import { Environment } from './Environment'
 import { ThemeControl } from './ThemeControl'
+import { WideModeControl } from './WideModeControl'
 
 /** The selected Workspace's connected agent + its advertised auth, for the Account section. */
 export interface AccountInfo {
@@ -64,6 +65,13 @@ export function SettingsView({
           Light, dark, or follow your OS appearance.
         </p>
         <ThemeControl />
+      </section>
+      <section className="flex flex-col gap-2">
+        <h2 className="text-[13px] font-semibold text-muted-foreground">Conversation width</h2>
+        <p className="text-[13px] text-muted-foreground">
+          Standard caps the transcript at 830px; Wide lets it use the full outlet.
+        </p>
+        <WideModeControl />
       </section>
       <section className="flex flex-col gap-2">
         <h2 className="text-[13px] font-semibold text-muted-foreground">Environment</h2>

--- a/apps/desktop/src/renderer/src/settings/WideModeControl.tsx
+++ b/apps/desktop/src/renderer/src/settings/WideModeControl.tsx
@@ -1,0 +1,45 @@
+import { type JSX } from 'react'
+import { useWideMode } from '../shell/wide-mode-store'
+import { cn } from '../lib/utils'
+
+/** Two-button toggle for the wide-mode reading-measure preference. */
+export function WideModeControl(): JSX.Element {
+  const [wide, setWide] = useWideMode()
+
+  return (
+    <div
+      className="flex overflow-hidden rounded-lg border border-border"
+      role="group"
+      aria-label="Conversation width"
+    >
+      <button
+        type="button"
+        onClick={() => setWide(false)}
+        aria-pressed={!wide}
+        title="Cap the conversation column at 830px"
+        className={cn(
+          'px-2.5 py-1 text-[13px] transition-colors',
+          !wide
+            ? 'bg-primary/10 text-primary'
+            : 'text-muted-foreground hover:text-primary',
+        )}
+      >
+        Standard
+      </button>
+      <button
+        type="button"
+        onClick={() => setWide(true)}
+        aria-pressed={wide}
+        title="Let the conversation column use the full outlet width"
+        className={cn(
+          'px-2.5 py-1 text-[13px] transition-colors',
+          wide
+            ? 'bg-primary/10 text-primary'
+            : 'text-muted-foreground hover:text-primary',
+        )}
+      >
+        Wide
+      </button>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/shell/EmptyState.tsx
+++ b/apps/desktop/src/renderer/src/shell/EmptyState.tsx
@@ -57,7 +57,7 @@ export function EmptyState({
     // the outlet) so first run doesn't look like an afterthought; the CLI
     // install steps ride along in a quiet card for users who land here fresh.
     return (
-      <div className="mx-auto flex h-full max-w-[830px] flex-col items-center justify-center gap-6 text-center">
+      <div className="conv-measure flex h-full flex-col items-center justify-center gap-6 text-center">
         <Logo size={52} />
         <h1 className="text-[37px] font-semibold tracking-[-0.6px] text-foreground">
           Open a <span className="text-primary">project</span> to begin
@@ -100,7 +100,7 @@ export function EmptyState({
   // selected Workspace name in orange (`--accent-emphasis`).
   const headline = heroHeadline(workspaceName)
   return (
-    <div className="mx-auto flex h-full max-w-[830px] flex-col items-center justify-center gap-6 text-center">
+    <div className="conv-measure flex h-full flex-col items-center justify-center gap-6 text-center">
       <Logo size={52} />
       <h1 className="text-[37px] font-semibold tracking-[-0.6px] text-foreground">
         {headline.lead}

--- a/apps/desktop/src/renderer/src/shell/Shell.tsx
+++ b/apps/desktop/src/renderer/src/shell/Shell.tsx
@@ -11,6 +11,7 @@ import {
   getSidebarWidth,
   setSidebarWidth,
 } from './sidebar-width-store'
+import { useWideMode } from './wide-mode-store'
 import { cn } from '../lib/utils'
 import { planLabel } from '../auth/plan-label'
 import { useAccountPlan } from '../auth/use-account-plan'
@@ -81,6 +82,10 @@ export function Shell({
   /** Open the Skills browser (#259) — from the primary nav's Skills row. */
   onOpenSkills: () => void
 }): JSX.Element {
+  // Wide mode: apply the --conv-measure-max CSS variable before paint. The
+  // hook is called here (Shell is always mounted) so the variable stays in
+  // sync even when Settings isn't open; the toggle itself lives in SettingsView.
+  useWideMode()
   // The sidebar's EXPANDED width (#drag-to-resize): renderer-only UI state, seeded from
   // localStorage (clamped) and persisted on drag-release. `dragging` disables the
   // collapse width-transition so the aside tracks the pointer 1:1 with no lag, and

--- a/apps/desktop/src/renderer/src/shell/wide-mode-store.test.ts
+++ b/apps/desktop/src/renderer/src/shell/wide-mode-store.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import {
+  DEFAULT_WIDE_MODE,
+  WIDE_MODE_STORAGE_KEY,
+  applyWideModeToDocument,
+  getWideMode,
+  initWideMode,
+  readWideMode,
+  setWideMode,
+  subscribeWideMode,
+} from './wide-mode-store'
+
+/** A minimal in-memory fake for the WideModeStorage interface. */
+function makeStorage(): { getItem: (k: string) => string | null; setItem: (k: string, v: string) => void } {
+  const store = new Map<string, string>()
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value)
+    },
+  }
+}
+
+/** A storage that throws on every access — simulates a blocked/corrupt store. */
+function throwingStorage(): { getItem: () => string | null; setItem: () => void } {
+  return {
+    getItem: () => {
+      throw new Error('blocked')
+    },
+    setItem: () => {
+      throw new Error('blocked')
+    },
+  }
+}
+
+describe('wide-mode-store', () => {
+  beforeEach(() => {
+    setWideMode(null, DEFAULT_WIDE_MODE)
+  })
+
+  describe('readWideMode', () => {
+    it('returns the default when storage is null', () => {
+      expect(readWideMode(null)).toBe(false)
+    })
+
+    it('returns false for an absent key', () => {
+      expect(readWideMode(makeStorage())).toBe(false)
+    })
+
+    it('returns true when the stored value is "true"', () => {
+      const storage = makeStorage()
+      storage.setItem(WIDE_MODE_STORAGE_KEY, 'true')
+      expect(readWideMode(storage)).toBe(true)
+    })
+
+    it('returns false for an unexpected stored value', () => {
+      const storage = makeStorage()
+      storage.setItem(WIDE_MODE_STORAGE_KEY, 'maybe')
+      expect(readWideMode(storage)).toBe(false)
+    })
+
+    it('falls back to the default when the store throws', () => {
+      expect(readWideMode(throwingStorage())).toBe(false)
+    })
+  })
+
+  describe('setWideMode', () => {
+    it('updates the in-memory state and persists to storage', () => {
+      const storage = makeStorage()
+      setWideMode(storage, true)
+      expect(getWideMode()).toBe(true)
+      expect(storage.getItem(WIDE_MODE_STORAGE_KEY)).toBe('true')
+    })
+
+    it('does not notify when the value is unchanged', () => {
+      let calls = 0
+      const unsubscribe = subscribeWideMode(() => {
+        calls++
+      })
+      setWideMode(null, false)
+      expect(calls).toBe(0)
+      unsubscribe()
+    })
+
+    it('notifies subscribers when the value changes', () => {
+      let calls = 0
+      const unsubscribe = subscribeWideMode(() => {
+        calls++
+      })
+      setWideMode(null, true)
+      expect(calls).toBe(1)
+      setWideMode(null, false)
+      expect(calls).toBe(2)
+      unsubscribe()
+    })
+
+    it('swallows a throwing store without losing the in-memory state', () => {
+      setWideMode(throwingStorage(), true)
+      expect(getWideMode()).toBe(true)
+    })
+  })
+
+  describe('initWideMode', () => {
+    it('loads the persisted value into the in-memory state', () => {
+      const storage = makeStorage()
+      storage.setItem(WIDE_MODE_STORAGE_KEY, 'true')
+      initWideMode(storage)
+      expect(getWideMode()).toBe(true)
+    })
+
+    it('is a no-op when the stored value matches the current state', () => {
+      let calls = 0
+      const unsubscribe = subscribeWideMode(() => {
+        calls++
+      })
+      initWideMode(makeStorage())
+      expect(calls).toBe(0)
+      unsubscribe()
+    })
+  })
+
+  describe('applyWideModeToDocument', () => {
+    it('does not throw when document is unavailable (node env guard)', () => {
+      expect(() => applyWideModeToDocument(true)).not.toThrow()
+      expect(() => applyWideModeToDocument(false)).not.toThrow()
+    })
+  })
+})

--- a/apps/desktop/src/renderer/src/shell/wide-mode-store.ts
+++ b/apps/desktop/src/renderer/src/shell/wide-mode-store.ts
@@ -1,0 +1,146 @@
+/**
+ * Wide mode: a renderer-only UI preference that lifts the conversation column's
+ * max-width cap so the transcript + composer use more of the available outlet
+ * width. Pure UI chrome — like the sidebar/side-panel width stores — so it lives
+ * in localStorage alone: no IPC, no main, no persistence store. Per-window.
+ *
+ * The store drives the `--conv-measure-max` CSS custom property on
+ * `document.documentElement`; `.conv-measure` in styles.css reads it with an
+ * 830px fallback, so the default (wide mode OFF) is pixel-identical to the
+ * pre-feature behaviour.
+ *
+ * The storage seam is INJECTED so tests pass a fake and render code passes
+ * `window.localStorage`; every path tolerates an unavailable/throwing/corrupt
+ * store and falls back to the default (wide mode OFF).
+ */
+
+import { useLayoutEffect, useSyncExternalStore } from 'react'
+
+/** The default state — the original 830px reading measure. */
+export const DEFAULT_WIDE_MODE = false
+
+/** The single localStorage key holding the wide-mode preference. */
+export const WIDE_MODE_STORAGE_KEY = 'vibe-mistro:wide-mode:v1'
+
+/** The value applied to --conv-measure-max when wide mode is ON. */
+export const CONV_MEASURE_MAX_WIDE = 'calc(100% - 6rem)'
+
+/** The value applied to --conv-measure-max when wide mode is OFF. */
+export const CONV_MEASURE_MAX_DEFAULT = '830px'
+
+/** The CSS custom property name set on document.documentElement. */
+export const CONV_MEASURE_MAX_PROPERTY = '--conv-measure-max'
+
+/** The slice of the Web Storage API we depend on — `window.localStorage` satisfies it. */
+export interface WideModeStorage {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+}
+
+// --- Module singleton (shared reactive state + localStorage persistence) ---
+
+let currentState: boolean = DEFAULT_WIDE_MODE
+const listeners = new Set<() => void>()
+
+/**
+ * Read the persisted preference from storage. Never throws — a blocked/throwing/
+ * corrupt store falls back to {@link DEFAULT_WIDE_MODE}.
+ */
+export function readWideMode(
+  storage: WideModeStorage | null | undefined,
+): boolean {
+  if (!storage) return DEFAULT_WIDE_MODE
+  try {
+    const raw = storage.getItem(WIDE_MODE_STORAGE_KEY)
+    if (raw === null) return DEFAULT_WIDE_MODE
+    return raw === 'true'
+  } catch {
+    return DEFAULT_WIDE_MODE
+  }
+}
+
+/** Persist the preference best-effort; a quota/security exception is swallowed. */
+function writeWideMode(
+  storage: WideModeStorage | null | undefined,
+  enabled: boolean,
+): void {
+  if (!storage) return
+  try {
+    storage.setItem(WIDE_MODE_STORAGE_KEY, String(enabled))
+  } catch {
+    // Best-effort: a full/blocked storage must never throw from a toggle.
+  }
+}
+
+/**
+ * Initialize from localStorage at module load (call once from a renderer entry
+ * point before first paint). Idempotent: a no-op if the stored value already
+ * matches the in-memory state. Safe to call with null/undefined storage.
+ */
+export function initWideMode(
+  storage: WideModeStorage | null | undefined,
+): void {
+  const stored = readWideMode(storage)
+  if (stored === currentState) return
+  currentState = stored
+  for (const listener of listeners) listener()
+}
+
+export function getWideMode(): boolean {
+  return currentState
+}
+
+export function subscribeWideMode(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+/**
+ * Toggle wide mode and persist to localStorage. Repeated values do not
+ * rerender subscribers.
+ */
+export function setWideMode(
+  storage: WideModeStorage | null | undefined,
+  enabled: boolean,
+): void {
+  if (enabled === currentState) return
+  currentState = enabled
+  writeWideMode(storage, enabled)
+  for (const listener of listeners) listener()
+}
+
+/**
+ * Apply the current wide-mode state to `document.documentElement` as the
+ * `--conv-measure-max` CSS custom property. Call from a `useLayoutEffect` so
+ * the property is set before paint, avoiding a flash of the default width.
+ */
+export function applyWideModeToDocument(enabled: boolean): void {
+  if (typeof document === 'undefined') return
+  document.documentElement.style.setProperty(
+    CONV_MEASURE_MAX_PROPERTY,
+    enabled ? CONV_MEASURE_MAX_WIDE : CONV_MEASURE_MAX_DEFAULT,
+  )
+}
+
+// --- React hook ---
+
+/**
+ * Subscribe to the wide-mode preference. Returns `[enabled, setEnabled]`.
+ * A `useLayoutEffect` applies the CSS custom property before paint so toggling
+ * is reflected without a flash. Call this from any always-mounted component
+ * (e.g. Shell) to keep `--conv-measure-max` in sync; the effect is idempotent.
+ */
+export function useWideMode(): [boolean, (next: boolean) => void] {
+  const enabled = useSyncExternalStore(subscribeWideMode, getWideMode)
+
+  useLayoutEffect(() => {
+    applyWideModeToDocument(enabled)
+  }, [enabled])
+
+  const set = (next: boolean): void => {
+    setWideMode(typeof window !== 'undefined' ? window.localStorage : null, next)
+  }
+  return [enabled, set]
+}

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -512,10 +512,12 @@ body {
 
 /* The conversation column's shared reading measure: transcript content and the
    Composer cap to the same centered width, so collapsing the sidebar/side panel
-   widens the outlet without the transcript sprawling past the composer. */
+   widens the outlet without the transcript sprawling past the composer.
+   --conv-measure-max is toggled by the wide-mode store (shell/wide-mode-store.ts);
+   when absent it falls back to the original 830px. */
 .conv-measure {
   width: 100%;
-  max-width: 830px;
+  max-width: var(--conv-measure-max, 830px);
   margin-inline: auto;
 }
 


### PR DESCRIPTION
Resolves #415.

## What

The conversation column (`.conv-measure`) is capped at `max-width: 830px`, which wastes space when the sidebar and side panel are collapsed on a wide monitor. The codebase's own comment notes that "the window stays wide, so viewport breakpoints would never fire."

This PR adds a **Standard / Wide** toggle in **Settings > Appearance** that lifts the cap to `calc(100% - 6rem)` when enabled.

## How

- **CSS custom property**: `.conv-measure` now reads `var(--conv-measure-max, 830px)`. The fallback is the original value, so the default (wide mode OFF) is pixel-identical to the pre-feature behaviour — zero visual change unless the user opts in.
- **Store** (`shell/wide-mode-store.ts`): renderer-only UI chrome persisted in `localStorage`, following the same pattern as the sidebar and side-panel width stores (`panel-width-store.ts`, `sidebar-width-store.ts`). Uses `useSyncExternalStore` for reactivity (same as `resolved-theme-store.ts`). Throw-tolerant storage seam — a blocked/corrupt store falls back to the default.
- **Hook** (`useWideMode`): a `useLayoutEffect` applies the CSS variable before paint so toggling is reflected without a flash.
- **Init**: `initWideMode(window.localStorage)` is called in `main.tsx` before first paint so the variable is correct on mount.
- **UI** (`WideModeControl.tsx`): two-button toggle matching the `ThemeControl` pattern.
- **Mount**: `Shell.tsx` calls `useWideMode()` (always mounted) to keep the variable in sync even when Settings isn't open.

## Files

| File | Change |
|---|---|
| `shell/wide-mode-store.ts` | New — pure store + `useWideMode` hook |
| `shell/wide-mode-store.test.ts` | New — 12 unit tests |
| `settings/WideModeControl.tsx` | New — two-button toggle |
| `settings/SettingsView.tsx` | Toggle added under Appearance section |
| `shell/Shell.tsx` | Mount `useWideMode()` for global CSS variable sync |
| `shell/EmptyState.tsx` | Replace `max-w-[830px]` with `conv-measure` class |
| `main.tsx` | Eager `initWideMode()` before first paint |
| `styles.css` | `.conv-measure` reads `var(--conv-measure-max, 830px)` |

## Gates

- `bun run lint` — pass
- `bun run typecheck` — pass
- `bun run --cwd apps/desktop build` — pass
- `bun run test` — pass (1687 tests, including 12 new)

## Design decisions

- **localStorage, not IPC**: wide mode is pure UI chrome (like panel widths), not durable state. Per AGENTS.md: "Renderer-only UI state stays in localStorage; durable state goes through IPC."
- **CSS variable, not conditional class**: changing one CSS property via `--conv-measure-max` is less invasive than conditionally adding/removing a class on all `conv-measure` elements (MessageScroller, ColdThread, Composer, EmptyState). The variable is set once on `document.documentElement`.
- **calc(100% - 6rem)**: leaves ~48px of margin on each side so the text doesn't sprawl edge-to-edge. The value is easy to tune.
- **Appearance section**: the toggle lives under Appearance (alongside ThemeControl) since both are visual preferences, rather than a standalone section.

Generated by Mistral Vibe.
Co-Authored-By: Mistral Vibe <vibe@mistral.ai>
