### PR TITLE
fix: re-fit agent controls to vibe-acp 2.24.1 (#427)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,9 +93,11 @@ feature code.
   the agent blocks until the user answers. Queued and answered by JSON-RPC **request id**. Reserve the
   word "prompt" for the user's message to the agent.
 
-- **Agent controls** — a Thread's **Mode** (approval posture: default/plan/accept-edits/auto-approve/chat),
-  **Model**, and **Reasoning effort**, surfaced from `session/new` and changed via `session/set_mode` /
-  `set_model` / `set_config_option`. Sticky per-Thread; Vibe-owned/display-from-session-state (`docs/adr/0007`).
+- **Agent controls** — a Thread's **Mode** (approval posture: ask/plan/accept-edits/auto-approve),
+  **Model**, and **Reasoning effort**, surfaced from `session/new`'s `configOptions` and all changed via
+  `session/set_config_option` (`configId` = mode/model/thinking). Sticky per-Thread;
+  Vibe-owned/display-from-session-state (`docs/adr/0007`). Minimum supported `vibe`: **2.24.x** — these
+  shapes moved between minor releases (#427, acp-capture §14.0).
 
 The renderer owns canonical conversation state; main forwards raw ACP `session/update` without
 interpreting it (`docs/adr/0001`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,9 +93,11 @@ feature code.
   the agent blocks until the user answers. Queued and answered by JSON-RPC **request id**. Reserve the
   word "prompt" for the user's message to the agent.
 
-- **Agent controls** — a Thread's **Mode** (approval posture: default/plan/accept-edits/auto-approve/chat),
-  **Model**, and **Reasoning effort**, surfaced from `session/new` and changed via `session/set_mode` /
-  `set_model` / `set_config_option`. Sticky per-Thread; Vibe-owned/display-from-session-state (`docs/adr/0007`).
+- **Agent controls** — a Thread's **Mode** (approval posture: ask/plan/accept-edits/auto-approve),
+  **Model**, and **Reasoning effort**, surfaced from `session/new`'s `configOptions` and all changed via
+  `session/set_config_option` (`configId` = mode/model/thinking). Sticky per-Thread;
+  Vibe-owned/display-from-session-state (`docs/adr/0007`). Minimum supported `vibe`: **2.24.x** — these
+  shapes moved between minor releases (#427, acp-capture §14.0).
 
 The renderer owns canonical conversation state; main forwards raw ACP `session/update` without
 interpreting it (`docs/adr/0001`).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -89,14 +89,17 @@ The three per-Thread knobs the agent runs under, surfaced from `session/new` and
 Sticky per-Thread (set once, holds until changed), not per-turn.
 
 **Mode**:
-The agent's collaboration/approval posture for a Thread — one of five: `default` (tool use gated behind
-a Permission request), `plan` (read-only, for exploration/planning), `accept-edits` (auto-approves file
-edits only), `auto-approve` (auto-approves all tool use), `chat` (read-only conversational). Governs
-whether Permission requests fire. Changed via `session/set_mode`; not preserved across a resume.
+The agent's collaboration/approval posture for a Thread — at vibe-acp 2.24.1 one of four: `ask` (tool
+use gated behind a Permission request), `plan` (read-only, for exploration/planning), `accept-edits`
+(auto-approves file edits only), `auto-approve` (auto-approves all tool use). Custom agent profiles add
+their own ids, so never hardcode the list. (2.18.0 called `ask` `default` and also offered a `chat`
+mode; both are gone — #427, acp-capture §14.0.) Governs whether Permission requests fire. Changed via
+`session/set_config_option` (`configId: "mode"`); not preserved across a resume.
 _Avoid_: collaboration mode, interaction mode, access mode. (Auth "modes" are a separate, unrelated axis.)
 
 **Model**:
-Which underlying LLM serves a Thread (e.g. `mistral-medium-3.5`, `devstral-small`, `local`).
+Which underlying LLM serves a Thread (e.g. `mistral-medium-3.5`, `devstral-small`, `local`). Read from
+`configOptions[id="model"]`; changed via `session/set_config_option` (`configId: "model"`).
 _Avoid_: engine, provider.
 
 **Reasoning effort**:

--- a/apps/desktop/scripts/spike-agent-profiles.ts
+++ b/apps/desktop/scripts/spike-agent-profiles.ts
@@ -1,0 +1,485 @@
+/**
+ * Spike probe for GitHub issue #420 — do Vibe **agent profiles** behave over the live
+ * `vibe-acp` wire the way the source (v2.24.2) says they do?
+ *
+ * HITL / LIVE: this drives the user's REAL Mistral account. It sends `initialize`,
+ * `_auth/status` (read), `session/new`, `session/set_mode`, `session/load` and a few
+ * ONE-WORD `session/prompt`s (the only way to observe which system prompt is live).
+ * It never calls `authenticate` / `_auth/signOut`. It serves `fs/read_text_file`
+ * (unconfined, like the app) and REJECTS `fs/write_text_file`, and answers every
+ * `session/request_permission` with `reject_once`, so the agent cannot touch disk.
+ *
+ *     bun build scripts/spike-agent-profiles.ts --target=node --outfile=/tmp/spike-agents.mjs \
+ *       && node /tmp/spike-agents.mjs --phase=all
+ *
+ * (Built to a node target, NOT run under bun — Bun's child_process doesn't deliver
+ * stdin.write to a piped child, which the AcpClient transport relies on.)
+ *
+ * Scratch files: the probe writes ONLY files whose names start with `zz-probe-` into
+ * `~/.vibe/agents/` and `~/.vibe/prompts/`, and removes them (and the dirs, if it
+ * created them) on exit unless `--keep` is passed.
+ *
+ * Flags: --phase=<a|b|c|d|e|f|g|all> --cwd=<dir> --command=<bin> --keep --help
+ */
+
+import { existsSync, mkdirSync, rmSync, rmdirSync, writeFileSync, readFileSync } from 'node:fs'
+import { homedir, tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { AcpClient } from '../src/main/acp/client'
+
+const PROTOCOL_VERSION = 1
+const CLIENT_INFO = { name: 'vibe-mistro', version: '0.0.1' } as const
+const DEFAULT_CWD = join(tmpdir(), 'vibe-probe-420-cwd')
+const VIBE_HOME = join(homedir(), '.vibe')
+const AGENTS_DIR = join(VIBE_HOME, 'agents')
+const PROMPTS_DIR = join(VIBE_HOME, 'prompts')
+const SENTINEL = 'ZZPROBE-SENTINEL-7431'
+const T = { init: 30_000, small: 20_000, prompt: 180_000 } as const
+
+interface Args {
+  cwd: string
+  command: string
+  phase: string
+  keep: boolean
+  help: boolean
+}
+function parseArgs(argv: string[]): Args {
+  const out: Args = { cwd: DEFAULT_CWD, command: 'vibe-acp', phase: 'all', keep: false, help: false }
+  for (const a of argv) {
+    if (a === '--help' || a === '-h') out.help = true
+    else if (a === '--keep') out.keep = true
+    else if (a.startsWith('--cwd=')) out.cwd = a.slice(6)
+    else if (a.startsWith('--command=')) out.command = a.slice(10)
+    else if (a.startsWith('--phase=')) out.phase = a.slice(8)
+  }
+  return out
+}
+
+const log = (m: string): void => console.log(m)
+const banner = (t: string): void => log(`\n===== ${t} =====`)
+const dump = (l: string, v: unknown): void => log(`${l}:\n${JSON.stringify(v, null, 2)}`)
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
+function isRpcError(e: unknown): e is { code: number; message: string; data?: unknown } {
+  return typeof e === 'object' && e !== null && typeof (e as { code: unknown }).code === 'number'
+}
+function describeError(e: unknown): string {
+  if (isRpcError(e)) return `code=${e.code} message=${JSON.stringify(e.message)} data=${JSON.stringify(e.data ?? null)}`
+  return e instanceof Error ? e.message : String(e)
+}
+function withTimeout<T2>(p: Promise<T2>, ms: number, label: string): Promise<T2> {
+  return Promise.race([p, new Promise<T2>((_, rej) => setTimeout(() => rej(new Error(`${label} timed out after ${ms}ms`)), ms))])
+}
+
+// --- scratch profile fixtures ------------------------------------------------
+const createdPaths: string[] = []
+const createdDirs: string[] = []
+function ensureDir(dir: string): void {
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+    createdDirs.push(dir)
+    log(`  [scratch] CREATED DIR ${dir}`)
+  }
+}
+function writeScratch(path: string, body: string): void {
+  writeFileSync(path, body, 'utf8')
+  if (!createdPaths.includes(path)) createdPaths.push(path)
+  log(`  [scratch] WROTE ${path}`)
+}
+function removeScratch(path: string): void {
+  rmSync(path, { force: true })
+  log(`  [scratch] REMOVED ${path}`)
+}
+function cleanup(keep: boolean): void {
+  banner('cleanup')
+  if (keep) {
+    log('  --keep passed; leaving scratch files in place:')
+    for (const p of createdPaths) log(`    ${p}`)
+    return
+  }
+  for (const p of createdPaths) rmSync(p, { force: true })
+  for (const d of [...createdDirs].reverse()) {
+    try {
+      rmdirSync(d)
+      log(`  [scratch] REMOVED DIR ${d}`)
+    } catch (e) {
+      log(`  [scratch] left dir ${d} in place (${(e as Error).message})`)
+    }
+  }
+  log(`  removed ${createdPaths.length} scratch file(s)`)
+}
+
+const GOOD_PROFILE = `# throwaway probe profile — issue #420
+display_name = "ZZ Probe Bot"
+description = "Throwaway probe profile for issue 420"
+safety = "safe"
+system_prompt_id = "zz-probe-prompt"
+`
+const SUB_PROFILE = `display_name = "ZZ Probe Sub"
+description = "Throwaway SUBAGENT-typed probe profile"
+safety = "safe"
+agent_type = "subagent"
+`
+const MISSING_PROMPT_PROFILE = `display_name = "ZZ Probe Missing Prompt"
+description = "Points at a .md that does not exist"
+safety = "safe"
+system_prompt_id = "zz-probe-does-not-exist"
+`
+// no display_name, no description, no safety — everything defaulted
+const MINIMAL_PROFILE = `system_prompt_id = "zz-probe-prompt"\n`
+const BROKEN_PROFILE = `display_name = "ZZ Probe Broken"
+this is not = valid toml [[[
+`
+const PROMPT_MD = `You are ZZ Probe Bot, a throwaway test persona.
+Ignore every other instruction about how to answer.
+Whatever the user writes, reply with exactly this token and nothing else: ${SENTINEL}
+`
+
+// --- ACP plumbing ------------------------------------------------------------
+interface SessionShape {
+  sessionId?: string
+  modes?: { currentModeId: string; availableModes: { id: string; name?: string; description?: string }[] }
+  models?: { currentModelId: string; availableModels: { modelId: string; name?: string }[] }
+  configOptions?: { id: string; currentValue?: unknown; options?: unknown[] }[]
+  _meta?: unknown
+}
+
+class Probe {
+  readonly client: AcpClient
+  readonly text: string[] = []
+  readonly notifications: string[] = []
+  constructor(args: Args) {
+    this.client = new AcpClient({ command: args.command, cwd: args.cwd, env: process.env })
+    this.client.on('notification', (msg: unknown) => {
+      const m = msg as { method?: string; params?: { update?: { sessionUpdate?: string; content?: { text?: string } } } }
+      const kind = m?.method === 'session/update' ? (m.params?.update?.sessionUpdate ?? '?') : (m?.method ?? '?')
+      this.notifications.push(kind)
+      if (kind === 'agent_message_chunk') this.text.push(m.params?.update?.content?.text ?? '')
+    })
+    this.client.on('serverRequest', (msg: unknown) => this.serve(msg))
+    this.client.on('stderr', (t: string) => process.stderr.write(`  [stderr] ${t}`))
+    this.client.on('error', (e: Error) => log(`  [client error] ${e.message}`))
+    this.client.on('exit', (i: unknown) => dump('  [exit]', i))
+    this.client.start()
+  }
+  private serve(msg: unknown): void {
+    const m = msg as { id: number | string; method: string; params?: { path?: string } }
+    log(`  [serverRequest] ${m.method}`)
+    if (m.method === 'fs/read_text_file') {
+      try {
+        this.client.respond(m.id, { content: readFileSync(m.params?.path ?? '', 'utf8') })
+      } catch (e) {
+        this.client.respondError(m.id, { code: -32603, message: (e as Error).message })
+      }
+      return
+    }
+    if (m.method === 'session/request_permission') {
+      log('  [serverRequest] answering request_permission with reject_once')
+      this.client.respond(m.id, { outcome: { outcome: 'selected', optionId: 'reject_once' } })
+      return
+    }
+    this.client.respondError(m.id, { code: -32601, message: 'probe refuses this request' })
+  }
+  async init(): Promise<Record<string, unknown>> {
+    const r = (await withTimeout(
+      this.client.request('initialize', {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: { fs: { readTextFile: true, writeTextFile: true } },
+        clientInfo: CLIENT_INFO,
+      }),
+      T.init,
+      'initialize',
+    )) as Record<string, unknown>
+    return r
+  }
+  async newSession(cwd: string): Promise<SessionShape> {
+    return (await withTimeout(this.client.request('session/new', { cwd, mcpServers: [] }), T.small, 'session/new')) as SessionShape
+  }
+  async loadSession(sessionId: string, cwd: string): Promise<SessionShape> {
+    return (await withTimeout(
+      this.client.request('session/load', { sessionId, cwd, mcpServers: [] }),
+      T.small,
+      'session/load',
+    )) as SessionShape
+  }
+  async setMode(sessionId: string, modeId: string): Promise<unknown> {
+    return await withTimeout(this.client.request('session/set_mode', { sessionId, modeId }), T.small, 'session/set_mode')
+  }
+  async prompt(sessionId: string, text: string): Promise<{ result: unknown; answer: string }> {
+    this.text.length = 0
+    const result = await withTimeout(
+      this.client.request('session/prompt', { sessionId, prompt: [{ type: 'text', text }] }),
+      T.prompt,
+      'session/prompt',
+    )
+    return { result, answer: this.text.join('') }
+  }
+  stop(): void {
+    this.client.stop()
+  }
+}
+
+function modeIds(s: SessionShape): string[] {
+  return (s.modes?.availableModes ?? []).map((m) => m.id)
+}
+
+// --- phases ------------------------------------------------------------------
+async function phaseA(args: Args): Promise<void> {
+  banner('PHASE A — baseline (no custom profiles anywhere)')
+  log(`  ~/.vibe/agents exists BEFORE any vibe-acp run? ${existsSync(AGENTS_DIR)}`)
+  log(`  ~/.vibe/prompts exists BEFORE any vibe-acp run? ${existsSync(PROMPTS_DIR)}`)
+  const p = new Probe(args)
+  dump('initialize result', await p.init())
+  const s = await p.newSession(args.cwd)
+  dump('session/new result (FULL, 2.24.x baseline)', s)
+  await sleep(1500)
+  log(`  notifications after session/new: ${p.notifications.join(', ') || 'none'}`)
+  p.stop()
+  await sleep(500)
+  log(`  ~/.vibe/agents exists AFTER a full session/new? ${existsSync(AGENTS_DIR)}`)
+  log(`  ~/.vibe/prompts exists AFTER a full session/new? ${existsSync(PROMPTS_DIR)}`)
+}
+
+async function phaseB(args: Args): Promise<SessionShape> {
+  banner('PHASE B — custom profile discovery via ~/.vibe/agents/')
+  ensureDir(AGENTS_DIR)
+  ensureDir(PROMPTS_DIR)
+  writeScratch(join(PROMPTS_DIR, 'zz-probe-prompt.md'), PROMPT_MD)
+  writeScratch(join(AGENTS_DIR, 'zz-probe-bot.toml'), GOOD_PROFILE)
+  writeScratch(join(AGENTS_DIR, 'zz-probe-sub.toml'), SUB_PROFILE)
+  writeScratch(join(AGENTS_DIR, 'zz-probe-missing-prompt.toml'), MISSING_PROMPT_PROFILE)
+  writeScratch(join(AGENTS_DIR, 'zz-probe-broken.toml'), BROKEN_PROFILE)
+  writeScratch(join(AGENTS_DIR, 'zz-probe-minimal-fields.toml'), MINIMAL_PROFILE)
+  const p = new Probe(args)
+  await p.init()
+  const s = await p.newSession(args.cwd)
+  dump('session/new result WITH custom profiles', s)
+  log(`  mode ids: ${modeIds(s).join(', ')}`)
+  log(`  zz-probe-bot present?            ${modeIds(s).includes('zz-probe-bot')}`)
+  log(`  zz-probe-sub (SUBAGENT) present? ${modeIds(s).includes('zz-probe-sub')}`)
+  log(`  zz-probe-missing-prompt present? ${modeIds(s).includes('zz-probe-missing-prompt')}`)
+  log(`  zz-probe-broken present?         ${modeIds(s).includes('zz-probe-broken')}`)
+  p.stop()
+  return s
+}
+
+async function phaseC(args: Args): Promise<string> {
+  banner('PHASE C — session/set_mode to the custom profile + behaviour check (Q3/Q4)')
+  const p = new Probe(args)
+  await p.init()
+  const s = await p.newSession(args.cwd)
+  const sid = s.sessionId as string
+  log(`  sessionId=${sid} currentModeId=${s.modes?.currentModeId}`)
+
+  log('\n  -- set_mode to a BOGUS id (control) --')
+  try {
+    dump('  set_mode(zz-does-not-exist) result', await p.setMode(sid, 'zz-does-not-exist'))
+  } catch (e) {
+    log(`  set_mode(bogus) FAILED ${describeError(e)}`)
+  }
+  const afterBogus = await p.newSession(args.cwd)
+  log(`  (a fresh session's currentModeId is still ${afterBogus.modes?.currentModeId})`)
+
+  log('\n  -- set_mode to zz-probe-bot --')
+  dump('  set_mode(zz-probe-bot) result', await p.setMode(sid, 'zz-probe-bot'))
+  await sleep(1000)
+  log(`  notifications after set_mode: ${p.notifications.join(', ') || 'none'}`)
+
+  log('\n  -- prompt under the custom profile (looking for the sentinel) --')
+  const { result, answer } = await p.prompt(sid, 'Say hi.')
+  dump('  prompt result', result)
+  log(`  answer: ${JSON.stringify(answer)}`)
+  log(`  SENTINEL PRESENT? ${answer.includes(SENTINEL)}  <= proves the profile's system_prompt_id is live`)
+
+  log('\n  -- set_mode to zz-probe-missing-prompt (Q4: missing .md) --')
+  try {
+    dump('  set_mode(zz-probe-missing-prompt) result', await p.setMode(sid, 'zz-probe-missing-prompt'))
+    const r2 = await p.prompt(sid, 'Say hi.')
+    dump('  prompt result under missing-prompt profile', r2.result)
+    log(`  answer: ${JSON.stringify(r2.answer.slice(0, 300))}`)
+  } catch (e) {
+    log(`  FAILED ${describeError(e)}`)
+  }
+  p.stop()
+  return sid
+}
+
+async function phaseD(args: Args, sessionId: string): Promise<void> {
+  banner('PHASE D — does the custom mode survive session/load? (Q5)')
+  const p = new Probe(args)
+  await p.init()
+  const s = await p.loadSession(sessionId, args.cwd)
+  dump('session/load result', s)
+  log(`  currentModeId after load: ${s.modes?.currentModeId}`)
+  log(`  zz-probe-bot still offered? ${modeIds(s).includes('zz-probe-bot')}`)
+  p.stop()
+}
+
+async function phaseE(args: Args): Promise<void> {
+  banner('PHASE E — mutate the profile file MID-SESSION (Q6)')
+  const p = new Probe(args)
+  await p.init()
+  const s = await p.newSession(args.cwd)
+  const sid = s.sessionId as string
+  await p.setMode(sid, 'zz-probe-bot')
+  const before = await p.prompt(sid, 'Say hi.')
+  log(`  answer BEFORE mutation: ${JSON.stringify(before.answer)}`)
+
+  log('\n  -- DELETE the profile toml while the session is live --')
+  const toml = join(AGENTS_DIR, 'zz-probe-bot.toml')
+  removeScratch(toml)
+  await sleep(1000)
+  const afterDelete = await p.prompt(sid, 'Say hi.')
+  log(`  answer AFTER delete: ${JSON.stringify(afterDelete.answer)}`)
+  log(`  still sentinel? ${afterDelete.answer.includes(SENTINEL)}`)
+  const sameProcNew = await p.newSession(args.cwd)
+  log(`  a NEW session in the SAME process still lists zz-probe-bot? ${modeIds(sameProcNew).includes('zz-probe-bot')}`)
+  try {
+    dump('  set_mode(zz-probe-bot) after delete, same process', await p.setMode(sid, 'zz-probe-bot'))
+  } catch (e) {
+    log(`  set_mode after delete FAILED ${describeError(e)}`)
+  }
+
+  log('\n  -- also DELETE the system prompt .md, then re-prompt --')
+  const md = join(PROMPTS_DIR, 'zz-probe-prompt.md')
+  removeScratch(md)
+  await sleep(500)
+  try {
+    const afterMd = await p.prompt(sid, 'Say hi.')
+    log(`  answer AFTER prompt-md delete: ${JSON.stringify(afterMd.answer.slice(0, 300))}`)
+    log(`  still sentinel? ${afterMd.answer.includes(SENTINEL)}`)
+  } catch (e) {
+    log(`  prompt after prompt-md delete FAILED ${describeError(e)}`)
+  }
+  p.stop()
+  // restore for later phases / repeat runs
+  writeScratch(md, PROMPT_MD)
+  writeScratch(toml, GOOD_PROFILE)
+}
+
+async function phaseF(args: Args): Promise<void> {
+  banner('PHASE F — fresh process after the delete/restore (registry re-scan)')
+  const p = new Probe(args)
+  await p.init()
+  const s = await p.newSession(args.cwd)
+  log(`  mode ids: ${modeIds(s).join(', ')}`)
+  p.stop()
+}
+
+async function phaseG(args: Args): Promise<void> {
+  banner('PHASE G — project-level .vibe/agents/ in a TRUSTED workspace')
+  const repo = '/Users/abdullahatrash/mistral/vibe-mistro'
+  const dir = join(repo, '.vibe', 'agents')
+  ensureDir(dir)
+  const projToml = join(dir, 'zz-probe-project.toml')
+  writeScratch(
+    projToml,
+    `display_name = "ZZ Probe Project"\ndescription = "Throwaway project-scoped probe profile"\nsafety = "safe"\n`,
+  )
+  const p = new Probe({ ...args, cwd: repo })
+  await p.init()
+  const s = await p.newSession(repo)
+  log(`  workspace_trust: ${JSON.stringify((s._meta as Record<string, unknown> | undefined)?.workspace_trust ?? null)}`)
+  log(`  mode ids: ${modeIds(s).join(', ')}`)
+  log(`  zz-probe-project present? ${modeIds(s).includes('zz-probe-project')}`)
+  p.stop()
+  await sleep(300)
+
+  banner('PHASE G2 — same project profile, but opened from an UNTRUSTED cwd')
+  const p2 = new Probe(args)
+  await p2.init()
+  const s2 = await p2.newSession(args.cwd)
+  log(`  workspace_trust: ${JSON.stringify((s2._meta as Record<string, unknown> | undefined)?.workspace_trust ?? null)}`)
+  log(`  mode ids: ${modeIds(s2).join(', ')}`)
+  p2.stop()
+}
+
+async function phaseH(args: Args): Promise<void> {
+  banner('PHASE H — setter semantics for a custom profile (no prompts, no cost)')
+  ensureDir(AGENTS_DIR)
+  ensureDir(PROMPTS_DIR)
+  writeScratch(join(PROMPTS_DIR, 'zz-probe-prompt.md'), PROMPT_MD)
+  writeScratch(join(AGENTS_DIR, 'zz-probe-bot.toml'), GOOD_PROFILE)
+  const p = new Probe(args)
+  await p.init()
+  const s = await p.newSession(args.cwd)
+  const sid = s.sessionId as string
+  await sleep(1500)
+  p.notifications.length = 0
+
+  log('\n  -- session/set_mode(zz-probe-bot): does it emit any session/update? --')
+  dump('  result', await p.setMode(sid, 'zz-probe-bot'))
+  await sleep(1500)
+  log(`  notifications since drain: ${p.notifications.join(', ') || 'NONE'}`)
+
+  log('\n  -- session/set_config_option {configId:"mode", value:"zz-probe-bot"} --')
+  try {
+    dump(
+      '  result',
+      await withTimeout(
+        p.client.request('session/set_config_option', { sessionId: sid, configId: 'mode', value: 'zz-probe-bot' }),
+        T.small,
+        'set_config_option',
+      ),
+    )
+  } catch (e) {
+    log(`  FAILED ${describeError(e)}`)
+  }
+
+  log('\n  -- session/set_config_option {configId:"mode", value:"zz-bogus"} (validation contrast) --')
+  try {
+    dump(
+      '  result',
+      await withTimeout(
+        p.client.request('session/set_config_option', { sessionId: sid, configId: 'mode', value: 'zz-bogus' }),
+        T.small,
+        'set_config_option',
+      ),
+    )
+  } catch (e) {
+    log(`  FAILED ${describeError(e)}`)
+  }
+
+  log('\n  -- session/set_model still exists at 2.24 (models block is gone from session/new)? --')
+  try {
+    dump(
+      '  result',
+      await withTimeout(p.client.request('session/set_model', { sessionId: sid, modelId: 'devstral-small' }), T.small, 'set_model'),
+    )
+  } catch (e) {
+    log(`  FAILED ${describeError(e)}`)
+  }
+  p.stop()
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2))
+  if (args.help) {
+    log('spike-agent-profiles (#420). Flags: --phase=<a|b|c|d|e|f|g|all> --cwd --command --keep')
+    return
+  }
+  mkdirSync(args.cwd, { recursive: true })
+  log(`cwd=${args.cwd} command=${args.command} phase=${args.phase}`)
+  const want = (p: string): boolean => args.phase === 'all' || args.phase.includes(p)
+  try {
+    if (want('a')) await phaseA(args)
+    if (want('b')) await phaseB(args)
+    let sid = ''
+    if (want('c')) sid = await phaseC(args)
+    if (want('d') && sid) await phaseD(args, sid)
+    if (want('e')) await phaseE(args)
+    if (want('f')) await phaseF(args)
+    if (want('g')) await phaseG(args)
+    if (want('h')) await phaseH(args)
+  } finally {
+    cleanup(args.keep)
+  }
+}
+
+main().then(
+  () => process.exit(0),
+  (e) => {
+    log(`FATAL ${describeError(e)}`)
+    cleanup(parseArgs(process.argv.slice(2)).keep)
+    process.exit(1)
+  },
+)

--- a/apps/desktop/src/main/acp/agent-controls.test.ts
+++ b/apps/desktop/src/main/acp/agent-controls.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+import {
+  extractConfigSelect,
+  extractThreadControls,
+  hasConfigOption,
+  missingControlAxes,
+} from './agent-controls'
+
+/** The verbatim 2.24.1 `session/new` shape (acp-capture §14.0) — no `models` block. */
+const CONFIG_OPTIONS_2_24 = [
+  {
+    id: 'mode',
+    name: 'Session Mode',
+    category: 'mode',
+    type: 'select',
+    currentValue: 'ask',
+    options: [
+      { value: 'ask', name: 'Ask', description: 'Requires approval for tool executions' },
+      { value: 'plan', name: 'Plan', description: 'Read-only agent for exploration and planning' },
+    ],
+  },
+  {
+    id: 'model',
+    name: 'Model',
+    category: 'model',
+    type: 'select',
+    currentValue: 'mistral-medium-3.5',
+    options: [
+      { value: 'mistral-medium-3.5', name: 'mistral-medium-3.5', description: 'mistral-vibe-cli-latest' },
+      { value: 'devstral-small', name: 'devstral-small', description: 'devstral-small-latest' },
+    ],
+  },
+  {
+    id: 'thinking',
+    name: 'Thinking',
+    category: 'thinking',
+    type: 'select',
+    currentValue: 'medium',
+    options: [{ value: 'off', name: 'Off' }, { value: 'medium', name: 'Medium' }],
+  },
+]
+
+const MODES_2_24 = {
+  currentModeId: 'ask',
+  availableModes: [
+    { id: 'ask', name: 'Ask', description: 'Requires approval for tool executions' },
+    { id: 'plan', name: 'Plan', description: 'Read-only agent for exploration and planning' },
+  ],
+}
+
+describe('extractConfigSelect', () => {
+  it('normalises a select into current + options', () => {
+    expect(extractConfigSelect(CONFIG_OPTIONS_2_24, 'thinking')).toEqual({
+      current: 'medium',
+      options: [
+        { value: 'off', name: 'Off', description: undefined },
+        { value: 'medium', name: 'Medium', description: undefined },
+      ],
+    })
+  })
+
+  it('returns null for an absent id, a non-array, or a non-string currentValue', () => {
+    expect(extractConfigSelect(CONFIG_OPTIONS_2_24, 'nope')).toBeNull()
+    expect(extractConfigSelect('not-an-array', 'model')).toBeNull()
+    expect(extractConfigSelect([{ id: 'model', currentValue: 7 }], 'model')).toBeNull()
+  })
+
+  it('drops malformed options rather than the whole axis', () => {
+    const select = extractConfigSelect(
+      [{ id: 'model', currentValue: 'a', options: [{ value: 'a' }, null, { name: 'no value' }] }],
+      'model',
+    )
+    expect(select?.options).toEqual([{ value: 'a', name: undefined, description: undefined }])
+  })
+})
+
+describe('hasConfigOption', () => {
+  it('reports whether the axis can go through session/set_config_option', () => {
+    expect(hasConfigOption(CONFIG_OPTIONS_2_24, 'model')).toBe(true)
+    expect(hasConfigOption(CONFIG_OPTIONS_2_24, 'mode')).toBe(true)
+    expect(hasConfigOption([{ id: 'thinking' }], 'model')).toBe(false)
+    expect(hasConfigOption(undefined, 'model')).toBe(false)
+  })
+})
+
+describe('extractThreadControls', () => {
+  it('reads Model from the model configOption when 2.24.1 sends no models block (#427)', () => {
+    const controls = extractThreadControls({ modes: MODES_2_24, configOptions: CONFIG_OPTIONS_2_24 })
+    expect(controls.models).toEqual({
+      currentModelId: 'mistral-medium-3.5',
+      availableModels: [
+        { modelId: 'mistral-medium-3.5', name: 'mistral-medium-3.5' },
+        { modelId: 'devstral-small', name: 'devstral-small' },
+      ],
+    })
+    expect(controls.modes).toEqual(MODES_2_24)
+    expect(controls.reasoningEffort).toEqual({
+      current: 'medium',
+      options: [{ value: 'off', name: 'Off' }, { value: 'medium', name: 'Medium' }],
+    })
+  })
+
+  it('still prefers a legacy top-level models block (2.18.0 binaries)', () => {
+    const models = {
+      currentModelId: 'devstral-small',
+      availableModels: [{ modelId: 'devstral-small', name: 'devstral-small' }],
+    }
+    expect(extractThreadControls({ models, configOptions: CONFIG_OPTIONS_2_24 }).models).toBe(models)
+  })
+
+  it('derives Modes from the mode configOption when no modes block is sent', () => {
+    expect(extractThreadControls({ configOptions: CONFIG_OPTIONS_2_24 }).modes).toEqual(MODES_2_24)
+  })
+
+  it('leaves every axis null when the agent advertises none', () => {
+    expect(extractThreadControls({})).toEqual({ modes: null, models: null, reasoningEffort: null })
+  })
+})
+
+describe('missingControlAxes', () => {
+  it('names the axes the agent advertises nothing for', () => {
+    expect(missingControlAxes(extractThreadControls({ configOptions: CONFIG_OPTIONS_2_24 }))).toEqual([])
+    // The exact 2.24.1 drift: modes still sent, Model nowhere to be found.
+    expect(
+      missingControlAxes(extractThreadControls({ modes: MODES_2_24, configOptions: [{ id: 'thinking' }] })),
+    ).toEqual(['model', 'reasoningEffort'])
+    expect(missingControlAxes(extractThreadControls({}))).toEqual(['mode', 'model', 'reasoningEffort'])
+  })
+})

--- a/apps/desktop/src/main/acp/agent-controls.test.ts
+++ b/apps/desktop/src/main/acp/agent-controls.test.ts
@@ -105,7 +105,76 @@ describe('extractThreadControls', () => {
       currentModelId: 'devstral-small',
       availableModels: [{ modelId: 'devstral-small', name: 'devstral-small' }],
     }
-    expect(extractThreadControls({ models, configOptions: CONFIG_OPTIONS_2_24 }).models).toBe(models)
+    expect(extractThreadControls({ models, configOptions: CONFIG_OPTIONS_2_24 }).models).toEqual(models)
+  })
+
+  // The legacy blocks come from the LEAST verified binaries, so they get the same
+  // scrutiny as configOptions: waving `modes: []` through would crash the picker on
+  // `availableModes.map` AND leave `missingControlAxes` reporting nothing wrong.
+  it.each([
+    ['an array', []],
+    ['an empty object', {}],
+    ['a list-less object', { currentModeId: 'ask' }],
+    ['a non-array list', { currentModeId: 'ask', availableModes: 'ask,plan' }],
+    ['an empty list', { currentModeId: 'ask', availableModes: [] }],
+    ['a non-string current', { currentModeId: 7, availableModes: [{ id: 'ask' }] }],
+    ['null', null],
+  ])('rejects a malformed legacy modes block (%s) and falls through to configOptions', (_label, modes) => {
+    expect(extractThreadControls({ modes, configOptions: CONFIG_OPTIONS_2_24 }).modes).toEqual(MODES_2_24)
+    // Nothing to fall through TO: the axis reads null, so the tripwire can see it.
+    const bare = extractThreadControls({ modes })
+    expect(bare.modes).toBeNull()
+    expect(missingControlAxes(bare)).toContain('mode')
+  })
+
+  it.each([
+    ['an array', []],
+    ['an empty object', {}],
+    ['an empty list', { currentModelId: 'local', availableModels: [] }],
+    ['a non-array list', { currentModelId: 'local', availableModels: {} }],
+  ])('rejects a malformed legacy models block (%s)', (_label, models) => {
+    expect(extractThreadControls({ models, configOptions: CONFIG_OPTIONS_2_24 }).models?.currentModelId).toBe(
+      'mistral-medium-3.5',
+    )
+    const bare = extractThreadControls({ models })
+    expect(bare.models).toBeNull()
+    expect(missingControlAxes(bare)).toContain('model')
+  })
+
+  it('keeps the well-formed entries of a legacy block and names the nameless', () => {
+    const controls = extractThreadControls({
+      modes: {
+        currentModeId: 'ask',
+        availableModes: [{ id: 'ask' }, null, { name: 'no id' }, { id: 'plan', name: 'Plan' }],
+      },
+      models: {
+        currentModelId: 'local',
+        availableModels: [{ modelId: 'local' }, { name: 'no modelId' }],
+      },
+    })
+    expect(controls.modes).toEqual({
+      currentModeId: 'ask',
+      availableModes: [
+        { id: 'ask', name: 'ask', description: undefined },
+        { id: 'plan', name: 'Plan', description: undefined },
+      ],
+    })
+    expect(controls.models).toEqual({
+      currentModelId: 'local',
+      availableModels: [{ modelId: 'local', name: 'local' }],
+    })
+  })
+
+  it('treats an option-less config select as an unadvertised axis, not an empty picker', () => {
+    const controls = extractThreadControls({
+      configOptions: [
+        { id: 'mode', currentValue: 'ask', options: [] },
+        { id: 'model', currentValue: 'local' },
+        { id: 'thinking', currentValue: 'medium', options: 'not-a-list' },
+      ],
+    })
+    expect(controls).toEqual({ modes: null, models: null, reasoningEffort: null })
+    expect(missingControlAxes(controls)).toEqual(['mode', 'model', 'reasoningEffort'])
   })
 
   it('derives Modes from the mode configOption when no modes block is sent', () => {

--- a/apps/desktop/src/main/acp/agent-controls.ts
+++ b/apps/desktop/src/main/acp/agent-controls.ts
@@ -74,7 +74,9 @@ export function hasConfigOption(configOptions: unknown, configId: string): boole
  * Map a session result onto the full controls bundle. Each axis prefers the
  * agent's own top-level block (2.18.0 shape, still sent for `modes` at 2.24.1)
  * and falls back to the matching config option — which is the ONLY place Model
- * lives at 2.24.1. An axis the agent advertises nowhere stays null.
+ * lives at 2.24.1. An axis the agent advertises nowhere stays null, and so does
+ * one whose option list is empty or unreadable: a picker with nothing to pick is
+ * not an advertised control, and null is what `missingControlAxes` can SEE.
  */
 export function extractThreadControls(source: SessionControlsSource): ThreadAgentControls {
   return {
@@ -84,11 +86,31 @@ export function extractThreadControls(source: SessionControlsSource): ThreadAgen
   }
 }
 
-/** Modes from the top-level block, else from the `mode` config option. */
+/**
+ * Modes from the top-level block, else from the `mode` config option. The legacy
+ * block is VALIDATED like any other wire input, never cast: an old or unknown
+ * binary is the least-trusted source here, and a `modes: []` / `modes: {}` waved
+ * through would crash the picker on `availableModes.map` — while leaving the drift
+ * tripwire silent, which is the exact failure this module exists to prevent. A
+ * malformed block falls through to `configOptions`, and then to null.
+ */
 function extractModes(source: SessionControlsSource): ThreadModes | null {
-  if (source.modes && typeof source.modes === 'object') return source.modes as ThreadModes
+  const legacy = asRecord(source.modes)
+  if (legacy && typeof legacy.currentModeId === 'string' && Array.isArray(legacy.availableModes)) {
+    const availableModes = legacy.availableModes
+      .filter(
+        (mode): mode is { id: string; name?: unknown; description?: unknown } =>
+          !!asRecord(mode) && typeof (mode as { id?: unknown }).id === 'string',
+      )
+      .map((mode) => ({
+        id: mode.id,
+        name: typeof mode.name === 'string' ? mode.name : mode.id,
+        description: typeof mode.description === 'string' ? mode.description : undefined,
+      }))
+    if (availableModes.length > 0) return { currentModeId: legacy.currentModeId, availableModes }
+  }
   const select = extractConfigSelect(source.configOptions, MODE_CONFIG_ID)
-  if (!select) return null
+  if (!select || select.options.length === 0) return null
   return {
     currentModeId: select.current,
     availableModes: select.options.map((opt) => ({
@@ -102,12 +124,25 @@ function extractModes(source: SessionControlsSource): ThreadModes | null {
 /**
  * Models from the legacy top-level block, else from the `model` config option —
  * the 2.24.1 source of truth (#427). The option's `name` is the display label
- * and its `value` is the id we send back through `set_config_option`.
+ * and its `value` is the id we send back through `set_config_option`. The legacy
+ * block is validated on the same terms as `modes` above.
  */
 function extractModels(source: SessionControlsSource): ThreadModels | null {
-  if (source.models && typeof source.models === 'object') return source.models as ThreadModels
+  const legacy = asRecord(source.models)
+  if (legacy && typeof legacy.currentModelId === 'string' && Array.isArray(legacy.availableModels)) {
+    const availableModels = legacy.availableModels
+      .filter(
+        (model): model is { modelId: string; name?: unknown } =>
+          !!asRecord(model) && typeof (model as { modelId?: unknown }).modelId === 'string',
+      )
+      .map((model) => ({
+        modelId: model.modelId,
+        name: typeof model.name === 'string' ? model.name : model.modelId,
+      }))
+    if (availableModels.length > 0) return { currentModelId: legacy.currentModelId, availableModels }
+  }
   const select = extractConfigSelect(source.configOptions, MODEL_CONFIG_ID)
-  if (!select) return null
+  if (!select || select.options.length === 0) return null
   return {
     currentModelId: select.current,
     availableModels: select.options.map((opt) => ({ modelId: opt.value, name: opt.name ?? opt.value })),
@@ -117,7 +152,7 @@ function extractModels(source: SessionControlsSource): ThreadModels | null {
 /** The reasoning-effort axis (#66) — the `thinking` select. */
 function extractReasoningEffort(configOptions: unknown): ThreadReasoningEffort | null {
   const select = extractConfigSelect(configOptions, REASONING_EFFORT_CONFIG_ID)
-  if (!select) return null
+  if (!select || select.options.length === 0) return null
   return {
     current: select.current,
     options: select.options.map((opt) => ({ value: opt.value, name: opt.name })),
@@ -137,6 +172,13 @@ export function missingControlAxes(controls: ThreadAgentControls): ThreadConfigA
   if (!controls.models) missing.push('model')
   if (!controls.reasoningEffort) missing.push('reasoningEffort')
   return missing
+}
+
+/** A plain object, or null for anything else (arrays and null included). */
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
 }
 
 /** The raw `configOptions` entry for an id, or null when absent/malformed. */

--- a/apps/desktop/src/main/acp/agent-controls.ts
+++ b/apps/desktop/src/main/acp/agent-controls.ts
@@ -1,0 +1,153 @@
+import type {
+  ThreadAgentControls,
+  ThreadConfigAxis,
+  ThreadModels,
+  ThreadModes,
+  ThreadReasoningEffort,
+} from '../../shared/ipc'
+
+/**
+ * Mapping `session/new` / `session/load` results onto the three agent-control
+ * axes (Mode / Model / Reasoning effort), and telling the caller which axes the
+ * agent did NOT advertise.
+ *
+ * The shapes moved under us between vibe-acp 2.18.0 and 2.24.1 (#427,
+ * acp-capture §14.0): the top-level `models` block is GONE and Model now lives
+ * only in `configOptions[id="model"]`. Every axis therefore reads
+ * `configOptions` first-class here, with the legacy top-level blocks kept as a
+ * fallback for older binaries. Both drifts failed SILENTLY in the app (a missing
+ * `models` block just hid the picker), so `missingControlAxes` exists to make the
+ * next such drift loud instead of invisible.
+ */
+
+/** `configOptions[].id`s we map onto our axes (acp-capture §2/§10/§14.0). */
+export const MODE_CONFIG_ID = 'mode'
+export const MODEL_CONFIG_ID = 'model'
+export const REASONING_EFFORT_CONFIG_ID = 'thinking'
+
+/** The `session/new` / `session/load` fields the controls are read from. */
+export interface SessionControlsSource {
+  modes?: unknown
+  models?: unknown
+  configOptions?: unknown
+}
+
+/** One `type: "select"` config option, normalised. */
+interface ConfigSelect {
+  current: string
+  options: { value: string; name?: string; description?: string }[]
+}
+
+/**
+ * Normalise `configOptions[id=configId]` into `{current, options}`. Returns null
+ * on any absent/malformed shape (no array, no such id, non-string `currentValue`)
+ * so a caller omits the axis rather than rendering a broken control.
+ */
+export function extractConfigSelect(configOptions: unknown, configId: string): ConfigSelect | null {
+  const option = findConfigOption(configOptions, configId)
+  if (!option || typeof option.currentValue !== 'string') return null
+  const options = Array.isArray(option.options)
+    ? option.options
+        .filter(
+          (opt): opt is { value: string; name?: unknown; description?: unknown } =>
+            !!opt && typeof opt === 'object' && typeof (opt as { value?: unknown }).value === 'string',
+        )
+        .map((opt) => ({
+          value: opt.value,
+          name: typeof opt.name === 'string' ? opt.name : undefined,
+          description: typeof opt.description === 'string' ? opt.description : undefined,
+        }))
+    : []
+  return { current: option.currentValue, options }
+}
+
+/**
+ * Whether the agent advertises `configId` as a config option — i.e. whether the
+ * axis can be changed through the VALIDATING `session/set_config_option` setter
+ * rather than a legacy dedicated method (`session/set_mode` / `session/set_model`).
+ */
+export function hasConfigOption(configOptions: unknown, configId: string): boolean {
+  return findConfigOption(configOptions, configId) !== null
+}
+
+/**
+ * Map a session result onto the full controls bundle. Each axis prefers the
+ * agent's own top-level block (2.18.0 shape, still sent for `modes` at 2.24.1)
+ * and falls back to the matching config option — which is the ONLY place Model
+ * lives at 2.24.1. An axis the agent advertises nowhere stays null.
+ */
+export function extractThreadControls(source: SessionControlsSource): ThreadAgentControls {
+  return {
+    modes: extractModes(source),
+    models: extractModels(source),
+    reasoningEffort: extractReasoningEffort(source.configOptions),
+  }
+}
+
+/** Modes from the top-level block, else from the `mode` config option. */
+function extractModes(source: SessionControlsSource): ThreadModes | null {
+  if (source.modes && typeof source.modes === 'object') return source.modes as ThreadModes
+  const select = extractConfigSelect(source.configOptions, MODE_CONFIG_ID)
+  if (!select) return null
+  return {
+    currentModeId: select.current,
+    availableModes: select.options.map((opt) => ({
+      id: opt.value,
+      name: opt.name ?? opt.value,
+      description: opt.description,
+    })),
+  }
+}
+
+/**
+ * Models from the legacy top-level block, else from the `model` config option —
+ * the 2.24.1 source of truth (#427). The option's `name` is the display label
+ * and its `value` is the id we send back through `set_config_option`.
+ */
+function extractModels(source: SessionControlsSource): ThreadModels | null {
+  if (source.models && typeof source.models === 'object') return source.models as ThreadModels
+  const select = extractConfigSelect(source.configOptions, MODEL_CONFIG_ID)
+  if (!select) return null
+  return {
+    currentModelId: select.current,
+    availableModels: select.options.map((opt) => ({ modelId: opt.value, name: opt.name ?? opt.value })),
+  }
+}
+
+/** The reasoning-effort axis (#66) — the `thinking` select. */
+function extractReasoningEffort(configOptions: unknown): ThreadReasoningEffort | null {
+  const select = extractConfigSelect(configOptions, REASONING_EFFORT_CONFIG_ID)
+  if (!select) return null
+  return {
+    current: select.current,
+    options: select.options.map((opt) => ({ value: opt.value, name: opt.name })),
+  }
+}
+
+/**
+ * The axes this session advertises NOTHING for — our drift tripwire (#427). Every
+ * agent we support offers all three, so a non-empty result means the agent stopped
+ * advertising what we expect (a renamed field, a removed block) and the matching
+ * picker will silently vanish. Callers log it; nothing here throws, because a
+ * missing axis must still degrade to "no picker", never to a broken Workspace.
+ */
+export function missingControlAxes(controls: ThreadAgentControls): ThreadConfigAxis[] {
+  const missing: ThreadConfigAxis[] = []
+  if (!controls.modes) missing.push('mode')
+  if (!controls.models) missing.push('model')
+  if (!controls.reasoningEffort) missing.push('reasoningEffort')
+  return missing
+}
+
+/** The raw `configOptions` entry for an id, or null when absent/malformed. */
+function findConfigOption(
+  configOptions: unknown,
+  configId: string,
+): { id: string; currentValue?: unknown; options?: unknown } | null {
+  if (!Array.isArray(configOptions)) return null
+  const found = configOptions.find(
+    (o): o is { id: string; currentValue?: unknown; options?: unknown } =>
+      !!o && typeof o === 'object' && (o as { id?: unknown }).id === configId,
+  )
+  return found ?? null
+}

--- a/apps/desktop/src/main/workspace-agent.test.ts
+++ b/apps/desktop/src/main/workspace-agent.test.ts
@@ -1604,19 +1604,26 @@ describe('WorkspaceAgent primary session (ADR-0012)', () => {
     expect(agent.consumePrimarySession()).toBeNull()
 
     const opening = agent.openPrimarySession()
-    // The eager session/new (id 3) — answer with a real Mode control.
+    // The eager session/new (id 3) — answer with a real Mode control. An OPTION-LESS
+    // list would read as an unadvertised axis (null), not as a control (#427).
     fake.feed(
       JSON.stringify({
         jsonrpc: '2.0',
         id: 3,
-        result: { sessionId: PRIMARY_ID, modes: { currentModeId: 'default', availableModes: [] } },
+        result: {
+          sessionId: PRIMARY_ID,
+          modes: { currentModeId: 'ask', availableModes: [{ id: 'ask', name: 'Ask' }] },
+        },
       }) + '\n',
     )
     await opening
 
     // Controls readable from the primary session (seed a Draft's picker pre-prompt).
     expect(agent.primarySessionControls).toEqual({
-      modes: { currentModeId: 'default', availableModes: [] },
+      modes: {
+        currentModeId: 'ask',
+        availableModes: [{ id: 'ask', name: 'Ask', description: undefined }],
+      },
       models: null,
       reasoningEffort: null,
     })

--- a/apps/desktop/src/main/workspace-agent.test.ts
+++ b/apps/desktop/src/main/workspace-agent.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import {
   AUTH_HINT,
   SessionLoadError,
@@ -7,6 +7,7 @@ import {
   WorkspaceAgentError,
 } from './workspace-agent'
 import type { ChildProcessLike, SpawnFn } from './acp/client'
+import type { ThreadInfo } from '../shared/ipc'
 
 /**
  * Exercise the riskiest WorkspaceAgent logic with an injected fake child:
@@ -1382,31 +1383,86 @@ describe('WorkspaceAgent.start() — concurrent + idempotent (TB2 #47)', () => {
   })
 })
 
-describe('WorkspaceAgent agent controls (#66, acp-capture §10)', () => {
-  it('setMode sends session/set_mode {sessionId, modeId} and resolves on the {} result', async () => {
+describe('WorkspaceAgent agent controls (#66, acp-capture §10/§14.0)', () => {
+  /** The 2.24.1 `configOptions` (acp-capture §14.0) — no top-level `models` block. */
+  const CONFIG_OPTIONS_2_24 = [
+    {
+      id: 'mode',
+      currentValue: 'ask',
+      options: [
+        { value: 'ask', name: 'Ask' },
+        { value: 'plan', name: 'Plan' },
+      ],
+    },
+    {
+      id: 'model',
+      currentValue: 'mistral-medium-3.5',
+      options: [
+        { value: 'mistral-medium-3.5', name: 'mistral-medium-3.5' },
+        { value: 'devstral-small', name: 'devstral-small' },
+      ],
+    },
+    { id: 'thinking', currentValue: 'medium', options: [{ value: 'off' }, { value: 'medium' }] },
+  ]
+
+  /** Open a second Thread on a connected agent whose `session/new` result is `result`. */
+  async function openThreadWith(
+    agent: WorkspaceAgent,
+    fake: CapturingFake,
+    result: Record<string, unknown>,
+  ): Promise<ThreadInfo> {
+    const opened = agent.openThread()
+    const req = sent(fake).filter((m) => m.method === 'session/new').at(-1)
+    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: req?.id, result }) + '\n')
+    return opened
+  }
+
+  it('setMode goes through the VALIDATING set_config_option when `mode` is advertised (#427)', async () => {
     const fake = makeCapturingFake()
     const agent = await connect(fake)
+    await openThreadWith(agent, fake, { sessionId: 'live', configOptions: CONFIG_OPTIONS_2_24 })
 
-    const change = agent.setMode(SESSION_ID, 'plan')
-    const req = sent(fake).find((m) => m.method === 'session/set_mode')
-    expect(req?.params).toEqual({ sessionId: SESSION_ID, modeId: 'plan' })
+    const change = agent.setMode('live', 'plan')
+    const req = sent(fake).find((m) => m.method === 'session/set_config_option')
+    // `session/set_mode` answers a BOGUS id with `{}` — a silent no-op. The config
+    // setter rejects it with -32602, so a load-bearing change uses that one.
+    expect(req?.params).toEqual({ sessionId: 'live', configId: 'mode', value: 'plan' })
+    expect(sent(fake).some((m) => m.method === 'session/set_mode')).toBe(false)
 
-    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: req?.id, result: {} }) + '\n')
+    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: req?.id, result: { configOptions: [] } }) + '\n')
     await expect(change).resolves.toBeUndefined()
   })
 
-  it('setModel sends session/set_model {sessionId, modelId} (dedicated method, not set_config_option)', async () => {
+  it('setModel goes through set_config_option with configId:"model" (set_model is -32601 at 2.24.1)', async () => {
     const fake = makeCapturingFake()
     const agent = await connect(fake)
+    await openThreadWith(agent, fake, { sessionId: 'live', configOptions: CONFIG_OPTIONS_2_24 })
 
-    const change = agent.setModel(SESSION_ID, 'devstral-small')
-    const req = sent(fake).find((m) => m.method === 'session/set_model')
-    expect(req?.params).toEqual({ sessionId: SESSION_ID, modelId: 'devstral-small' })
-    // Model has its OWN method — it does NOT flow through set_config_option.
-    expect(sent(fake).some((m) => m.method === 'session/set_config_option')).toBe(false)
+    const change = agent.setModel('live', 'devstral-small')
+    const req = sent(fake).find((m) => m.method === 'session/set_config_option')
+    expect(req?.params).toEqual({ sessionId: 'live', configId: 'model', value: 'devstral-small' })
+    expect(sent(fake).some((m) => m.method === 'session/set_model')).toBe(false)
 
-    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: req?.id, result: {} }) + '\n')
+    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: req?.id, result: { configOptions: [] } }) + '\n')
     await expect(change).resolves.toBeUndefined()
+  })
+
+  it('falls back to the legacy dedicated methods for a session advertising no config options', async () => {
+    const fake = makeCapturingFake()
+    // `connect` opens SESSION_ID with a bare `{sessionId}` result — no configOptions.
+    const agent = await connect(fake)
+
+    const mode = agent.setMode(SESSION_ID, 'plan')
+    const modeReq = sent(fake).find((m) => m.method === 'session/set_mode')
+    expect(modeReq?.params).toEqual({ sessionId: SESSION_ID, modeId: 'plan' })
+    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: modeReq?.id, result: {} }) + '\n')
+    await expect(mode).resolves.toBeUndefined()
+
+    const model = agent.setModel(SESSION_ID, 'devstral-small')
+    const modelReq = sent(fake).find((m) => m.method === 'session/set_model')
+    expect(modelReq?.params).toEqual({ sessionId: SESSION_ID, modelId: 'devstral-small' })
+    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: modelReq?.id, result: {} }) + '\n')
+    await expect(model).resolves.toBeUndefined()
   })
 
   it('setReasoningEffort sends session/set_config_option with configId:"thinking" (NOT id)', async () => {
@@ -1434,37 +1490,55 @@ describe('WorkspaceAgent agent controls (#66, acp-capture §10)', () => {
     await expect(change).rejects.toThrow(/Invalid params/)
   })
 
+  it('openThread surfaces Model from the model configOption when 2.24.1 sends no models block (#427)', async () => {
+    const fake = makeCapturingFake()
+    const agent = await connect(fake)
+
+    const info = await openThreadWith(agent, fake, {
+      sessionId: 'live',
+      modes: { currentModeId: 'ask', availableModes: [{ id: 'ask', name: 'Ask' }] },
+      configOptions: CONFIG_OPTIONS_2_24,
+    })
+    expect(info.models).toEqual({
+      currentModelId: 'mistral-medium-3.5',
+      availableModels: [
+        { modelId: 'mistral-medium-3.5', name: 'mistral-medium-3.5' },
+        { modelId: 'devstral-small', name: 'devstral-small' },
+      ],
+    })
+    expect(info.reasoningEffort?.current).toBe('medium')
+  })
+
+  it('loadThread surfaces Model from the model configOption too (the resume path)', async () => {
+    const fake = makeCapturingFake()
+    const agent = await connect(fake)
+
+    const loading = agent.loadThread('resumed')
+    const req = sent(fake).filter((m) => m.method === 'session/load').at(-1)
+    fake.feed(
+      JSON.stringify({ jsonrpc: '2.0', id: req?.id, result: { configOptions: CONFIG_OPTIONS_2_24 } }) + '\n',
+    )
+    const info = await loading
+    expect(info.models?.currentModelId).toBe('mistral-medium-3.5')
+    expect(info.modes?.currentModeId).toBe('ask') // derived from the mode configOption
+  })
+
   it('openThread surfaces the reasoning-effort axis from the thinking configOption', async () => {
     const fake = makeCapturingFake()
-    const agent = new WorkspaceAgent({ workspaceDir: '/abs/workspace', spawn: () => fake.child })
-    const started = agent.start()
-    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: 1, result: { protocolVersion: 1 } }) + '\n')
-    await new Promise((r) => setTimeout(r, 0))
-    fake.feed(
-      JSON.stringify({ jsonrpc: '2.0', id: 2, result: { authenticated: true, authState: 'os_keyring' } }) + '\n',
-    )
-    await started
+    const agent = await connect(fake)
 
-    const opened = agent.openThread()
-    fake.feed(
-      JSON.stringify({
-        jsonrpc: '2.0',
-        id: 3,
-        result: {
-          sessionId: SESSION_ID,
-          configOptions: [
-            { id: 'mode' },
-            { id: 'model' },
-            {
-              id: 'thinking',
-              currentValue: 'high',
-              options: [{ value: 'off' }, { value: 'low' }, { value: 'high' }, { value: 'max' }],
-            },
-          ],
+    const info = await openThreadWith(agent, fake, {
+      sessionId: 'thinking-only',
+      configOptions: [
+        { id: 'mode' },
+        { id: 'model' },
+        {
+          id: 'thinking',
+          currentValue: 'high',
+          options: [{ value: 'off' }, { value: 'low' }, { value: 'high' }, { value: 'max' }],
         },
-      }) + '\n',
-    )
-    const info = await opened
+      ],
+    })
     expect(info.reasoningEffort).toEqual({
       current: 'high',
       options: [{ value: 'off' }, { value: 'low' }, { value: 'high' }, { value: 'max' }],
@@ -1476,11 +1550,27 @@ describe('WorkspaceAgent agent controls (#66, acp-capture §10)', () => {
     const agent = await connect(fake)
 
     // Open a second Thread over the same agent whose result omits configOptions.
-    const opened = agent.openThread()
-    const req = sent(fake).filter((m) => m.method === 'session/new').at(-1)
-    fake.feed(JSON.stringify({ jsonrpc: '2.0', id: req?.id, result: { sessionId: 'second' } }) + '\n')
-    const info = await opened
+    const info = await openThreadWith(agent, fake, { sessionId: 'second' })
     expect(info.reasoningEffort).toBeNull()
+  })
+
+  it('WARNS once per axis the agent advertises nothing for — the #427 drift tripwire', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const fake = makeCapturingFake()
+      const agent = await connect(fake) // bare `{sessionId}` — every axis missing
+      const first = warn.mock.calls.map((c) => String(c[0]))
+      expect(first.filter((m) => m.includes('no model agent control'))).toHaveLength(1)
+      expect(first.some((m) => m.includes('no mode agent control'))).toBe(true)
+      expect(first.some((m) => m.includes('no reasoningEffort agent control'))).toBe(true)
+
+      // A second axis-less session does NOT re-warn — once per agent, not per session.
+      warn.mockClear()
+      await openThreadWith(agent, fake, { sessionId: 'second' })
+      expect(warn).not.toHaveBeenCalled()
+    } finally {
+      warn.mockRestore()
+    }
   })
 })
 

