### PR TITLE
Reserve the threads row before session/new (#417)

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -662,7 +662,10 @@ async function runPromptTurn(
   // Thread whose stored session isn't hosted resumes via `session/load` (re-binding
   // fresh on a resume failure); an already-bound Thread reuses its session — no
   // second `session/new`. A binding failure surfaces WITHOUT teeing: nothing was
-  // logged yet, so a failed first prompt leaves no transcript residue.
+  // logged yet, so a failed first prompt leaves no transcript residue — and the
+  // draft's mint RESERVES its `threads` row before the `session/new` round-trip
+  // (#417), releasing it again if the mint fails, so the bridge below is never
+  // pointed at a Thread whose row doesn't exist yet.
   let sessionId: string
   let rebound: boolean
   try {

--- a/apps/desktop/src/main/persistence/transcript-bridge.ts
+++ b/apps/desktop/src/main/persistence/transcript-bridge.ts
@@ -17,6 +17,11 @@ import type { TranscriptEntry } from './transcript'
  * not rendered) is dropped from replay. The Thread title is unaffected — it's also
  * persisted in the metadata record.
  *
+ * A tee routed through the FALLBACK map for a Thread whose row isn't written yet used
+ * to reach the sink and be rejected by the transcript FK (#417). The mint now RESERVES
+ * the `threads` row before the `session/new` round-trip (`thread-binding.ts`), so a
+ * bound Thread id always has a parent row and those entries persist.
+ *
  * TOMBSTONES: Thread ids whose JSONL has been (or is being) removed and must NEVER be
  * re-created ("Remove project" — a Workspace can be removed MID-TURN).
  * `TranscriptStore.delete` only drops the tail of the append chain; it can't cancel a

--- a/apps/desktop/src/main/thread-binding.test.ts
+++ b/apps/desktop/src/main/thread-binding.test.ts
@@ -4,6 +4,8 @@ import { ensureBoundSession, resolveContinueTarget, type SessionBinder } from '.
 import { openStateDb } from './persistence/sqlite-db'
 import { SqliteMetadataStore } from './persistence/sqlite-metadata-store'
 import { STATE_MIGRATIONS } from './persistence/state-migrations'
+import { SqliteTranscriptStore } from './persistence/sqlite-transcript-store'
+import { acpEventEntry } from './persistence/transcript'
 import { SessionLoadError, WorkspaceAgentError } from './workspace-agent'
 import type { ThreadInfo } from '../shared/ipc'
 
@@ -343,3 +345,111 @@ describe('resolveContinueTarget — continue without opening a Thread (TB4 #33)'
 function randomName(): string {
   return Math.random().toString(36).slice(2, 10)
 }
+
+/**
+ * The transcript-tee race (#417). `transcript_entries.thread_id` references
+ * `threads(id)`, and `runPromptTurn` points the transcript bridge at the Thread
+ * BEFORE awaiting the bind — so every event teed while a draft's `session/new` was
+ * in flight hit the foreign key and was silently dropped. The mint now reserves the
+ * row up front, and releases it again if the mint fails so the "a failed first
+ * prompt leaves no residue" guarantee survives. Pinned at the store seam over a REAL
+ * database, with the tee fired from INSIDE `openThread` to sit in the window.
+ */
+describe('ensureBoundSession — the threads row is reserved across session/new (#417)', () => {
+  interface RaceFixture {
+    meta: SqliteMetadataStore
+    transcripts: SqliteTranscriptStore
+    workspaceId: string
+  }
+
+  async function raceFixture(): Promise<RaceFixture> {
+    const stateDb = openStateDb({ path: ':memory:', migrations: STATE_MIGRATIONS })
+    const meta = new SqliteMetadataStore({ stateDb })
+    await meta.load()
+    const ws = await meta.upsertWorkspace({ dir: `/proj/${randomName()}` })
+    return { meta, transcripts: new SqliteTranscriptStore({ stateDb }), workspaceId: ws.id }
+  }
+
+  /** A binder whose `session/new` round-trip runs `duringFlight` before resolving. */
+  function racingOpener(duringFlight: () => Promise<void>, outcome?: Error): SessionBinder {
+    return {
+      loadSessionAvailable: true,
+      hasSession: () => false,
+      loadThread() {
+        throw new Error('loadThread should not be called here')
+      },
+      async openThread(): Promise<ThreadInfo> {
+        await duringFlight()
+        if (outcome) throw outcome
+        return { sessionId: 'sess-1', title: null, modes: null, models: null, reasoningEffort: null }
+      },
+    }
+  }
+
+  it('persists an event teed while a draft session/new is still in flight', async () => {
+    const { meta, transcripts, workspaceId } = await raceFixture()
+    const threadId = randomUUID()
+    const teed = acpEventEntry({ method: 'session/update', params: { sessionId: 'sess-1' } })
+    // The bridge is already pointed at this draft, so the in-flight event tees to
+    // it — the append that used to fail with FOREIGN KEY constraint failed.
+    const agent = racingOpener(async () => {
+      expect(meta.snapshot().threads.map((t) => t.id)).toContain(threadId) // reserved
+      await transcripts.append(threadId, teed)
+    })
+
+    const bound = await ensureBoundSession({ agent, store: meta, threadId, workspaceId, sessionId: null })
+
+    expect(bound).toMatchObject({ sessionId: 'sess-1', minted: true })
+    expect(await transcripts.read(threadId)).toEqual([teed]) // kept, not silently lost
+    // The reservation is the SAME row the bind fills in — one record, one cursor.
+    const threads = meta.snapshot().threads
+    expect(threads).toHaveLength(1)
+    expect(threads[0]).toMatchObject({ id: threadId, sessionId: 'sess-1' })
+  })
+
+  it('releases the reserved row (and anything teed into it) when the mint fails', async () => {
+    const { meta, transcripts, workspaceId } = await raceFixture()
+    const threadId = randomUUID()
+    const boom = new WorkspaceAgentError('session/new failed', null, null)
+    const agent = racingOpener(
+      () => transcripts.append(threadId, acpEventEntry({ method: 'session/update' })),
+      boom,
+    )
+
+    await expect(
+      ensureBoundSession({ agent, store: meta, threadId, workspaceId, sessionId: null }),
+    ).rejects.toBe(boom)
+
+    // A failed first prompt leaves NO residue: no record, and the cascade took the
+    // orphaned entry with it.
+    expect(meta.snapshot().threads).toHaveLength(0)
+    expect(await transcripts.read(threadId)).toEqual([])
+  })
+
+  it('leaves an ALREADY-persisted Thread alone when a re-bind mint fails', async () => {
+    const { meta, transcripts, workspaceId } = await raceFixture()
+    const threadId = (await meta.upsertThread({ workspaceId, sessionId: 'dead-sess' })).id
+    const kept = acpEventEntry({ method: 'session/update', params: { sessionId: 'dead-sess' } })
+    await transcripts.append(threadId, kept)
+    const boom = new WorkspaceAgentError('session/new failed', null, null)
+    const agent: SessionBinder = {
+      loadSessionAvailable: true,
+      hasSession: () => false,
+      async loadThread(): Promise<ThreadInfo> {
+        throw new SessionLoadError('Session not found: dead-sess')
+      },
+      async openThread(): Promise<ThreadInfo> {
+        throw boom
+      },
+    }
+
+    // Resume fails, so the re-bind mints — and that fails too. The reservation
+    // rollback must NOT touch a row this bind didn't create.
+    await expect(
+      ensureBoundSession({ agent, store: meta, threadId, workspaceId, sessionId: 'dead-sess' }),
+    ).rejects.toBe(boom)
+
+    expect(meta.snapshot().threads.find((t) => t.id === threadId)?.sessionId).toBe('dead-sess')
+    expect(await transcripts.read(threadId)).toEqual([kept])
+  })
+})

--- a/apps/desktop/src/main/thread-binding.ts
+++ b/apps/desktop/src/main/thread-binding.ts
@@ -36,13 +36,20 @@ export interface SessionBinder extends SessionOpener {
   readonly loadSessionAvailable: boolean
 }
 
-/** The minimal store surface for binding: re-target a Thread by id (upsert). */
+/**
+ * The minimal store surface for binding: re-target a Thread by id (upsert), plus
+ * the two reads/writes the RESERVATION needs (#417) — `snapshot` to tell a row this
+ * bind created from one that was already there, and `deleteThread` to roll a
+ * reservation back when the mint it was reserved for fails.
+ */
 export interface ThreadBindStore {
   upsertThread(input: {
     id: string
     workspaceId: string
-    sessionId: string
+    sessionId?: string
   }): Promise<ThreadRecord>
+  snapshot(): { threads: ThreadRecord[] }
+  deleteThread(id: string): Promise<void>
 }
 
 /** The seed needed to connect to a CONTINUED (already-persisted) Thread (TB4 #33). */
@@ -167,14 +174,72 @@ export async function ensureBoundSession(args: {
   return { ...(await mintAndBind(args)), rebound: true }
 }
 
-/** Mint a fresh `session/new` and bind it onto the Thread id (draft or re-bind). */
+/**
+ * Mint a fresh `session/new` and bind it onto the Thread id (draft or re-bind).
+ *
+ * The `threads` row is RESERVED before the round-trip (#417): `transcript_entries`
+ * carries `thread_id ... REFERENCES threads(id)`, and the caller points the
+ * transcript bridge at this Thread BEFORE prompting, so every agent event teed
+ * while `session/new` is in flight used to hit the foreign key and be dropped —
+ * silent loss in the very log the search index and fold snapshots derive from. The
+ * reservation writes the id + Workspace with a NULL `session_id`; `bindThread`
+ * fills the cursor in when the round-trip returns.
+ *
+ * A mint that FAILS releases a row it reserved, so a failed first prompt still
+ * leaves no residue (the cascade takes any entry teed inside the window with it).
+ * A row that was already there — every re-bind (case ii), and a retry after an
+ * earlier failure — is left alone. Both halves are best-effort (ADR-0005): a store
+ * failure logs and never gates the turn.
+ */
 async function mintAndBind(args: {
   agent: SessionBinder
   store: ThreadBindStore
   threadId: string
   workspaceId: string
 }): Promise<BoundSession> {
-  return bindThread(args, await args.agent.openThread())
+  const reserved = await reserveThread(args)
+  try {
+    return await bindThread(args, await args.agent.openThread())
+  } catch (err) {
+    if (reserved) await releaseThread(args)
+    throw err
+  }
+}
+
+/**
+ * Insert the Thread's row up front so the transcript FK is satisfied for the whole
+ * `session/new` window. Returns whether THIS call created it (the only case a
+ * failed mint may roll back); false when the row already existed or the write
+ * failed — the mint proceeds either way.
+ */
+async function reserveThread(args: {
+  store: ThreadBindStore
+  threadId: string
+  workspaceId: string
+}): Promise<boolean> {
+  try {
+    if (args.store.snapshot().threads.some((t) => t.id === args.threadId)) return false
+    await args.store.upsertThread({ id: args.threadId, workspaceId: args.workspaceId })
+    return true
+  } catch (err) {
+    console.error(
+      `[vibe-mistro:metadata] reserveThread failed (${args.threadId}): ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+    )
+    return false
+  }
+}
+
+/** Drop a reserved row (and, by cascade, anything teed into it) after a failed mint. */
+async function releaseThread(args: { store: ThreadBindStore; threadId: string }): Promise<void> {
+  try {
+    await args.store.deleteThread(args.threadId)
+  } catch (err) {
+    console.error(
+      `[vibe-mistro:metadata] releaseThread failed (${args.threadId}): ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+    )
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes #417.

## The race

A draft Thread's first prompt could drop its opening transcript entries with
`FOREIGN KEY constraint failed`.

`runPromptTurn` points the transcript bridge at the Thread (`index.ts:672`) **before**
awaiting `ensureBoundSession`, but the `threads` row was only written **after** the
`session/new` round-trip returned (`thread-binding.ts` → `mintAndBind` → `bindThread`).
For exactly one ACP round-trip the bridge resolved a `threadId` with no parent row —
`transcript_entries.thread_id` is `NOT NULL REFERENCES threads(id)` — so every event
teed in that window was rejected and rolled back.

The UI was unaffected (persistence is best-effort by design), but the entries were
silently lost from the event log that ADR-0019's FTS prose index and fold snapshots
both derive from. A reopened Thread already has its row, so only a draft's **first**
prompt hit it — hence the intermittency.

## The fix

Option **(b)** from the issue. `mintAndBind` now reserves the `threads` row (id +
Workspace, `NULL` `session_id` — the column was already nullable) **before**
`openThread()`; `bindThread` fills the session cursor in when the round-trip returns.
Early events stay teeable and the FK is unreachable.

A mint that **fails** releases a row it reserved, so the "a failed first prompt leaves
no transcript residue" guarantee survives — the cascade takes anything teed inside the
window with it. A row that was already there — every re-bind (case ii), and a retry
after an earlier failure — is left alone.

Both halves are best-effort per ADR-0005: `reserveThread` / `releaseThread` log and
never gate the turn.

`ThreadBindStore` is widened with `snapshot` (to tell a row this bind created from one
that was already there) and `deleteThread`. Doc comments updated where the old ordering
was reasoned about: the `runPromptTurn` bind comment and the `TranscriptBridge`
residual note.

## Tests

Three regression tests in `thread-binding.test.ts`, over a real SQLite database with
the tee fired from **inside** `openThread` so it sits in the window:

- an event teed while a draft's `session/new` is in flight now persists — this one
  fails on the old code (`expected [] to include '<threadId>'`);
- a failed mint leaves no record and no entries;
- a failed re-bind leaves an already-persisted Thread and its entries intact.

## Gates

`lint`, `typecheck`, `build`, `test` all pass — 1678 tests across 154 files.