### PR TITLE
feat: Subagents — capture the protocol and render Vibe's in-turn helper agents legibly

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,6 +34,16 @@ agent blocks until the user picks a Permission option (allow once / reject once 
 pending queue and answered by request id.
 _Avoid_: approval, confirmation, prompt (reserve "prompt" for the user's message to the agent).
 
+**Subagent**:
+A Vibe-spawned helper agent that runs inside a single turn of a Thread and reports back to it. Vibe
+owns it entirely — we neither spawn nor configure it; the model reaches it through Vibe's `task` tool.
+On the wire it is an ordinary tool call (`kind: "think"`, `_meta.effect_kind: "subagent"`), never its
+own ACP session, and it is capped at one level deep. Only two things about its work reach us: a live
+step line per successful tool call it makes, and its final response — its own messages and reasoning
+never leave Vibe (see `docs/acp-capture.md` §15).
+_Avoid_: sub-thread, child agent, task (that is Vibe's tool name, not the domain concept),
+parallel agent (that is our own multi-Thread orchestration, a different axis entirely).
+
 **Search**:
 Finding past conversations by what was said — matches Thread titles and the conversation proper
 (the user's prompts and the agent's replies), across all Workspaces. Never matches the agent's

--- a/apps/desktop/scripts/spike-subagent.ts
+++ b/apps/desktop/scripts/spike-subagent.ts
@@ -1,0 +1,407 @@
+/**
+ * Spike probe — LIVE capture of Mistral Vibe **subagent** (`task` tool) traffic over ACP.
+ *
+ * HITL / LIVE: drives the user's REAL Mistral account (consumes credits). Not part of
+ * the test suite. Same infra gotcha as every other probe here — Bun's
+ * `node:child_process` does not deliver `stdin.write()` to a piped child, so build to a
+ * node target and run under node:
+ *
+ *   bun build scripts/spike-subagent.ts --target=node --outfile=/tmp/spike-sub.mjs \
+ *     && node /tmp/spike-sub.mjs --phase=all
+ *
+ * Phases
+ *   1  auto-approve mode  — one `explore` subagent; capture every frame.
+ *   2  default mode       — one `explore` subagent; capture permission behaviour.
+ *   3  parallel fan-out   — ask for two subagents in one turn; capture interleaving.
+ *   4  session/load       — resume phase-1's session in a FRESH process; does the
+ *                           subagent tool_call replay with `_meta` + content intact?
+ *
+ * Every frame is logged VERBATIM in both directions:
+ *   >>> client → agent      <<< agent → client
+ */
+
+import { mkdirSync, writeFileSync, readFileSync, existsSync, appendFileSync } from 'node:fs'
+import { spawn } from 'node:child_process'
+import { join } from 'node:path'
+import { AcpClient, type ChildProcessLike, type SpawnFn } from '../src/main/acp/client'
+
+const PROTOCOL_VERSION = 1
+const CLIENT_INFO = { name: 'vibe-mistro', version: '0.0.1' } as const
+const DEFAULT_WS = '/tmp/vibe-subagent-ws'
+const DEFAULT_LOG = '/tmp/vibe-subagent-capture.log'
+const STATE_FILE = '/tmp/vibe-subagent-state.json'
+
+const TIMEOUT = { initialize: 30_000, sessionNew: 30_000, prompt: 300_000, load: 60_000 }
+
+interface Args {
+  phase: '1' | '2' | '3' | '4' | 'all'
+  ws: string
+  log: string
+  command: string
+}
+
+function parseArgs(argv: string[]): Args {
+  const out: Args = { phase: 'all', ws: DEFAULT_WS, log: DEFAULT_LOG, command: 'vibe-acp' }
+  for (const arg of argv) {
+    if (arg.startsWith('--phase=')) out.phase = arg.slice(8) as Args['phase']
+    else if (arg.startsWith('--ws=')) out.ws = arg.slice(5)
+    else if (arg.startsWith('--log=')) out.log = arg.slice(6)
+    else if (arg.startsWith('--command=')) out.command = arg.slice(10)
+    else throw new Error(`Unknown argument: ${arg}`)
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Verbatim both-direction logging
+// ---------------------------------------------------------------------------
+
+let LOG_FILE = DEFAULT_LOG
+
+function out(text: string): void {
+  console.log(text)
+  try {
+    appendFileSync(LOG_FILE, text + '\n')
+  } catch {
+    /* best effort */
+  }
+}
+
+function banner(text: string): void {
+  out(`\n=== ${text} ===`)
+}
+
+function pretty(raw: string): string {
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2)
+  } catch {
+    return raw
+  }
+}
+
+function logFrame(dir: '>>>' | '<<<', raw: string): void {
+  out(`${dir} ${new Date().toISOString()}`)
+  out(pretty(raw))
+}
+
+/** Wraps the real spawn so every stdin write and stdout line is teed verbatim. */
+const loggingSpawn: SpawnFn = (command, args, options) => {
+  const child = spawn(command, args, { ...options, stdio: ['pipe', 'pipe', 'pipe'] })
+  let stdoutBuf = ''
+  const wrapper = {
+    stdout: {
+      setEncoding: (enc: BufferEncoding) => child.stdout.setEncoding(enc),
+      on: (event: 'data', listener: (chunk: string) => void) => {
+        child.stdout.on(event, (chunk: string) => {
+          stdoutBuf += chunk
+          let i: number
+          while ((i = stdoutBuf.indexOf('\n')) !== -1) {
+            const line = stdoutBuf.slice(0, i).trim()
+            stdoutBuf = stdoutBuf.slice(i + 1)
+            if (line) logFrame('<<<', line)
+          }
+          listener(chunk)
+        })
+      },
+    },
+    stderr: {
+      setEncoding: (enc: BufferEncoding) => child.stderr.setEncoding(enc),
+      on: (event: 'data', listener: (chunk: string) => void) => child.stderr.on(event, listener),
+    },
+    stdin: {
+      write: (data: string) => {
+        logFrame('>>>', data.trim())
+        child.stdin.write(data)
+      },
+    },
+    on: (event: string, listener: (...a: never[]) => void) =>
+      child.on(event as 'error', listener as never),
+    kill: () => child.kill(),
+  }
+  return wrapper as unknown as ChildProcessLike
+}
+
+// ---------------------------------------------------------------------------
+// Probe
+// ---------------------------------------------------------------------------
+
+class Probe {
+  readonly client: AcpClient
+  lastActivity = Date.now()
+  permissionCount = 0
+  /** Answer permission requests automatically? (phase 2 needs to see them first.) */
+  autoAllow = true
+
+  constructor(command: string, cwd: string) {
+    this.client = new AcpClient({ command, cwd, env: process.env, spawn: loggingSpawn })
+    this.client.on('notification', () => {
+      this.lastActivity = Date.now()
+    })
+    this.client.on('serverRequest', (msg: unknown) => {
+      this.lastActivity = Date.now()
+      this.onServerRequest(msg)
+    })
+    this.client.on('stderr', (t: string) => {
+      const s = t.trimEnd()
+      if (s) out(`  [stderr] ${s}`)
+    })
+    this.client.on('exit', (i: unknown) => out(`  [exit] ${JSON.stringify(i)}`))
+  }
+
+  private onServerRequest(msg: unknown): void {
+    const req = msg as { id?: number | string; method?: string; params?: unknown }
+    if (req.id === undefined) return
+    if (req.method === 'fs/read_text_file') {
+      const p = (req.params as { path?: string })?.path
+      let content = ''
+      try {
+        if (p && existsSync(p)) content = readFileSync(p, 'utf8')
+      } catch {
+        /* empty */
+      }
+      this.client.respond(req.id, { content })
+    } else if (req.method === 'fs/write_text_file') {
+      const p = req.params as { path?: string; content?: string }
+      try {
+        if (p?.path) writeFileSync(p.path, p.content ?? '')
+      } catch {
+        /* empty */
+      }
+      this.client.respond(req.id, {})
+    } else if (req.method === 'session/request_permission') {
+      this.permissionCount++
+      out(`  [PERMISSION #${this.permissionCount}] answering allow_once`)
+      const opts = (req.params as { options?: { optionId: string; kind?: string }[] })?.options ?? []
+      const allow =
+        opts.find((o) => o.kind === 'allow_once')?.optionId ??
+        opts.find((o) => o.optionId.includes('allow'))?.optionId ??
+        'allow_once'
+      this.client.respond(req.id, { outcome: { outcome: 'selected', optionId: allow } })
+    } else {
+      this.client.respondError(req.id, { code: -32601, message: 'method not found (probe)' })
+    }
+  }
+
+  start(): void {
+    this.client.start()
+  }
+  stop(): void {
+    this.client.stop()
+  }
+
+  async initialize(): Promise<void> {
+    banner('initialize')
+    await withTimeout(
+      this.client.request('initialize', {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {
+          fs: { readTextFile: true, writeTextFile: true },
+          _meta: { 'browser-auth-delegated': true },
+        },
+        clientInfo: CLIENT_INFO,
+      }),
+      TIMEOUT.initialize,
+      'initialize',
+    )
+    const status = await withTimeout(this.client.request('_auth/status'), 15_000, '_auth/status')
+    if ((status as { authenticated?: boolean })?.authenticated === false) {
+      out('NOT SIGNED IN — run `vibe` to sign in first.')
+      process.exit(2)
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms))
+}
+
+function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>
+  const t = new Promise<never>((_r, rej) => {
+    timer = setTimeout(() => rej(new Error(`Timed out after ${ms}ms waiting for ${label}`)), ms)
+  })
+  return Promise.race([p, t]).finally(() => clearTimeout(timer)) as Promise<T>
+}
+
+function describeError(err: unknown): string {
+  if (err && typeof err === 'object' && 'code' in err) return JSON.stringify(err)
+  if (err instanceof Error) return err.message
+  return String(err)
+}
+
+// ---------------------------------------------------------------------------
+// Scratch workspace
+// ---------------------------------------------------------------------------
+
+function makeWorkspace(dir: string): void {
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(
+    join(dir, 'README.md'),
+    '# Widget Factory\n\nA tiny demo project that turns orders into widgets.\n',
+  )
+  writeFileSync(
+    join(dir, 'alpha.py'),
+    'def build_widget(order):\n    """Build one widget from an order."""\n    return {"id": order["id"], "kind": "widget"}\n',
+  )
+  writeFileSync(
+    join(dir, 'beta.js'),
+    'export function shipWidget(widget) {\n  // Hand the widget to the courier.\n  return { ...widget, shipped: true }\n}\n',
+  )
+  writeFileSync(
+    join(dir, 'gamma.txt'),
+    'Order pipeline: intake -> build (alpha.py) -> ship (beta.js).\n',
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Phases
+// ---------------------------------------------------------------------------
+
+const SINGLE_PROMPT =
+  'Use the task tool to launch the explore subagent with the task ' +
+  '"Summarise what this project does by reading README.md, alpha.py and beta.js". ' +
+  'Do NOT read any files yourself — you must delegate to the explore subagent via the task tool. ' +
+  'When it returns, reply with one sentence.'
+
+const PARALLEL_PROMPT =
+  'Call the task tool TWICE IN THE SAME ASSISTANT MESSAGE so both explore subagents run in parallel. ' +
+  'First call: agent="explore", task="Read alpha.py and describe what it does". ' +
+  'Second call: agent="explore", task="Read beta.js and describe what it does". ' +
+  'Do NOT read any files yourself. Emit both task tool calls at once, then summarise both answers.'
+
+async function runPrompt(
+  probe: Probe,
+  sessionId: string,
+  text: string,
+  label: string,
+): Promise<void> {
+  banner(`session/prompt — ${label}`)
+  try {
+    const res = await withTimeout(
+      probe.client.request('session/prompt', { sessionId, prompt: [{ type: 'text', text }] }),
+      TIMEOUT.prompt,
+      'session/prompt',
+    )
+    out(`\n[turn end] ${JSON.stringify(res)}`)
+  } catch (err) {
+    out(`\n[prompt FAILED] ${describeError(err)}`)
+  }
+  await sleep(1000)
+}
+
+async function newSession(probe: Probe, cwd: string): Promise<string> {
+  banner('session/new')
+  const res = await withTimeout(
+    probe.client.request('session/new', { cwd, mcpServers: [] }),
+    TIMEOUT.sessionNew,
+    'session/new',
+  )
+  return (res as { sessionId: string }).sessionId
+}
+
+async function phaseSingle(args: Args, mode: string, label: string): Promise<string> {
+  banner(`PHASE — ${label} (mode=${mode})`)
+  makeWorkspace(args.ws)
+  const probe = new Probe(args.command, args.ws)
+  try {
+    probe.start()
+    await probe.initialize()
+    const sessionId = await newSession(probe, args.ws)
+    if (mode !== 'default') {
+      banner(`session/set_mode → ${mode}`)
+      await withTimeout(
+        probe.client.request('session/set_mode', { sessionId, modeId: mode }),
+        15_000,
+        'set_mode',
+      )
+    }
+    await runPrompt(probe, sessionId, SINGLE_PROMPT, label)
+    out(`\n[permission requests seen this phase] ${probe.permissionCount}`)
+    out(`[sessionId] ${sessionId}`)
+    return sessionId
+  } finally {
+    probe.stop()
+  }
+}
+
+async function phaseParallel(args: Args): Promise<string> {
+  banner('PHASE 3 — parallel fan-out (mode=auto-approve)')
+  makeWorkspace(args.ws)
+  const probe = new Probe(args.command, args.ws)
+  try {
+    probe.start()
+    await probe.initialize()
+    const sessionId = await newSession(probe, args.ws)
+    await withTimeout(
+      probe.client.request('session/set_mode', { sessionId, modeId: 'auto-approve' }),
+      15_000,
+      'set_mode',
+    )
+    await runPrompt(probe, sessionId, PARALLEL_PROMPT, 'parallel fan-out')
+    out(`[sessionId] ${sessionId}`)
+    return sessionId
+  } finally {
+    probe.stop()
+  }
+}
+
+async function phaseLoad(args: Args, sessionId: string): Promise<void> {
+  banner(`PHASE 4 — session/load replay of ${sessionId}`)
+  const probe = new Probe(args.command, args.ws)
+  try {
+    probe.start()
+    await probe.initialize()
+    try {
+      await withTimeout(
+        probe.client.request('session/load', { sessionId, cwd: args.ws, mcpServers: [] }),
+        TIMEOUT.load,
+        'session/load',
+      )
+    } catch (err) {
+      out(`[session/load FAILED] ${describeError(err)}`)
+    }
+    // Let any post-result replay land.
+    const start = Date.now()
+    while (Date.now() - probe.lastActivity < 4000 && Date.now() - start < 40_000) await sleep(250)
+  } finally {
+    probe.stop()
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2))
+  LOG_FILE = args.log
+  writeFileSync(LOG_FILE, '')
+  out(`vibe-acp SUBAGENT capture — phase=${args.phase} ws=${args.ws} log=${args.log}`)
+
+  const state: Record<string, string> = existsSync(STATE_FILE)
+    ? JSON.parse(readFileSync(STATE_FILE, 'utf8'))
+    : {}
+
+  if (args.phase === '1' || args.phase === 'all') {
+    state.phase1 = await phaseSingle(args, 'auto-approve', 'PHASE 1 single subagent, auto-approve')
+    writeFileSync(STATE_FILE, JSON.stringify(state, null, 2))
+  }
+  if (args.phase === '2' || args.phase === 'all') {
+    state.phase2 = await phaseSingle(args, 'default', 'PHASE 2 single subagent, DEFAULT mode')
+    writeFileSync(STATE_FILE, JSON.stringify(state, null, 2))
+  }
+  if (args.phase === '3' || args.phase === 'all') {
+    state.phase3 = await phaseParallel(args)
+    writeFileSync(STATE_FILE, JSON.stringify(state, null, 2))
+  }
+  if (args.phase === '4' || args.phase === 'all') {
+    const target = state.phase1 ?? state.phase2 ?? state.phase3
+    if (!target) throw new Error('no session id to load — run phase 1 first')
+    await phaseLoad(args, target)
+  }
+  banner('CAPTURE COMPLETE')
+  out(`log written to ${args.log}`)
+  out(`sessions: ${JSON.stringify(state)}`)
+}
+
+main().catch((err) => {
+  banner('PROBE FAILED')
+  console.error(describeError(err))
+  process.exit(1)
+})

--- a/apps/desktop/src/renderer/src/conversation/Conversation.tsx
+++ b/apps/desktop/src/renderer/src/conversation/Conversation.tsx
@@ -603,9 +603,14 @@ export function Conversation({
           // Escape hatch: if a turn wedges (e.g. a permission prompt is dismissed
           // and `session/prompt` never resolves), deny any pending permission and
           // re-enable input instead of sticking disabled forever (carry-over #4).
-          <button className="recover" onClick={recover}>
-            Turn stuck? End it and re-enable input ▶
-          </button>
+          // `.conv-measure` is what aligns it with the Composer: `.conv` is the
+          // full-width column, so an unwrapped control sits flush against the
+          // window edge while everything else caps to the centered 830px measure.
+          <div className="conv-measure">
+            <button className="recover" onClick={recover}>
+              Turn stuck? End it and re-enable input ▶
+            </button>
+          </div>
         )}
 
         <Composer

--- a/apps/desktop/src/renderer/src/conversation/items/PermissionRow.tsx
+++ b/apps/desktop/src/renderer/src/conversation/items/PermissionRow.tsx
@@ -5,6 +5,23 @@ import { isRejectOption } from '../permission-option'
 import { useTimelineHandlers } from '../timeline-context'
 import type { PermissionItem } from '../reducer'
 
+/**
+ * The " · …" suffix naming where a request came from.
+ *
+ * An ORPHAN request — one whose `toolCallId` matches no tool call in the
+ * conversation — is the signature of a Subagent asking: those ids belong to a
+ * child session the client never sees (docs/acp-capture.md §15 finding F). Say
+ * so in words rather than printing an id that means nothing to the user.
+ *
+ * We deliberately do NOT name WHICH subagent. No child identifier reaches the
+ * client on a permission callback, and during a parallel fan-out the request
+ * corresponds to neither visible row — so naming one would be a guess.
+ */
+function permissionSource(item: PermissionItem): string {
+  if (item.orphan) return ' · from a Subagent'
+  return item.toolCallId ? ` · ${item.toolCallId}` : ''
+}
+
 export function PermissionRow({ item }: { item: PermissionItem }): JSX.Element {
   // The answer relay (context, #386) — identity-stable so the memoized Item bails.
   const { onPermission } = useTimelineHandlers()
@@ -18,7 +35,7 @@ export function PermissionRow({ item }: { item: PermissionItem }): JSX.Element {
     <div className="flex flex-col gap-2.5 rounded-lg border border-primary/30 bg-primary/10 p-3">
       <div className="flex items-center gap-1.5 text-[13px] font-semibold text-primary">
         <ShieldAlert className="size-4 shrink-0" aria-hidden />
-        <span>Permission request{item.toolCallId ? ` · ${item.toolCallId}` : ''}</span>
+        <span>Permission request{permissionSource(item)}</span>
       </div>
       {item.chosenName ? (
         <div className="flex items-center gap-1.5 text-[13px] text-muted-foreground">

--- a/apps/desktop/src/renderer/src/conversation/items/ToolRow.tsx
+++ b/apps/desktop/src/renderer/src/conversation/items/ToolRow.tsx
@@ -13,6 +13,7 @@ import {
   Loader2,
   Move,
   PanelRightOpen,
+  Bot,
   Search,
   SquarePen,
   Terminal,
@@ -25,6 +26,14 @@ import { cn } from '../../lib/utils'
 import { describeToolStatus, type ToolStatusGlyph as ToolStatusGlyphName } from '../tool-status'
 import { toolKindIcon, type ToolIconName } from '../tool-icon'
 import { toolDetail, toolPreview } from '../tool-detail'
+import {
+  isSubagentTool,
+  readSubagentMeta,
+  subagentSteps,
+  subagentHeading,
+  subagentTurnLabel,
+} from '../subagent'
+import { Response } from '../Response'
 import { useRowStreaming, useTimelineHandlers } from '../timeline-context'
 import {
   changeLinePreview,
@@ -72,11 +81,90 @@ function ToolStatusGlyph({ glyph }: { glyph: ToolStatusGlyphName }): JSX.Element
 }
 
 export function ToolRow({ item, index }: { item: ToolItem; index: number }): JSX.Element {
+  // A Subagent is an ordinary tool call on the wire (kind `think`), so it would
+  // otherwise render as the agent merely THINKING while a second agent does real
+  // work (§15). Checked first, and only on `_meta` — never on the title.
+  if (isSubagentTool(item)) return <SubagentToolRow item={item} index={index} />
   const changes = fileChanges(item)
   return changes.length > 0 ? (
     <FileChangeToolRow item={item} index={index} changes={changes} />
   ) : (
     <GenericToolRow item={item} index={index} />
+  )
+}
+
+/**
+ * A Vibe Subagent run (docs/acp-capture.md §15). Collapsed: which subagent, the
+ * task it was given, turns used, live status. Expanded: the streamed step ledger
+ * and its final answer as prose.
+ *
+ * The ledger is shown WITHOUT a count on purpose — Vibe emits a line only for a
+ * SUCCEEDED child tool call (a captured run logged succeeded:3 failed:9 and
+ * streamed three lines), so it is a sample of the work, never an inventory.
+ */
+function SubagentToolRow({ item, index }: { item: ToolItem; index: number }): JSX.Element {
+  const streaming = useRowStreaming(index)
+  const [expanded, setExpanded] = useState(false)
+  const status = describeToolStatus(item.status, streaming)
+  const meta = readSubagentMeta(item)
+  const steps = subagentSteps(item)
+  const turns = subagentTurnLabel(meta)
+  const canExpand = steps.length > 0 || meta.response !== null
+
+  return (
+    <FoldableRow
+      open={expanded}
+      onOpenChange={setExpanded}
+      canExpand={canExpand}
+      toggleZone="container"
+      className={cn(
+        'flex flex-col rounded-md px-0.5 py-0.5 transition-colors',
+        canExpand && 'cursor-pointer hover:bg-primary/10 focus-visible:bg-primary/10 outline-none',
+      )}
+      headerClassName="flex items-center gap-1.5 select-none"
+      header={
+        <>
+          <span className="flex size-5 shrink-0 items-center justify-center text-muted-foreground">
+            <Bot className="size-3.5 shrink-0 stroke-[1.8]" aria-hidden />
+          </span>
+          <p className="flex min-w-0 flex-1 items-baseline gap-1.5 text-[13px] leading-5">
+            <span className="min-w-0 shrink truncate font-medium text-foreground">
+              {subagentHeading(meta)}
+            </span>
+            {meta.task && (
+              <span className="min-w-0 flex-1 truncate text-muted-foreground">{meta.task}</span>
+            )}
+          </p>
+          <span className="flex shrink-0 items-center gap-1.5">
+            {turns && <span className="text-[11px] text-muted-foreground">{turns}</span>}
+            {canExpand && <FoldChevron open={expanded} className="text-muted-foreground" />}
+            <span className="flex size-4 shrink-0 items-center justify-center">
+              <ToolStatusGlyph glyph={status.glyph} />
+            </span>
+          </span>
+        </>
+      }
+    >
+      <div className="mt-1 ms-7 cursor-default border-s border-border ps-3">
+        {steps.length > 0 && (
+          <>
+            <p className="text-[11px] font-medium text-muted-foreground">Steps</p>
+            <ul className="mt-0.5 space-y-0.5">
+              {steps.map((step, i) => (
+                <li key={i} className="font-mono text-[11px] break-words text-muted-foreground">
+                  {step}
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+        {meta.response && (
+          <div className={cn('text-[13px]', steps.length > 0 && 'mt-2')}>
+            <Response text={meta.response} />
+          </div>
+        )}
+      </div>
+    </FoldableRow>
   )
 }
 

--- a/apps/desktop/src/renderer/src/conversation/items/ToolRow.tsx
+++ b/apps/desktop/src/renderer/src/conversation/items/ToolRow.tsx
@@ -1,4 +1,4 @@
-import { useState, type JSX } from 'react'
+import { useEffect, useRef, useState, type JSX } from 'react'
 import {
   Brain,
   Check,
@@ -32,8 +32,10 @@ import {
   subagentSteps,
   subagentHeading,
   subagentTurnLabel,
+  subagentDetail,
 } from '../subagent'
 import { Response } from '../Response'
+import { formatElapsed } from '../working-time'
 import { useRowStreaming, useTimelineHandlers } from '../timeline-context'
 import {
   changeLinePreview,
@@ -94,6 +96,31 @@ export function ToolRow({ item, index }: { item: ToolItem; index: number }): JSX
 }
 
 /**
+ * Live elapsed for a running Subagent, in the WorkingRow idiom: mount time is
+ * the start, and the tick writes straight into the text node so a per-second
+ * clock never re-renders the conversation.
+ *
+ * Shown ONLY while running, and deliberately not persisted: a reopened Thread
+ * replays from our transcript log with no wall-clock, so a stored duration
+ * would either be missing or invented. Turns take over once settled.
+ */
+function SubagentElapsed(): JSX.Element {
+  const startRef = useRef(Date.now())
+  const textRef = useRef<HTMLSpanElement>(null)
+  useEffect(() => {
+    const tick = (): void => {
+      if (textRef.current) {
+        textRef.current.textContent = formatElapsed((Date.now() - startRef.current) / 1000)
+      }
+    }
+    tick()
+    const id = window.setInterval(tick, 1000)
+    return () => window.clearInterval(id)
+  }, [])
+  return <span ref={textRef} className="text-[11px] text-muted-foreground tabular-nums" />
+}
+
+/**
  * A Vibe Subagent run (docs/acp-capture.md §15). Collapsed: which subagent, the
  * task it was given, turns used, live status. Expanded: the streamed step ledger
  * and its final answer as prose.
@@ -109,6 +136,8 @@ function SubagentToolRow({ item, index }: { item: ToolItem; index: number }): JS
   const meta = readSubagentMeta(item)
   const steps = subagentSteps(item)
   const turns = subagentTurnLabel(meta)
+  const running = status.state === 'running' || status.state === 'pending'
+  const detail = subagentDetail(meta, steps, running)
   const canExpand = steps.length > 0 || meta.response !== null
 
   return (
@@ -118,7 +147,7 @@ function SubagentToolRow({ item, index }: { item: ToolItem; index: number }): JS
       canExpand={canExpand}
       toggleZone="container"
       className={cn(
-        'flex flex-col rounded-md px-0.5 py-0.5 transition-colors',
+        'ms-2 flex flex-col rounded-md border-s-2 border-border/70 py-0.5 pe-0.5 ps-2 transition-colors',
         canExpand && 'cursor-pointer hover:bg-primary/10 focus-visible:bg-primary/10 outline-none',
       )}
       headerClassName="flex items-center gap-1.5 select-none"
@@ -131,12 +160,16 @@ function SubagentToolRow({ item, index }: { item: ToolItem; index: number }): JS
             <span className="min-w-0 shrink truncate font-medium text-foreground">
               {subagentHeading(meta)}
             </span>
-            {meta.task && (
-              <span className="min-w-0 flex-1 truncate text-muted-foreground">{meta.task}</span>
+            {detail && (
+              <span className="min-w-0 flex-1 truncate text-muted-foreground">{detail}</span>
             )}
           </p>
           <span className="flex shrink-0 items-center gap-1.5">
-            {turns && <span className="text-[11px] text-muted-foreground">{turns}</span>}
+            {running ? (
+              <SubagentElapsed />
+            ) : (
+              turns && <span className="text-[11px] text-muted-foreground tabular-nums">{turns}</span>
+            )}
             {canExpand && <FoldChevron open={expanded} className="text-muted-foreground" />}
             <span className="flex size-4 shrink-0 items-center justify-center">
               <ToolStatusGlyph glyph={status.glyph} />

--- a/apps/desktop/src/renderer/src/conversation/reducer.test.ts
+++ b/apps/desktop/src/renderer/src/conversation/reducer.test.ts
@@ -437,3 +437,239 @@ describe('system-notice', () => {
     expect(next.isProcessing).toBe(true)
   })
 })
+
+/**
+ * Seam A — Subagents (#430). Frames are verbatim from docs/acp-capture.md §15,
+ * a live capture against vibe-acp 2.24.1. These assert the conversation state a
+ * user would see, never how it was computed.
+ */
+describe('conversationReducer — subagents (§15)', () => {
+  const TOOL_ID = '8FuX35f6u'
+
+  /** The bare opening frame: no agent, no task, no rawInput (§15 finding A). */
+  const OPEN = update({
+    sessionUpdate: 'tool_call',
+    toolCallId: TOOL_ID,
+    title: 'Running subagent',
+    kind: 'think',
+    status: 'in_progress',
+    _meta: { tool_name: 'task', effect_kind: 'subagent' },
+  })
+
+  /** Identity lands one frame later. */
+  const IDENTIFY = update({
+    sessionUpdate: 'tool_call_update',
+    toolCallId: TOOL_ID,
+    kind: 'think',
+    status: 'in_progress',
+    title: 'Running explore agent: Summarise what this project does',
+    rawInput: { task: 'Summarise what this project does', agent: 'explore' },
+    _meta: {
+      tool_name: 'task',
+      effect_kind: 'subagent',
+      agent: 'explore',
+      task: 'Summarise what this project does',
+    },
+  })
+
+  function progress(text: string): unknown {
+    return update({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: TOOL_ID,
+      status: 'in_progress',
+      content: [{ type: 'content', content: { type: 'text', text } }],
+    })
+  }
+
+  function feedAll(frames: unknown[]): ConversationState {
+    return frames.reduce<ConversationState>(feed, initialConversationState)
+  }
+
+  function toolItem(state: ConversationState, toolCallId = TOOL_ID): ToolItem {
+    const item = state.items.find(
+      (i): i is ToolItem => i.kind === 'tool' && i.toolCallId === toolCallId,
+    )
+    if (!item) throw new Error(`no tool item ${toolCallId}`)
+    return item
+  }
+
+  it('carries _meta through and merges it across frames', () => {
+    const state = feedAll([OPEN, IDENTIFY])
+    expect(state.items).toHaveLength(1)
+    expect(toolItem(state).meta).toMatchObject({
+      effect_kind: 'subagent',
+      agent: 'explore',
+      task: 'Summarise what this project does',
+    })
+  })
+
+  it('keeps the subagent tag when a later frame omits _meta entirely', () => {
+    const bare = update({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: TOOL_ID,
+      status: 'completed',
+    })
+    const state = feedAll([OPEN, bare])
+    expect(toolItem(state).meta).toMatchObject({ effect_kind: 'subagent' })
+  })
+
+  it('ACCUMULATES the step ledger — the bug this slice fixes', () => {
+    // §15 finding C: each frame carries ONE new entry, not the running list.
+    const state = feedAll([
+      OPEN,
+      IDENTIFY,
+      progress('read_file: Read 3 lines from alpha.py'),
+      progress('read_file: Read 4 lines from beta.js'),
+      progress('grep: 2 matches'),
+    ])
+    expect(toolItem(state).content).toHaveLength(3)
+  })
+
+  it('still REPLACES content for a non-subagent tool', () => {
+    // The regression guard: appending blindly would duplicate diffs in the
+    // file-change row, the most-used row in the app.
+    const edit = (path: string) =>
+      update({
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'edit-1',
+        kind: 'edit',
+        status: 'in_progress',
+        content: [{ type: 'diff', path, oldText: 'a', newText: 'b' }],
+      })
+    const state = feedAll([
+      update({ sessionUpdate: 'tool_call', toolCallId: 'edit-1', kind: 'edit', status: 'pending' }),
+      edit('one.ts'),
+      edit('two.ts'),
+    ])
+    expect(toolItem(state, 'edit-1').content).toHaveLength(1)
+  })
+
+  it('surfaces the final response and turn count on completion', () => {
+    const done = update({
+      sessionUpdate: 'tool_call_update',
+      toolCallId: TOOL_ID,
+      status: 'completed',
+      rawOutput: { response: 'It is a desktop app.', turnsUsed: 5, completed: true },
+      _meta: { effect_kind: 'subagent', turn_count: 5, response: 'It is a desktop app.' },
+    })
+    const state = feedAll([OPEN, IDENTIFY, done])
+    const item = toolItem(state)
+    expect(item.status).toBe('completed')
+    expect(item.meta).toMatchObject({ turn_count: 5, response: 'It is a desktop app.' })
+  })
+
+  it('surfaces an interrupted subagent as failed', () => {
+    // §15: completed:false maps to ACP "failed" even though the effect finished.
+    const state = feedAll([
+      OPEN,
+      update({
+        sessionUpdate: 'tool_call_update',
+        toolCallId: TOOL_ID,
+        status: 'failed',
+        rawOutput: { response: 'partial', turnsUsed: 2, completed: false },
+      }),
+    ])
+    expect(toolItem(state).status).toBe('failed')
+  })
+
+  it('keeps a parallel fan-out as two independent items', () => {
+    // §15 finding G: distinct toolCallIds, freely interleaved, one finishing
+    // early must not make the other look finished.
+    const openTwo = (id: string) =>
+      update({
+        sessionUpdate: 'tool_call',
+        toolCallId: id,
+        kind: 'think',
+        status: 'in_progress',
+        _meta: { tool_name: 'task', effect_kind: 'subagent', agent: 'explore' },
+      })
+    const state = feedAll([
+      openTwo('6CjZc36Mi'),
+      openTwo('nUL83qaSJ'),
+      update({
+        sessionUpdate: 'tool_call_update',
+        toolCallId: '6CjZc36Mi',
+        status: 'completed',
+        content: [{ type: 'content', content: { type: 'text', text: 'grep: done' } }],
+      }),
+    ])
+    expect(state.items.filter((i) => i.kind === 'tool')).toHaveLength(2)
+    expect(toolItem(state, '6CjZc36Mi').status).toBe('completed')
+    expect(toolItem(state, 'nUL83qaSJ').status).toBe('in_progress')
+    expect(toolItem(state, 'nUL83qaSJ').content).toHaveLength(0)
+  })
+
+  it('leaves a malformed _meta as an ordinary tool item', () => {
+    const state = feedAll([
+      update({
+        sessionUpdate: 'tool_call',
+        toolCallId: 'plain-1',
+        kind: 'read',
+        status: 'pending',
+        _meta: 'nonsense',
+      }),
+    ])
+    const item = toolItem(state, 'plain-1')
+    expect(item.kind).toBe('tool')
+    expect(item.meta).toBe('nonsense')
+  })
+})
+
+describe('conversationReducer — orphan permission requests (§15 finding F)', () => {
+  function permission(toolCallId: string | null): unknown {
+    return {
+      jsonrpc: '2.0',
+      id: 7,
+      method: 'session/request_permission',
+      params: {
+        sessionId: SESSION_ID,
+        ...(toolCallId === null ? {} : { toolCall: { toolCallId } }),
+        options: [{ optionId: 'allow', name: 'Allow', kind: 'allow_once' }],
+      },
+    }
+  }
+
+  function permissionItem(state: ConversationState): PermissionItem {
+    const item = state.items.find((i): i is PermissionItem => i.kind === 'permission')
+    if (!item) throw new Error('no permission item')
+    return item
+  }
+
+  it('flags a request whose toolCallId matches nothing — a subagent asking', () => {
+    // The child session's tool call id; the client never received a tool_call for it.
+    const state = feed(initialConversationState, permission('v1KK2WmAn'))
+    expect(permissionItem(state).orphan).toBe(true)
+  })
+
+  it('does NOT flag a request that matches a tool call we have', () => {
+    const withTool = feed(
+      initialConversationState,
+      update({
+        sessionUpdate: 'tool_call',
+        toolCallId: 'EcjzekVw0',
+        kind: 'edit',
+        status: 'pending',
+      }),
+    )
+    const state = feed(withTool, permission('EcjzekVw0'))
+    expect(permissionItem(state).orphan).toBe(false)
+  })
+
+  it('does NOT flag a request carrying no toolCallId at all', () => {
+    // A session-level prompt is not mis-attributed, just unlinked.
+    const state = feed(initialConversationState, permission(null))
+    expect(permissionItem(state).orphan).toBe(false)
+  })
+
+  it('still answers by requestId, orphan or not', () => {
+    const asked = feed(initialConversationState, permission('v1KK2WmAn'))
+    const answered = conversationReducer(asked, {
+      type: 'resolve-permission',
+      requestId: 7,
+      optionId: 'allow',
+      name: 'Allow',
+    })
+    expect(permissionItem(answered).chosenOptionId).toBe('allow')
+    expect(permissionItem(answered).orphan).toBe(true)
+  })
+})

--- a/apps/desktop/src/renderer/src/conversation/reducer.test.ts
+++ b/apps/desktop/src/renderer/src/conversation/reducer.test.ts
@@ -673,3 +673,39 @@ describe('conversationReducer — orphan permission requests (§15 finding F)', 
     expect(permissionItem(answered).orphan).toBe(true)
   })
 })
+
+describe('conversationReducer — user_message_chunk echo (#438)', () => {
+  it('ignores the echo instead of adding a fallback row under every message', () => {
+    const state = feed(
+      initialConversationState,
+      update({
+        sessionUpdate: 'user_message_chunk',
+        content: { type: 'text', text: 'Summarise this project' },
+        messageId: 'u1',
+      }),
+    )
+    expect(state.items).toHaveLength(0)
+  })
+
+  it('leaves an optimistic user message untouched — no duplicate', () => {
+    const sent = conversationReducer(initialConversationState, {
+      type: 'send-prompt',
+      id: 'local-1',
+      text: 'Summarise this project',
+    })
+    const state = feed(
+      sent,
+      update({
+        sessionUpdate: 'user_message_chunk',
+        content: { type: 'text', text: 'Summarise this project' },
+        messageId: 'u1',
+      }),
+    )
+    expect(state.items.filter((i) => i.kind === 'user')).toHaveLength(1)
+  })
+
+  it('still falls back for genuinely unknown kinds — nothing else is silenced', () => {
+    const state = feed(initialConversationState, update({ sessionUpdate: 'some_future_kind' }))
+    expect(state.items.map((i) => i.kind)).toEqual(['fallback'])
+  })
+})

--- a/apps/desktop/src/renderer/src/conversation/reducer.ts
+++ b/apps/desktop/src/renderer/src/conversation/reducer.ts
@@ -75,6 +75,13 @@ export interface ToolItem {
   rawInput: unknown
   rawOutput: unknown
   content: unknown[]
+  /**
+   * The update's `_meta` blob, carried through VERBATIM and uninterpreted.
+   * Vibe tags a Subagent run here (`_meta.effect_kind`) rather than with its
+   * own `sessionUpdate` kind (§15); `subagent.ts` owns every reading of it.
+   * Optional, so old fold snapshots stay valid.
+   */
+  meta?: unknown
 }
 
 /** One option offered by `session/request_permission`. */
@@ -100,6 +107,14 @@ export interface PermissionItem {
   /** The option the user picked, or null while still pending. */
   chosenOptionId: string | null
   chosenName: string | null
+  /**
+   * True when `toolCallId` matches NO tool item we have — the signature of a
+   * request raised by a Subagent, whose tool call ids belong to a child session
+   * the client never sees (§15 finding F). Decided HERE because only the
+   * reducer holds the items to match against. Optional: absent means "not
+   * known to be an orphan", which is what every old snapshot means.
+   */
+  orphan?: boolean
 }
 
 /** A surfaced turn/agent failure — keeps a wedged turn from hiding the cause. */
@@ -189,7 +204,23 @@ export const REBOUND_NOTICE =
  * bump is one full re-fold per Thread, lazily, on its next open — never data
  * loss (snapshots are disposable projections of the transcript event log).
  */
-export const REDUCER_SCHEMA_VERSION = 1
+/**
+ * `_meta.effect_kind` marking a Subagent run (§15). Duplicated from
+ * `subagent.ts` deliberately: the reducer must not import the interpreter it
+ * feeds, and this one string is the whole coupling.
+ */
+const SUBAGENT_EFFECT_KIND = 'subagent'
+
+/**
+ * Bumped 1 -> 2 for CORRECTNESS, not shape (#430). The new `meta`/`orphan`
+ * fields are additive and optional, so an old blob still type-checks — but
+ * blobs written before the delta fix hold a TRUNCATED subagent step ledger
+ * (only the last frame's entry survived the old wholesale replace). Left at 1,
+ * those Threads would rehydrate the truncated ledger forever, i.e. the fix
+ * would skip exactly the conversations that motivated it. The bump forces one
+ * lazy re-fold from the transcript event log, which replays the deltas whole.
+ */
+export const REDUCER_SCHEMA_VERSION = 2
 
 export const initialConversationState: ConversationState = {
   items: [],
@@ -274,6 +305,8 @@ interface SessionUpdate {
   locations?: ToolLocation[]
   rawInput?: unknown
   rawOutput?: unknown
+  /** Vibe's out-of-band tagging; snake_case on the wire (§15). */
+  _meta?: unknown
 }
 
 function reduceAcpEvent(state: ConversationState, payload: unknown): ConversationState {
@@ -417,6 +450,11 @@ function applyToolCall(state: ConversationState, update: SessionUpdate): Convers
   )
   const existing = index >= 0 ? (state.items[index] as ToolItem) : null
 
+  // `_meta` arrives in pieces: the first frame has only `tool_name`+`effect_kind`,
+  // identity lands on the next one. Merge rather than replace so the subagent
+  // tag survives a later frame that omits it (§15 finding A).
+  const meta = mergeToolMeta(existing?.meta, update._meta)
+
   const merged: ToolItem = {
     kind: 'tool',
     id: `tool:${toolCallId}`,
@@ -427,7 +465,8 @@ function applyToolCall(state: ConversationState, update: SessionUpdate): Convers
     locations: Array.isArray(update.locations) ? update.locations : (existing?.locations ?? []),
     rawInput: update.rawInput !== undefined ? update.rawInput : existing?.rawInput,
     rawOutput: update.rawOutput !== undefined ? update.rawOutput : existing?.rawOutput,
-    content: Array.isArray(update.content) ? update.content : (existing?.content ?? []),
+    content: mergeToolContent(existing, update, meta),
+    meta,
   }
 
   if (existing) {
@@ -436,6 +475,40 @@ function applyToolCall(state: ConversationState, update: SessionUpdate): Convers
     return { ...state, items }
   }
   return { ...state, items: [...state.items, merged] }
+}
+
+/**
+ * Shallow-merge successive `_meta` payloads, newest wins per key.
+ */
+function mergeToolMeta(existing: unknown, incoming: unknown): unknown {
+  if (incoming === undefined) return existing
+  if (!isPlainRecord(existing) || !isPlainRecord(incoming)) return incoming
+  return { ...existing, ...incoming }
+}
+
+/**
+ * Merge a tool call's `content`.
+ *
+ * Subagents stream DELTAS — each `tool_call_update` carries only the newly
+ * produced entry, so replacing would show just the last fragment of the step
+ * ledger (§15 finding C, the bug this fixes). Every OTHER tool is left on
+ * replace: delta semantics are proven for subagents alone, and appending
+ * blindly would duplicate content in the file-change row.
+ */
+function mergeToolContent(
+  existing: ToolItem | null,
+  update: SessionUpdate,
+  meta: unknown,
+): unknown[] {
+  if (!Array.isArray(update.content)) return existing?.content ?? []
+  const isSubagent =
+    isPlainRecord(meta) && (meta.effect_kind ?? meta.effectKind) === SUBAGENT_EFFECT_KIND
+  if (!isSubagent || !existing) return update.content
+  return [...existing.content, ...update.content]
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
 }
 
 function appendPermission(state: ConversationState, request: PermissionRequest): ConversationState {
@@ -447,8 +520,23 @@ function appendPermission(state: ConversationState, request: PermissionRequest):
     options: request.options,
     chosenOptionId: null,
     chosenName: null,
+    orphan: isOrphanToolCall(state, request.toolCallId),
   }
   return { ...state, items: [...state.items, item] }
+}
+
+/**
+ * Does this permission's `toolCallId` match no tool call we have seen?
+ *
+ * A Subagent's own permission requests arrive on the ROOT session carrying the
+ * CHILD session's tool call id, which the client never receives a `tool_call`
+ * for (§15 finding F) — so "matches nothing" is the only signal available that
+ * a Subagent is asking. A request with no `toolCallId` at all is NOT an orphan:
+ * that is an ordinary session-level prompt, not a mis-attributed one.
+ */
+function isOrphanToolCall(state: ConversationState, toolCallId: string | null): boolean {
+  if (toolCallId === null) return false
+  return !state.items.some((item) => item.kind === 'tool' && item.toolCallId === toolCallId)
 }
 
 function resolvePermission(

--- a/apps/desktop/src/renderer/src/conversation/reducer.ts
+++ b/apps/desktop/src/renderer/src/conversation/reducer.ts
@@ -331,6 +331,21 @@ function reduceAcpEvent(state: ConversationState, payload: unknown): Conversatio
       return typeof update.title === 'string' ? { ...state, title: update.title } : state
     case 'usage_update':
       return applyUsage(state, update)
+    case 'user_message_chunk':
+      // Vibe echoes the user's OWN prompt back (#438). We already rendered it
+      // optimistically from `send-prompt` the moment it was sent, so rendering
+      // the echo too would duplicate every message — and before this case
+      // existed it fell to `appendFallback`, putting a raw-JSON row under every
+      // user message. Ignored DELIBERATELY, which is why it is spelled out
+      // rather than left to the default.
+      //
+      // CAVEAT for a future `session/list` import (acp-capture §13): opening a
+      // CLI-created session replays its history as `session/update`s in which
+      // `user_message_chunk` is the ONLY source of the user's messages, with no
+      // optimistic item to pair with. That importer must materialize these
+      // itself (main captures the replay into our transcript log) — it cannot
+      // rely on this reducer branch, which assumes the live path.
+      return state
     case 'available_commands_update':
       return { ...state, availableCommands: extractCommands(update) }
     default:

--- a/apps/desktop/src/renderer/src/conversation/subagent.test.ts
+++ b/apps/desktop/src/renderer/src/conversation/subagent.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isSubagentTool,
+  readSubagentMeta,
+  subagentSteps,
+  subagentHeading,
+  subagentTurnLabel,
+} from './subagent'
+import type { ToolItem } from './reducer'
+
+/**
+ * Seam 2: the pure Subagent interpreter. Fed the verbatim `_meta` / content
+ * shapes captured in docs/acp-capture.md §15 — snake_case on `_meta`,
+ * camelCase inside `rawOutput`.
+ */
+
+function tool(overrides: Partial<ToolItem> = {}): ToolItem {
+  return {
+    kind: 'tool',
+    id: 'tool:8FuX35f6u',
+    toolCallId: '8FuX35f6u',
+    toolKind: 'think',
+    status: 'in_progress',
+    title: 'Running subagent',
+    locations: [],
+    rawInput: undefined,
+    rawOutput: undefined,
+    content: [],
+    ...overrides,
+  }
+}
+
+/** A step line exactly as it arrives on the wire (§15 finding D). */
+function step(text: string): unknown {
+  return { type: 'content', content: { type: 'text', text } }
+}
+
+describe('isSubagentTool', () => {
+  it('detects the bare FIRST frame, which has no identity yet', () => {
+    // §15 finding A: the opening tool_call carries only these two keys.
+    expect(isSubagentTool(tool({ meta: { tool_name: 'task', effect_kind: 'subagent' } }))).toBe(true)
+  })
+
+  it('accepts camelCase effectKind defensively', () => {
+    expect(isSubagentTool(tool({ meta: { effectKind: 'subagent' } }))).toBe(true)
+  })
+
+  it('is false for an ordinary tool call', () => {
+    expect(isSubagentTool(tool({ toolKind: 'read', meta: undefined }))).toBe(false)
+  })
+
+  it('is false for a think-kind tool that is NOT a subagent', () => {
+    // `kind: "think"` alone must never imply a subagent — real reasoning tools share it.
+    expect(isSubagentTool(tool({ toolKind: 'think', meta: { effect_kind: 'reasoning' } }))).toBe(
+      false,
+    )
+  })
+
+  it('never keys on the title', () => {
+    // The placeholder title is present on a frame with no meta at all.
+    expect(isSubagentTool(tool({ title: 'Running subagent', meta: undefined }))).toBe(false)
+  })
+
+  it('survives a malformed meta without throwing', () => {
+    expect(isSubagentTool(tool({ meta: 'nonsense' }))).toBe(false)
+    expect(isSubagentTool(tool({ meta: null }))).toBe(false)
+    expect(isSubagentTool(tool({ meta: ['effect_kind'] }))).toBe(false)
+  })
+})
+
+describe('readSubagentMeta', () => {
+  it('reads the snake_case wire shape', () => {
+    const meta = readSubagentMeta(
+      tool({
+        meta: {
+          tool_name: 'task',
+          effect_kind: 'subagent',
+          agent: 'explore',
+          task: 'Summarise what this project does',
+          child_session_id: '178132b8-aaaa-bbbb-cccc-ddddeeeeffff',
+          turn_count: 5,
+          response: 'It is a desktop app.',
+        },
+      }),
+    )
+    expect(meta).toEqual({
+      agent: 'explore',
+      task: 'Summarise what this project does',
+      childSessionId: '178132b8-aaaa-bbbb-cccc-ddddeeeeffff',
+      turnCount: 5,
+      response: 'It is a desktop app.',
+    })
+  })
+
+  it('accepts camelCase spellings too', () => {
+    const meta = readSubagentMeta(
+      tool({ meta: { effectKind: 'subagent', childSessionId: 'c1', turnCount: 2 } }),
+    )
+    expect(meta.childSessionId).toBe('c1')
+    expect(meta.turnCount).toBe(2)
+  })
+
+  it('falls back to rawInput and rawOutput', () => {
+    // rawOutput is camelCase while _meta is snake_case — both in one tool call.
+    const meta = readSubagentMeta(
+      tool({
+        meta: { effect_kind: 'subagent' },
+        rawInput: { task: 'Read the README', agent: 'explore' },
+        rawOutput: { response: 'Done.', turnsUsed: 3, completed: true },
+      }),
+    )
+    expect(meta.agent).toBe('explore')
+    expect(meta.task).toBe('Read the README')
+    expect(meta.response).toBe('Done.')
+    expect(meta.turnCount).toBe(3)
+  })
+
+  it('prefers _meta over rawOutput when both are present', () => {
+    const meta = readSubagentMeta(
+      tool({ meta: { effect_kind: 'subagent', turn_count: 9 }, rawOutput: { turnsUsed: 1 } }),
+    )
+    expect(meta.turnCount).toBe(9)
+  })
+
+  it('returns all-null for the bare first frame', () => {
+    const meta = readSubagentMeta(tool({ meta: { tool_name: 'task', effect_kind: 'subagent' } }))
+    expect(meta).toEqual({
+      agent: null,
+      task: null,
+      childSessionId: null,
+      turnCount: null,
+      response: null,
+    })
+  })
+
+  it('ignores wrong-typed and empty values rather than surfacing them', () => {
+    const meta = readSubagentMeta(
+      tool({ meta: { effect_kind: 'subagent', agent: '', turn_count: 'five', response: 42 } }),
+    )
+    expect(meta.agent).toBeNull()
+    expect(meta.turnCount).toBeNull()
+    expect(meta.response).toBeNull()
+  })
+})
+
+describe('subagentSteps', () => {
+  it('derives the ledger from wire content entries', () => {
+    const item = tool({
+      content: [step('read_file: Read 3 lines from alpha.py'), step('grep: 2 matches')],
+    })
+    expect(subagentSteps(item)).toEqual([
+      'read_file: Read 3 lines from alpha.py',
+      'grep: 2 matches',
+    ])
+  })
+
+  it('is empty before anything has streamed', () => {
+    expect(subagentSteps(tool())).toEqual([])
+  })
+
+  it('skips entries that are not text content', () => {
+    const item = tool({
+      content: [
+        { type: 'diff', path: 'a.ts' },
+        step('read_file: ok'),
+        { type: 'content', content: { type: 'image' } },
+        null,
+        'garbage',
+      ],
+    })
+    expect(subagentSteps(item)).toEqual(['read_file: ok'])
+  })
+
+  it('exposes no count — the ledger is a sample, not an inventory', () => {
+    // §15 finding D: only SUCCEEDED child tool calls emit a line (a captured run
+    // logged succeeded:3 failed:9 and streamed 3). Nothing here may be presented
+    // as "what the subagent did", so the module offers no count helper at all.
+    const module = { isSubagentTool, readSubagentMeta, subagentSteps }
+    expect(Object.keys(module)).not.toContain('subagentStepCount')
+  })
+})
+
+describe('subagentHeading / subagentTurnLabel', () => {
+  it('names the agent once known', () => {
+    expect(subagentHeading(readSubagentMeta(tool({ meta: { agent: 'explore' } })))).toBe(
+      'explore subagent',
+    )
+  })
+
+  it('shows a starting placeholder while the first frame is bare', () => {
+    expect(subagentHeading(readSubagentMeta(tool({ meta: { effect_kind: 'subagent' } })))).toBe(
+      'Subagent starting…',
+    )
+  })
+
+  it('pluralises turns and stays silent when unknown', () => {
+    expect(subagentTurnLabel(readSubagentMeta(tool({ meta: { turn_count: 1 } })))).toBe('1 turn')
+    expect(subagentTurnLabel(readSubagentMeta(tool({ meta: { turn_count: 5 } })))).toBe('5 turns')
+    expect(subagentTurnLabel(readSubagentMeta(tool({ meta: {} })))).toBeNull()
+  })
+})

--- a/apps/desktop/src/renderer/src/conversation/subagent.test.ts
+++ b/apps/desktop/src/renderer/src/conversation/subagent.test.ts
@@ -5,6 +5,7 @@ import {
   subagentSteps,
   subagentHeading,
   subagentTurnLabel,
+  subagentDetail,
 } from './subagent'
 import type { ToolItem } from './reducer'
 
@@ -197,5 +198,26 @@ describe('subagentHeading / subagentTurnLabel', () => {
     expect(subagentTurnLabel(readSubagentMeta(tool({ meta: { turn_count: 1 } })))).toBe('1 turn')
     expect(subagentTurnLabel(readSubagentMeta(tool({ meta: { turn_count: 5 } })))).toBe('5 turns')
     expect(subagentTurnLabel(readSubagentMeta(tool({ meta: {} })))).toBeNull()
+  })
+})
+
+describe('subagentDetail', () => {
+  const meta = { agent: 'explore', task: 'Summarise the project', childSessionId: null, turnCount: null, response: null }
+
+  it('shows the latest step while running, so a long run visibly progresses', () => {
+    expect(subagentDetail(meta, ['read_file: a.py', 'grep: 2 matches'], true)).toBe('grep: 2 matches')
+  })
+
+  it('falls back to the task when running but nothing has streamed yet', () => {
+    // Only SUCCEEDED child tool calls emit a line — an early run has an empty ledger.
+    expect(subagentDetail(meta, [], true)).toBe('Summarise the project')
+  })
+
+  it('returns to the task once settled', () => {
+    expect(subagentDetail(meta, ['grep: 2 matches'], false)).toBe('Summarise the project')
+  })
+
+  it('is null when there is neither task nor step', () => {
+    expect(subagentDetail({ ...meta, task: null }, [], true)).toBeNull()
   })
 })

--- a/apps/desktop/src/renderer/src/conversation/subagent.ts
+++ b/apps/desktop/src/renderer/src/conversation/subagent.ts
@@ -1,0 +1,134 @@
+import type { ToolItem } from './reducer'
+
+/**
+ * Interpret a Subagent tool call — Vibe's `task` tool on the wire
+ * (docs/acp-capture.md §15).
+ *
+ * A Subagent is NOT a distinct `sessionUpdate` kind: it arrives as an ordinary
+ * `tool_call` whose ACP `kind` is `think`, tagged only by `_meta.effect_kind`.
+ * Everything that identifies it rides in `_meta`, which the reducer carries
+ * through opaquely — all interpretation lives here so it stays testable without
+ * rendering a row (tests run in `node`, there is no DOM).
+ *
+ * `_meta` is snake_case ON THE WIRE (`child_session_id`, `turn_count`) while
+ * `rawOutput` is camelCase (`turnsUsed`) — two conventions in one tool call. We
+ * accept either spelling everywhere, the same defensiveness `file-change.ts`
+ * applies to diffs, so a serializer change can't silently blank the row.
+ */
+
+/** `_meta.effect_kind` value that marks a tool call as a Subagent run. */
+const SUBAGENT_EFFECT_KIND = 'subagent'
+
+/** What a Subagent tool call tells us about itself. Every field may be absent. */
+export interface SubagentMeta {
+  /** The subagent profile that ran, e.g. `explore`. */
+  agent: string | null
+  /** The task it was handed. */
+  task: string | null
+  /** Vibe's child session id — correlation only; we never read that session. */
+  childSessionId: string | null
+  /** Turns the subagent used. NOT a step count — see `subagentSteps`. */
+  turnCount: number | null
+  /** Its final answer, authored prose. */
+  response: string | null
+}
+
+/**
+ * Is this tool call a Subagent run?
+ *
+ * Keyed on `_meta.effect_kind` and NEVER on the title: the first `tool_call`
+ * frame carries the bare placeholder title `"Running subagent"` with no
+ * identity at all (§15 finding A), and the real title only arrives a frame
+ * later. Anything unrecognized falls through to the generic tool row.
+ */
+export function isSubagentTool(item: ToolItem): boolean {
+  return readString(metaOf(item), 'effect_kind', 'effectKind') === SUBAGENT_EFFECT_KIND
+}
+
+/**
+ * Pull the Subagent's identity out of `_meta`, falling back to `rawInput` /
+ * `rawOutput` where the same value appears in both.
+ *
+ * All fields are nullable by design: the first frame has only `tool_name` +
+ * `effect_kind`, `agent`/`task` land on the next frame, and `child_session_id`
+ * on the one after. The row renders each state as it comes.
+ */
+export function readSubagentMeta(item: ToolItem): SubagentMeta {
+  const meta = metaOf(item)
+  const input = asRecord(item.rawInput)
+  const output = asRecord(item.rawOutput)
+
+  return {
+    agent: readString(meta, 'agent') ?? readString(input, 'agent'),
+    task: readString(meta, 'task') ?? readString(input, 'task'),
+    childSessionId: readString(meta, 'child_session_id', 'childSessionId'),
+    turnCount: readNumber(meta, 'turn_count', 'turnCount') ?? readNumber(output, 'turnsUsed'),
+    response: readString(meta, 'response') ?? readString(output, 'response'),
+  }
+}
+
+/**
+ * The step ledger — one line per subagent tool call, streamed live as
+ * `{type:'content',content:{type:'text',text:'read_file: Read 3 lines'}}`.
+ *
+ * DELIBERATELY UNCOUNTED. Vibe emits a line only for a SUCCEEDED child tool
+ * call: a captured run with `succeeded:3, failed:9` streamed three lines, and
+ * `turn_count` matched neither number (§15 finding D). These lines are
+ * therefore a sample of the work, never an inventory of it — never present
+ * `steps.length` as "what the Subagent did".
+ */
+export function subagentSteps(item: ToolItem): string[] {
+  const steps: string[] = []
+  for (const value of item.content) {
+    const entry = asRecord(value)
+    if (!entry || entry.type !== 'content') continue
+    const inner = asRecord(entry.content)
+    if (!inner || inner.type !== 'text') continue
+    if (typeof inner.text !== 'string' || inner.text.length === 0) continue
+    steps.push(inner.text)
+  }
+  return steps
+}
+
+/**
+ * Heading for the collapsed row. Falls back while `_meta` is still filling in,
+ * so the row is never blank and never claims an identity it doesn't have yet.
+ */
+export function subagentHeading(meta: SubagentMeta): string {
+  return meta.agent ? `${meta.agent} subagent` : 'Subagent starting…'
+}
+
+/** `"5 turns"` for the row's detail line, or null when Vibe hasn't said. */
+export function subagentTurnLabel(meta: SubagentMeta): string | null {
+  if (meta.turnCount === null) return null
+  return `${meta.turnCount} ${meta.turnCount === 1 ? 'turn' : 'turns'}`
+}
+
+function metaOf(item: ToolItem): Record<string, unknown> | null {
+  return asRecord(item.meta)
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  return value as Record<string, unknown>
+}
+
+/** First non-empty string among `keys`, or null. */
+function readString(source: Record<string, unknown> | null, ...keys: string[]): string | null {
+  if (!source) return null
+  for (const key of keys) {
+    const value = source[key]
+    if (typeof value === 'string' && value.length > 0) return value
+  }
+  return null
+}
+
+/** First finite number among `keys`, or null. */
+function readNumber(source: Record<string, unknown> | null, ...keys: string[]): number | null {
+  if (!source) return null
+  for (const key of keys) {
+    const value = source[key]
+    if (typeof value === 'number' && Number.isFinite(value)) return value
+  }
+  return null
+}

--- a/apps/desktop/src/renderer/src/conversation/subagent.ts
+++ b/apps/desktop/src/renderer/src/conversation/subagent.ts
@@ -104,6 +104,27 @@ export function subagentTurnLabel(meta: SubagentMeta): string | null {
   return `${meta.turnCount} ${meta.turnCount === 1 ? 'turn' : 'turns'}`
 }
 
+/**
+ * The dimmed line beside the heading in the COLLAPSED row.
+ *
+ * While the Subagent runs it shows its latest step, so a long delegation
+ * visibly progresses instead of sitting frozen on its task for minutes. Once
+ * settled the task returns — that is what you want to read afterwards, and the
+ * steps are a fold away.
+ *
+ * Falls back to the task whenever no step has arrived yet: Vibe emits a line
+ * only for a SUCCEEDED child tool call, so an early or unlucky run can be
+ * several turns in with an empty ledger.
+ */
+export function subagentDetail(
+  meta: SubagentMeta,
+  steps: readonly string[],
+  running: boolean,
+): string | null {
+  if (running && steps.length > 0) return steps[steps.length - 1]
+  return meta.task
+}
+
 function metaOf(item: ToolItem): Record<string, unknown> | null {
   return asRecord(item.meta)
 }

--- a/apps/desktop/src/renderer/src/typeset.css
+++ b/apps/desktop/src/renderer/src/typeset.css
@@ -546,3 +546,13 @@
   margin-block-start: var(--typeset-flow);
   margin-block-end: 0;
 }
+
+/* A BARE table in prose is flush-left, so its first column aligns with the text
+   measure — that is what `th:first-child, td:first-child { padding-inline-start: 0 }`
+   above is for. Streamdown, though, frames its tables in a bordered, rounded,
+   scrollable card (`rounded-md border border-border`), and inside a frame flush-left
+   means the first column's text collides with the border. Restore the inline padding
+   there, matching the other cells. */
+.typeset-chat :where([data-streamdown='table-wrapper']) :is(th, td):first-child {
+  padding-inline-start: 1em;
+}

--- a/docs/acp-capture.md
+++ b/docs/acp-capture.md
@@ -705,3 +705,302 @@ The probe answers every `session/request_permission` with `reject_once` and refu
 or `_auth/signOut`. Scratch profile names are prefixed `zz-probe-` so they can never shadow a Vibe
 builtin (a custom profile whose **file stem equals a builtin name overrides that builtin** — source
 `registry.py` logs `Custom agent '%s' overrides builtin agent`; deliberately **not** probed).
+## 15. Subagents — the `task` tool on the wire (captured 2026-08-19 via `scripts/spike-subagent.ts`, vibe-acp **2.24.1**)
+
+LIVE capture against a scratch workspace (`/tmp/vibe-subagent-ws` — README.md + alpha.py + beta.js +
+gamma.txt). Four phases: (1) one `explore` subagent in **auto-approve**, (2) one under the session's
+own default posture (the probe sends no `session/set_mode` at all — NOT the retired `default` mode
+id, see §14), (3) a **parallel fan-out** of two, (4) `session/load` **replay** of phase 1. Every frame below is
+verbatim from that run.
+
+A subagent is an agent profile with `agent_type = "subagent"` — the same profile system §14 covers,
+which is why subagents do NOT appear in `availableModes`: the ACP layer filters that list to primary
+profiles only. Built-in subagent: **`explore`** (read-only,
+`enabled_tools = ["grep","read_file","skill"]`). The model reaches it through a tool named **`task`**
+with input `{task, agent}`.
+
+### A — it is an ORDINARY `tool_call`, `kind: "think"` ✅ confirmed
+
+There is **no new `sessionUpdate` kind**. A subagent run is one `tool_call` + a stream of
+`tool_call_update`s on the SAME `toolCallId`. `kind` is **`"think"`**.
+
+```json
+<<< {"jsonrpc":"2.0","method":"session/update","params":{
+  "sessionId":"bbc711a4-ae6b-8cb6-81c5-9f95bab8a526",
+  "update":{
+    "toolCallId":"8FuX35f6u",
+    "title":"Running subagent",
+    "kind":"think",
+    "status":"in_progress",
+    "_meta":{"tool_name":"task","effect_kind":"subagent"},
+    "sessionUpdate":"tool_call"}}}
+```
+
+The **very first `tool_call` frame carries no `agent` / `task` / `rawInput`** — only
+`tool_name` + `effect_kind`, with the placeholder title `"Running subagent"`. The identity arrives on
+the *next* frame (a `tool_call_update`), and `child_session_id` on the one after that:
+
+```json
+<<< {"update":{
+  "toolCallId":"8FuX35f6u","kind":"think","status":"in_progress",
+  "title":"Running explore agent: Summarise what this project does by reading README.md, alpha.py and beta.js",
+  "rawInput":{"task":"Summarise what this project does by reading README.md, alpha.py and beta.js","agent":"explore"},
+  "_meta":{"tool_name":"task","effect_kind":"subagent",
+           "agent":"explore",
+           "task":"Summarise what this project does by reading README.md, alpha.py and beta.js"},
+  "sessionUpdate":"tool_call_update"}}
+
+<<< {"update":{
+  "toolCallId":"8FuX35f6u","kind":"think","status":"in_progress",
+  "title":"Running explore agent: …","rawInput":{…},
+  "_meta":{"tool_name":"task","effect_kind":"subagent","agent":"explore","task":"…",
+           "child_session_id":"178132b8-4e9f-1fe3-9c4a-a32c2722d5e8"},
+  "sessionUpdate":"tool_call_update"}}
+```
+
+⇒ **Do not detect a subagent by the title.** Detect it by `_meta.effect_kind === "subagent"` (or
+`_meta.tool_name === "task"`), which is present from the first frame, and expect `agent`/`task`/
+`child_session_id` to be **filled in late**.
+
+### B — `_meta` is **snake_case**, sits **on the update object** ✅ confirmed
+
+`_meta` hangs directly off `params.update` (a sibling of `toolCallId`/`status`/`content`), NOT nested
+under `rawInput`/`toolCall`/anything else. Keys are **snake_case** — `tool_name`, `effect_kind`,
+`child_session_id`, `turn_count`, `response` — even though the surrounding ACP fields
+(`toolCallId`, `rawInput`, `rawOutput`) are camelCase. The camelCase twins live only inside
+`rawOutput` (`turnsUsed`). Same trap as the `mime_type` one in §11: **Vibe extension fields are
+snake_case; ACP-standard fields are camelCase.**
+
+Terminal frame — `_meta.turn_count` + `_meta.response` and `rawOutput` appear together:
+
+```json
+<<< {"update":{
+  "toolCallId":"8FuX35f6u","kind":"think","status":"completed",
+  "content":[{"content":{"text":"Completed in 5 turns","type":"text"},"type":"content"}],
+  "rawOutput":{"response":"```\nWidget Factory\n├── README.md: \"turns orders into widgets\"\n…","turnsUsed":5,"completed":true},
+  "_meta":{"tool_name":"task","effect_kind":"subagent","agent":"explore","task":"…",
+           "child_session_id":"178132b8-4e9f-1fe3-9c4a-a32c2722d5e8",
+           "turn_count":5,
+           "response":"```\nWidget Factory\n├── README.md: \"turns orders into widgets\"\n…"},
+  "sessionUpdate":"tool_call_update"}}
+```
+
+### C — 🚨 `content` is **DELTA, NOT cumulative** — this is a live bug in our reducer
+
+Every progress `tool_call_update` carries a **one-element** `content` array holding **only the new
+entry**. Prior entries are never re-sent. Two consecutive frames, verbatim and unabridged, from the
+phase-1 run:
+
+```json
+<<< 2026-08-19T08:15:53.276Z
+{"jsonrpc":"2.0","method":"session/update","params":{
+ "sessionId":"bbc711a4-ae6b-8cb6-81c5-9f95bab8a526",
+ "update":{"toolCallId":"8FuX35f6u","kind":"think","status":"in_progress",
+  "content":[{"content":{"text":"read_file: Read 3 lines from alpha.py","type":"text"},"type":"content"}],
+  "_meta":{…,"child_session_id":"178132b8-…"},"sessionUpdate":"tool_call_update"}}}
+
+<<< 2026-08-19T08:15:53.277Z
+{"jsonrpc":"2.0","method":"session/update","params":{
+ "sessionId":"bbc711a4-ae6b-8cb6-81c5-9f95bab8a526",
+ "update":{"toolCallId":"8FuX35f6u","kind":"think","status":"in_progress",
+  "content":[{"content":{"text":"read_file: Read 4 lines from beta.js","type":"text"},"type":"content"}],
+  "_meta":{…,"child_session_id":"178132b8-…"},"sessionUpdate":"tool_call_update"}}}
+```
+
+The second frame does **not** contain `"read_file: Read 3 lines from alpha.py"`. The full observed
+sequence was three separate single-entry frames (`README.md` → `alpha.py` → `beta.js`) and then the
+terminal `"Completed in 5 turns"` frame — again a **single**-entry array that does **not** carry the
+three progress lines.
+
+⇒ **The renderer's wholesale REPLACE of `content` on every `tool_call_update` shows only the last
+fragment and silently drops the rest.** For `effect_kind:"subagent"` the reducer must **APPEND** new
+`content` entries to the existing list, keyed by `toolCallId`.
+(Whether non-subagent tools are cumulative was NOT re-tested here — this section only proves the
+subagent case. Treat "append for subagent" as the narrow, verified change.)
+
+### D — progress entries: one line per **successful** subagent tool call
+
+Exactly the shape hypothesised — an ACP `ToolCallContent` of `type:"content"` wrapping a text block:
+
+```json
+{"type":"content","content":{"type":"text","text":"read_file: Read 3 lines from README.md"}}
+```
+Note the **field order on the wire is `content` first, then `type`** (irrelevant to parsing, but it is
+what the raw frames look like). Observed texts across the runs:
+`"read_file: Read 3 lines from README.md"`, `"read_file: Read 4 lines from beta.js"`,
+`"grep: Searched beta\\.js (1 match)"`, `"grep: Searched .* (11 matches)"`, and the terminal
+`"Completed in 5 turns"` / `"Completed in 6 turns"`.
+
+**Failed subagent tool calls emit NO content entry.** Phase 1's child session recorded
+`tool_calls_succeeded: 3, tool_calls_failed: 9` (the model wasted 9 calls probing a scratchpad path),
+yet exactly **3** progress entries reached the wire. So the progress stream is a partial view: the
+client cannot count subagent steps from it, and `_meta.turn_count` (5) matches neither the entry
+count (3) nor the tool-call count (12).
+
+### E — **no subagent assistant text or reasoning reaches the wire at all**
+
+Only the one-line progress summaries and the final `response`. The child's own reasoning lives solely
+in its on-disk log (§I). Grepping the full phase-1 frame capture for distinctive child reasoning
+strings (`"The user wants me to summarize what the project does"`, `"scratchpad directory"`,
+`"grep search timed out"`) returned **0 hits** — while all three are present verbatim in
+`agents/explore_…/messages.jsonl`. There is **no** `agent_message_chunk` / `agent_thought_chunk` for
+the child, and **no** `session/update` tagged with the `child_session_id`. Every notification in the
+turn carries the ROOT `sessionId`.
+
+### F — permissions: the `task` call is NOT gated, but the SUBAGENT'S tools ARE — on the ROOT session, with an **unknown `toolCallId`**
+
+**The `task` tool itself raises no `session/request_permission`.** Under the default posture the task
+tool_call `s9JsbnwLb` streamed straight to `in_progress` with no gate — the `task` tool ships with
+`allowlist = ["explore"]`, which resolves to permission `ALWAYS` for the built-in subagent. (A custom
+subagent not on the allowlist would presumably gate; not captured.)
+
+**The subagent's own tool calls DO raise `session/request_permission`, on the ROOT session, and
+`params.toolCall` contains ONLY a `toolCallId` the client has never seen:**
+
+```json
+<<< {"jsonrpc":"2.0","id":0,"method":"session/request_permission","params":{
+  "sessionId":"4df1f09e-2d1c-7fa7-4ee9-38835fe1e800",
+  "toolCall":{"toolCallId":"v1KK2WmAn"},
+  "options":[
+    {"optionId":"allow_once","name":"Allow once","kind":"allow_once"},
+    {"optionId":"allow_always","name":"Allow for remainder of this session","kind":"allow_always",
+     "_meta":{"required_permissions":[{"scope":"outside_directory",
+       "invocation_pattern":"/private/var/folders/…/vibe-scratchpad-4df1f09e-wzcu4ww0/*",
+       "session_pattern":"/private/var/folders/…/vibe-scratchpad-4df1f09e-wzcu4ww0/*",
+       "label":"outside workdir (/private/var/folders/…/vibe-scratchpad-4df1f09e-wzcu4ww0/*)"}]}},
+    {"optionId":"allow_always_permanent","name":"Always allow","kind":"allow_always","_meta":{…}},
+    {"optionId":"reject_once","name":"Deny","kind":"reject_once"}]}}
+```
+
+`params.toolCall` is **`{toolCallId}` and nothing else** — no `title`, no `kind`, no `rawInput`, no
+`_meta`, no `agent`, and **no reference to the parent `task` toolCallId**. In the default-mode run the
+three gated ids were `LEWz9LBLq`, `VPSPomuCr`, `v1KK2WmAn`; the task's own id was `s9JsbnwLb`. **None
+of the gated ids ever appeared in a `tool_call` update.** They are the *child* session's tool-call ids
+— proved against disk: phase 1's permission `{"toolCallId":"KE8X8vsM8"}` matches
+`agents/explore_…/messages.jsonl` line `{"role":"tool","name":"read_file","tool_call_id":"KE8X8vsM8",…}`.
+
+⇒ **A permission-request UI that renders `toolCall.title` / looks the id up in its conversation state
+will render an EMPTY, unattributable prompt for every subagent tool.** The only correlation available
+to the client is "a `task` tool call is currently `in_progress`" — attribute the request to the
+in-flight subagent, and expect no title. With a parallel fan-out (§G) even that is ambiguous: two
+subagents in flight, and the request names neither.
+
+**Root Mode does NOT propagate into the subagent.** Phase 1 ran with `session/set_mode` →
+`auto-approve` (root profile `{"name":"auto-approve","overrides":{"bypass_tool_permissions":true,…}}`)
+and still received **9** permission requests from the child. The subagent runs under its OWN profile
+(`explore`, safety `safe`), whose tool permissions gate independently of the root Mode. **Auto-approve
+is not an escape hatch for subagent permission traffic.**
+
+### G — parallel fan-out: two independent `toolCallId`s, freely interleaved ✅
+
+One assistant message emitting two `task` calls produces two `tool_call` frames back-to-back, then
+two independent update streams, each with its own `child_session_id`:
+
+```json
+<<< 08:19:15.552  {"update":{"toolCallId":"6CjZc36Mi","title":"Running subagent","kind":"think","status":"in_progress",
+                   "_meta":{"tool_name":"task","effect_kind":"subagent"},"sessionUpdate":"tool_call"}}
+<<< 08:19:15.555  {"update":{"toolCallId":"nUL83qaSJ","title":"Running subagent","kind":"think","status":"in_progress",
+                   "_meta":{"tool_name":"task","effect_kind":"subagent"},"sessionUpdate":"tool_call"}}
+```
+
+and the progress streams interleave arbitrarily:
+
+```json
+<<< 08:20:11.667 {"update":{"toolCallId":"6CjZc36Mi","status":"in_progress",
+  "content":[{"content":{"text":"grep: Searched .+ (0 matches)","type":"text"},"type":"content"}],
+  "_meta":{…,"agent":"explore","task":"Read alpha.py and describe what it does",
+           "child_session_id":"9a5c4f3a-2791-8b10-b3ee-7c39cbd11bb2"},"sessionUpdate":"tool_call_update"}}
+
+<<< 08:20:53.085 {"update":{"toolCallId":"nUL83qaSJ","status":"in_progress",
+  "content":[{"content":{"text":"grep: Searched beta\\.js (0 matches)","type":"text"},"type":"content"}],
+  "_meta":{…,"agent":"explore","task":"Read beta.js and describe what it does",
+           "child_session_id":"1cfbf44e-7cad-02c9-a7b1-7b02fe082314"},"sessionUpdate":"tool_call_update"}}
+```
+
+Lifecycles are fully independent: `6CjZc36Mi` reached `status:"completed"` (`"Completed in 6 turns"`)
+at **08:20:30**, while `nUL83qaSJ` kept streaming progress until **08:21:5x**. ⇒ subagent state must
+be keyed by `toolCallId` (never "the current subagent"), and the UI must tolerate N concurrent panels.
+
+### H — `session/load` replays the subagent, but **only the condensed content**
+
+Resuming phase 1's session in a fresh process replays the subagent as a **single `tool_call`** frame
+(NOT `tool_call_update`) already in its terminal state, with `_meta` and `rawOutput` **fully intact**:
+
+```json
+<<< {"update":{
+ "toolCallId":"8FuX35f6u",
+ "title":"Running explore agent: Summarise what this project does by reading README.md, alpha.py and beta.js",
+ "kind":"think","status":"completed",
+ "content":[
+   {"content":{"text":"response: ```\nWidget Factory\n…\nturns_used: 5\ncompleted: True","type":"text"},"type":"content"},
+   {"content":{"text":"Completed in 5 turns","type":"text"},"type":"content"}],
+ "rawInput":{"task":"…","agent":"explore"},
+ "rawOutput":{"response":"…","turnsUsed":5,"completed":true},
+ "_meta":{"tool_name":"task","effect_kind":"subagent","agent":"explore","task":"…",
+          "child_session_id":"178132b8-4e9f-1fe3-9c4a-a32c2722d5e8","turn_count":5,"response":"…"},
+ "sessionUpdate":"tool_call"}}
+```
+
+**The three live progress lines (`read_file: …`) are NOT replayed** — replay substitutes a 2-entry
+list: a flattened `"response: …\nturns_used: 5\ncompleted: True"` blob plus `"Completed in 5 turns"`.
+So the live and replayed content arrays differ in both length and text. Since our own transcript log
+is the reopen source of truth (ADR-0019), **we must persist the appended progress entries ourselves**
+if we want them after a reopen; Vibe will not give them back. Replay also appends the usual
+`checkpoint:resume` pseudo tool_call (`_meta:{"checkpoint_kind":"resume"}`).
+
+### I — on disk: the child session is a nested session directory
+
+`~/.vibe/logs/session/session_<yyyymmdd>_<hhmmss>_<short-parent-id>/` gains an **`agents/`**
+subdirectory, one directory per subagent run:
+
+```
+session_20260819_081428_bbc711a4/
+├── messages.jsonl
+├── meta.json
+└── agents/
+    └── explore_20260819_081433_178132b8/   #  <agent>_<timestamp>_<short-child-id>
+        ├── messages.jsonl
+        └── meta.json
+```
+The parallel run produced two sibling directories under one `agents/`. The child `messages.jsonl` is
+**JSONL, one chat message per line** (18 lines for a 5-turn run), same shape as the parent's:
+`{role, content, injected, message_id}` for `user`; `{role, content, injected, reasoning_content,
+reasoning_message_id, tool_calls, message_id}` for `assistant`; `{role, content, injected, name,
+tool_call_id[, tool_result]}` for `tool`. The child `meta.json` carries
+`{session_id, parent_session_id, …, stats:{steps, tool_calls_succeeded, tool_calls_failed, …},
+agent_profile, system_prompt, tools_available}`, and the PARENT `meta.json` gains the link:
+```json
+"child_sessions":[{"session_id":"178132b8-…","tool_call_id":"8FuX35f6u",
+                   "agent":"explore","relative_path":"agents/explore_20260819_081433_178132b8"}]
+```
+**Reported for information only — do not build on it.** It is an internal log directory, not a
+protocol surface: nothing here is exposed over ACP, and `tool_call_id` ↔ `session_id` correlation
+should come from `_meta.child_session_id` on the wire, not from disk.
+
+### Infra — same `node`-not-`bun` gotcha as §9–§12
+`bun build scripts/spike-subagent.ts --target=node --outfile=/tmp/spike-sub.mjs && node /tmp/spike-sub.mjs --phase=all`
+(`--phase=1|2|3|4`, `--ws=<dir>`, `--log=<file>`). The probe wraps `AcpClient`'s `spawn` so every stdin
+write and stdout line is teed verbatim in both directions. LIVE — costs credits; it only sends
+`session/*` + `_auth/status` and answers `fs/*` + permissions, so it is safe under the house rules.
+
+### Client posture — three gaps we design AROUND, not fixes we wait for
+
+Findings C, F and H are Vibe-side behaviours, **not defects in our client**, and we have decided not
+to file them upstream. They are permanent constraints on any subagent UI we build. Recorded here so a
+later session does not mistake the resulting UI for something half-finished:
+
+1. **Root Mode does not propagate to a subagent** (F). A Thread in `auto-approve` still gets the
+   child's Permission requests. Do NOT auto-answer them on the user's behalf to "restore"
+   auto-approve — that would silently grant tool permissions the user never saw, on a request we
+   cannot even attribute.
+2. **A subagent's Permission request is unattributable** (F). `params.toolCall` is `{toolCallId}`
+   and nothing else, and that id belongs to the *child* session, so it matches no `tool_call` we ever
+   received. There is no child id on the callback. Label such a request honestly ("from a subagent")
+   and never print the raw id or imply WHICH subagent asked — during a fan-out (G) it names neither.
+3. **`session/load` does not replay the live progress lines** (H). Harmless for us: per ADR-0019 we
+   replay from our OWN transcript event log, never from `session/load`. Do not "optimise" replay onto
+   `session/load` — it would silently lose the step ledger.
+
+The child session directory (I) is the only place the subagent's real transcript exists. It stays
+off-limits: reading it would couple us to an unversioned internal format, which is exactly what
+ADR-0002 forbids.


### PR DESCRIPTION
Closes #429. Closes #430. Closes #438. Spec: #428.

Vibe can delegate work mid-turn to a **Subagent**. Our app rendered that badly enough to be
misleading: a Subagent arrives as an ordinary `tool_call` whose ACP kind is `think`, so it went
through the generic tool row and looked identical to the agent merely **thinking** — while a second
agent read files and did real work. Everything identifying it rides in the update's `_meta`, and the
reducer never read `_meta` at all.

Two commits: the protocol capture, then the behaviour.

## Slice 0 — the capture (#429)

`docs/acp-capture.md` **§15**, from a live four-phase run against vibe-acp 2.24.1 (one Subagent under
`auto-approve`, one under the session's own posture, a parallel fan-out of two, a resume replay). The
probe is committed and re-runnable per phase. `CONTEXT.md` gains the **Subagent** glossary entry,
whose `_Avoid_` list keeps it distinct from the separate multi-Thread Parallel Agents work.

## Slice 1 — make it legible (#430)

- **`_meta` is plumbed through.** `ToolItem` gains an optional `meta`, carried verbatim and **merged**
  across frames — the opening `tool_call` has only `tool_name` + `effect_kind`, identity lands a frame
  later, `child_session_id` the frame after. Merging rather than replacing keeps the subagent tag when
  a later frame omits `_meta` entirely.
- **New pure module `subagent.ts`** owns every reading of `_meta`. It accepts snake_case and camelCase
  alike, because `_meta` is snake_case while `rawOutput` is camelCase *in the same tool call*.
  Detection keys on `_meta.effect_kind` and **never** on the title, which is a bare placeholder on the
  first frame.
- **Content now accumulates for Subagents.** Each `tool_call_update` carries only the newly produced
  entry, so the previous wholesale replace displayed just the **last fragment** of the step ledger.
  Every other tool stays on replace — delta is proven for Subagents alone, and appending blindly would
  duplicate diffs in the file-change row.
- **`SubagentToolRow`**: which Subagent, its task, turns used, live status; expands to the step ledger
  and the final answer as prose.
- **Orphan permission requests are labelled honestly.** A Subagent's own permission requests arrive on
  the **root** session carrying the **child** session's tool call id, which we never receive a
  `tool_call` for. The reducer stamps an optional `orphan` flag when a request matches no tool item,
  and the row says "from a Subagent" instead of printing a meaningless id.

## Two decisions worth reviewing

**The ledger is deliberately uncounted.** Vibe emits a line only for a *succeeded* child tool call — a
captured run logged `succeeded:3, failed:9` and streamed three lines, and `turn_count` matched
neither. So the ledger is a sample of the work, never an inventory, and no step count may be rendered
as if complete. `subagent.test.ts` asserts the module exposes no count helper; that is testing an
absence, which is normally a smell, kept because a future helpful-looking `subagentStepCount` would
reintroduce the lie silently. Happy to drop it to a comment if you'd rather.

**The reducer decides orphan-ness, not the row.** "Does this tool call id match anything?" is a state
question and only the reducer holds the items, so deciding it at render time would put the one tricky
predicate outside every test seam. This revises the spec's earlier sketch.

**We never name *which* Subagent asked.** No child identifier reaches the client on a permission
callback, and during a fan-out the request corresponds to neither visible row. Naming one would be a
guess.

**We never auto-answer these**, including under `auto-approve`. Thread Mode genuinely does not
propagate into a Subagent (9 child requests in a captured `auto-approve` run) — but answering on the
user's behalf would grant tool permissions they never saw, on a request we cannot attribute.

## `REDUCER_SCHEMA_VERSION` 1 → 2

Not for shape — the new fields are additive and optional — but for **correctness**: snapshots written
under the old replace behaviour hold a truncated ledger, and without a bump the fix would skip exactly
the Threads that motivated it. One lazy re-fold per Thread, never data loss.

⚠️ #328/#331/#336 also intend a bump. First to land wins; the rest rebase.

## Testing

Two seams, both fed **verbatim §15 frames**, neither rendering a component (tests run in `node`):

- **The reducer** — `_meta` merge across the bare first frame, ledger accumulation, the
  **non-Subagent replace regression**, fan-out independence, orphan detection (matching, non-matching,
  and no-id cases), completion, interruption, malformed `_meta`.
- **`subagent.ts`** — the predicate, extraction under snake_case/camelCase/partial/absent `_meta`,
  ledger derivation.

Also verified, since the append is stateful: a `session/load` resume **cannot** double-append its
condensed replay onto a hydrated ledger — main already suppresses replayed notifications while a load
is in flight (the TB4 #33 guard). No change needed.

## Not in this PR

Authoring or invoking Subagents; a Subagents sidebar view (**parked**, with the TOML profile format
recorded in #428 so the research is not repeated); a turn-level "N Subagents running" aggregate (that
is #322's); reading the child session directory from disk (ADR-0002); and any general delta fix for
other tools — whether they also stream deltas is unproven and needs its own capture.

## Gates

`lint`, `typecheck`, `build`, `test` — **158 files / 1760 tests** green locally.