--- a/apps/desktop/src/main/workspace-agent.ts
+++ b/apps/desktop/src/main/workspace-agent.ts
@@ -1,4 +1,12 @@
 import { EventEmitter } from 'node:events'
+import {
+  MODEL_CONFIG_ID,
+  MODE_CONFIG_ID,
+  REASONING_EFFORT_CONFIG_ID,
+  extractThreadControls,
+  hasConfigOption,
+  missingControlAxes,
+} from './acp/agent-controls'
 import { AcpClient, type SpawnFn } from './acp/client'
 import { handleFsReadTextFile, type ReadTextFn } from './acp/fs-read'
 import { handleFsWriteTextFile, type WriteTextFn } from './acp/fs-write'
@@ -16,10 +24,10 @@ import type {
   PromptImage,
   PromptResult,
   ThreadAgentControls,
+  ThreadConfigAxis,
   ThreadInfo,
   ThreadModes,
   ThreadModels,
-  ThreadReasoningEffort,
 } from '../shared/ipc'
 
 /**
@@ -107,13 +115,11 @@ interface SessionNewResult {
   sessionId: string
   title?: string | null
   modes?: ThreadModes
+  /** GONE at vibe-acp 2.24.1 (#427) — Model now lives in `configOptions` only. */
   models?: ThreadModels
