### PR TITLE
feat: responsive sidebar collapse + hover-to-peek

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -67,6 +67,14 @@ import {
   setSidebarCollapsed as setSidebarCollapsedStore,
 } from './shell/sidebar-collapsed-store'
 import {
+  SIDEBAR_COLLAPSE_QUERY,
+  nextSidebarToggle,
+  resolveSidebarLayout,
+  sidebarToggleExpands,
+} from './shell/sidebar-responsive'
+import { useSidebarPeek } from './shell/sidebar-peek'
+import { useMediaQuery } from './lib/use-media-query'
+import {
   closeWorkspaceSurface,
   getWorkspacePanel,
   openWorkspaceSideThreadSurface,
@@ -116,12 +124,43 @@ export function App(): JSX.Element {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() =>
     getSidebarCollapsed(window.localStorage),
   )
+  // Responsive collapse: below 1160px the sidebar folds itself. This is an OVERRIDE
+  // layered over the stored preference, never a write to it — see `sidebar-responsive.ts`.
+  // Widening the window therefore restores whatever the user actually chose.
+  const sidebarNarrow = useMediaQuery(SIDEBAR_COLLAPSE_QUERY)
+  // Pinned-open-while-narrow: transient by design (a narrow window is not a preference),
+  // so it resets whenever the window crosses the breakpoint.
+  const [sidebarNarrowOpen, setSidebarNarrowOpen] = useState(false)
+  useEffect(() => {
+    setSidebarNarrowOpen(false)
+  }, [sidebarNarrow])
+  const sidebarLayoutBase = resolveSidebarLayout({
+    stored: sidebarCollapsed,
+    narrow: sidebarNarrow,
+    peeking: false,
+    narrowOpen: sidebarNarrowOpen,
+  })
+  // Hover-to-peek is only armed when there IS something to reveal.
+  const sidebarPeek = useSidebarPeek(sidebarLayoutBase.collapsed)
+  const sidebarLayout = resolveSidebarLayout({
+    stored: sidebarCollapsed,
+    narrow: sidebarNarrow,
+    peeking: sidebarPeek.peeking,
+    narrowOpen: sidebarNarrowOpen,
+  })
   function toggleSidebar(): void {
-    setSidebarCollapsed((prev) => {
-      const next = !prev
-      setSidebarCollapsedStore(window.localStorage, next)
-      return next
+    // A click is an explicit decision: drop any hover-peek so the two don't fight.
+    sidebarPeek.cancelPeek()
+    const next = nextSidebarToggle({
+      stored: sidebarCollapsed,
+      narrow: sidebarNarrow,
+      narrowOpen: sidebarNarrowOpen,
     })
+    if (next.stored !== sidebarCollapsed) {
+      setSidebarCollapsed(next.stored)
+      setSidebarCollapsedStore(window.localStorage, next.stored)
+    }
+    setSidebarNarrowOpen(next.narrowOpen)
   }
   // The Search palette (#174): renderer-only open flag; ⌘K toggles it from
   // anywhere (window-level, so it works with the composer focused).
@@ -1009,11 +1048,15 @@ export function App(): JSX.Element {
         {/* Sidebar collapse toggle (#127): controls the left sidebar, so it sits in the
             header's LEFT region. Always visible (the header never hides), usable in both
             states; opts out of the drag region like every other header control. */}
-        <div className="ml-2 flex items-center [-webkit-app-region:no-drag]">
+        <div
+          className="ml-2 flex items-center [-webkit-app-region:no-drag]"
+          onMouseEnter={sidebarPeek.hoverProps.onMouseEnter}
+          onMouseLeave={sidebarPeek.hoverProps.onMouseLeave}
+        >
           <IconButton
             size="icon-sm"
-            aria-label={sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-            title={sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            aria-label={sidebarToggleExpands(sidebarLayout) ? 'Expand sidebar' : 'Collapse sidebar'}
+            title={sidebarToggleExpands(sidebarLayout) ? 'Expand sidebar' : 'Collapse sidebar'}
             onClick={toggleSidebar}
           >
             <PanelLeft className="size-4" aria-hidden />
@@ -1085,7 +1128,9 @@ export function App(): JSX.Element {
       )}
 
       <Shell
-        collapsed={sidebarCollapsed}
+        collapsed={sidebarLayout.collapsed}
+        overlay={sidebarLayout.overlay}
+        peekHoverProps={sidebarPeek.hoverProps}
         workspaces={recents}
         nav={nav}
         workspaceFlags={wsFlags}

--- a/apps/desktop/src/renderer/src/shell/Shell.tsx
+++ b/apps/desktop/src/renderer/src/shell/Shell.tsx
@@ -38,6 +38,8 @@ export type { WorkspaceFlags } from './workspace-nav'
  */
 export function Shell({
   collapsed,
+  overlay,
+  peekHoverProps,
   workspaces,
   nav,
   workspaceFlags,
@@ -54,6 +56,12 @@ export function Shell({
 }: {
   /** Whether the left sidebar is collapsed (#127) — animate its width to 0 (still mounted). */
   collapsed: boolean
+  /** Whether the sidebar FLOATS above the outlet instead of pushing it (hover-peek, or
+   * the toggle pressed while the window is narrow). See `shell/sidebar-responsive.ts`. */
+  overlay: boolean
+  /** Hover handlers shared with the header's collapse toggle, so travelling between the
+   * toggle and the revealed sidebar reads as one hover and never closes mid-traverse. */
+  peekHoverProps: { onMouseEnter: () => void; onMouseLeave: () => void }
   /** Persisted Workspaces (cold metadata) for the switcher rows + display names. */
   workspaces: ListMetadataResult
   /** The current navigation selection (controlled by App). */
@@ -125,6 +133,11 @@ export function Shell({
     if (collapsed) setDragging(false)
   }, [collapsed])
 
+  // Off-screen entirely: collapsed AND not floating. An overlaid sidebar is collapsed for
+  // LAYOUT (the outlet keeps its width) but fully present for the user, so it must stay in
+  // the a11y tree and keep its border.
+  const hidden = collapsed && !overlay
+
   return (
     <div className={cn('flex min-h-0 flex-1', dragging && 'select-none')}>
       {/* The sidebar stays MOUNTED when collapsed (#127) — its state (open projects,
@@ -138,12 +151,28 @@ export function Shell({
           transition is disabled WHILE DRAGGING so the aside tracks the pointer with no
           lag, but kept for the collapse animation. */}
       <aside
-        aria-hidden={collapsed || undefined}
-        inert={collapsed || undefined}
-        style={{ width: collapsed ? 0 : width }}
+        onMouseEnter={peekHoverProps.onMouseEnter}
+        onMouseLeave={peekHoverProps.onMouseLeave}
+        aria-hidden={hidden || undefined}
+        inert={hidden || undefined}
+        // Floating is done with a NEGATIVE MARGIN, not `position: absolute`. A flex item
+        // consumes `width + margin`, so -width cancels the width and the outlet keeps its
+        // full size while the sidebar paints over it. Crucially both properties animate
+        // with the SAME duration and easing, so during the peek's open/close transition
+        // they cancel at EVERY frame — the outlet never moves, not even mid-animation.
+        //
+        // `position: absolute` cannot do this: leaving the flow is instantaneous, so the
+        // aside would rejoin the flow at full width on close and shove the outlet across
+        // for the length of the transition.
+        //
+        // The pinned collapse (the toggle on a wide window) is untouched — margin stays 0
+        // there, so the width animation still pushes the outlet exactly as it always has.
+        style={{ width: hidden ? 0 : width, marginRight: overlay ? -width : 0 }}
         className={cn(
-          'flex flex-none overflow-hidden border-border bg-sidebar transition-[width] duration-200',
-          collapsed ? 'border-r-0' : 'border-r',
+          'flex flex-none overflow-hidden border-border bg-sidebar transition-[width,margin-right] duration-200',
+          hidden ? 'border-r-0' : 'border-r',
+          // z-index applies to flex items without positioning; the shadow sells "above".
+          overlay && 'relative z-30 shadow-2xl',
           dragging && 'transition-none',
         )}
       >

--- a/apps/desktop/src/renderer/src/shell/sidebar-peek.test.ts
+++ b/apps/desktop/src/renderer/src/shell/sidebar-peek.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+import {
+  PEEK_CLOSE_DELAY_MS,
+  PEEK_OPEN_DELAY_MS,
+  createPeekController,
+  type PeekTimers,
+} from './sidebar-peek'
+
+/** A synchronous fake clock — the injected timer seam, driven by hand. */
+function fakeTimers(): PeekTimers & { advance: (ms: number) => void; pending: () => number } {
+  let now = 0
+  let nextHandle = 1
+  const queued = new Map<number, { at: number; fn: () => void }>()
+  return {
+    setTimeout(fn: () => void, ms: number): number {
+      const handle = nextHandle++
+      queued.set(handle, { at: now + ms, fn })
+      return handle
+    },
+    clearTimeout(handle: number): void {
+      queued.delete(handle)
+    },
+    advance(ms: number): void {
+      now += ms
+      for (const [handle, entry] of [...queued]) {
+        if (entry.at <= now) {
+          queued.delete(handle)
+          entry.fn()
+        }
+      }
+    },
+    pending: () => queued.size,
+  }
+}
+
+function setup() {
+  const timers = fakeTimers()
+  const changes: boolean[] = []
+  const controller = createPeekController({ onChange: (v) => changes.push(v), timers })
+  return { timers, changes, controller }
+}
+
+describe('createPeekController', () => {
+  it('does not reveal until the open delay elapses', () => {
+    const { timers, changes, controller } = setup()
+    controller.pointerEnter()
+    timers.advance(PEEK_OPEN_DELAY_MS - 1)
+    expect(changes).toEqual([])
+    timers.advance(1)
+    expect(changes).toEqual([true])
+  })
+
+  it('swallows a pointer passing straight through the toggle', () => {
+    const { timers, changes, controller } = setup()
+    controller.pointerEnter()
+    timers.advance(PEEK_OPEN_DELAY_MS - 50)
+    controller.pointerLeave()
+    timers.advance(1000)
+    expect(changes).toEqual([])
+    expect(timers.pending()).toBe(0)
+  })
+
+  it('keeps the sidebar open while crossing the gap from toggle to sidebar', () => {
+    const { timers, changes, controller } = setup()
+    controller.pointerEnter()
+    timers.advance(PEEK_OPEN_DELAY_MS)
+    expect(changes).toEqual([true])
+    // Leaving the toggle, then landing on the sidebar before the grace expires.
+    controller.pointerLeave()
+    timers.advance(PEEK_CLOSE_DELAY_MS - 60)
+    controller.pointerEnter()
+    timers.advance(1000)
+    expect(changes).toEqual([true])
+  })
+
+  it('closes once the pointer stays away past the close delay', () => {
+    const { timers, changes, controller } = setup()
+    controller.pointerEnter()
+    timers.advance(PEEK_OPEN_DELAY_MS)
+    controller.pointerLeave()
+    timers.advance(PEEK_CLOSE_DELAY_MS - 1)
+    expect(changes).toEqual([true])
+    timers.advance(1)
+    expect(changes).toEqual([true, false])
+  })
+
+  it('emits only on CHANGE, never a repeat', () => {
+    const { timers, changes, controller } = setup()
+    controller.pointerEnter()
+    timers.advance(PEEK_OPEN_DELAY_MS)
+    controller.pointerEnter()
+    timers.advance(1000)
+    expect(changes).toEqual([true])
+  })
+
+  it('cancel() closes immediately and drops a pending open', () => {
+    const { timers, changes, controller } = setup()
+    controller.pointerEnter()
+    timers.advance(PEEK_OPEN_DELAY_MS)
+    controller.cancel()
+    expect(changes).toEqual([true, false])
+    controller.pointerEnter()
+    controller.cancel()
+    timers.advance(1000)
+    expect(changes).toEqual([true, false])
+  })
+
+  it('cancel() on a closed controller emits nothing', () => {
+    const { changes, controller } = setup()
+    controller.cancel()
+    expect(changes).toEqual([])
+  })
+
+  it('dispose() drops pending timers WITHOUT emitting', () => {
+    const { timers, changes, controller } = setup()
+    controller.pointerEnter()
+    controller.dispose()
+    timers.advance(1000)
+    expect(changes).toEqual([])
+    expect(timers.pending()).toBe(0)
+  })
+
+  it('leaves no timer behind after a full open/close cycle', () => {
+    const { timers, controller } = setup()
+    controller.pointerEnter()
+    timers.advance(PEEK_OPEN_DELAY_MS)
+    controller.pointerLeave()
+    timers.advance(PEEK_CLOSE_DELAY_MS)
+    expect(timers.pending()).toBe(0)
+  })
+
+  it('opens faster than it closes, so intent is required but the gap is forgiving', () => {
+    expect(PEEK_OPEN_DELAY_MS).toBeLessThan(PEEK_CLOSE_DELAY_MS)
+  })
+})

--- a/apps/desktop/src/renderer/src/shell/sidebar-peek.ts
+++ b/apps/desktop/src/renderer/src/shell/sidebar-peek.ts
@@ -1,0 +1,138 @@
+/**
+ * Hover-to-peek for the collapsed left sidebar: hovering the header's collapse toggle
+ * reveals the sidebar as an overlay, and leaving it hides it again.
+ *
+ * Hover reveals need INTENT, not raw events. A pointer crossing the toggle on its way
+ * somewhere else must not fling the sidebar open, and the short gap between the toggle
+ * and the revealed sidebar must not slam it shut mid-traverse. Two asymmetric delays do
+ * that: a short open delay swallows pass-through, and a longer close delay tolerates the
+ * gap. The toggle and the sidebar share ONE controller, so moving between them is just
+ * leave-then-enter and the pending close is cancelled.
+ *
+ * The timer seam is INJECTED so tests drive it synchronously with fakes — the repo tests
+ * renderer logic as pure modules in the `node` environment, never through the DOM.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+/** Pointer must rest this long before the sidebar reveals — swallows pass-through. */
+export const PEEK_OPEN_DELAY_MS = 180
+
+/** Grace after the pointer leaves — long enough to cross the gap from toggle to sidebar. */
+export const PEEK_CLOSE_DELAY_MS = 260
+
+/** The slice of the timer API we depend on — `window` satisfies it. */
+export interface PeekTimers {
+  setTimeout(handler: () => void, ms: number): number
+  clearTimeout(handle: number): void
+}
+
+export interface PeekController {
+  /** Pointer entered the toggle OR the revealed sidebar. */
+  pointerEnter(): void
+  /** Pointer left the toggle OR the revealed sidebar. */
+  pointerLeave(): void
+  /** Close immediately and drop any pending transition (a click pins or unpins instead). */
+  cancel(): void
+  /** Drop pending timers WITHOUT emitting — for unmount. */
+  dispose(): void
+}
+
+/**
+ * The hover-intent state machine. Pure apart from the injected timers: it owns the
+ * open/closed flag and emits every CHANGE through `onChange`, never a repeat.
+ */
+export function createPeekController({
+  onChange,
+  timers,
+  openDelayMs = PEEK_OPEN_DELAY_MS,
+  closeDelayMs = PEEK_CLOSE_DELAY_MS,
+}: {
+  onChange: (peeking: boolean) => void
+  timers: PeekTimers
+  openDelayMs?: number
+  closeDelayMs?: number
+}): PeekController {
+  let open = false
+  let pending: number | null = null
+
+  function clearPending(): void {
+    if (pending === null) return
+    timers.clearTimeout(pending)
+    pending = null
+  }
+
+  function settle(next: boolean): void {
+    pending = null
+    if (open === next) return
+    open = next
+    onChange(next)
+  }
+
+  return {
+    pointerEnter(): void {
+      clearPending()
+      if (open) return
+      pending = timers.setTimeout(() => settle(true), openDelayMs)
+    },
+    pointerLeave(): void {
+      clearPending()
+      if (!open) return
+      pending = timers.setTimeout(() => settle(false), closeDelayMs)
+    },
+    cancel(): void {
+      clearPending()
+      if (!open) return
+      open = false
+      onChange(false)
+    },
+    dispose(): void {
+      clearPending()
+    },
+  }
+}
+
+/** Mouse handlers to spread onto the toggle and the revealed sidebar. */
+export interface PeekHoverProps {
+  onMouseEnter: () => void
+  onMouseLeave: () => void
+}
+
+/**
+ * React binding for {@link createPeekController}. `enabled` gates the whole behaviour —
+ * an expanded sidebar has nothing to peek at, and flipping to disabled closes any peek
+ * in flight.
+ *
+ * MOUSE events, not pointer events: a pointer enter also fires for touch and pen, where
+ * there is no hover and the reveal would strand with no matching leave.
+ */
+export function useSidebarPeek(enabled: boolean): {
+  peeking: boolean
+  hoverProps: PeekHoverProps
+  cancelPeek: () => void
+} {
+  const [peeking, setPeeking] = useState(false)
+  const controller = useMemo(
+    () => createPeekController({ onChange: setPeeking, timers: window }),
+    [],
+  )
+  const controllerRef = useRef(controller)
+  controllerRef.current = controller
+
+  useEffect(() => () => controllerRef.current.dispose(), [])
+  useEffect(() => {
+    if (!enabled) controller.cancel()
+  }, [enabled, controller])
+
+  const onMouseEnter = useCallback(() => {
+    if (enabled) controller.pointerEnter()
+  }, [enabled, controller])
+  const onMouseLeave = useCallback(() => {
+    controller.pointerLeave()
+  }, [controller])
+  const cancelPeek = useCallback(() => {
+    controller.cancel()
+  }, [controller])
+
+  return { peeking, hoverProps: { onMouseEnter, onMouseLeave }, cancelPeek }
+}

--- a/apps/desktop/src/renderer/src/shell/sidebar-responsive.test.ts
+++ b/apps/desktop/src/renderer/src/shell/sidebar-responsive.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+import {
+  SIDEBAR_COLLAPSE_QUERY,
+  nextSidebarToggle,
+  resolveSidebarLayout,
+  sidebarToggleExpands,
+} from './sidebar-responsive'
+
+const WIDE = { narrow: false, peeking: false, narrowOpen: false }
+const NARROW = { narrow: true, peeking: false, narrowOpen: false }
+
+describe('SIDEBAR_COLLAPSE_QUERY', () => {
+  it('is a stable module constant, and staggers ABOVE the side panel 980px breakpoint', () => {
+    expect(SIDEBAR_COLLAPSE_QUERY).toBe('(max-width: 1160px)')
+  })
+})
+
+describe('resolveSidebarLayout', () => {
+  it('expands inline on a wide window when nothing is stored', () => {
+    expect(resolveSidebarLayout({ ...WIDE, stored: false })).toEqual({
+      collapsed: false,
+      overlay: false,
+    })
+  })
+
+  it('honours the stored collapse on a wide window', () => {
+    expect(resolveSidebarLayout({ ...WIDE, stored: true })).toEqual({
+      collapsed: true,
+      overlay: false,
+    })
+  })
+
+  it('collapses on a narrow window even when the user stored EXPANDED', () => {
+    expect(resolveSidebarLayout({ ...NARROW, stored: false })).toEqual({
+      collapsed: true,
+      overlay: false,
+    })
+  })
+
+  it('overlays — never un-collapses — when peeking a collapsed sidebar', () => {
+    expect(resolveSidebarLayout({ ...WIDE, stored: true, peeking: true })).toEqual({
+      collapsed: true,
+      overlay: true,
+    })
+  })
+
+  it('ignores a peek while the sidebar is already expanded', () => {
+    expect(resolveSidebarLayout({ ...WIDE, stored: false, peeking: true })).toEqual({
+      collapsed: false,
+      overlay: false,
+    })
+  })
+
+  it('overlays a peek on a narrow window regardless of what is stored', () => {
+    expect(resolveSidebarLayout({ ...NARROW, stored: false, peeking: true })).toEqual({
+      collapsed: true,
+      overlay: true,
+    })
+  })
+
+  it('overlays when the toggle pinned it open while narrow', () => {
+    expect(resolveSidebarLayout({ ...NARROW, stored: false, narrowOpen: true })).toEqual({
+      collapsed: true,
+      overlay: true,
+    })
+  })
+
+  it('keeps the outlet full-width in EVERY narrow case (an overlay never pushes)', () => {
+    for (const peeking of [true, false]) {
+      for (const narrowOpen of [true, false]) {
+        for (const stored of [true, false]) {
+          expect(resolveSidebarLayout({ narrow: true, peeking, narrowOpen, stored }).collapsed).toBe(
+            true,
+          )
+        }
+      }
+    }
+  })
+})
+
+describe('nextSidebarToggle', () => {
+  it('flips the stored preference on a wide window', () => {
+    expect(nextSidebarToggle({ stored: false, narrow: false, narrowOpen: false })).toEqual({
+      stored: true,
+      narrowOpen: false,
+    })
+    expect(nextSidebarToggle({ stored: true, narrow: false, narrowOpen: false })).toEqual({
+      stored: false,
+      narrowOpen: false,
+    })
+  })
+
+  it('clears a transient narrow overlay when the window is wide', () => {
+    expect(nextSidebarToggle({ stored: true, narrow: false, narrowOpen: true }).narrowOpen).toBe(
+      false,
+    )
+  })
+
+  it('toggles the transient overlay while narrow and LEAVES the stored preference alone', () => {
+    expect(nextSidebarToggle({ stored: false, narrow: true, narrowOpen: false })).toEqual({
+      stored: false,
+      narrowOpen: true,
+    })
+    expect(nextSidebarToggle({ stored: true, narrow: true, narrowOpen: true })).toEqual({
+      stored: true,
+      narrowOpen: false,
+    })
+  })
+
+  it('never leaves the button inert while narrow — one press always changes the layout', () => {
+    // The regression this guards: with a naive `stored || narrow`, pressing the toggle
+    // while narrow flips a flag nothing reads, so the sidebar never moves.
+    const before = resolveSidebarLayout({ stored: false, narrow: true, peeking: false, narrowOpen: false })
+    const next = nextSidebarToggle({ stored: false, narrow: true, narrowOpen: false })
+    const after = resolveSidebarLayout({ ...next, narrow: true, peeking: false })
+    expect(after).not.toEqual(before)
+    expect(after.overlay).toBe(true)
+  })
+})
+
+describe('sidebarToggleExpands', () => {
+  it('reads as "will expand" only when nothing is on screen', () => {
+    expect(sidebarToggleExpands({ collapsed: true, overlay: false })).toBe(true)
+    expect(sidebarToggleExpands({ collapsed: true, overlay: true })).toBe(false)
+    expect(sidebarToggleExpands({ collapsed: false, overlay: false })).toBe(false)
+  })
+})

--- a/apps/desktop/src/renderer/src/shell/sidebar-responsive.ts
+++ b/apps/desktop/src/renderer/src/shell/sidebar-responsive.ts
@@ -1,0 +1,88 @@
+/**
+ * Responsive collapse + overlay presentation for the left sidebar.
+ *
+ * Two behaviours resolve here, as ONE pure function, because they interact:
+ *
+ * 1. RESPONSIVE COLLAPSE — below a width threshold the sidebar folds itself, and
+ *    unfolds when the window grows back.
+ * 2. OVERLAY — a temporarily-revealed sidebar (hover-peek, or the toggle pressed
+ *    while the window is narrow) floats ABOVE the outlet instead of pushing it, so
+ *    a hover never reflows the conversation under the pointer.
+ *
+ * The breakpoint is 1160px: the point where the sidebar's default 338px and the
+ * conversation's 830px reading measure stop both fitting. It deliberately does NOT
+ * reuse the side panel's 980px `NARROW_QUERY` (`side-panel/SurfacePanel.tsx`) —
+ * staggering the two thresholds degrades the shell in two calm steps as the window
+ * narrows, instead of folding the sidebar AND swapping the side panel to a Sheet at
+ * the same instant.
+ *
+ * CRITICAL: the responsive state is an OVERRIDE, never a write. `sidebar-collapsed-store`
+ * holds the user's explicit choice and this module never touches it, so widening the
+ * window restores whatever they picked. Persisting `true` on resize would silently
+ * destroy that preference — the sidebar would stay shut after the window grew back.
+ */
+
+/** Below this width the sidebar folds itself. Stable module constant — `useMediaQuery` re-subscribes on a new string. */
+export const SIDEBAR_COLLAPSE_QUERY = '(max-width: 1160px)'
+
+/** How the sidebar renders: whether the outlet reclaims its space, and whether it floats. */
+export interface SidebarLayout {
+  /** The outlet reclaims the sidebar's space (the aside animates to 0 width). */
+  collapsed: boolean
+  /** The aside floats ABOVE the outlet at full width, leaving the layout untouched. */
+  overlay: boolean
+}
+
+export interface SidebarLayoutInput {
+  /** The user's persisted choice (`sidebar-collapsed-store`). */
+  stored: boolean
+  /** Whether the window is under {@link SIDEBAR_COLLAPSE_QUERY}. */
+  narrow: boolean
+  /** Whether a hover-peek is currently revealing the sidebar. */
+  peeking: boolean
+  /** Whether the toggle pinned the sidebar open WHILE narrow (transient, never persisted). */
+  narrowOpen: boolean
+}
+
+/**
+ * Resolve the sidebar's presentation. Pure — the single source of truth for
+ * "is it folded, and is it floating".
+ *
+ * While narrow the layout is ALWAYS collapsed: a narrow window has no room to give,
+ * so any reveal is an overlay. While wide the stored preference wins, and a peek can
+ * only overlay a sidebar that is already collapsed (there is nothing to reveal otherwise).
+ */
+export function resolveSidebarLayout(input: SidebarLayoutInput): SidebarLayout {
+  if (input.narrow) {
+    return { collapsed: true, overlay: input.peeking || input.narrowOpen }
+  }
+  return { collapsed: input.stored, overlay: input.stored && input.peeking }
+}
+
+/** The state the toggle button moves to. Separated from the reducer so App stays a thin wrapper. */
+export interface SidebarToggleState {
+  stored: boolean
+  narrowOpen: boolean
+}
+
+/**
+ * What pressing the collapse toggle does.
+ *
+ * While NARROW it opens/closes the transient overlay and leaves the stored preference
+ * alone — otherwise the button would look broken, since `resolveSidebarLayout` forces
+ * `collapsed` regardless of what is stored. While WIDE it flips the stored preference
+ * and clears any transient overlay.
+ */
+export function nextSidebarToggle(input: {
+  stored: boolean
+  narrow: boolean
+  narrowOpen: boolean
+}): SidebarToggleState {
+  if (input.narrow) return { stored: input.stored, narrowOpen: !input.narrowOpen }
+  return { stored: !input.stored, narrowOpen: false }
+}
+
+/** Whether the toggle currently reads as "will expand" — drives its label and tooltip. */
+export function sidebarToggleExpands(layout: SidebarLayout): boolean {
+  return layout.collapsed && !layout.overlay
+}


### PR DESCRIPTION
## What

The left sidebar never reacted to window size — it only folded when the header toggle was pressed. It now:

- **folds itself below 1160px** and unfolds when the window grows back, and
- **reveals as an overlay on hover** of the header toggle.

## Patterns

Two distinct patterns, with different failure modes:

- **Responsive (adaptive) collapse** — the expanded state is a navigation drawer, the folded state a rail; the width threshold switches between them.
- **Hover-to-peek** (flyout / overlay drawer) — the reveal **overlays** the outlet rather than pushing it, so a hover never reflows the conversation under the pointer.

## How

Two pure modules carry the logic, tested in the `node` environment per the repo's convention (no jsdom):

| Module | Responsibility |
|---|---|
| `shell/sidebar-responsive.ts` | Resolves presentation (collapsed / overlay) from the stored preference, the breakpoint, and the transient reveal states. 13 tests. |
| `shell/sidebar-peek.ts` | Hover-intent state machine + `useSidebarPeek`. Timers injected so tests drive them synchronously. 11 tests. |

`App.tsx` and `Shell.tsx` stay thin wrappers over them.

Hover uses **asymmetric intent delays**: 180ms to open, so a pointer crossing the toggle doesn't fling it open; 260ms to close, so the gap between toggle and sidebar doesn't slam it shut mid-traverse. The toggle and the sidebar share one controller, so travelling between them reads as a single hover.

## Three decisions worth reviewing

**1. The responsive state is an OVERRIDE, never a write.** Narrowing the window does not persist `collapsed: true`, so widening restores whatever the user actually chose. Writing on resize would silently destroy the preference — the sidebar would stay shut after the window grew back.

**2. While narrow, the toggle drives a separate transient overlay** rather than the stored flag. A naive `stored || narrow` leaves the button inert: pressed, it flips a flag nothing reads and the sidebar never moves. `nextSidebarToggle` covers that case, and there is a regression test pinning it.

**3. The overlay uses a NEGATIVE MARGIN, not `position: absolute`.** A flex item consumes `width + margin`, so `-width` cancels the width and the outlet keeps its size while the sidebar paints over it. Both properties share one transition, so they cancel at *every frame*.

`position: absolute` cannot do this — leaving the flow is instantaneous and cannot be eased, so on close the aside rejoined the flow at full width and animated down from there. Measured, sampling the outlet across the close transition:

| Approach | Distinct outlet widths during close | Range |
|---|---|---|
| `position: absolute` | 23 | 671 → 1000 px |
| negative margin | 1 | 1000 px, constant |

That ~330px shove-and-spring was visible in the app; the negative-margin version does not move at all.

The **pinned collapse** (toggle on a wide window) is untouched — margin stays 0 there, so the width animation still pushes the outlet exactly as it always has. That push is intentional; only the hover-peek needed to be weightless.

## Breakpoint choice

1160px = the sidebar's default 338px + the conversation's 830px reading measure — the point where both stop fitting.

It deliberately does **not** reuse the side panel's 980px `NARROW_QUERY` (`side-panel/SurfacePanel.tsx`). Staggering the two degrades the shell in two calm steps as the window narrows, instead of folding the sidebar and swapping the side panel to a Sheet at the same instant.

## Gates

- `bun run lint` — pass
- `bun run typecheck` — pass
- `bun run build` — pass
- `bun run test` — pass (**1699** tests: 1675 baseline + 24 new)

## Not included

- Click-outside-to-close on the narrow overlay.
- A scrim — the peeked sidebar paints over the conversation, but the conversation is still interactive underneath.
- No keyboard equivalent for the peek (hover-only by nature). The click path covers keyboard users, so nothing is unreachable.
