### PR TITLE
fix: make context exhaustion visible (#433)

### DIFF
--- a/apps/desktop/src/renderer/src/conversation/Conversation.tsx
+++ b/apps/desktop/src/renderer/src/conversation/Conversation.tsx
@@ -52,14 +52,12 @@ import {
   subscribeWorkspaceCommands,
 } from './workspace-commands'
 import { buildComposerHistoryEntries } from './composer-history'
+import { turnErrorNotice } from './turn-error-notice'
 import { MessageSelectionToolbar } from './message-selection-toolbar'
 import type { MessageSelection } from './message-selection'
 
 /** Process-local counter for unique echoed-prompt ids. */
 let promptSeq = 0
-
-/** Vibe's app code for "this model can't ingest images" (acp-capture §11, #100). */
-const IMAGES_UNSUPPORTED_CODE = -31008
 
 const CONTROL_AXIS_LABELS: Record<ThreadConfigAxis, string> = {
   mode: 'Mode',
@@ -370,13 +368,10 @@ export function Conversation({
         onAuthExpired(result.authMethods)
       } else {
         // Surface a failed turn as a conversation item rather than dropping it.
-        // -31008 (images-unsupported, acp-capture §11) gets an actionable hint —
-        // the staged images are kept above, so switching model + resend just works.
-        const message =
-          result.code === IMAGES_UNSUPPORTED_CODE
-            ? "This model can't see images. Switch to a vision-capable model (e.g. mistral-medium-3.5) and resend."
-            : result.error
-        dispatch({ type: 'turn-error', message })
+        // Codes we understand become an actionable sentence (turn-error-notice):
+        // -31008 keeps the staged images so switch-model-and-resend just works;
+        // -31004 / -31006 name the way out of an exhausted context (#433).
+        dispatch({ type: 'turn-error', message: turnErrorNotice(result.code, result.error) })
       }
     } finally {
       // The turn's stopReason resolves sendPrompt; flip back to the user's turn and

--- a/apps/desktop/src/renderer/src/conversation/context-usage.test.ts
+++ b/apps/desktop/src/renderer/src/conversation/context-usage.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CONTEXT_CRITICAL_RATIO,
+  CONTEXT_WARN_RATIO,
+  contextUsageLevel,
+  contextUsageNotice,
+  contextUsagePercent,
+  contextUsageRatio,
+} from './context-usage'
+
+const SIZE = 200_000
+
+describe('contextUsageLevel', () => {
+  it('stays quiet for most of a conversation, including past Vibe\'s own 50% warning', () => {
+    expect(contextUsageLevel({ used: 0, size: SIZE })).toBe('normal')
+    expect(contextUsageLevel({ used: SIZE * 0.5, size: SIZE })).toBe('normal')
+    expect(contextUsageLevel({ used: SIZE * 0.74, size: SIZE })).toBe('normal')
+  })
+
+  it('warns from the warn ratio and escalates from the critical ratio', () => {
+    expect(contextUsageLevel({ used: SIZE * CONTEXT_WARN_RATIO, size: SIZE })).toBe('warn')
+    expect(contextUsageLevel({ used: SIZE * 0.89, size: SIZE })).toBe('warn')
+    expect(contextUsageLevel({ used: SIZE * CONTEXT_CRITICAL_RATIO, size: SIZE })).toBe('critical')
+  })
+
+  it('stays critical past the threshold — the compaction-thrash case is real, not a glitch', () => {
+    // #433 measured context climbing ABOVE the threshold across consecutive
+    // compactions, so a ratio > 1 must not wrap around to something reassuring.
+    expect(contextUsageLevel({ used: SIZE * 1.4, size: SIZE })).toBe('critical')
+    expect(contextUsagePercent({ used: SIZE * 1.4, size: SIZE })).toBe(140)
+  })
+
+  it('never cries wolf on an unusable reading', () => {
+    for (const usage of [
+      { used: 10, size: 0 },
+      { used: 10, size: -1 },
+      { used: -1, size: SIZE },
+      { used: Number.NaN, size: SIZE },
+      { used: 10, size: Number.POSITIVE_INFINITY },
+    ]) {
+      expect(contextUsageLevel(usage)).toBe('normal')
+      expect(contextUsageRatio(usage)).toBeNull()
+      expect(contextUsagePercent(usage)).toBeNull()
+    }
+  })
+})
+
+describe('contextUsageNotice', () => {
+  it('says nothing at normal, and names the consequence at critical', () => {
+    expect(contextUsageNotice('normal')).toBeNull()
+    expect(contextUsageNotice('warn')).toMatch(/approaching/i)
+    // The point of the critical line is that compaction is LOSSY — say so.
+    expect(contextUsageNotice('critical')).toMatch(/summarised/i)
+  })
+})

--- a/apps/desktop/src/renderer/src/conversation/context-usage.ts
+++ b/apps/desktop/src/renderer/src/conversation/context-usage.ts
@@ -1,0 +1,69 @@
+/**
+ * Reading the `usage_update {used, size}` gauge as a HEALTH signal rather than a
+ * pair of numbers (#433).
+ *
+ * `size` is Vibe's `auto_compact_threshold` (default 200_000), so `used/size` is
+ * how close this conversation is to being compacted — and compaction is lossy:
+ * assistant turns, tool calls and reasoning are discarded, only user prose and a
+ * summary survive. A user who can see that coming can finish the thought, start a
+ * fresh Thread, or `/compact` deliberately instead of being surprised.
+ *
+ * Vibe already injects its own one-shot `<vibe_warning>` at 50%, so warning that
+ * early here would just double up on a message the user has already read. We speak
+ * later, and only twice.
+ */
+
+/** How close a conversation is to its compaction threshold. */
+export type ContextUsageLevel = 'normal' | 'warn' | 'critical'
+
+/** Fraction of the threshold at which we first say something. */
+export const CONTEXT_WARN_RATIO = 0.75
+/** Fraction at which compaction is imminent enough to name the consequence. */
+export const CONTEXT_CRITICAL_RATIO = 0.9
+
+export interface ContextUsage {
+  used: number
+  size: number
+}
+
+/**
+ * Classify a usage reading. A non-positive or non-finite `size` yields `normal`:
+ * an unusable denominator must not render as an alarm (we would rather under-warn
+ * than cry wolf on a garbled reading).
+ */
+export function contextUsageLevel(usage: ContextUsage): ContextUsageLevel {
+  const ratio = contextUsageRatio(usage)
+  if (ratio === null) return 'normal'
+  if (ratio >= CONTEXT_CRITICAL_RATIO) return 'critical'
+  if (ratio >= CONTEXT_WARN_RATIO) return 'warn'
+  return 'normal'
+}
+
+/**
+ * `used / size`, or null when the reading cannot be trusted (non-finite, negative,
+ * or a zero denominator). Not clamped: a ratio above 1 is real and means Vibe is
+ * past its own threshold — see the compaction-thrash case in #433.
+ */
+export function contextUsageRatio(usage: ContextUsage): number | null {
+  const { used, size } = usage
+  if (!Number.isFinite(used) || !Number.isFinite(size)) return null
+  if (size <= 0 || used < 0) return null
+  return used / size
+}
+
+/** Whole-percent reading for display. Null whenever the ratio is untrustworthy. */
+export function contextUsagePercent(usage: ContextUsage): number | null {
+  const ratio = contextUsageRatio(usage)
+  return ratio === null ? null : Math.round(ratio * 100)
+}
+
+/**
+ * The short line shown beside the numbers once we have something to say. Null at
+ * `normal` — the gauge stays silent for most of a conversation's life, so that
+ * when it does speak the user has reason to read it.
+ */
+export function contextUsageNotice(level: ContextUsageLevel): string | null {
+  if (level === 'critical') return 'compacting soon — older turns will be summarised'
+  if (level === 'warn') return 'approaching the context limit'
+  return null
+}

--- a/apps/desktop/src/renderer/src/conversation/items/UsageBar.tsx
+++ b/apps/desktop/src/renderer/src/conversation/items/UsageBar.tsx
@@ -1,22 +1,45 @@
 import type { JSX } from 'react'
+import {
+  contextUsageLevel,
+  contextUsageNotice,
+  contextUsagePercent,
+} from '../context-usage'
 
+/**
+ * The per-Thread readout under the transcript: context used and turn cost.
+ *
+ * Context is a HEALTH signal, not just a number (#433) — past 75% of Vibe's
+ * compaction threshold the reading colours and names what is about to happen, so
+ * a lossy compaction is something the user sees coming rather than discovers.
+ */
 export function UsageBar({
   state,
 }: {
   state: { usage: { used: number; size: number } | null; cost: { amount: number; currency: string } | null }
 }): JSX.Element | null {
   if (!state.usage && !state.cost) return null
+  const level = state.usage ? contextUsageLevel(state.usage) : 'normal'
+  const notice = contextUsageNotice(level)
+  const percent = state.usage ? contextUsagePercent(state.usage) : null
   return (
     <div className="usage">
       {state.usage && (
-        <span className="usage__item">
+        <span className={`usage__item usage__item--${level}`}>
           context <strong>{state.usage.used.toLocaleString()}</strong> /{' '}
           {state.usage.size.toLocaleString()} tokens
+          {percent !== null && level !== 'normal' && <> ({percent}%)</>}
         </span>
       )}
       {state.cost && (
         <span className="usage__item">
           cost <strong>{formatCost(state.cost.amount, state.cost.currency)}</strong>
+        </span>
+      )}
+      {/* `role="status"` so the warning is announced when it appears, not silently
+          repainted — this is the one thing on the bar worth interrupting for. */}
+      {notice && (
+        <span className={`usage__notice usage__notice--${level}`} role="status">
+          {notice}
         </span>
       )}
     </div>

--- a/apps/desktop/src/renderer/src/conversation/turn-error-notice.test.ts
+++ b/apps/desktop/src/renderer/src/conversation/turn-error-notice.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import {
+  COMPACTION_FAILED_CODE,
+  CONTEXT_TOO_LONG_CODE,
+  IMAGES_UNSUPPORTED_CODE,
+  turnErrorNotice,
+} from './turn-error-notice'
+
+describe('turnErrorNotice', () => {
+  it('keeps the agent\'s own message for a code we do not understand', () => {
+    expect(turnErrorNotice(-31001, 'Rate limited')).toBe('Rate limited')
+    expect(turnErrorNotice(null, 'Something broke')).toBe('Something broke')
+    expect(turnErrorNotice(undefined, 'Something broke')).toBe('Something broke')
+  })
+
+  it('tells an images failure how to recover (#100)', () => {
+    const notice = turnErrorNotice(IMAGES_UNSUPPORTED_CODE, 'raw agent message')
+    expect(notice).toMatch(/vision-capable/i)
+    expect(notice).not.toBe('raw agent message')
+  })
+
+  it('points an exhausted context at /compact or a new Thread (#433)', () => {
+    const notice = turnErrorNotice(CONTEXT_TOO_LONG_CODE, 'context too long')
+    expect(notice).toMatch(/\/compact/)
+    expect(notice).toMatch(/new Thread/i)
+  })
+
+  it('tells a failed compaction that the Thread may be unrecoverable (#433)', () => {
+    const notice = turnErrorNotice(COMPACTION_FAILED_CODE, 'compaction failed')
+    expect(notice).toMatch(/new Thread/i)
+  })
+
+  it('gives every code we claim to handle its own distinct message', () => {
+    const codes = [IMAGES_UNSUPPORTED_CODE, CONTEXT_TOO_LONG_CODE, COMPACTION_FAILED_CODE]
+    const notices = codes.map((code) => turnErrorNotice(code, 'fallback'))
+    expect(new Set(notices).size).toBe(codes.length)
+    expect(notices).not.toContain('fallback')
+  })
+})

--- a/apps/desktop/src/renderer/src/conversation/turn-error-notice.ts
+++ b/apps/desktop/src/renderer/src/conversation/turn-error-notice.ts
@@ -1,0 +1,42 @@
+/**
+ * Turning a failed turn's JSON-RPC/app error code into something a user can ACT on
+ * (#433, #100).
+ *
+ * Vibe's `-31xxx` application codes carry meanings its raw messages do not make
+ * actionable — "context too long" does not tell you that `/compact` exists. Every
+ * code we understand gets a sentence naming the way out; everything else falls
+ * through to the agent's own message, which is still better than inventing one.
+ *
+ * Extracted from `Conversation.tsx` so the mapping is testable without rendering,
+ * and so the next code we learn about has an obvious home.
+ */
+
+/** Vibe's app code for "this model can't ingest images" (acp-capture §11, #100). */
+export const IMAGES_UNSUPPORTED_CODE = -31008
+/** The conversation no longer fits the model's context window (acp-capture §8). */
+export const CONTEXT_TOO_LONG_CODE = -31004
+/**
+ * Compaction ran and could not produce a summary (acp-capture §8). Only reachable
+ * when `raise_on_compaction_failure` is ON — with Vibe's default (off) the same
+ * failure is SILENT: the turn continues having quietly dropped everything that was
+ * not a user message (#433). So seeing this error is the lucky case.
+ */
+export const COMPACTION_FAILED_CODE = -31006
+
+/**
+ * The message to show for a failed turn. `code` is the preserved JSON-RPC/app code
+ * (null when the failure carried none) and `fallback` is the agent's own message.
+ */
+export function turnErrorNotice(code: number | null | undefined, fallback: string): string {
+  switch (code) {
+    case IMAGES_UNSUPPORTED_CODE:
+      // The staged images are kept, so switching model and resending just works.
+      return "This model can't see images. Switch to a vision-capable model (e.g. mistral-medium-3.5) and resend."
+    case CONTEXT_TOO_LONG_CODE:
+      return 'This conversation no longer fits the model\'s context. Run /compact to summarise the history, or start a new Thread to keep going.'
+    case COMPACTION_FAILED_CODE:
+      return 'Vibe could not compact this conversation\'s history, so the turn was stopped. Starting a new Thread is the reliable way forward — this one may be too large to recover.'
+    default:
+      return fallback
+  }
+}

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -510,6 +510,28 @@ body {
   font-weight: 600;
 }
 
+/* Context health (#433). The gauge is silent for most of a conversation's life;
+   past 75% of Vibe's compaction threshold it warms, and past 90% it takes the
+   destructive tone — because what happens next (a lossy compaction that discards
+   assistant turns, tool calls and reasoning) is genuinely destructive to context. */
+.usage__item--warn,
+.usage__notice--warn {
+  color: color-mix(in srgb, var(--destructive) 55%, var(--muted-foreground));
+}
+
+.usage__item--critical,
+.usage__notice--critical {
+  color: var(--destructive);
+}
+
+.usage__item--critical strong {
+  color: var(--destructive);
+}
+
+.usage__notice {
+  font-style: italic;
+}
+
 /* The conversation column's shared reading measure: transcript content and the
    Composer cap to the same centered width, so collapsing the sidebar/side panel
    widens the outlet without the transcript sprawling past the composer. */


### PR DESCRIPTION
Partial fix for #433 — the two small, self-contained pieces. Thrash detection and silent-amnesia detection are deliberately **not** here: they need a decision about what the user is actually shown, not just a threshold.

## Context health

`usage_update {used, size}` was already captured and rendered — as raw numbers that looked identical at 4% and at 99%. It now classifies:

| Ratio | Treatment |
|---|---|
| < 75% | silent, exactly as today |
| ≥ 75% | warmed colour + "approaching the context limit" |
| ≥ 90% | destructive tone + "compacting soon — older turns will be summarised" |

Two deliberate choices:

- **We speak later than Vibe does.** Vibe already injects a one-shot `<vibe_warning>` at 50%; warning there too would just double up on a message the user has read. We speak twice, late.
- **A ratio above 1 stays critical.** #433 measured context climbing *past* the threshold across consecutive compactions (`15,726 → 15,967 → 16,742` against a 12,000 threshold), so >100% is a real state, not a glitch to clamp away.

An unusable reading (zero/negative/non-finite `size`, negative `used`) renders as `normal` — better to under-warn than to cry wolf on a garbled gauge.

## Error classification

`-31004` (context-too-long) and `-31006` (compaction-failed) fell through to the generic path and rendered as a bare agent string. They now name the way out — `/compact`, or a new Thread.

The existing `-31008` images hint moved out of `Conversation.tsx` into the same pure module, so the mapping is testable without rendering and the next code we learn about has an obvious home. Behaviour for `-31008` is unchanged.

Worth flagging: **`-31006` is the lucky case.** It is only reachable when `raise_on_compaction_failure` is ON, and Vibe's default is off — where the identical failure is *silent*, continuing the turn having quietly dropped everything that was not a user message. That silence is the harder half of #433 and is not addressed here.

## Verification

Gates green: lint clean, typecheck 0 errors across both projects, build complete, **159 files / 1739 tests** (+10 from the two new suites). The new CSS classes are confirmed present in the built stylesheet.

**Not visually verified in the running app.** The logic is unit-tested, but reproducing a >75% context state in the real app needs a very long live Thread; the colours and copy are worth a human glance before merge.

Leaves #433 open for the remaining two pieces.