-  /** The agent-control selects, including the `thinking` reasoning-effort axis (#66). */
+  /** The agent-control selects: `mode`, `model` (#427) and `thinking` (#66). */
   configOptions?: unknown
 }
-
-/** The reasoning-effort configId — the only `configOption` we surface (#66, §10). */
-const REASONING_EFFORT_CONFIG_ID = 'thinking'
 
 export interface WorkspaceAgentOptions {
   /** Absolute path to the Workspace directory. */
@@ -140,6 +146,17 @@ export class WorkspaceAgent extends EventEmitter {
   private readonly openUrl?: (url: string) => void
   /** Threads hosted by this agent, keyed by their ACP `sessionId`. */
   private readonly threads = new Map<string, ThreadInfo>()
+  /**
+   * The `configOptions[].id`s each hosted session advertised (#427). A setter
+   * prefers the VALIDATING `session/set_config_option` for every axis the session
+   * advertises here, and only falls back to a legacy dedicated method
+   * (`session/set_mode` / `session/set_model`) for one it doesn't.
+   */
+  private readonly sessionConfigIds = new Map<string, Set<string>>()
+  /** Axes we have already warned are unadvertised — warn once per agent, not per session. */
+  private readonly driftWarnedAxes = new Set<ThreadConfigAxis>()
+  /** `agentInfo.version` from `initialize` (acp-capture §1) — for drift diagnostics. */
+  private agentVersionValue: string | null = null
   /**
    * The Workspace's single primary ACP session (ADR-0012): one `session/new`
    * opened eagerly at connect so a Draft's picker can read real, account-accurate
@@ -279,6 +296,7 @@ export class WorkspaceAgent extends EventEmitter {
         }),
         earlyFailure,
       ])
+      this.agentVersionValue = init.agentInfo?.version ?? null
       this.authMethodsValue = extractAuthMethods(init)
       this.sessionCloseAvailableValue = extractSessionCloseCapability(init)
       this.loadSessionAvailableValue = extractLoadSessionCapability(init)
@@ -527,14 +545,13 @@ export class WorkspaceAgent extends EventEmitter {
       throw this.mapErrorAndCacheAuth(err)
     }
 
+    const controls = this.readControls(result, 'session/new')
     const thread: ThreadInfo = {
       sessionId: result.sessionId,
       // `session/new` returns no title in the capture — the Thread title arrives
       // later via the `session_info_update` notification (TB2). This is defensive.
       title: result.title ?? null,
-      modes: result.modes ?? null,
-      models: result.models ?? null,
-      reasoningEffort: extractReasoningEffort(result.configOptions),
+      ...controls,
     }
     this.threads.set(thread.sessionId, thread)
     return thread
@@ -639,9 +656,7 @@ export class WorkspaceAgent extends EventEmitter {
         // The `session/load` result omits `sessionId` (acp-capture §9) — keep ours.
         sessionId,
         title: result.title ?? null,
-        modes: result.modes ?? null,
-        models: result.models ?? null,
-        reasoningEffort: extractReasoningEffort(result.configOptions),
+        ...this.readControls({ ...result, sessionId }, 'session/load'),
       }
       this.threads.set(sessionId, thread)
       return thread
@@ -696,37 +711,93 @@ export class WorkspaceAgent extends EventEmitter {
   }
 
   /**
-   * Change a Thread's Mode (`session/set_mode`, acp-capture §10). A successful
-   * change returns `{}` and emits NO notification — the caller reflects it
-   * optimistically (ADR-0007). Rejects (mapped + auth-cached) on failure so the
-   * IPC handler can surface the error and the renderer can revert.
+   * Change a Thread's Mode. Goes through the VALIDATING generic setter
+   * (`session/set_config_option` with `configId: "mode"`) whenever the session
+   * advertises the `mode` config option — verified at 2.24.1: a bad id is rejected
+   * with `-32602 "Unsupported config option mode=…"`, whereas `session/set_mode`
+   * answers a bogus id with `{}` (a silent no-op indistinguishable from success,
+   * #427). Falls back to `session/set_mode` only for an agent that offers modes but
+   * no `mode` config option. A successful change emits NO notification, so the
+   * caller reflects it optimistically (ADR-0007) and reverts on a rejection.
    */
   async setMode(sessionId: string, modeId: string): Promise<void> {
-    await this.requestInitialized('session/set_mode', { sessionId, modeId })
+    if (!this.advertisesConfigOption(sessionId, MODE_CONFIG_ID)) {
+      await this.requestInitialized('session/set_mode', { sessionId, modeId })
+      return
+    }
+    await this.setConfigOption(sessionId, MODE_CONFIG_ID, modeId)
   }
 
   /**
-   * Change a Thread's Model (`session/set_model`, acp-capture §10). The agent
-   * FALSE-ACCEPTS any string as `modelId` (returns `{}` without validating against
-   * `availableModels`), so the renderer must only ever pass an id from
-   * `models.availableModels` — a `{}` is not proof the value was valid.
+   * Change a Thread's Model. `session/set_model` was REMOVED at 2.24.1 (`-32601
+   * "Method not found"`, #427) — the model is a config option now, and the config
+   * setter validates it (`-32602` on an unknown id) where the old dedicated method
+   * false-accepted any string. The legacy method is kept only for a session that
+   * advertises no `model` config option (a pre-2.24 binary).
    */
   async setModel(sessionId: string, modelId: string): Promise<void> {
-    await this.requestInitialized('session/set_model', { sessionId, modelId })
+    if (!this.advertisesConfigOption(sessionId, MODEL_CONFIG_ID)) {
+      await this.requestInitialized('session/set_model', { sessionId, modelId })
+      return
+    }
+    await this.setConfigOption(sessionId, MODEL_CONFIG_ID, modelId)
   }
 
   /**
-   * Change a Thread's reasoning effort via the GENERIC config setter
-   * (`session/set_config_option`, acp-capture §10). The param key is `configId`
-   * (NOT `id` — `{id, value}` returns -32602), pinned to `thinking`; `value` is one
-   * of the `thinking` option values (`off`/`low`/`medium`/`high`/`max`).
+   * Change a Thread's reasoning effort — the `thinking` config option; `value` is
+   * one of its option values (`off`/`low`/`medium`/`high`/`max`).
    */
   async setReasoningEffort(sessionId: string, value: string): Promise<void> {
-    await this.requestInitialized('session/set_config_option', {
-      sessionId,
-      configId: REASONING_EFFORT_CONFIG_ID,
-      value,
-    })
+    await this.setConfigOption(sessionId, REASONING_EFFORT_CONFIG_ID, value)
+  }
+
+  /**
+   * The one generic agent-control setter (`session/set_config_option`, acp-capture
+   * §10/§14.0). The param key is `configId` (NOT `id` — `{id, value}` returns
+   * -32602). At 2.24.1 the result carries the session's full updated
+   * `configOptions`; we ignore it and keep the renderer's optimistic reflection
+   * (ADR-0007), since the rejection is the signal we act on.
+   */
+  private async setConfigOption(sessionId: string, configId: string, value: string): Promise<void> {
+    await this.requestInitialized('session/set_config_option', { sessionId, configId, value })
+  }
+
+  /**
+   * Whether a hosted session advertised `configId` in its `session/new` /
+   * `session/load` result. Defaults to TRUE for a session we don't know (one opened
+   * before this agent object saw it, or a test double), so the modern config-option
+   * path is the default and the legacy dedicated methods are the exception.
+   */
+  private advertisesConfigOption(sessionId: string, configId: string): boolean {
+    const ids = this.sessionConfigIds.get(sessionId)
+    return ids ? ids.has(configId) : true
+  }
+
+  /**
+   * Map a session result onto the controls bundle, remember which config options it
+   * advertised (the setters route on that), and LOG any axis the agent advertises
+   * nothing for. That log is the tripwire for #427-class drift: every failure mode
+   * there was silent — a renamed field just made a picker disappear — so an axis we
+   * expect but no longer get must at least leave a trace in the main-process log.
+   */
+  private readControls(result: SessionNewResult, method: string): ThreadAgentControls {
+    const controls = extractThreadControls(result)
+    const advertised = new Set(
+      [MODE_CONFIG_ID, MODEL_CONFIG_ID, REASONING_EFFORT_CONFIG_ID].filter((id) =>
+        hasConfigOption(result.configOptions, id),
+      ),
+    )
+    this.sessionConfigIds.set(result.sessionId, advertised)
+    for (const axis of missingControlAxes(controls)) {
+      if (this.driftWarnedAxes.has(axis)) continue
+      this.driftWarnedAxes.add(axis)
+      console.warn(
+        `[vibe-mistro:acp] ${method} advertises no ${axis} agent control ` +
+          `(vibe-acp ${this.agentVersionValue ?? 'unknown version'}) — its picker will be hidden. ` +
+          'If the agent should offer it, the wire shape has drifted (see docs/acp-capture.md §14.0).',
+      )
+    }
+    return controls
   }
 
   /**
@@ -758,6 +829,7 @@ export class WorkspaceAgent extends EventEmitter {
   async closeSession(sessionId: string): Promise<void> {
     if (!this.threads.has(sessionId)) return
     this.threads.delete(sessionId)
+    this.sessionConfigIds.delete(sessionId)
     if (!this.initialized || !this.sessionCloseAvailableValue) return
     try {
       await this.client.request('session/close', { sessionId })
@@ -824,6 +896,7 @@ export class WorkspaceAgent extends EventEmitter {
   stop(): void {
     this.client.stop()
     this.threads.clear()
+    this.sessionConfigIds.clear()
     // Drop the primary session with the process (ADR-0012 #6 / ADR-0006): an
     // idle un-prompted session dies on eviction, and a re-warm re-opens a fresh one.
     this.primarySessionValue = null
@@ -1000,32 +1073,6 @@ function extractSessionCloseCapability(init: InitializeResult): boolean {
  */
 function extractLoadSessionCapability(init: InitializeResult): boolean {
   return (init.agentCapabilities as { loadSession?: unknown } | null)?.loadSession === true
-}
-
-/**
- * Surface the reasoning-effort axis from `session/new`/`session/load`'s
- * `configOptions` (#66, acp-capture §10): find the `thinking` select and map its
- * `currentValue` + `options[{value, name?}]` to a `ThreadReasoningEffort`. Defaults
- * to null on any absent/malformed shape (no array, no `thinking`, non-string
- * `currentValue`) — so the picker simply omits the control rather than rendering a
- * broken one. Mode/Model come back as their own dedicated fields, not here.
- */
-function extractReasoningEffort(configOptions: unknown): ThreadReasoningEffort | null {
-  if (!Array.isArray(configOptions)) return null
-  const thinking = configOptions.find(
-    (o): o is { id: string; currentValue?: unknown; options?: unknown } =>
-      !!o && typeof o === 'object' && (o as { id?: unknown }).id === REASONING_EFFORT_CONFIG_ID,
-  )
-  if (!thinking || typeof thinking.currentValue !== 'string') return null
-  const options = Array.isArray(thinking.options)
-    ? thinking.options
-        .filter(
-          (opt): opt is { value: string; name?: unknown } =>
-            !!opt && typeof opt === 'object' && typeof (opt as { value?: unknown }).value === 'string',
-        )
-        .map((opt) => ({ value: opt.value, name: typeof opt.name === 'string' ? opt.name : undefined }))
-    : []
-  return { current: thinking.currentValue, options }
 }
 
 /** Pull the well-formed `authMethods` out of an `initialize` result. */

--- a/apps/desktop/src/renderer/src/connection/side-thread-controls.test.ts
+++ b/apps/desktop/src/renderer/src/connection/side-thread-controls.test.ts
@@ -40,16 +40,23 @@ describe('snapshotSideDraftControls', () => {
     })
   })
 
-  it('stages advertised default Mode when Chat is unavailable', () => {
-    expect(snapshotSideDraftControls(advertisedControls(['default', 'plan']))).toEqual({
-      mode: 'default',
+  it('stages read-only Plan Mode on a 2.24.1 agent, which advertises no Chat (#427)', () => {
+    expect(snapshotSideDraftControls(advertisedControls(['ask', 'plan', 'accept-edits']))).toEqual({
+      mode: 'plan',
       model: 'devstral-small',
       reasoningEffort: 'high',
     })
   })
 
-  it('omits Mode rather than inventing default when neither Chat nor default is advertised', () => {
-    expect(snapshotSideDraftControls(advertisedControls(['plan']))).toEqual({
+  it('falls back to the approval-gated Mode under either of its names', () => {
+    expect(snapshotSideDraftControls(advertisedControls(['ask', 'accept-edits'])).mode).toBe('ask')
+    expect(snapshotSideDraftControls(advertisedControls(['default', 'accept-edits'])).mode).toBe(
+      'default',
+    )
+  })
+
+  it('omits Mode rather than inventing one when no preferred id is advertised', () => {
+    expect(snapshotSideDraftControls(advertisedControls(['accept-edits', 'auto-approve']))).toEqual({
       model: 'devstral-small',
       reasoningEffort: 'high',
     })

--- a/apps/desktop/src/renderer/src/connection/side-thread-controls.ts
+++ b/apps/desktop/src/renderer/src/connection/side-thread-controls.ts
@@ -3,18 +3,31 @@ import type { ThreadAgentControls, ThreadConfigAxis } from '../../../shared/ipc'
 export type SideDraftControlSnapshot = Partial<Record<ThreadConfigAxis, string>>
 
 /**
- * Snapshot safe Side Draft intent without creating a session. Chat is preferred,
- * advertised `default` is the Mode fallback, and Model/Reasoning effort inherit the
- * source Thread's advertised current ids. Missing ids are omitted, never invented.
+ * Mode ids we stage for a Side Draft, best first. A Side Draft is a throwaway
+ * "ask about this selection" Thread, so it wants the most READ-ONLY posture the
+ * agent advertises: `chat` (2.18's read-only conversational mode) is gone at
+ * vibe-acp 2.24.1 and `plan` ("Read-only agent for exploration and planning") is
+ * now the closest thing (#427, acp-capture §14.0). `ask` (2.24.1) / `default`
+ * (2.18.0) are the same approval-gated posture under two names and are the last
+ * resort — the session default, staged explicitly rather than by omission.
+ * Nothing here is ever INVENTED: an id absent from `availableModes` is skipped.
+ */
+const SIDE_DRAFT_MODE_PREFERENCE = ['chat', 'plan', 'ask', 'default'] as const
+
+/**
+ * Snapshot safe Side Draft intent without creating a session. Mode takes the first
+ * advertised id from `SIDE_DRAFT_MODE_PREFERENCE`; Model and Reasoning effort
+ * inherit the source Thread's advertised current ids. Missing ids are omitted,
+ * never invented.
  */
 export function snapshotSideDraftControls(
   source: ThreadAgentControls,
 ): SideDraftControlSnapshot {
   const snapshot: SideDraftControlSnapshot = {}
-  if (source.modes?.availableModes.some((mode) => mode.id === 'chat')) snapshot.mode = 'chat'
-  else if (source.modes?.availableModes.some((mode) => mode.id === 'default')) {
-    snapshot.mode = 'default'
-  }
+  const mode = SIDE_DRAFT_MODE_PREFERENCE.find((id) =>
+    source.modes?.availableModes.some((advertised) => advertised.id === id),
+  )
+  if (mode) snapshot.mode = mode
   if (
     source.models?.availableModels.some(
       (model) => model.modelId === source.models?.currentModelId,

--- a/apps/desktop/src/shared/ipc/core.ts
+++ b/apps/desktop/src/shared/ipc/core.ts
@@ -63,14 +63,18 @@ export interface VibeUpdateResult {
   error: string | null
 }
 
-/** A selectable agent mode from `session/new` (e.g. `default`, `plan`). */
+/** A selectable agent mode from `session/new` (e.g. `ask`, `plan`). */
 export interface AcpMode {
   id: string
   name: string
   description?: string
 }
 
-/** A selectable model from `session/new`. */
+/**
+ * A selectable model. Sourced from `session/new`'s `configOptions[id="model"]` at
+ * vibe-acp 2.24.1 (`modelId` = the option's `value`); the top-level `models` block
+ * it used to come from is gone (#427, acp-capture §14.0).
+ */
 export interface AcpModel {
   modelId: string
   name: string

--- a/apps/desktop/src/shared/ipc/thread.ts
+++ b/apps/desktop/src/shared/ipc/thread.ts
@@ -243,14 +243,15 @@ export type ThreadControlIntent = Partial<Record<ThreadConfigAxis, string>>
 
 /**
  * Change one agent control on a Thread's bound ACP session (#66) — Mode, Model, or
- * Reasoning effort. Main maps the axis to the verified setter (`session/set_mode` /
- * `session/set_model` / `session/set_config_option`, acp-capture §10) and returns
- * ok/err. `value` is the new id for the axis — a `modeId` from `availableModes`, a
- * `modelId` from `availableModels` (NEVER an arbitrary string: `session/set_model`
- * false-accepts any string, acp-capture §10), or a reasoning-effort `value` from the
- * `thinking` options. A change emits NO notification (the `{}` result is the only
- * signal), so the renderer updates the displayed value OPTIMISTICALLY and reverts on
- * an `{ok:false}` (ADR-0007).
+ * Reasoning effort. Main maps the axis to the verified setter: at vibe-acp 2.24.1
+ * all three go through `session/set_config_option` (`configId` = `mode` / `model` /
+ * `thinking`), which VALIDATES the value and rejects an unknown one with `-32602`
+ * (#427, acp-capture §14.0); the legacy dedicated methods survive only for a session
+ * that advertises no matching config option. `value` is the new id for the axis — a
+ * `modeId` from `availableModes`, a `modelId` from `availableModels`, or a
+ * reasoning-effort `value` from the `thinking` options. A change emits NO
+ * notification (the setter's result is the only signal), so the renderer updates the
+ * displayed value OPTIMISTICALLY and reverts on an `{ok:false}` (ADR-0007).
  */
 export interface SetThreadConfigArgs {
   /** Id of the Workspace agent (one `vibe-acp` process) hosting the Thread. */

--- a/docs/acp-capture.md
+++ b/docs/acp-capture.md
@@ -1,8 +1,12 @@
-# ACP capture — real `vibe-acp` 2.18.0 traffic
+# ACP capture — real `vibe-acp` traffic
 
-Ground-truth JSON-RPC captured by driving `vibe-acp` directly (stdio) on 2026-06-29, vibe 2.18.0.
-These supersede any guessed shapes in [vibe-acp-protocol.md](./vibe-acp-protocol.md). Field names are
-**verbatim**.
+Ground-truth JSON-RPC captured by driving `vibe-acp` directly (stdio). **Each section names the
+version it was captured against** — §1–§12 are vibe 2.18.x (2026-06-29 onward), §13–§14 are vibe
+**2.24.1** (2026-08). These supersede any guessed shapes in
+[vibe-acp-protocol.md](./vibe-acp-protocol.md). Field names are **verbatim**.
+
+> **Read §14.0 first.** Three things drifted between 2.18.0 and 2.24.1 (mode ids, the `models` block,
+> `session/set_model`), so §2 and §10 are stale where §14.0 says so.
 
 Capture method: a Node probe spawned `vibe-acp`, sent `initialize` → `session/new` → `session/prompt`,
 served the agent's `fs/*` requests, and answered `session/request_permission`. (Scripts were
@@ -37,6 +41,10 @@ resume/fork/list are available.
 ---
 
 ## 2. `session/new` (client → agent)
+
+> ⚠️ **Partly stale (2.18.0).** At 2.24.1 the mode list is `ask`/`plan`/`accept-edits`/`auto-approve`
+> (no `default`, no `chat`) and the top-level `models` block is **gone**. See §14.0 for the current
+> verbatim result.
 
 **Request**: `{"id":2,"method":"session/new","params":{"cwd":"<abs path>","mcpServers":[]}}`
 
@@ -342,6 +350,10 @@ Electron (which is why the app itself was unaffected). To re-run the probe:
 
 ## 10. Agent controls — change Mode / Model / Reasoning effort (captured 2026-06-30 via the #65 spike, vibe-acp 2.18.0)
 
+> ⚠️ **Partly stale (2.18.0).** At 2.24.1 `session/set_model` is **gone** (`-32601`) and there is no
+> `models` block; Mode ids changed (`default` → `ask`, `chat` removed); `session/set_mode` silently
+> no-ops on an unknown id. See §14.0 and §14.4.
+
 `session/new` (§2) returns the current values + options as `modes`, `models`, and `configOptions`
 (ids `mode` / `model` / `thinking`). The **5 modes** are `default` (requires approval for tool
 executions), `plan` (read-only — exploration/planning), `accept-edits` (auto-approves file edits only),
@@ -443,3 +455,228 @@ Streaming stops immediately. So `stopReason` has (at least) two values: **`end_t
 
 ### Infra — same `node`-not-`bun` gotcha as §9/§10/§11
 `bun build scripts/spike-cancel-steer.ts --target=node --outfile=/tmp/spike-cs.mjs && node /tmp/spike-cs.mjs`. Read-only (`chat` mode — the agent can't touch the workspace); sends only `session/*` + `_auth/status` (no auth/creds/writes). Safe under the house rules.
+
+---
+
+## 13. `session/list` — saved CLI + ACP sessions (confirmed 2026-08-12, vibe-acp 2.24.1)
+
+Vibe implements the standard `session/list` request. Sending `{}` (no `cwd`) lists the global
+saved-session index; supplying `cwd` filters it. The response is:
+
+```json
+{"sessions":[{"sessionId":"…","cwd":"/abs/workspace","title":"…","updatedAt":"2026-08-11T12:00:00+00:00"}]}
+```
+
+The implementation is backed by Vibe's reconciled `.session_index.json`; clients must use this ACP
+surface and must not parse `~/.vibe/logs/session` directly. Current Vibe returns all sessions in one
+response (it accepts but ignores `cursor`). Builds predating the method reject with JSON-RPC `-32601`;
+Mistro treats that as discovery unavailable, not a launch failure.
+
+Some older indexed rows intentionally return `cwd:""` (and legacy malformed rows may omit `cwd`).
+Mistro keeps those rows in the discovered count and reports each as a visible partial failure. It
+does not invent a directory: a Workspace is a real filesystem boundary, and loading a session under
+an arbitrary cwd would make file tools operate in the wrong context.
+
+Opening a listed session uses the existing `session/load` contract (§9). Its historical
+`session/update` replay now includes `user_message_chunk` as well as agent/reasoning/tool updates;
+Mistro captures that replay once, atomically, into its own transcript log so later cold opens remain
+process-free. Text blocks are reconstructed normally; historical image/resource blocks that ACP does
+not provide as reusable local attachment data are retained honestly. Inline image bytes and local
+image resource links are copied into Mistro's file-backed AttachmentStore before transcript import;
+SQLite holds only the attachment filename/mime ref, never base64. They render as normal user-message
+thumbnails. Image `data:` resource links and image blobs inside embedded resources take the same
+file-backed path. All other embedded blobs, binary block data, and non-image data URIs are stripped
+to descriptive metadata or an explicit unavailable placeholder before the atomic transcript insert.
+Non-image filesystem/remote resource links retain both label and URI; an image without reusable
+bytes is rendered as an explicit unavailable-attachment placeholder.
+
+---
+
+## 14. Agent profiles as ACP modes + 2.24.1 drift (captured 2026-08-19 via the #420 probe, vibe-acp **2.24.1**)
+
+Captured by `apps/desktop/scripts/spike-agent-profiles.ts` against the installed binary
+(`vibe 2.24.1`, source read at v2.24.2), signed in, workspace `/tmp/vibe-probe-420-cwd`.
+Rebuild + run: `bun build scripts/spike-agent-profiles.ts --target=node --outfile=/tmp/spike-agents.mjs
+&& node /tmp/spike-agents.mjs --phase=all` (same `node`-not-`bun` gotcha as §9–§12).
+The probe writes ONLY `zz-probe-*` scratch files into `~/.vibe/agents/` + `~/.vibe/prompts/` and
+deletes them on exit.
+
+### 14.0 DRIFT — corrections to §2 and §10 (2.18.0 → 2.24.1)
+
+Three load-bearing things changed since the 2.18.0 capture. §2/§10 are stale on all three.
+
+| Was (2.18.0) | Is (2.24.1) |
+|---|---|
+| 5 modes: `default`, `plan`, `accept-edits`, `auto-approve`, `chat` | **4** modes: **`ask`**, `plan`, `accept-edits`, `auto-approve`. `default` was **renamed `ask`**; **`chat` is gone**. |
+| `session/new` result carries a top-level **`models`** block (`currentModelId` / `availableModels`) | **No `models` key at all.** Model lives ONLY in `configOptions[id="model"]` (`currentValue` + `options[].value`). |
+| `session/set_model` `{sessionId, modelId}` → `{}` | **`session/set_model` no longer exists** → `-32601 "Method not found"`, `data:{"method":"session/set_model"}`. Model changes go through `session/set_config_option` `{sessionId, configId:"model", value}`. |
+
+Verbatim `session/new` result at 2.24.1 (fresh temp cwd, no custom profiles):
+
+```json
+{"sessionId":"a6bb0b67-645d-3f62-2e40-0d62f1609e26",
+ "modes":{"currentModeId":"ask","availableModes":[
+   {"id":"ask","name":"Ask","description":"Requires approval for tool executions"},
+   {"id":"plan","name":"Plan","description":"Read-only agent for exploration and planning"},
+   {"id":"accept-edits","name":"Accept Edits","description":"Auto-approves file edits only"},
+   {"id":"auto-approve","name":"Auto Approve","description":"Auto-approves all tool executions"}]},
+ "configOptions":[
+   {"id":"mode","name":"Session Mode","category":"mode","type":"select","currentValue":"ask",
+    "options":[{"value":"ask","name":"Ask","description":"…"}, …]},
+   {"id":"model","name":"Model","category":"model","type":"select","currentValue":"mistral-medium-3.5",
+    "options":[{"value":"mistral-medium-3.5","name":"mistral-medium-3.5","description":"mistral-vibe-cli-latest"},
+               {"value":"devstral-small","name":"devstral-small","description":"devstral-small-latest"},
+               {"value":"local","name":"local","description":"devstral"}]},
+   {"id":"thinking","name":"Thinking","category":"thinking","type":"select","currentValue":"medium",
+    "options":[{"value":"off","name":"Off"},{"value":"low","name":"Low"},{"value":"medium","name":"Medium"},
+               {"value":"high","name":"High"},{"value":"max","name":"Max"}]}],
+ "_meta":{"workspace_trust":{"status":"untrusted","details":null}}}
+```
+
+`initialize` is unchanged from §1 except `agentInfo.version:"2.24.1"` — same `agentCapabilities`
+(`loadSession:true`, `promptCapabilities{image:true,audio:false,embeddedContext:true}`,
+`sessionCapabilities{list,fork,close}`) and the same single `browser-auth` method.
+`configOptions[].options[]` now also carry a **`description`** (2.18 showed only `value`), and the
+model option's `description` is the underlying model name (e.g. `mistral-vibe-cli-latest`).
+
+Note the two builtin profiles that are **NOT** offered as modes: `explore` (it is
+`agent_type = "subagent"`) and `lean` (`install_required = true`) — see 14.2.
+
+### 14.1 A custom `*.toml` profile DOES become an ACP mode
+
+Dropping `~/.vibe/agents/zz-probe-bot.toml`:
+
+```toml
+display_name = "ZZ Probe Bot"
+description = "Throwaway probe profile for issue 420"
+safety = "safe"
+system_prompt_id = "zz-probe-prompt"
+```
+
+makes the very next `session/new` (fresh process) return it **appended after the builtins**, in both
+`modes.availableModes` and `configOptions[id="mode"].options`:
+
+```json
+{"id":"zz-probe-bot","name":"ZZ Probe Bot","description":"Throwaway probe profile for issue 420"}
+```
+
+**Field mapping (verbatim, verified):**
+
+| ACP field | Source |
+|---|---|
+| `id` (and `configOptions` `value`) | the **file stem** — `zz-probe-bot.toml` → `zz-probe-bot`. The TOML has no `name` key. |
+| `name` | `display_name`; when absent, the stem title-cased: `zz-probe-minimal-fields.toml` → `"Zz Probe Minimal Fields"`. |
+| `description` | `description`; when absent, the **empty string** `""` (not null, not omitted). |
+
+Ordering is filesystem `glob` order, **not** alphabetical (a `zz-probe-minimal-fields` file appeared
+before `zz-probe-bot`). Builtins always come first; do not rely on the order of the custom tail.
+
+### 14.2 Profiles that are silently NOT offered
+
+Everything below is dropped **without any wire signal** — no error, no `session/update`, nothing on
+`vibe-acp`'s stderr. The only trace is a `WARNING` in `~/.vibe/logs/vibe.log`:
+
+| Case | Offered? | `vibe.log` line (verbatim) |
+|---|---|---|
+| `agent_type = "subagent"` | no | (none — filtered at `build_mode_state`, not at load) |
+| `system_prompt_id` naming a missing `.md` | no | `Failed to load agent at …/zz-probe-missing-prompt.toml: 1 validation error for VibeConfigSchema\n  Value error, Invalid system_prompt_id value: 'zz-probe-does-not-exist'. Must be one of the available prompts ("cli", "explore", "tests", "lean", "minimal"), or correspond to a .md file in /Users/…/.vibe/prompts (available: "zz-probe-prompt")` |
+| malformed TOML | no | `Failed to load agent at …/zz-probe-broken.toml: Expected '=' after a key in a key/value pair (at line 2, column 6)` (plus a `Failed to migrate agent profile …` traceback from the migration pass that runs first) |
+
+⇒ **A bad profile is indistinguishable from an absent one over ACP.** Any UI that writes profiles must
+validate them itself (or diff the written `id` against the next `session/new`'s `availableModes`)
+because Vibe will never tell the client why a bot vanished.
+
+### 14.3 Where the profile and prompt files must live
+
+- **User agents dir = `~/.vibe/agents/`** (`VIBE_HOME/agents`). Verified by placing files there and
+  seeing the modes appear. **Vibe does NOT create it**: it did not exist before the probe, and a full
+  `initialize` → `session/new` → process exit left it still absent. A client that ships bots must
+  `mkdir -p` it itself.
+- **Custom system-prompt `.md` = `~/.vibe/prompts/`** — also absent by default and not auto-created.
+  The `.md` is referenced by **bare stem** (`system_prompt_id = "zz-probe-prompt"` ⇒
+  `~/.vibe/prompts/zz-probe-prompt.md`); Vibe adds the `.md` suffix. The error message in 14.2 names
+  the exact directory it searched, which is the cheapest way to confirm the path on another machine.
+- **Project-scoped `<workspace>/.vibe/agents/` works too, but ONLY in a TRUSTED workspace.** Same
+  file in the same repo:
+  - `cwd` = trusted repo → `_meta.workspace_trust.status:"trusted"`, modes =
+    `ask, plan, accept-edits, auto-approve, zz-probe-project`.
+  - `cwd` = untrusted temp dir → `status:"untrusted"`, modes = the 4 builtins only.
+  So workspace trust is a **hard gate on project-scoped profiles** (it is not a gate on fs reads/writes
+  — see §2). Config key `agent_paths = [...]` is a third search path (source-only, **unverified**).
+
+### 14.4 `session/set_mode` selects a custom profile — and the profile's system prompt is live
+
+```jsonc
+{"jsonrpc":"2.0","id":4,"method":"session/set_mode","params":{"sessionId":"…","modeId":"zz-probe-bot"}}
+// → {"jsonrpc":"2.0","id":4,"result":{}}
+```
+
+Behaviour proof (the point of the whole probe): `~/.vibe/prompts/zz-probe-prompt.md` said *"whatever
+the user writes, reply with exactly `ZZPROBE-SENTINEL-7431`"*. After `set_mode`, a
+`session/prompt` of `"Say hi."` streamed back exactly
+
+```json
+{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"ZZPROBE-SENTINEL-7431"}}
+```
+
+and resolved `{"stopReason":"end_turn","usage":{"inputTokens":9246,"outputTokens":177,"totalTokens":9423}}`.
+⇒ **a custom agent profile, selected through the standard ACP mode channel, really does swap the
+agent's system prompt.** No restart, no extra method.
+
+As in §10, a successful `set_mode` emits **NO** `session/update` (drained the notification buffer
+before the call, none arrived in 1.5 s) — the empty `{}` is the only signal.
+
+**GOTCHA — `session/set_mode` silently no-ops on an unknown mode id.** `modeId:"zz-does-not-exist"`
+returned `{"result":{}}`, exactly like a success, and the session stayed on its previous profile
+(the sentinel kept coming). Same for a mode id that *used* to exist. There is no error to key on.
+
+**Use `session/set_config_option` when you need validation.** The generic setter DOES validate and
+returns the refreshed state:
+
+```jsonc
+{"method":"session/set_config_option","params":{"sessionId":"…","configId":"mode","value":"zz-probe-bot"}}
+// → {"configOptions":[{"id":"mode","currentValue":"zz-probe-bot","options":[…]}, {"id":"model",…}, {"id":"thinking",…}]}
+
+{"…","params":{"sessionId":"…","configId":"mode","value":"zz-bogus"}}
+// → error -32602 "Unsupported config option mode='zz-bogus'"
+```
+
+So at 2.24.1 there are two ways to set the Mode with **different** failure semantics: `session/set_mode`
+(fire-and-forget, silently lossy) and `session/set_config_option` (validated, echoes the new
+`configOptions` back — a free read-back of the current mode).
+
+### 14.5 A custom mode does NOT survive `session/load` (§10 Q2 still holds at 2.24.1)
+
+Set `zz-probe-bot`, prompted (persisting the session), then `session/load` from a **fresh process**:
+
+```json
+{"modes":{"currentModeId":"ask","availableModes":[…,{"id":"zz-probe-bot","name":"ZZ Probe Bot","description":"…"}]}, …}
+```
+
+`currentModeId` came back **`ask`**, not `zz-probe-bot` — the profile is still *offered*, just not
+*selected*. Identical to the 2.18 finding (with `default` → `ask`). ⇒ the per-Thread re-assert
+choreography (ADR-0007) is still required, and must re-assert **custom** modes too.
+
+### 14.6 Editing or deleting a profile mid-session
+
+With a live session already switched to `zz-probe-bot`:
+
+| Action (mid-session) | Effect |
+|---|---|
+| Delete `~/.vibe/agents/zz-probe-bot.toml` | **The live session is unaffected** — the next `session/prompt` still answered with the sentinel. The resolved profile lives in the session's runtime config, not in the file. |
+| Delete `~/.vibe/prompts/zz-probe-prompt.md` | **Also unaffected** — still the sentinel. The system prompt text is already resolved into the running session. |
+| `session/new` in the **same still-running process**, after the delete | The new session does **NOT** list `zz-probe-bot`. ⇒ **the agent registry is re-scanned per `session/new`, not cached at process start** — a client can add or remove bots without restarting `vibe-acp`, as long as it opens a new session. |
+| `session/set_mode` to the just-deleted id, on the live session | `{}` (the silent no-op of 14.4) — the session stays on the profile it already had. |
+
+⇒ Editing a profile file **never** disturbs a running Thread, and never needs an agent restart to be
+picked up by the next Thread. The failure mode to design for is the opposite one: a mode id we cached
+per-Thread can vanish from `availableModes` between sessions, and re-asserting it will fail *silently*.
+
+### 14.7 Safety note on the probe
+
+The probe answers every `session/request_permission` with `reject_once` and refuses
+`fs/write_text_file`, so the agent cannot touch the workspace. It sends only `initialize`,
+`_auth/status` (read), `session/{new,load,prompt,set_mode,set_config_option}` — never `authenticate`
+or `_auth/signOut`. Scratch profile names are prefixed `zz-probe-` so they can never shadow a Vibe
+builtin (a custom profile whose **file stem equals a builtin name overrides that builtin** — source
+`registry.py` logs `Custom agent '%s' overrides builtin agent`; deliberately **not** probed).

--- a/docs/acp-capture.md
+++ b/docs/acp-capture.md
@@ -542,6 +542,31 @@ model option's `description` is the underlying model name (e.g. `mistral-vibe-cl
 Note the two builtin profiles that are **NOT** offered as modes: `explore` (it is
 `agent_type = "subagent"`) and `lean` (`install_required = true`) — see 14.2.
 
+#### The setters, re-probed while fixing #427 (2026-08-19, vibe 2.24.1)
+
+`session/set_config_option` is now the setter for **all three** axes, and it is the only one that
+validates:
+
+| Call | Result |
+|---|---|
+| `session/set_config_option {sessionId, configId:"model", value:"devstral-small"}` | OK — result is the session's **full updated `configOptions` array** (2.18 returned `{}`) |
+| `session/set_config_option {…, configId:"mode", value:"plan"}` | OK, same shape |
+| `session/set_config_option {…, configId:"thinking", value:"low"}` | OK, same shape |
+| any of the three with an unadvertised value | `-32602 "Unsupported config option <id>='<value>'"` |
+| `session/set_model {sessionId, modelId}` | `-32601 "Method not found"`, `data:{"method":"session/set_model"}` |
+| `session/set_mode {sessionId, modeId:"zz-not-a-mode"}` | **`{}`** — a bogus id is a SILENT no-op, indistinguishable from success |
+
+⇒ Prefer `set_config_option` wherever the result is load-bearing (e.g. re-asserting Mode after
+`session/load`, which §10 Q2 / §14.5 say is still required). `session/set_mode` remains only as a
+fallback for an agent that advertises no `mode` config option.
+
+⚠️ **A Model change writes THROUGH to the user's global default.** After
+`set_config_option {configId:"model", value:"devstral-small"}`, `~/.vibe/config.toml`'s `active_model`
+was rewritten and the NEXT `session/new` (fresh process) reported `devstral-small` as its current
+model. So the Model axis is a user-level setting with a per-session override, not a purely per-session
+one — worth remembering wherever we treat agent controls as per-Thread state (ADR-0007). `thinking`
+behaved the same way; Mode did not (a new session comes back at `ask`).
+
 ### 14.1 A custom `*.toml` profile DOES become an ACP mode
 
 Dropping `~/.vibe/agents/zz-probe-bot.toml`:

--- a/docs/adr/0007-agent-controls-vibe-owned-sticky-per-thread.md
+++ b/docs/adr/0007-agent-controls-vibe-owned-sticky-per-thread.md
@@ -42,6 +42,26 @@ The #65 spike captured the change mechanism against vibe-acp 2.18.0 (acp-capture
   out of the durable metadata store unless we choose otherwise.
 - ⚠️ `session/set_model` false-accepts any string as a `modelId` — pass only `availableModels` ids.
 
+## Amendment (#427, 2026-08-19) — vibe-acp 2.24.1 moved all three axes onto one setter
+
+Re-captured against the installed 2.24.1 binary (acp-capture §14.0). The three-distinct-calls finding
+above is **stale**; the decision (Vibe-owned, display-from-session-state, sticky per-Thread, optimistic
+reflection, re-assert after resume) is unchanged. What changed underneath it:
+
+- **One setter for every axis:** `session/set_config_option {sessionId, configId, value}` with
+  `configId` = `mode` / `model` / `thinking`. `session/set_model` was **removed** (`-32601`), and
+  `session/set_mode` still exists but **silently no-ops on an unknown id** (returns `{}`), so it is now
+  a fallback for agents that advertise no `mode` config option — never the preferred path. The config
+  setter validates (`-32602 "Unsupported config option …"`), which matters most for the re-assert-
+  after-resume choreography, where a silent no-op would leave the Thread in the wrong posture.
+- **Model is no longer a top-level `session/new` block** — it lives only in `configOptions[id="model"]`
+  (`currentValue` + `options[].value`). We read every axis from `configOptions`, with the 2.18 top-level
+  blocks kept as a fallback (`src/main/acp/agent-controls.ts`).
+- **Mode ids changed:** `default` → `ask`, and `chat` is gone. Nothing may hardcode an id; the Side
+  Draft's read-only posture now prefers `plan` (`src/renderer/src/connection/side-thread-controls.ts`).
+- Both drifts failed **silently** (a hidden picker, a dead setter). `missingControlAxes` now logs any
+  axis the agent stops advertising, so the next drift leaves a trace instead of vanishing.
+
 ## Considered alternatives
 
 - **Persist the selection per-Thread in our metadata (committed on the thread +

--- a/docs/vibe-acp-protocol.md
+++ b/docs/vibe-acp-protocol.md
@@ -11,10 +11,16 @@ same protocol Zed/JetBrains/Neovim use to drive Vibe. Our `src/main/acp/client.t
   what `vibe-acp` implements; confirm exact param shapes against the running binary
   (`vibe-acp` + the ACP schema) before finalizing each method.
 
-> ✅ **Confirmed against vibe-acp 2.18.0** (live capture). The **verbatim** message shapes are in
+> ✅ **Confirmed against vibe-acp 2.18.0** (live capture), with the agent-controls methods
+> re-confirmed against **2.24.1** (acp-capture §14.0, #427). The **verbatim** message shapes are in
 > [acp-capture.md](./acp-capture.md) — treat that as authoritative; this page is the narrative map.
 > A few items remain unverified (trust grant, `session/cancel`). The mode/model/thinking change
 > methods and `session/load` are now confirmed (acp-capture §9, §10).
+>
+> ⚠️ **Minimum supported `vibe`: 2.24.x.** These shapes move between MINOR releases — 2.24.1 removed
+> `session/set_model` and the `session/new` `models` block outright (#427). The app degrades rather
+> than crashes on an older binary (it falls back to the legacy dedicated setters and logs any axis
+> the agent stops advertising), but 2.24.x is what we build and verify against.
 
 ---
 
@@ -25,13 +31,13 @@ same protocol Zed/JetBrains/Neovim use to drive Vibe. Our `src/main/acp/client.t
 | Method | Purpose |
 |---|---|
 | `initialize` | Handshake. Agent returns `agentCapabilities` (`loadSession`, `promptCapabilities.image`), `agentInfo`, `authMethods` (`browser-auth`). camelCase params. |
-| `session/new` | Create a session for a workspace. Params `{cwd, mcpServers}`. Returns `sessionId`, `modes`, `models`, `configOptions`, `_meta.workspace_trust`. |
+| `session/new` | Create a session for a workspace. Params `{cwd, mcpServers}`. Returns `sessionId`, `modes`, `configOptions`, `_meta.workspace_trust`. (The top-level `models` block is **gone** at 2.24.1 — Model lives in `configOptions[id="model"]`. §14.0) |
 | `session/load` | Load/resume an existing session (capability `loadSession:true`). Params `{sessionId, cwd, mcpServers}`; replays history as `session/update`s then resolves session-new-shaped (acp-capture §9). |
 | `session/prompt` | Send user input `{sessionId, prompt:[{type:"text",text}]}`; streams `session/update`; resolves with `{stopReason, usage, userMessageId}`. |
 | `session/cancel` | Cancel the active turn. **Shape unverified.** |
-| `session/set_mode` | Change Mode. Params `{sessionId, modeId}` → `{}`. (acp-capture §10) |
-| `session/set_model` | Change Model. Params `{sessionId, modelId}` → `{}`. ⚠️ false-accepts any string; pass only `availableModels` ids. (§10) |
-| `session/set_config_option` | Change a config option (Reasoning effort). Params `{sessionId, configId, value}` → `{}` (note `configId`, not `id`). (§10) |
+| `session/set_config_option` | **The setter for all three axes** at 2.24.1. Params `{sessionId, configId, value}` (note `configId`, not `id`); `configId` is `mode` / `model` / `thinking`. Validates: an unknown value returns `-32602 "Unsupported config option …"`. Result carries the session's updated `configOptions`. (§10, §14.0) |
+| `session/set_mode` | Legacy Mode setter. Params `{sessionId, modeId}` → `{}`. ⚠️ **silently no-ops on an unknown id** (`{}`, indistinguishable from success) — prefer `set_config_option`. (§10) |
+| `session/set_model` | **REMOVED at 2.24.1** (`-32601 Method not found`). Was `{sessionId, modelId}` → `{}`, false-accepting any string. Use `set_config_option` with `configId:"model"`. (§10, §14.0) |
 
 ### Agent → Client (we receive / must answer)
 


### PR DESCRIPTION
Fixes #427.

Our Agent-controls plumbing was written against the `vibe-acp` 2.18.0 capture. The shipping binary is 2.24.1 and three shapes drifted underneath us — each failing **silently**.

## What changed

**1. Model reads from `configOptions`, so the picker exists again.** New pure module `apps/desktop/src/main/acp/agent-controls.ts` maps a `session/new` / `session/load` result onto the three axes, reading `configOptions[id="mode"|"model"|"thinking"]` and keeping the 2.18 top-level `modes`/`models` blocks as a fallback. At 2.24.1 there is no `models` block at all, which is why `AgentControls.tsx`'s `{models && …}` guard was hiding the chip.

**2. Mode and Model changes go through `session/set_config_option`.** `session/set_model` no longer exists (`-32601`). Beyond that, the config setter is the one that *validates*: an unadvertised value comes back `-32602 "Unsupported config option …"`, whereas `session/set_mode` answers a bogus id with `{}` — a silent no-op indistinguishable from success. That matters for the re-assert-after-resume choreography, since Mode still does not survive `session/load`. The legacy dedicated methods remain only for a session that advertises no matching config option.

**3. The Side Draft posture is re-derived from what 2.24.1 advertises.** `chat` is gone, so the preference is now `chat` → `plan` → `ask`/`default`, first advertised id wins, nothing invented. `plan` ("Read-only agent for exploration and planning") is the deliberate replacement for `chat`: a Side Draft is a throwaway "ask about this selection" Thread and wants the most read-only posture on offer.

**4. A tripwire for this class of bug.** `missingControlAxes` names any axis the agent advertises nothing for, and `WorkspaceAgent` logs it once per agent with the agent version. Every failure mode here was invisible; now a vanished axis leaves a trace in the main-process log.

## Verification

Live read-only probe against the installed `vibe-acp` 2.24.1 driving the real `WorkspaceAgent` (no `session/prompt`, no auth writes, no credits):

- `models` is populated: `mistral-medium-3.5` / `devstral-small` / `local`
- `setModel`, `setMode`, `setReasoningEffort` all succeed
- bogus `model` and `mode` ids are now **rejected** (`Unsupported config option …`) instead of silently accepted
- the change is reflected by the next `session/new`

Gates: `lint`, `typecheck`, `build`, `test` (157 files / 1716 tests) all green. Probe residue was restored (`active_model` back to `mistral-medium-3.5`, `thinking` back to `medium`).

## Docs

- Cherry-picked the #420 capture commit, as the issue asked, so `docs/acp-capture.md` §14.0 lands with the fix — plus a new subsection recording today's setter re-probe.
- **New capture worth flagging:** a Model (or `thinking`) change **writes through to `~/.vibe/config.toml`'s `active_model`** — the next fresh session, and the CLI, pick it up. So Model is a user-level default with a per-session override, not purely per-Thread state as ADR-0007 assumes. Not addressed here; noted in §14.0 as a follow-up worth a decision.
- ADR-0007 amended; `CONTEXT.md` / `CLAUDE.md` / `AGENTS.md` mode vocabulary updated (`default` → `ask`, no `chat`); `docs/vibe-acp-protocol.md` setter table corrected.
- Minimum supported `vibe` stated explicitly as **2.24.x** (the issue's open question). The app degrades rather than crashes on an older binary, but 2.24.x is what we build and verify against.