### PR TITLE
feat: Mistro Bots slice 2 — the bounded sidebar section, the Bot conversation, and the Threads/Search split (#446)

### DIFF
--- a/apps/desktop/src/main/bots/mark-bot-threads.test.ts
+++ b/apps/desktop/src/main/bots/mark-bot-threads.test.ts
@@ -68,7 +68,6 @@ describe('markBotThreads', () => {
     const input = workspaces()
     const marked = markBotThreads(input, botNamesByThread([botRecord('t-bot')]))
     expect(marked[1]).toBe(input[1])
-    expect(marked[0]).not.toBe(input[0])
   })
 
   it('does not mutate the snapshot it was given', () => {
@@ -96,6 +95,13 @@ describe('the Thread-list / Search split (#446)', () => {
   it('reports an ordinary Thread with no bot identity at all', () => {
     const hit = searchThreads(marked, 'chore').find((h) => h.threadId === 't-plain')
     expect(hit?.botName).toBeUndefined()
+  })
+
+  it('demotes a Bot Thread title without making it unsearchable', () => {
+    // The name takes the title tier, but the Vibe-generated title still joins the
+    // haystack — so it ranks lower than a name match rather than vanishing.
+    const hits = searchThreads(marked, 'Fix the parser')
+    expect(hits.map((h) => h.threadId)).toContain('t-bot')
   })
 
   it('still finds a Bot by what was SAID in it (the prose half, PRD story 11)', () => {

--- a/apps/desktop/src/main/bots/mark-bot-threads.test.ts
+++ b/apps/desktop/src/main/bots/mark-bot-threads.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest'
+import type { BotRecord, ListMetadataResult } from '../../shared/ipc'
+import { botNamesByThread, markBotThreads } from './mark-bot-threads'
+import { searchThreads } from '../search/search-threads'
+
+function workspaces(): ListMetadataResult {
+  return [
+    {
+      id: 'ws-1',
+      dir: '/tmp/one',
+      displayName: 'one',
+      lastOpenedAt: 10,
+      threads: [
+        { id: 't-bot', workspaceId: 'ws-1', sessionId: null, title: 'Fix the parser', createdAt: 1, lastActiveAt: 9 },
+        { id: 't-plain', workspaceId: 'ws-1', sessionId: null, title: 'chore', createdAt: 1, lastActiveAt: 8 },
+      ],
+    },
+    {
+      id: 'ws-2',
+      dir: '/tmp/two',
+      displayName: 'two',
+      lastOpenedAt: 5,
+      threads: [
+        { id: 't-other', workspaceId: 'ws-2', sessionId: null, title: 'other', createdAt: 1, lastActiveAt: 4 },
+      ],
+    },
+  ]
+}
+
+function botRecord(threadId: string): BotRecord {
+  return {
+    threadId,
+    workspaceId: 'ws-1',
+    profileId: 'mistro-bot-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    name: 'Rex',
+    colour: '#e8734a',
+    description: 'reviews my changes',
+    instructions: 'Be blunt.',
+    createdAt: 1,
+    updatedAt: 2,
+  }
+}
+
+describe('markBotThreads', () => {
+  it('flags a Bot Thread and leaves every ordinary Thread untouched', () => {
+    const marked = markBotThreads(workspaces(), botNamesByThread([botRecord('t-bot')]))
+    const [first, second] = marked
+    expect(first?.threads[0]?.bot).toEqual({ name: 'Rex' })
+    expect(first?.threads[1]?.bot).toBeUndefined()
+    expect(second?.threads[0]?.bot).toBeUndefined()
+  })
+
+  it('NEVER drops a row — the marked snapshot is the same shape as the input', () => {
+    // The whole point (ADR-0027): a filter here would delete Bots from Search too.
+    const input = workspaces()
+    const marked = markBotThreads(input, botNamesByThread([botRecord('t-bot')]))
+    expect(marked.map((w) => w.threads.map((t) => t.id))).toEqual(
+      input.map((w) => w.threads.map((t) => t.id)),
+    )
+  })
+
+  it('returns the input untouched when there are no Bots', () => {
+    const input = workspaces()
+    expect(markBotThreads(input, botNamesByThread([]))).toBe(input)
+  })
+
+  it('leaves a Workspace with no Bot in it referentially unchanged', () => {
+    const input = workspaces()
+    const marked = markBotThreads(input, botNamesByThread([botRecord('t-bot')]))
+    expect(marked[1]).toBe(input[1])
+    expect(marked[0]).not.toBe(input[0])
+  })
+
+  it('does not mutate the snapshot it was given', () => {
+    const input = workspaces()
+    markBotThreads(input, botNamesByThread([botRecord('t-bot')]))
+    expect(input[0]?.threads[0]?.bot).toBeUndefined()
+  })
+})
+
+describe('the Thread-list / Search split (#446)', () => {
+  const marked = markBotThreads(workspaces(), botNamesByThread([botRecord('t-bot')]))
+
+  it('Search finds a Bot by its NAME — not by the title Vibe generated', () => {
+    const hits = searchThreads(marked, 'Rex')
+    expect(hits.map((h) => h.threadId)).toContain('t-bot')
+    expect(hits.find((h) => h.threadId === 't-bot')?.botName).toBe('Rex')
+  })
+
+  it('Search keeps a Bot in the RESTING recents (a switcher lists what you switch to)', () => {
+    const resting = searchThreads(marked, '')
+    expect(resting.map((h) => h.threadId)).toContain('t-bot')
+    expect(resting.find((h) => h.threadId === 't-bot')?.botName).toBe('Rex')
+  })
+
+  it('reports an ordinary Thread with no bot identity at all', () => {
+    const hit = searchThreads(marked, 'chore').find((h) => h.threadId === 't-plain')
+    expect(hit?.botName).toBeUndefined()
+  })
+
+  it('still finds a Bot by what was SAID in it (the prose half, PRD story 11)', () => {
+    const prose = new Map([
+      ['t-bot', [{ index: 0, text: 'we decided to keep the parser as it is', itemId: 'u-1' }]],
+    ])
+    const hits = searchThreads(marked, 'parser', 20, prose)
+    expect(hits.map((h) => h.threadId)).toContain('t-bot')
+    expect(hits.find((h) => h.threadId === 't-bot')?.snippet).toContain('parser')
+  })
+})

--- a/apps/desktop/src/main/bots/mark-bot-threads.ts
+++ b/apps/desktop/src/main/bots/mark-bot-threads.ts
@@ -1,0 +1,50 @@
+import type { ListMetadataResult, ThreadMeta } from '../../shared/ipc'
+import type { BotRecord } from '../../shared/ipc'
+
+/**
+ * Tag the Threads that are **Mistro Bot** conversations (#446, ADR-0027) with the
+ * per-row `bot` flag, over the grouped cold snapshot both `metadata:list` and
+ * `search:query` are served from.
+ *
+ * This is the whole visibility mechanism, and its SHAPE is the load-bearing part.
+ * ADR-0027: "The Search exclusion cannot be a store-level filter. The Thread list
+ * and Search share one expression, so hiding Bots in the store would hide them
+ * from Search too. It is a per-row flag, read differently by each side."
+ *
+ * Concretely: `listMetadata` and `searchQuery` both call
+ * `groupThreadsByWorkspace(store.snapshot())`. A filter in the store, in
+ * `snapshot()`, or in `groupThreadsByWorkspace` would delete Bots from Search as
+ * well as from the sidebar — so this MARKS and never drops. The sidebar does the
+ * dropping (`partitionBots`, renderer-side); Search keeps every row and badges it;
+ * the FTS prose projection needs no change at all, because it keys on `threadId`
+ * alone and never consults this snapshot.
+ *
+ * Pure and allocation-frugal: with no Bots the input is returned untouched, and a
+ * Workspace with no Bot in it keeps its original `threads` array.
+ */
+export function markBotThreads(
+  workspaces: ListMetadataResult,
+  botNamesByThread: ReadonlyMap<string, string>,
+): ListMetadataResult {
+  if (botNamesByThread.size === 0) return workspaces
+  return workspaces.map((workspace) => {
+    if (!workspace.threads.some((thread) => botNamesByThread.has(thread.id))) return workspace
+    return {
+      ...workspace,
+      threads: workspace.threads.map((thread) => {
+        const name = botNamesByThread.get(thread.id)
+        return name === undefined ? thread : markBotThread(thread, name)
+      }),
+    }
+  })
+}
+
+/** Each Bot's name keyed by its Thread id, for {@link markBotThreads}. */
+export function botNamesByThread(bots: readonly BotRecord[]): ReadonlyMap<string, string> {
+  return new Map(bots.map((bot) => [bot.threadId, bot.name]))
+}
+
+/** One row, flagged. Split out so the flag's shape is written down exactly once. */
+function markBotThread(thread: ThreadMeta, name: string): ThreadMeta {
+  return { ...thread, bot: { name } }
+}

--- a/apps/desktop/src/main/bots/mark-bot-threads.ts
+++ b/apps/desktop/src/main/bots/mark-bot-threads.ts
@@ -1,5 +1,4 @@
-import type { ListMetadataResult, ThreadMeta } from '../../shared/ipc'
-import type { BotRecord } from '../../shared/ipc'
+import type { BotRecord, ListMetadataResult, ThreadMeta } from '../../shared/ipc'
 
 /**
  * Tag the Threads that are **Mistro Bot** conversations (#446, ADR-0027) with the

--- a/apps/desktop/src/main/bots/select-bot-profile.test.ts
+++ b/apps/desktop/src/main/bots/select-bot-profile.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { ThreadAgentControls } from '../../shared/ipc'
+import { applyBotProfile, planBotProfileSelection } from './select-bot-profile'
+
+const PROFILE = 'mistro-bot-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+
+function controls(currentModeId: string, ids: string[]): ThreadAgentControls {
+  return {
+    modes: {
+      currentModeId,
+      availableModes: ids.map((id) => ({ id, name: id })),
+    },
+    models: null,
+    reasoningEffort: null,
+  }
+}
+
+describe('planBotProfileSelection', () => {
+  it('does nothing for an ordinary Thread', () => {
+    expect(planBotProfileSelection(null, controls('ask', ['ask']))).toEqual({ kind: 'satisfied' })
+  })
+
+  it('does nothing on a plain session REUSE — the earlier bind already selected it', () => {
+    expect(planBotProfileSelection(PROFILE, null)).toEqual({ kind: 'satisfied' })
+  })
+
+  it('selects the profile on a fresh session that offers it', () => {
+    const plan = planBotProfileSelection(PROFILE, controls('ask', ['ask', PROFILE]))
+    expect(plan).toEqual({ kind: 'select', profileId: PROFILE })
+  })
+
+  it('re-selects after a resume, where Mode falls back to a builtin', () => {
+    // Mode does not survive session/load — the reason this runs on every bind.
+    const plan = planBotProfileSelection(PROFILE, controls('plan', ['ask', 'plan', PROFILE]))
+    expect(plan).toEqual({ kind: 'select', profileId: PROFILE })
+  })
+
+  it('is satisfied when the session already reports the profile as current', () => {
+    expect(planBotProfileSelection(PROFILE, controls(PROFILE, [PROFILE]))).toEqual({
+      kind: 'satisfied',
+    })
+  })
+
+  it('reports MISSING when Vibe no longer lists the profile (the file is gone)', () => {
+    const plan = planBotProfileSelection(PROFILE, controls('ask', ['ask', 'plan']))
+    expect(plan.kind).toBe('missing')
+  })
+
+  it('reports MISSING when the session advertises no modes at all', () => {
+    const plan = planBotProfileSelection(PROFILE, { modes: null, models: null, reasoningEffort: null })
+    expect(plan.kind).toBe('missing')
+  })
+})
+
+describe('applyBotProfile', () => {
+  it('sends the profile through the validating mode setter', async () => {
+    const setMode = vi.fn().mockResolvedValue(undefined)
+    const outcome = await applyBotProfile({ setMode }, 'sess-1', {
+      kind: 'select',
+      profileId: PROFILE,
+    })
+    expect(setMode).toHaveBeenCalledWith('sess-1', PROFILE)
+    expect(outcome).toEqual({ ok: true, selected: PROFILE })
+  })
+
+  it('calls nothing when the plan is satisfied', async () => {
+    const setMode = vi.fn()
+    expect(await applyBotProfile({ setMode }, 'sess-1', { kind: 'satisfied' })).toEqual({
+      ok: true,
+      selected: null,
+    })
+    expect(setMode).not.toHaveBeenCalled()
+  })
+
+  it('SURFACES a rejection instead of letting the Bot answer as a plain agent', async () => {
+    const setMode = vi.fn().mockRejectedValue(new Error('Unsupported config option mode=…'))
+    const outcome = await applyBotProfile({ setMode }, 'sess-1', {
+      kind: 'select',
+      profileId: PROFILE,
+    })
+    expect(outcome.ok).toBe(false)
+    if (outcome.ok) return
+    expect(outcome.message).toContain(PROFILE)
+    expect(outcome.message).toContain('Unsupported config option')
+  })
+
+  it('never throws — a persona failure must not fail the turn', async () => {
+    const setMode = vi.fn().mockRejectedValue(new Error('boom'))
+    await expect(
+      applyBotProfile({ setMode }, 'sess-1', { kind: 'select', profileId: PROFILE }),
+    ).resolves.toMatchObject({ ok: false })
+  })
+
+  it('reports a missing profile without calling the agent', async () => {
+    const setMode = vi.fn()
+    const outcome = await applyBotProfile({ setMode }, 'sess-1', {
+      kind: 'missing',
+      profileId: PROFILE,
+      reason: 'its profile file is missing',
+    })
+    expect(setMode).not.toHaveBeenCalled()
+    expect(outcome).toMatchObject({ ok: false })
+  })
+})

--- a/apps/desktop/src/main/bots/select-bot-profile.ts
+++ b/apps/desktop/src/main/bots/select-bot-profile.ts
@@ -1,0 +1,116 @@
+import type { ThreadAgentControls } from '../../shared/ipc'
+
+/**
+ * Selecting a Mistro Bot's persona on the session its Thread just bound to (#446,
+ * ADR-0027 decision 3): "a Vibe agent profile ... selected on bind via the mode
+ * axis".
+ *
+ * This has to happen on EVERY bind, not once at creation: Mode does not survive
+ * `session/load`, and ADR-0007's re-assert cache is in-memory by design — so a Bot
+ * reopened after a restart would answer as a nameless agent with no persona if the
+ * profile weren't re-selected here.
+ *
+ * The plan is pure so the interesting question — *when is a persona missing rather
+ * than merely unselected?* — is decided in a unit test rather than against a live
+ * binary. The applier is the thin half.
+ */
+
+/** What a bind must do about a Bot's persona. */
+export type BotProfilePlan =
+  /** Nothing to do: not a Bot, or the session already has the persona selected. */
+  | { kind: 'satisfied' }
+  /** Select `profileId` on the mode axis. */
+  | { kind: 'select'; profileId: string }
+  /**
+   * The session does not offer this profile as a mode. Vibe re-scans `~/.vibe/agents/`
+   * on every `session/new`, so an absent profile means the FILE is gone or unreadable
+   * — not a timing race. Sending it anyway would earn a `-32602`; reporting it is
+   * strictly more useful, and slice 4 turns this into the rebuild banner.
+   */
+  | { kind: 'missing'; profileId: string; reason: string }
+
+/**
+ * Decide what this bind owes the Bot's persona.
+ *
+ * `controls` are the session's REPORTED agent controls — non-null whenever the bind
+ * produced a fresh `session/new` / `session/load` result, and null on a plain reuse
+ * of an already-hosted session. A reuse is `satisfied`: the session was bound
+ * earlier in this same run, which is precisely when the persona was already
+ * selected on it.
+ */
+export function planBotProfileSelection(
+  profileId: string | null,
+  controls: ThreadAgentControls | null,
+): BotProfilePlan {
+  if (!profileId) return { kind: 'satisfied' } // an ordinary Thread
+  if (!controls) return { kind: 'satisfied' } // reuse — selected on the earlier bind
+  const modes = controls.modes
+  if (!modes) {
+    return {
+      kind: 'missing',
+      profileId,
+      reason: 'this session advertises no modes, so no agent profile can be selected',
+    }
+  }
+  if (modes.currentModeId === profileId) return { kind: 'satisfied' }
+  if (!modes.availableModes.some((mode) => mode.id === profileId)) {
+    return {
+      kind: 'missing',
+      profileId,
+      reason: 'Vibe does not list it as an agent profile — its profile file is missing or unreadable',
+    }
+  }
+  return { kind: 'select', profileId }
+}
+
+/** The one agent call this needs: the VALIDATING mode setter. */
+export interface BotProfileModeAgent {
+  /**
+   * `session/set_config_option` with `configId: "mode"` where the session advertises
+   * it — which VALIDATES (`-32602` on an unknown id), unlike `session/set_mode`,
+   * which answers a bogus id with `{}`: a silent no-op indistinguishable from
+   * success (#427). `WorkspaceAgent.setMode` already routes this way.
+   */
+  setMode(sessionId: string, modeId: string): Promise<void>
+}
+
+/** The outcome of {@link applyBotProfile} — a failure is a message, never a throw. */
+export type BotProfileOutcome =
+  | { ok: true; selected: string | null }
+  | { ok: false; message: string }
+
+/**
+ * Carry out a plan. Never rejects: a Bot whose persona could not be selected must
+ * still get its turn, but it must NOT get it silently — the message is surfaced to
+ * the renderer on `thread:bound` and logged in main.
+ */
+export async function applyBotProfile(
+  agent: BotProfileModeAgent,
+  sessionId: string,
+  plan: BotProfilePlan,
+): Promise<BotProfileOutcome> {
+  if (plan.kind === 'satisfied') return { ok: true, selected: null }
+  if (plan.kind === 'missing') {
+    return { ok: false, message: botProfileMissingMessage(plan.profileId, plan.reason) }
+  }
+  try {
+    await agent.setMode(sessionId, plan.profileId)
+    return { ok: true, selected: plan.profileId }
+  } catch (err) {
+    return {
+      ok: false,
+      message:
+        `This Bot's persona (${plan.profileId}) was rejected by the agent: ` +
+        `${err instanceof Error ? err.message : String(err)}. ` +
+        'It is answering with its default instructions.',
+    }
+  }
+}
+
+/** The copy for a persona the session never offered — one place, so it stays honest. */
+function botProfileMissingMessage(profileId: string, reason: string): string {
+  return (
+    `This Bot's persona (${profileId}) could not be selected: ${reason}. ` +
+    'It is answering with its default instructions.'
+  )
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -109,6 +109,8 @@ import { registerFilesIpc } from './files/register-ipc'
 import { registerSkillsIpc } from './skills/register-ipc'
 import { createBotLifecycleDeps, registerBotsIpc } from './bots/register-ipc'
 import { cleanRemovedBots } from './bots/clean-removed-bots'
+import { botNamesByThread, markBotThreads } from './bots/mark-bot-threads'
+import { applyBotProfile, planBotProfileSelection } from './bots/select-bot-profile'
 import { SqliteBotStore } from './persistence/sqlite-bot-store'
 import type { BotStoreApi } from './persistence/bot-store-api'
 import { registerEditorsIpc } from './editors/register-ipc'
@@ -120,6 +122,7 @@ import { clampWebviewAttachment } from './browser/webview-clamp'
 import { safeExternalUrl } from './files/safe-external-url'
 import { APP_DISPLAY_NAME, buildMenuTemplate } from './app-menu'
 import { applyPendingThreadControls } from './pending-thread-controls'
+import { controlsWithCurrentValue } from '../shared/thread-control-intent'
 import { resolveTheme, THEME_BACKGROUND } from './theme/resolve-theme'
 import {
   DEFAULT_THEME_PREFERENCE,
@@ -439,6 +442,21 @@ interface MainDeps {
 }
 
 /**
+ * The cold Workspace/Thread snapshot, with Mistro Bot Threads FLAGGED (#446).
+ *
+ * The one expression behind BOTH `metadata:list` and `search:query`, which is
+ * exactly why the Bot handling is a per-row mark and not a filter (ADR-0027):
+ * whatever this returns, the sidebar and Search both see. The sidebar drops Bot
+ * rows from its Thread list (`partitionBots`, renderer-side) and Search keeps them.
+ */
+function coldSnapshotWithBots(deps: MainDeps): ListMetadataResult {
+  return markBotThreads(
+    groupThreadsByWorkspace(deps.store.snapshot()),
+    botNamesByThread(deps.bots.list()),
+  )
+}
+
+/**
  * Push an eviction notice to every renderer (TB5 #50) so it drops the now-dead
  * agents' Workspace connections and re-warms them lazily on next select. Also
  * clears the agents' activity + transcript-bridge entries so neither can leak
@@ -697,6 +715,8 @@ async function runPromptTurn(
     const reportedControls = bound.controls
     let actualControls = reportedControls
     let controlFailures: ThreadConfigAxis[] = []
+    /** A Bot whose persona could not be selected on this session (#446) — surfaced below. */
+    let botProfileError: string | undefined
     if (reportedControls && args.controlIntent) {
       const applied = await applyPendingThreadControls(
         agent,
@@ -712,6 +732,31 @@ async function runPromptTurn(
       )
       actualControls = applied.controls
       controlFailures = applied.failedAxes
+    }
+    // A Mistro Bot's persona is a Vibe agent profile selected on the MODE axis
+    // (#446, ADR-0027), and it must be re-selected on EVERY bind: Mode does not
+    // survive `session/load` and ADR-0007's re-assert cache is in-memory, so a Bot
+    // reopened after a restart would otherwise answer as a nameless agent. It runs
+    // AFTER any pending control intent so the Bot's profile always wins the axis.
+    //
+    // `setMode` routes through the VALIDATING `session/set_config_option` (a bogus
+    // id is rejected with -32602), never `session/set_mode`, which answers a bad id
+    // with `{}` — a silent no-op indistinguishable from success (#427). A failure
+    // is reported, never swallowed: a Bot that quietly answers with no persona is
+    // the one failure ADR-0027 forbids.
+    const botProfileId = deps.bots.get(args.threadId)?.profileId ?? null
+    const profileOutcome = await applyBotProfile(
+      agent,
+      sessionId,
+      planBotProfileSelection(botProfileId, reportedControls),
+    )
+    if (profileOutcome.ok) {
+      if (profileOutcome.selected && actualControls) {
+        actualControls = controlsWithCurrentValue(actualControls, 'mode', profileOutcome.selected)
+      }
+    } else {
+      botProfileError = profileOutcome.message
+      console.error(`[vibe-mistro:bots] ${args.threadId}: ${profileOutcome.message}`)
     }
     // Tell the renderer this Thread is now bound after any validated pending Side
     // Draft controls have been awaited, and BEFORE `agent.prompt` streams below
@@ -737,6 +782,7 @@ async function runPromptTurn(
         rebound,
         controls: actualControls,
         controlFailures: controlFailures.length > 0 ? controlFailures : undefined,
+        botProfileError,
       })
     }
   } catch (err) {
@@ -1408,7 +1454,11 @@ function registerIpc(deps: MainDeps): void {
   ipcMain.handle(IPC.listMetadata, (): ListMetadataResult => {
     // The cold launch list (ADR-0005): persisted Workspaces + Threads from
     // metadata alone — no agent spawned, no transcript loaded.
-    return groupThreadsByWorkspace(deps.store.snapshot())
+    //
+    // Mistro Bot Threads are MARKED, never dropped (#446, ADR-0027): this
+    // expression is shared with `searchQuery` below, so a filter here would delete
+    // Bots from Search too. The sidebar does its own excluding from the flag.
+    return coldSnapshotWithBots(deps)
   })
 
   ipcMain.handle(
@@ -1419,7 +1469,9 @@ function registerIpc(deps: MainDeps): void {
       // A NON-empty query also searches transcript prose via the FTS projection
       // (ADR-0019, #296) — the "measured slow" moment ADR-0005 deferred the
       // index for arrived with the epic.
-      const snapshot = groupThreadsByWorkspace(deps.store.snapshot())
+      // The SAME expression `listMetadata` serves — Bot rows marked and kept, so a
+      // Bot's conversation is findable here even though the sidebar hides it (#446).
+      const snapshot = coldSnapshotWithBots(deps)
       let prose: Map<string, ProseEntry[]> | undefined
       const tokens = tokenizeQuery(args.query)
       if (tokens.length > 0 && !deps.stateDb.locked) {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -442,12 +442,9 @@ interface MainDeps {
 }
 
 /**
- * The cold Workspace/Thread snapshot, with Mistro Bot Threads FLAGGED (#446).
- *
- * The one expression behind BOTH `metadata:list` and `search:query`, which is
- * exactly why the Bot handling is a per-row mark and not a filter (ADR-0027):
- * whatever this returns, the sidebar and Search both see. The sidebar drops Bot
- * rows from its Thread list (`partitionBots`, renderer-side) and Search keeps them.
+ * The cold Workspace/Thread snapshot, with Mistro Bot Threads FLAGGED (#446) —
+ * the ONE expression behind both `metadata:list` and `search:query`, which is why
+ * the flag is a mark and not a filter. See `bots/mark-bot-threads.ts`.
  */
 function coldSnapshotWithBots(deps: MainDeps): ListMetadataResult {
   return markBotThreads(
@@ -1453,11 +1450,8 @@ function registerIpc(deps: MainDeps): void {
 
   ipcMain.handle(IPC.listMetadata, (): ListMetadataResult => {
     // The cold launch list (ADR-0005): persisted Workspaces + Threads from
-    // metadata alone — no agent spawned, no transcript loaded.
-    //
-    // Mistro Bot Threads are MARKED, never dropped (#446, ADR-0027): this
-    // expression is shared with `searchQuery` below, so a filter here would delete
-    // Bots from Search too. The sidebar does its own excluding from the flag.
+    // metadata alone — no agent spawned, no transcript loaded. Bot rows arrive
+    // MARKED, never dropped (#446 — see `bots/mark-bot-threads.ts`).
     return coldSnapshotWithBots(deps)
   })
 
@@ -1469,8 +1463,7 @@ function registerIpc(deps: MainDeps): void {
       // A NON-empty query also searches transcript prose via the FTS projection
       // (ADR-0019, #296) — the "measured slow" moment ADR-0005 deferred the
       // index for arrived with the epic.
-      // The SAME expression `listMetadata` serves — Bot rows marked and kept, so a
-      // Bot's conversation is findable here even though the sidebar hides it (#446).
+      // The SAME expression `listMetadata` serves, Bot rows included (#446).
       const snapshot = coldSnapshotWithBots(deps)
       let prose: Map<string, ProseEntry[]> | undefined
       const tokens = tokenizeQuery(args.query)

--- a/apps/desktop/src/main/search/search-threads.ts
+++ b/apps/desktop/src/main/search/search-threads.ts
@@ -17,6 +17,11 @@ import { buildSnippet, type ProseEntry } from './transcript-prose'
  * - An EMPTY query is the palette's resting state: recent Threads, ARCHIVED
  *   EXCLUDED (a switcher context, not a search). A non-empty query includes
  *   archived Threads — archived is exactly what scrolling can't find.
+ * - **Mistro Bots are included in both** (#446, ADR-0027). They are hidden from
+ *   the sidebar's Thread list, so Search is the only place their conversations can
+ *   be found; and the same "switcher context" argument that EXCLUDES archived
+ *   Threads from the resting recents ARGUES FOR including the things you switch to
+ *   most. Their rows carry `bot` so the palette can badge them.
  */
 
 /** Ranked-hit cap (top-N); the palette never pages. */
@@ -80,7 +85,10 @@ export function searchThreads(
     for (const thread of workspace.threads) {
       const archived = thread.archived === true
       if (resting && archived) continue // switcher context — archived stays out
-      const foldedTitle = foldSearchText(thread.title ?? '')
+      // A Mistro Bot is searched — and ranked — by its NAME, not by the title Vibe
+      // generated from its first prompt (#446): the name is what the user knows it
+      // as, and Search is the only place a Bot's conversation can be found by text.
+      const foldedTitle = foldSearchText(thread.bot?.name ?? thread.title ?? '')
       const prose = proseByThread?.get(thread.id) ?? []
       let strong: { entry: ProseEntry; count: number } | null = null
       if (!resting) {
@@ -104,6 +112,9 @@ export function searchThreads(
           workspaceName: workspace.displayName,
           title: thread.title,
           archived,
+          // A Mistro Bot (#446) stays fully searchable — it is only the SIDEBAR
+          // that hides it — so the identity is carried through, never filtered on.
+          ...(thread.bot ? { botName: thread.bot.name } : {}),
           lastActiveAt: thread.lastActiveAt,
           ...(strong
             ? {

--- a/apps/desktop/src/main/search/search-threads.ts
+++ b/apps/desktop/src/main/search/search-threads.ts
@@ -85,10 +85,13 @@ export function searchThreads(
     for (const thread of workspace.threads) {
       const archived = thread.archived === true
       if (resting && archived) continue // switcher context — archived stays out
-      // A Mistro Bot is searched — and ranked — by its NAME, not by the title Vibe
-      // generated from its first prompt (#446): the name is what the user knows it
-      // as, and Search is the only place a Bot's conversation can be found by text.
+      // A Mistro Bot RANKS on its NAME rather than on the title Vibe generated from
+      // its first prompt (#446): the name is what the user knows it as, and Search
+      // is the only place a Bot's conversation can be found by text. The displaced
+      // title still joins the haystack below, so it is demoted, never made
+      // unsearchable.
       const foldedTitle = foldSearchText(thread.bot?.name ?? thread.title ?? '')
+      const foldedAlias = thread.bot ? foldSearchText(thread.title ?? '') : ''
       const prose = proseByThread?.get(thread.id) ?? []
       let strong: { entry: ProseEntry; count: number } | null = null
       if (!resting) {
@@ -101,7 +104,7 @@ export function searchThreads(
           else strong = { entry: prose[i] as ProseEntry, count: 1 }
         }
         if (!strong) {
-          const haystack = `${foldedTitle}\n${foldedWorkspace}\n${foldedProse.join('\n')}`
+          const haystack = `${foldedTitle}\n${foldedAlias}\n${foldedWorkspace}\n${foldedProse.join('\n')}`
           if (!tokens.every((token) => haystack.includes(token))) continue
         }
       }

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -85,6 +85,10 @@ import {
   type SideThreadLifecycle,
 } from './side-panel/side-panel-store'
 import { deriveUnifiedThreads, workspaceFlags, type UnifiedThreadRow } from './shell/unified-threads'
+import { deriveBotRows, type BotSidebarRow } from './bots/bot-rows'
+import { getBotsSeen, markBotSeen } from './bots/bot-seen-store'
+import { useBots } from './bots/use-bots'
+import type { BotIdentity } from './bots/BotHeader'
 import { EmptyState } from './shell/EmptyState'
 import { ColdOutlet, TransientOutlet } from './shell/Outlet'
 import { SettingsView } from './settings/SettingsView'
@@ -198,6 +202,14 @@ export function App(): JSX.Element {
   // Persisted Workspaces + Threads (ADR-0005), listed cold on launch from
   // metadata alone — no agent spawned, no transcript loaded.
   const [recents, setRecents] = useState<ListMetadataResult>([])
+  // The Mistro Bot records (#446, ADR-0027). Their ORDER and timestamps come from
+  // the Threads in `recents`, not from these records — a record moves on an edit,
+  // a conversation moves on a turn, and the sidebar answers "who did I speak to
+  // most recently" (PRD story 5).
+  const { bots } = useBots()
+  // When each Bot was last OPENED — renderer-only UI state (localStorage), the one
+  // input the unread dot needs that nothing else in the app tracks.
+  const [botsSeen, setBotsSeen] = useState(() => getBotsSeen(window.localStorage))
   // Restoration reconciliation must happen exactly once. Re-running it for live
   // state changes can race a just-bound Side Thread's metadata refresh or erase an
   // in-memory Draft (which intentionally has no metadata yet).
@@ -334,6 +346,12 @@ export function App(): JSX.Element {
     }
     selectThreadInNavigation({ workspaceId, threadId })
     hostSelectedThread(workspaceId, threadId, promotion.view)
+    // Opening a Mistro Bot clears its unread dot (#446) — here rather than in the
+    // sidebar's handler, so a ⌘K hit on a Bot (PRD story 11) counts as reading it
+    // exactly as a click on its row does.
+    if (bots.some((bot) => bot.threadId === threadId)) {
+      setBotsSeen(markBotSeen(window.localStorage, threadId, Date.now()))
+    }
   }
 
   /**
@@ -736,6 +754,45 @@ export function App(): JSX.Element {
     }
   }
 
+  // The Bots section (#446): the records joined with their Threads' activity and
+  // live status. Bots do NOT appear in the Thread list — `partitionBots` drops them
+  // there — but they are still ordinary Threads underneath, which is why selecting
+  // one is just `selectThreadInWorkspace`.
+  const botRows = deriveBotRows({
+    bots,
+    workspaces: recents,
+    statuses,
+    seen: botsSeen,
+    selectedThreadId: nav.selectedThreadId,
+  })
+
+  /**
+   * Open a Bot from the sidebar section. It is the ORDINARY Thread-selection path —
+   * which connects its Workspace if needed, hosts the Thread, and replays its
+   * history — because a Bot's conversation IS an ordinary Thread conversation
+   * (ADR-0027). Nothing Bot-specific happens here.
+   */
+  function selectBot(row: BotSidebarRow): void {
+    selectThreadInWorkspace(row.workspaceId, row.bot.threadId)
+  }
+
+  /**
+   * Who a Thread is, when it is a Bot — the conversation header's source (#446).
+   * Null for every ordinary Thread, which is what keeps the Bot-ness out of the
+   * conversation slice: it renders an identity it was handed, it never looks one up.
+   */
+  function botIdentityFor(threadId: string): BotIdentity | null {
+    const bot = bots.find((b) => b.threadId === threadId)
+    if (!bot) return null
+    return {
+      threadId: bot.threadId,
+      name: bot.name,
+      colour: bot.colour,
+      description: bot.description,
+      projectName: recents.find((w) => w.id === bot.workspaceId)?.displayName ?? '',
+    }
+  }
+
   /** The connected view for a Workspace (the controlled outlet). `busy` is the
    *  Workspace's rolled-up streaming flag (#86) — threaded to the Changes panel so the
    *  commit affordance is disabled while a turn is in flight (the v1 guard). Sign-out now
@@ -855,6 +912,7 @@ export function App(): JSX.Element {
         key={conn.agentId}
         connection={conn}
         activeThread={activeThread}
+        activeBot={botIdentityFor(activeThread.id)}
         isLive={isLive}
         isActive={isActive}
         busy={busy}
@@ -1135,11 +1193,13 @@ export function App(): JSX.Element {
         nav={nav}
         workspaceFlags={wsFlags}
         rows={rows}
+        botRows={botRows}
         protectedThreadId={protectedThreadId}
         outlet={outlet}
         opening={opening}
         onOpenProject={() => void openProject()}
         onNewThread={startNewChat}
+        onSelectBot={selectBot}
         actions={{
           selectThread: selectThreadInWorkspace,
           newThreadInWorkspace,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -85,7 +85,7 @@ import {
   type SideThreadLifecycle,
 } from './side-panel/side-panel-store'
 import { deriveUnifiedThreads, workspaceFlags, type UnifiedThreadRow } from './shell/unified-threads'
-import { deriveBotRows, type BotSidebarRow } from './bots/bot-rows'
+import { botBeingRead, deriveBotRows, type BotSidebarRow } from './bots/bot-rows'
 import { getBotsSeen, markBotSeen } from './bots/bot-seen-store'
 import { useBots } from './bots/use-bots'
 import type { BotIdentity } from './bots/BotHeader'
@@ -346,12 +346,6 @@ export function App(): JSX.Element {
     }
     selectThreadInNavigation({ workspaceId, threadId })
     hostSelectedThread(workspaceId, threadId, promotion.view)
-    // Opening a Mistro Bot clears its unread dot (#446) — here rather than in the
-    // sidebar's handler, so a ⌘K hit on a Bot (PRD story 11) counts as reading it
-    // exactly as a click on its row does.
-    if (bots.some((bot) => bot.threadId === threadId)) {
-      setBotsSeen(markBotSeen(window.localStorage, threadId, Date.now()))
-    }
   }
 
   /**
@@ -576,6 +570,30 @@ export function App(): JSX.Element {
       void refreshRecents()
     })
   }, [])
+
+  // Keep the SELECTED Bot's "seen" stamp current (#446) — the input the sidebar's
+  // unread dot is derived from. The stamp is taken when a Bot becomes the selected
+  // Thread, again whenever its live status flips (a turn opening or settling while
+  // it is on screen), and once more as it stops being selected.
+  //
+  // Stamping ONLY at open is the bug this shape exists to avoid: your own prompt
+  // and the agent's reply both advance the Thread's `lastActiveAt` after the open,
+  // so on the next launch every Bot you had actually used would carry a dot that
+  // means "unread" about a conversation you read to the end. Re-stamping while it
+  // is watched is what makes the dot mean something.
+  //
+  // Keyed off the SELECTION, not off a click handler, so the sidebar row, a ⌘K hit
+  // and a back/forward jump all count as reading it. `markBotSeen` is monotonic, so
+  // a redundant stamp is harmless; the deps are primitives, so this cannot loop.
+  const readBotThreadId = botBeingRead(nav.selectedThreadId, bots)
+  const readBotStatus = readBotThreadId ? statuses[readBotThreadId] : undefined
+  useEffect(() => {
+    if (!readBotThreadId) return
+    const stamp = (): void =>
+      setBotsSeen(markBotSeen(window.localStorage, readBotThreadId, Date.now()))
+    stamp()
+    return stamp
+  }, [readBotThreadId, readBotStatus?.streaming, readBotStatus?.needsAttention])
 
   // Wire the replay-cache invalidation ONCE: any acp:event session-tagged to a
   // cached (unmounted) Thread means main teed to its transcript behind our back,

--- a/apps/desktop/src/renderer/src/bots/BotHeader.tsx
+++ b/apps/desktop/src/renderer/src/bots/BotHeader.tsx
@@ -1,0 +1,40 @@
+import type { JSX } from 'react'
+import { BotMark } from './BotMark'
+
+/**
+ * Who this Bot is, as the conversation needs to render it (#446). Assembled by App
+ * from the Bot record plus its Project's display name — the conversation itself
+ * knows nothing about the `bots` store.
+ */
+export interface BotIdentity {
+  threadId: string
+  name: string
+  colour: string
+  description: string
+  /** The Project's display name — the second half of the header's subtitle. */
+  projectName: string
+}
+
+/**
+ * The Bot conversation's header (#446, ADR-0027 decision 4), replacing the ordinary
+ * Thread head. Mark, name, and one subtitle line: `description · project`.
+ *
+ * A Thread's head shows its auto-generated title, which is the right answer for a
+ * conversation and the wrong one for a teammate — a Bot's identity does not change
+ * with what you last asked it. "Start over" belongs in this header too, but it is
+ * slice 3 (#447), so the row is deliberately left with room for it rather than
+ * carrying a button that cannot do its job yet.
+ */
+export function BotHeader({ bot }: { bot: BotIdentity }): JSX.Element {
+  return (
+    <div className="flex items-center gap-3 border-b border-border pb-3">
+      <BotMark name={bot.name} colour={bot.colour} size={28} />
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-[14px] font-semibold text-foreground">{bot.name}</div>
+        <div className="truncate text-[12px] text-muted-foreground">
+          {bot.description ? `${bot.description} · ${bot.projectName}` : bot.projectName}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/bots/BotMark.tsx
+++ b/apps/desktop/src/renderer/src/bots/BotMark.tsx
@@ -1,0 +1,41 @@
+import type { JSX } from 'react'
+
+/**
+ * A Mistro Bot's identity mark (#446): its initial on its own colour. The whole
+ * visual identity of a teammate, at every size it appears — the sidebar row, the
+ * conversation header, and (slice 3) the form.
+ *
+ * `colour` is whatever the record holds; main validates it on write
+ * (`validateBotColour`), so this renders it as given rather than re-deciding.
+ * `aria-hidden` because the Bot's name is always beside it — a screen reader
+ * announcing "R" before "Rex" is noise.
+ */
+export function BotMark({
+  name,
+  colour,
+  size = 20,
+}: {
+  name: string
+  colour: string
+  size?: number
+}): JSX.Element {
+  return (
+    <span
+      aria-hidden
+      className="flex flex-none items-center justify-center rounded-full font-semibold text-white"
+      style={{
+        background: colour,
+        width: size,
+        height: size,
+        fontSize: Math.round(size * 0.42),
+      }}
+    >
+      {botInitial(name)}
+    </span>
+  )
+}
+
+/** The mark's letter: the name's first character, uppercased ("?" for an empty name). */
+function botInitial(name: string): string {
+  return name.trim().slice(0, 1).toUpperCase() || '?'
+}

--- a/apps/desktop/src/renderer/src/bots/BotsSection.tsx
+++ b/apps/desktop/src/renderer/src/bots/BotsSection.tsx
@@ -11,20 +11,14 @@ import { cn } from '../lib/utils'
 /**
  * The **Bots** section of the sidebar, above Projects (#446, ADR-0027 decision 4).
  *
- * Two things here are decided, prototyped and captured on `proto/422-bots-view`,
- * and neither is a style preference:
+ * **It is BOUNDED**, and that is not a style preference: the row list carries its
+ * own `max-height` and scrollbar, so Projects stays reachable at any Bot count.
+ * Unbounded, twenty Bots push Projects entirely off screen (prototyped and
+ * captured on `proto/422-bots-view` as `D-scale-20.png`), and a *collapsible*
+ * section does NOT fix it — expanded is its default, so the first twenty-Bot user
+ * meets exactly the broken state.
  *
- * 1. **It is BOUNDED.** The row list carries its own `max-height` and scrollbar, so
- *    Projects stays reachable at any Bot count. Unbounded, twenty Bots push Projects
- *    entirely off screen (captured as `D-scale-20.png`), and a *collapsible* section
- *    does NOT fix it — expanded is its default, so the first twenty-Bot user meets
- *    exactly the broken state.
- * 2. **A row carries mark + name + right-aligned last-active + unread dot, and
- *    nothing else.** Description, message count and project were tried and rejected:
- *    at sidebar width they truncate to noise. The timestamp is the whole identity
- *    answer — colour and name alone read as a bookmark list, "Rex · 1h" reads as a
- *    teammate.
- *
+ * What a row may carry is decided in `bot-rows.ts`, which is also what orders them.
  * Selecting a row swaps the outlet to that Bot's conversation, exactly as selecting
  * a Thread does. There is no Bots page and no fourth outlet view.
  */
@@ -51,7 +45,13 @@ export function BotsSection({
    * rendered inert, because a button that does nothing is worse than no button.
    */
   onCreateBot?: () => void
-}): JSX.Element {
+}): JSX.Element | null {
+  // Nothing to show and nothing to do: the section is absent rather than an empty
+  // block. Without the ＋ (slice 3) an empty section is a permanent, actionless
+  // header in EVERY existing user's sidebar — so it earns its space only once
+  // there are Bots, or once there is a way to make one.
+  if (rows.length === 0 && !onCreateBot) return null
+
   // ONE Date.now() per render, injected into the pure formatter at each call site.
   const nowMs = Date.now()
   return (

--- a/apps/desktop/src/renderer/src/bots/BotsSection.tsx
+++ b/apps/desktop/src/renderer/src/bots/BotsSection.tsx
@@ -1,0 +1,151 @@
+import type { JSX } from 'react'
+import { Plus } from 'lucide-react'
+import type { BotSidebarRow } from './bot-rows'
+import { BotMark } from './BotMark'
+import { LogoSnakeSpinner } from '../shell/logo-snake-spinner'
+import { formatRelativeTime } from '../shell/relative-time'
+import { Badge } from '../ui/badge'
+import { IconButton } from '../ui/icon-button'
+import { cn } from '../lib/utils'
+
+/**
+ * The **Bots** section of the sidebar, above Projects (#446, ADR-0027 decision 4).
+ *
+ * Two things here are decided, prototyped and captured on `proto/422-bots-view`,
+ * and neither is a style preference:
+ *
+ * 1. **It is BOUNDED.** The row list carries its own `max-height` and scrollbar, so
+ *    Projects stays reachable at any Bot count. Unbounded, twenty Bots push Projects
+ *    entirely off screen (captured as `D-scale-20.png`), and a *collapsible* section
+ *    does NOT fix it — expanded is its default, so the first twenty-Bot user meets
+ *    exactly the broken state.
+ * 2. **A row carries mark + name + right-aligned last-active + unread dot, and
+ *    nothing else.** Description, message count and project were tried and rejected:
+ *    at sidebar width they truncate to noise. The timestamp is the whole identity
+ *    answer — colour and name alone read as a bookmark list, "Rex · 1h" reads as a
+ *    teammate.
+ *
+ * Selecting a row swaps the outlet to that Bot's conversation, exactly as selecting
+ * a Thread does. There is no Bots page and no fourth outlet view.
+ */
+
+/** The bound: about seven rows, then the section scrolls on its own. */
+const BOTS_SECTION_MAX_HEIGHT = 240
+
+export function BotsSection({
+  rows,
+  selectedThreadId,
+  onSelectBot,
+  onCreateBot,
+}: {
+  /** The Bots, most-recently-ACTIVE first (`deriveBotRows`). */
+  rows: BotSidebarRow[]
+  /** The nav selection, so the open Bot's row is highlighted. */
+  selectedThreadId: string | null
+  /** Open a Bot's conversation — App routes it through the ordinary Thread select. */
+  onSelectBot: (row: BotSidebarRow) => void
+  /**
+   * Open the create form. The section's ＋ is the create affordance that works in
+   * every state (the empty-state CTA only exists while there are no Bots), but the
+   * form itself is slice 3 (#447) — until it lands the ＋ is omitted rather than
+   * rendered inert, because a button that does nothing is worse than no button.
+   */
+  onCreateBot?: () => void
+}): JSX.Element {
+  // ONE Date.now() per render, injected into the pure formatter at each call site.
+  const nowMs = Date.now()
+  return (
+    <nav className="flex flex-none flex-col gap-0.5" aria-label="Bots">
+      <div className="flex items-center justify-between px-3 py-1.5">
+        <span className="text-[13px] font-medium text-muted-foreground">Bots</span>
+        {onCreateBot && (
+          <IconButton size="icon-xs" aria-label="New Bot" title="New Bot" onClick={onCreateBot}>
+            <Plus className="size-4" aria-hidden />
+          </IconButton>
+        )}
+      </div>
+
+      {rows.length === 0 ? (
+        <p className="px-3 py-1 text-[13px] leading-relaxed text-muted-foreground">
+          No Bots yet. A Bot keeps one running conversation about one project.
+        </p>
+      ) : (
+        <ul
+          // The bound itself. `overflow-y-auto` on the LIST (not the section) keeps
+          // the header and the ＋ pinned while the rows scroll under them.
+          className="flex flex-col gap-0.5 overflow-y-auto"
+          style={{ maxHeight: BOTS_SECTION_MAX_HEIGHT }}
+        >
+          {rows.map((row) => (
+            <BotRow
+              key={row.bot.threadId}
+              row={row}
+              nowMs={nowMs}
+              selected={row.bot.threadId === selectedThreadId}
+              onSelect={() => onSelectBot(row)}
+            />
+          ))}
+        </ul>
+      )}
+    </nav>
+  )
+}
+
+/**
+ * One Bot row. Deliberately NOT the shared `NavItem`: a Bot row's leading element is
+ * its mark (a coloured identity, not a status dot) and its trailing element is a
+ * timestamp that must survive at the default sidebar width — so it owns its layout,
+ * with the name as the only flexible column (`min-w-0 truncate`) and every other
+ * part `flex-none`.
+ */
+function BotRow({
+  row,
+  nowMs,
+  selected,
+  onSelect,
+}: {
+  row: BotSidebarRow
+  nowMs: number
+  selected: boolean
+  onSelect: () => void
+}): JSX.Element {
+  const timestamp = formatRelativeTime(row.lastActiveAt, nowMs)
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onSelect}
+        className={cn(
+          'flex w-full items-center gap-2.5 rounded-md px-3 py-[7px] text-left text-[13.5px] text-foreground outline-none transition-colors',
+          'hover:bg-primary/10 focus-visible:bg-primary/10',
+          selected && 'bg-primary/15 font-semibold',
+        )}
+      >
+        <BotMark name={row.bot.name} colour={row.bot.colour} size={20} />
+        <span className="min-w-0 flex-1 truncate">{row.bot.name}</span>
+        {row.streaming && <LogoSnakeSpinner size={15} label={`${row.bot.name} is working`} />}
+        {row.needsAttention && (
+          <Badge variant="destructive" title="Awaiting your response">
+            !
+          </Badge>
+        )}
+        {timestamp && (
+          <span className="flex-none text-[13px] tabular-nums text-muted-foreground">
+            {timestamp}
+          </span>
+        )}
+        {/* The unread dot sits OUTSIDE the timestamp column so the times stay in a
+            straight line whether or not a row has one. */}
+        <span
+          className={cn(
+            'size-1.5 flex-none rounded-full',
+            row.unread ? 'bg-primary' : 'bg-transparent',
+          )}
+          role={row.unread ? 'img' : undefined}
+          aria-label={row.unread ? `${row.bot.name} has new activity` : undefined}
+          aria-hidden={row.unread ? undefined : true}
+        />
+      </button>
+    </li>
+  )
+}

--- a/apps/desktop/src/renderer/src/bots/bot-rows.test.ts
+++ b/apps/desktop/src/renderer/src/bots/bot-rows.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest'
+import type { BotRecord, ListMetadataResult } from '../../../shared/ipc'
+import type { ThreadStatusMap } from '../conversation/thread-status'
+import { deriveBotRows, isBotUnread } from './bot-rows'
+
+function bot(name: string, threadId: string, updatedAt = 100): BotRecord {
+  return {
+    threadId,
+    workspaceId: 'ws-1',
+    profileId: `mistro-bot-${threadId}`,
+    name,
+    colour: '#e8734a',
+    description: '',
+    instructions: '',
+    createdAt: 1,
+    updatedAt,
+  }
+}
+
+function workspaces(threads: Array<{ id: string; lastActiveAt: number }>): ListMetadataResult {
+  return [
+    {
+      id: 'ws-1',
+      dir: '/tmp/one',
+      displayName: 'one',
+      lastOpenedAt: 1,
+      threads: threads.map((t) => ({
+        id: t.id,
+        workspaceId: 'ws-1',
+        sessionId: null,
+        title: null,
+        createdAt: 1,
+        lastActiveAt: t.lastActiveAt,
+        bot: { name: t.id },
+      })),
+    },
+  ]
+}
+
+const noStatus: ThreadStatusMap = {}
+
+describe('deriveBotRows — ordering', () => {
+  it('orders most-recently-ACTIVE first, from the Thread not the record', () => {
+    // Rex was EDITED last (updatedAt 900) but Ada was SPOKEN TO last. PRD story 5
+    // asks who I spoke to most recently, so Ada leads.
+    const rows = deriveBotRows({
+      bots: [bot('Rex', 't-rex', 900), bot('Ada', 't-ada', 100)],
+      workspaces: workspaces([
+        { id: 't-rex', lastActiveAt: 10 },
+        { id: 't-ada', lastActiveAt: 50 },
+      ]),
+      statuses: noStatus,
+      seen: {},
+      selectedThreadId: null,
+    })
+    expect(rows.map((r) => r.bot.name)).toEqual(['Ada', 'Rex'])
+  })
+
+  it('breaks ties on name so the section never jitters', () => {
+    const rows = deriveBotRows({
+      bots: [bot('Zed', 't-z'), bot('Ada', 't-a')],
+      workspaces: workspaces([
+        { id: 't-z', lastActiveAt: 5 },
+        { id: 't-a', lastActiveAt: 5 },
+      ]),
+      statuses: noStatus,
+      seen: {},
+      selectedThreadId: null,
+    })
+    expect(rows.map((r) => r.bot.name)).toEqual(['Ada', 'Zed'])
+  })
+
+  it('falls back to the record timestamp for a Bot whose Thread is not listed yet', () => {
+    const rows = deriveBotRows({
+      bots: [bot('Rex', 't-rex', 777)],
+      workspaces: workspaces([]),
+      statuses: noStatus,
+      seen: {},
+      selectedThreadId: null,
+    })
+    expect(rows[0]?.lastActiveAt).toBe(777)
+  })
+
+  it('drops a Bot whose Project is gone — a row that cannot be opened is worse than none', () => {
+    const orphan = { ...bot('Ghost', 't-ghost'), workspaceId: 'ws-removed' }
+    const rows = deriveBotRows({
+      bots: [orphan, bot('Rex', 't-rex')],
+      workspaces: workspaces([{ id: 't-rex', lastActiveAt: 1 }]),
+      statuses: noStatus,
+      seen: {},
+      selectedThreadId: null,
+    })
+    expect(rows.map((r) => r.bot.name)).toEqual(['Rex'])
+  })
+
+  it('is empty when there are no Bots', () => {
+    expect(
+      deriveBotRows({
+        bots: [],
+        workspaces: workspaces([]),
+        statuses: noStatus,
+        seen: {},
+        selectedThreadId: null,
+      }),
+    ).toEqual([])
+  })
+})
+
+describe('deriveBotRows — live flags', () => {
+  it('carries streaming and needsAttention from the status registry', () => {
+    const statuses: ThreadStatusMap = {
+      't-rex': { streaming: true, needsAttention: false },
+      't-ada': { streaming: false, needsAttention: true },
+    }
+    const rows = deriveBotRows({
+      bots: [bot('Rex', 't-rex'), bot('Ada', 't-ada')],
+      workspaces: workspaces([
+        { id: 't-rex', lastActiveAt: 2 },
+        { id: 't-ada', lastActiveAt: 1 },
+      ]),
+      statuses,
+      seen: { 't-rex': 99, 't-ada': 99 },
+      selectedThreadId: null,
+    })
+    expect(rows.find((r) => r.bot.name === 'Rex')).toMatchObject({ streaming: true })
+    expect(rows.find((r) => r.bot.name === 'Ada')).toMatchObject({ needsAttention: true })
+  })
+
+  it('defaults both flags to false for a Bot with no status entry', () => {
+    const rows = deriveBotRows({
+      bots: [bot('Rex', 't-rex')],
+      workspaces: workspaces([{ id: 't-rex', lastActiveAt: 1 }]),
+      statuses: noStatus,
+      seen: { 't-rex': 99 },
+      selectedThreadId: null,
+    })
+    expect(rows[0]).toMatchObject({ streaming: false, needsAttention: false, unread: false })
+  })
+})
+
+describe('isBotUnread', () => {
+  it('is unread when the Bot moved since it was last opened', () => {
+    expect(isBotUnread({ lastActiveAt: 20, seenAt: 10, needsAttention: false, selected: false })).toBe(true)
+  })
+
+  it('is read when nothing happened since it was last opened', () => {
+    expect(isBotUnread({ lastActiveAt: 10, seenAt: 10, needsAttention: false, selected: false })).toBe(false)
+  })
+
+  it('is unread when never opened', () => {
+    expect(isBotUnread({ lastActiveAt: 1, seenAt: undefined, needsAttention: false, selected: false })).toBe(true)
+  })
+
+  it('is unread whenever it needs an answer, read or not', () => {
+    expect(isBotUnread({ lastActiveAt: 1, seenAt: 99, needsAttention: true, selected: false })).toBe(true)
+  })
+
+  it('is never unread while it is the Bot on screen', () => {
+    expect(isBotUnread({ lastActiveAt: 99, seenAt: 0, needsAttention: true, selected: true })).toBe(false)
+  })
+})

--- a/apps/desktop/src/renderer/src/bots/bot-rows.test.ts
+++ b/apps/desktop/src/renderer/src/bots/bot-rows.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest'
 import type { BotRecord, ListMetadataResult } from '../../../shared/ipc'
 import type { ThreadStatusMap } from '../conversation/thread-status'
-import { deriveBotRows, isBotUnread } from './bot-rows'
+import { botBeingRead, deriveBotRows, isBotUnread } from './bot-rows'
+import { getBotsSeen, markBotSeen } from './bot-seen-store'
 
 function bot(name: string, threadId: string, updatedAt = 100): BotRecord {
   return {
@@ -135,6 +136,75 @@ describe('deriveBotRows — live flags', () => {
       selectedThreadId: null,
     })
     expect(rows[0]).toMatchObject({ streaming: false, needsAttention: false, unread: false })
+  })
+})
+
+describe('botBeingRead — the stamping policy', () => {
+  const bots = [bot('Rex', 't-rex'), bot('Ada', 't-ada')]
+
+  it('names the selected Bot, whose seen time must be kept current', () => {
+    expect(botBeingRead('t-rex', bots)).toBe('t-rex')
+  })
+
+  it('is null when the selection is an ordinary Thread', () => {
+    expect(botBeingRead('t-plain', bots)).toBeNull()
+  })
+
+  it('is null when nothing is selected', () => {
+    expect(botBeingRead(null, bots)).toBeNull()
+  })
+
+  it('is null before the Bot records have loaded', () => {
+    expect(botBeingRead('t-rex', [])).toBeNull()
+  })
+})
+
+describe('the relaunch case — a Bot you used must not be dotted on the next launch', () => {
+  function relaunchRow(args: { lastActiveAt: number; seenAt: number }): boolean {
+    // A relaunch: nothing is selected yet and the rows come from disk.
+    const rows = deriveBotRows({
+      bots: [bot('Rex', 't-rex')],
+      workspaces: workspaces([{ id: 't-rex', lastActiveAt: args.lastActiveAt }]),
+      statuses: noStatus,
+      seen: { 't-rex': args.seenAt },
+      selectedThreadId: null,
+    })
+    return rows[0]?.unread === true
+  }
+
+  it('is READ when the Bot was still on screen after its last activity', () => {
+    // Open at T0, prompt at T1 (which moves the Thread's lastActiveAt), read the
+    // reply — the turn settles at T2 while Rex is still selected, and App re-stamps
+    // then. Quit, relaunch: nothing new has happened, so there is no dot.
+    expect(relaunchRow({ lastActiveAt: 2_000, seenAt: 2_500 })).toBe(false)
+  })
+
+  it('is UNREAD when the last activity landed after you looked away', () => {
+    // The stamp is from the open; the turn finished while you were elsewhere.
+    expect(relaunchRow({ lastActiveAt: 2_000, seenAt: 1_000 })).toBe(true)
+  })
+
+  it('is UNREAD for a Bot that has never been opened', () => {
+    expect(relaunchRow({ lastActiveAt: 2_000, seenAt: 0 })).toBe(true)
+  })
+
+  it('stays READ across a second relaunch (the stamp is durable, not per-session)', () => {
+    const storage = new Map<string, string>()
+    const seenStore = {
+      getItem: (k: string) => storage.get(k) ?? null,
+      setItem: (k: string, v: string) => void storage.set(k, v),
+    }
+    // Session 1 stamps after the turn settled...
+    markBotSeen(seenStore, 't-rex', 2_500)
+    // ...session 2 reads it back and finds nothing new.
+    const rows = deriveBotRows({
+      bots: [bot('Rex', 't-rex')],
+      workspaces: workspaces([{ id: 't-rex', lastActiveAt: 2_000 }]),
+      statuses: noStatus,
+      seen: getBotsSeen(seenStore),
+      selectedThreadId: null,
+    })
+    expect(rows[0]?.unread).toBe(false)
   })
 })
 

--- a/apps/desktop/src/renderer/src/bots/bot-rows.ts
+++ b/apps/desktop/src/renderer/src/bots/bot-rows.ts
@@ -40,9 +40,15 @@ export type BotSeenMap = Readonly<Record<string, number>>
  *
  * We have no read receipts and inventing one would be dishonest, so "unread" is
  * defined from signals that already exist: the Bot has been active since the last
- * time the user opened it, or it is blocked on a permission (which needs you
+ * time the user WATCHED it, or it is blocked on a permission (which needs you
  * whether or not you have read it). The Bot currently on screen is never unread —
  * you are looking at it.
+ *
+ * "Watched" — not "opened" — is the load-bearing word, and it is what
+ * {@link botBeingRead} exists to keep true. Stamping only at open makes this rule
+ * compare against an input that is stale by construction: your own prompt and the
+ * reply both advance `lastActiveAt` AFTER the open, so every Bot you actually used
+ * would be dotted on the next launch and the dot would mean nothing.
  */
 export function isBotUnread(args: {
   lastActiveAt: number
@@ -53,6 +59,26 @@ export function isBotUnread(args: {
   if (args.selected) return false
   if (args.needsAttention) return true
   return args.lastActiveAt > (args.seenAt ?? 0)
+}
+
+/**
+ * The Bot whose "seen" time must be kept CURRENT: the selected one, because it is
+ * on screen and being read. Null when nothing is selected or the selection is an
+ * ordinary Thread.
+ *
+ * This is the whole stamping policy, stated once and purely, so the App effect
+ * that carries it out is a thin wrapper. Keying it off the SELECTION rather than
+ * off a click handler is what makes every route into a Bot count as reading it —
+ * the sidebar row, a ⌘K hit, and a back/forward history jump alike — and it is
+ * what lets the stamp be re-taken while the Bot stays on screen, so a turn read to
+ * the end is recorded as read.
+ */
+export function botBeingRead(
+  selectedThreadId: string | null,
+  bots: readonly BotRecord[],
+): string | null {
+  if (!selectedThreadId) return null
+  return bots.some((bot) => bot.threadId === selectedThreadId) ? selectedThreadId : null
 }
 
 /**

--- a/apps/desktop/src/renderer/src/bots/bot-rows.ts
+++ b/apps/desktop/src/renderer/src/bots/bot-rows.ts
@@ -1,0 +1,112 @@
+import type { BotRecord, ListMetadataResult } from '../../../shared/ipc'
+import type { ThreadStatusMap } from '../conversation/thread-status'
+
+/**
+ * The sidebar's Bots section, as data (#446, ADR-0027). Pure — no React, no IPC —
+ * so the two decisions that matter (what ORDER the section is in, and when a row
+ * is unread) are settled in a unit test rather than by eye.
+ *
+ * A row deliberately carries only what the design allows it to render: mark +
+ * name + right-aligned last-active + unread dot. Description, message count and
+ * project were rejected — at sidebar width they truncate to noise. The timestamp
+ * is the whole identity answer: colour and name alone read as a bookmark list,
+ * "Rex · 1h" reads as a teammate (PRD story 5).
+ */
+export interface BotSidebarRow {
+  bot: BotRecord
+  /** The Project the Bot lives in — where selecting it navigates. */
+  workspaceId: string
+  /**
+   * Epoch-ms of the Bot's last CONVERSATION activity — its Thread's
+   * `lastActiveAt`, which moves on every turn. NOT the record's `updatedAt`
+   * (which moves on a rename and never on a turn), so the section really does
+   * order by "who I spoke to most recently". Falls back to `updatedAt` only for a
+   * Bot whose Thread row hasn't been listed yet.
+   */
+  lastActiveAt: number
+  /** A turn is in flight on this Bot (from the per-Thread status registry). */
+  streaming: boolean
+  /** This Bot is blocked on a permission answer. */
+  needsAttention: boolean
+  /** The dot: this Bot has moved since you last opened it — see {@link isBotUnread}. */
+  unread: boolean
+}
+
+/** What the caller knows about when each Bot was last LOOKED AT (renderer-only). */
+export type BotSeenMap = Readonly<Record<string, number>>
+
+/**
+ * Whether a Bot's row shows its dot.
+ *
+ * We have no read receipts and inventing one would be dishonest, so "unread" is
+ * defined from signals that already exist: the Bot has been active since the last
+ * time the user opened it, or it is blocked on a permission (which needs you
+ * whether or not you have read it). The Bot currently on screen is never unread —
+ * you are looking at it.
+ */
+export function isBotUnread(args: {
+  lastActiveAt: number
+  seenAt: number | undefined
+  needsAttention: boolean
+  selected: boolean
+}): boolean {
+  if (args.selected) return false
+  if (args.needsAttention) return true
+  return args.lastActiveAt > (args.seenAt ?? 0)
+}
+
+/**
+ * Join the Bot records with their Threads' live metadata and status into the
+ * ordered section rows.
+ *
+ * Ordering is **most-recently-active first**, over the Thread's `lastActiveAt` —
+ * NOT `bots:list`'s most-recently-EDITED order, which is the record's own
+ * `updatedAt` and would reshuffle the sidebar on a rename while ignoring a
+ * conversation entirely. Ties break on name so the list never jitters.
+ *
+ * A Bot whose Project is no longer in `workspaces` is dropped: it cannot be
+ * navigated to, and a row that does nothing when clicked is worse than no row.
+ */
+export function deriveBotRows(args: {
+  bots: readonly BotRecord[]
+  workspaces: ListMetadataResult
+  statuses: ThreadStatusMap
+  seen: BotSeenMap
+  /** The Thread currently selected in nav — that Bot is being read, so never unread. */
+  selectedThreadId: string | null
+}): BotSidebarRow[] {
+  const lastActive = threadActivityIndex(args.workspaces)
+  const knownWorkspaces = new Set(args.workspaces.map((w) => w.id))
+  const rows: BotSidebarRow[] = []
+  for (const bot of args.bots) {
+    if (!knownWorkspaces.has(bot.workspaceId)) continue
+    const status = args.statuses[bot.threadId]
+    const needsAttention = status?.needsAttention ?? false
+    const lastActiveAt = lastActive.get(bot.threadId) ?? bot.updatedAt
+    rows.push({
+      bot,
+      workspaceId: bot.workspaceId,
+      lastActiveAt,
+      streaming: status?.streaming ?? false,
+      needsAttention,
+      unread: isBotUnread({
+        lastActiveAt,
+        seenAt: args.seen[bot.threadId],
+        needsAttention,
+        selected: bot.threadId === args.selectedThreadId,
+      }),
+    })
+  }
+  return rows.sort(
+    (a, b) => b.lastActiveAt - a.lastActiveAt || a.bot.name.localeCompare(b.bot.name),
+  )
+}
+
+/** Every listed Thread's `lastActiveAt`, keyed by Thread id. */
+function threadActivityIndex(workspaces: ListMetadataResult): Map<string, number> {
+  const index = new Map<string, number>()
+  for (const workspace of workspaces) {
+    for (const thread of workspace.threads) index.set(thread.id, thread.lastActiveAt)
+  }
+  return index
+}

--- a/apps/desktop/src/renderer/src/bots/bot-seen-store.test.ts
+++ b/apps/desktop/src/renderer/src/bots/bot-seen-store.test.ts
@@ -1,22 +1,24 @@
 import { describe, it, expect } from 'vitest'
 import { BOTS_SEEN_STORAGE_KEY, getBotsSeen, markBotSeen, type BotSeenStorage } from './bot-seen-store'
 
-function fakeStorage(initial?: string): BotSeenStorage & { value: string | null } {
+/** A throwaway in-memory Storage seam, KEYED like the real thing (project-open-store.test.ts). */
+function fakeStorage(seed?: Record<string, string>): BotSeenStorage & { map: Map<string, string> } {
+  const map = new Map<string, string>(Object.entries(seed ?? {}))
   return {
-    value: initial ?? null,
-    getItem() {
-      return this.value
-    },
-    setItem(_key: string, value: string) {
-      this.value = value
-    },
+    map,
+    getItem: (k) => map.get(k) ?? null,
+    setItem: (k, v) => void map.set(k, v),
   }
 }
 
 describe('getBotsSeen', () => {
-  it('reads back what was written', () => {
-    const storage = fakeStorage(JSON.stringify({ 't-rex': 42 }))
+  it('reads back what was written, from the key the module owns', () => {
+    const storage = fakeStorage({ [BOTS_SEEN_STORAGE_KEY]: JSON.stringify({ 't-rex': 42 }) })
     expect(getBotsSeen(storage)).toEqual({ 't-rex': 42 })
+  })
+
+  it('ignores a value stored under a different key', () => {
+    expect(getBotsSeen(fakeStorage({ 'some-other-key': JSON.stringify({ 't-rex': 42 }) }))).toEqual({})
   })
 
   it('is empty when nothing is stored', () => {
@@ -24,16 +26,16 @@ describe('getBotsSeen', () => {
   })
 
   it('is empty for corrupt JSON rather than throwing into the sidebar render', () => {
-    expect(getBotsSeen(fakeStorage('{not json'))).toEqual({})
+    expect(getBotsSeen(fakeStorage({ [BOTS_SEEN_STORAGE_KEY]: '{not json' }))).toEqual({})
   })
 
   it('is empty for a non-object payload', () => {
-    expect(getBotsSeen(fakeStorage('["t-rex"]'))).toEqual({})
+    expect(getBotsSeen(fakeStorage({ [BOTS_SEEN_STORAGE_KEY]: '["t-rex"]' }))).toEqual({})
   })
 
   it('drops non-numeric entries instead of trusting them', () => {
-    const storage = fakeStorage(JSON.stringify({ 't-rex': 'yesterday', 't-ada': 7, 't-nan': NaN }))
-    expect(getBotsSeen(storage)).toEqual({ 't-ada': 7 })
+    const raw = JSON.stringify({ 't-rex': 'yesterday', 't-ada': 7, 't-nan': null })
+    expect(getBotsSeen(fakeStorage({ [BOTS_SEEN_STORAGE_KEY]: raw }))).toEqual({ 't-ada': 7 })
   })
 
   it('tolerates an absent storage (never throws)', () => {
@@ -53,20 +55,27 @@ describe('getBotsSeen', () => {
 })
 
 describe('markBotSeen', () => {
-  it('records the time and persists it under the one key', () => {
+  it('round-trips through the store', () => {
     const storage = fakeStorage()
-    expect(markBotSeen(storage, 't-rex', 100)).toEqual({ 't-rex': 100 })
-    expect(JSON.parse(storage.value ?? '{}')).toEqual({ 't-rex': 100 })
+    markBotSeen(storage, 't-rex', 100)
+    expect(getBotsSeen(storage)).toEqual({ 't-rex': 100 })
+  })
+
+  it('writes to the key the module reads, so a reload finds it', () => {
+    const storage = fakeStorage()
+    markBotSeen(storage, 't-rex', 100)
+    expect([...storage.map.keys()]).toEqual([BOTS_SEEN_STORAGE_KEY])
   })
 
   it('keeps other Bots entries', () => {
-    const storage = fakeStorage(JSON.stringify({ 't-ada': 5 }))
+    const storage = fakeStorage({ [BOTS_SEEN_STORAGE_KEY]: JSON.stringify({ 't-ada': 5 }) })
     expect(markBotSeen(storage, 't-rex', 100)).toEqual({ 't-ada': 5, 't-rex': 100 })
   })
 
   it('never moves a recorded time BACKWARDS, so a stale write cannot resurrect a dot', () => {
-    const storage = fakeStorage(JSON.stringify({ 't-rex': 100 }))
+    const storage = fakeStorage({ [BOTS_SEEN_STORAGE_KEY]: JSON.stringify({ 't-rex': 100 }) })
     expect(markBotSeen(storage, 't-rex', 50)).toEqual({ 't-rex': 100 })
+    expect(getBotsSeen(storage)).toEqual({ 't-rex': 100 })
   })
 
   it('still returns the updated map when storage is unavailable (the dot clears for this run)', () => {
@@ -81,9 +90,5 @@ describe('markBotSeen', () => {
       },
     }
     expect(() => markBotSeen(full, 't-rex', 100)).not.toThrow()
-  })
-
-  it('uses a versioned key', () => {
-    expect(BOTS_SEEN_STORAGE_KEY).toMatch(/:v1$/)
   })
 })

--- a/apps/desktop/src/renderer/src/bots/bot-seen-store.test.ts
+++ b/apps/desktop/src/renderer/src/bots/bot-seen-store.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { BOTS_SEEN_STORAGE_KEY, getBotsSeen, markBotSeen, type BotSeenStorage } from './bot-seen-store'
+
+function fakeStorage(initial?: string): BotSeenStorage & { value: string | null } {
+  return {
+    value: initial ?? null,
+    getItem() {
+      return this.value
+    },
+    setItem(_key: string, value: string) {
+      this.value = value
+    },
+  }
+}
+
+describe('getBotsSeen', () => {
+  it('reads back what was written', () => {
+    const storage = fakeStorage(JSON.stringify({ 't-rex': 42 }))
+    expect(getBotsSeen(storage)).toEqual({ 't-rex': 42 })
+  })
+
+  it('is empty when nothing is stored', () => {
+    expect(getBotsSeen(fakeStorage())).toEqual({})
+  })
+
+  it('is empty for corrupt JSON rather than throwing into the sidebar render', () => {
+    expect(getBotsSeen(fakeStorage('{not json'))).toEqual({})
+  })
+
+  it('is empty for a non-object payload', () => {
+    expect(getBotsSeen(fakeStorage('["t-rex"]'))).toEqual({})
+  })
+
+  it('drops non-numeric entries instead of trusting them', () => {
+    const storage = fakeStorage(JSON.stringify({ 't-rex': 'yesterday', 't-ada': 7, 't-nan': NaN }))
+    expect(getBotsSeen(storage)).toEqual({ 't-ada': 7 })
+  })
+
+  it('tolerates an absent storage (never throws)', () => {
+    expect(getBotsSeen(null)).toEqual({})
+    expect(getBotsSeen(undefined)).toEqual({})
+  })
+
+  it('tolerates a throwing storage', () => {
+    const throwing: BotSeenStorage = {
+      getItem() {
+        throw new Error('blocked')
+      },
+      setItem() {},
+    }
+    expect(getBotsSeen(throwing)).toEqual({})
+  })
+})
+
+describe('markBotSeen', () => {
+  it('records the time and persists it under the one key', () => {
+    const storage = fakeStorage()
+    expect(markBotSeen(storage, 't-rex', 100)).toEqual({ 't-rex': 100 })
+    expect(JSON.parse(storage.value ?? '{}')).toEqual({ 't-rex': 100 })
+  })
+
+  it('keeps other Bots entries', () => {
+    const storage = fakeStorage(JSON.stringify({ 't-ada': 5 }))
+    expect(markBotSeen(storage, 't-rex', 100)).toEqual({ 't-ada': 5, 't-rex': 100 })
+  })
+
+  it('never moves a recorded time BACKWARDS, so a stale write cannot resurrect a dot', () => {
+    const storage = fakeStorage(JSON.stringify({ 't-rex': 100 }))
+    expect(markBotSeen(storage, 't-rex', 50)).toEqual({ 't-rex': 100 })
+  })
+
+  it('still returns the updated map when storage is unavailable (the dot clears for this run)', () => {
+    expect(markBotSeen(null, 't-rex', 100)).toEqual({ 't-rex': 100 })
+  })
+
+  it('swallows a quota failure from the write', () => {
+    const full: BotSeenStorage = {
+      getItem: () => null,
+      setItem() {
+        throw new Error('QuotaExceeded')
+      },
+    }
+    expect(() => markBotSeen(full, 't-rex', 100)).not.toThrow()
+  })
+
+  it('uses a versioned key', () => {
+    expect(BOTS_SEEN_STORAGE_KEY).toMatch(/:v1$/)
+  })
+})

--- a/apps/desktop/src/renderer/src/bots/bot-seen-store.ts
+++ b/apps/desktop/src/renderer/src/bots/bot-seen-store.ts
@@ -1,0 +1,70 @@
+import type { BotSeenMap } from './bot-rows'
+
+/**
+ * When each Mistro Bot was last OPENED (#446) — the only input the sidebar's
+ * unread dot needs that the app does not already have.
+ *
+ * Renderer-only UI state, so it lives in localStorage alone (like the sidebar's
+ * fold state #138 and composer drafts #60): no IPC, no main, no persistence store.
+ * Losing it costs one stale dot, which is the right price for not adding read
+ * receipts to a durable store.
+ *
+ * The storage seam is INJECTED so tests pass a fake and render code passes
+ * `window.localStorage`; every path tolerates an unavailable/throwing/corrupt
+ * store and falls back to "nothing seen", so a blocked store never breaks the
+ * sidebar's render.
+ */
+
+/** The single localStorage key holding `{ [threadId]: epochMs }`. */
+export const BOTS_SEEN_STORAGE_KEY = 'vibe-mistro:bots-seen:v1'
+
+/** The slice of the Web Storage API we depend on — `window.localStorage` satisfies it. */
+export interface BotSeenStorage {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+}
+
+/**
+ * The persisted last-opened times, or `{}` when absent/corrupt/unavailable.
+ * Non-numeric entries are dropped rather than trusted — a stale string would make
+ * `lastActiveAt > seenAt` compare against a string and mark a Bot read forever.
+ */
+export function getBotsSeen(storage: BotSeenStorage | null | undefined): BotSeenMap {
+  if (!storage) return {}
+  try {
+    const raw = storage.getItem(BOTS_SEEN_STORAGE_KEY)
+    if (!raw) return {}
+    const parsed: unknown = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+    const seen: Record<string, number> = {}
+    for (const [threadId, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof value === 'number' && Number.isFinite(value)) seen[threadId] = value
+    }
+    return seen
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * Record that a Bot was just opened, returning the NEW map (pure at the value
+ * level — the caller re-renders from what comes back). A recorded time never goes
+ * backwards, so a stale write can't resurrect a dot.
+ */
+export function markBotSeen(
+  storage: BotSeenStorage | null | undefined,
+  threadId: string,
+  atMs: number,
+): BotSeenMap {
+  const current = getBotsSeen(storage)
+  if ((current[threadId] ?? 0) >= atMs) return current
+  const next = { ...current, [threadId]: atMs }
+  if (storage) {
+    try {
+      storage.setItem(BOTS_SEEN_STORAGE_KEY, JSON.stringify(next))
+    } catch {
+      // Best-effort: a full/blocked storage must never throw from opening a Bot.
+    }
+  }
+  return next
+}

--- a/apps/desktop/src/renderer/src/bots/use-bots.ts
+++ b/apps/desktop/src/renderer/src/bots/use-bots.ts
@@ -1,0 +1,34 @@
+import { useCallback, useEffect, useState } from 'react'
+import type { BotRecord } from '../../../shared/ipc'
+
+/**
+ * The Mistro Bot RECORDS (#446): name, colour, description, instructions, Project.
+ * Read once over `bots:list` and refreshed only when a record changes — creating,
+ * editing or deleting a Bot, all of which arrive in slice 3 (#447), which is why
+ * `refresh` is returned rather than called on a timer.
+ *
+ * The rows' ORDER and their timestamps deliberately do NOT come from here: a
+ * record only moves on an edit, so `deriveBotRows` joins these against the Threads'
+ * `lastActiveAt` from the metadata list, which the app already refreshes on the
+ * events that matter.
+ */
+export function useBots(): { bots: BotRecord[]; refreshBots: () => void } {
+  const [bots, setBots] = useState<BotRecord[]>([])
+
+  const refreshBots = useCallback(() => {
+    void window.api
+      .botsList()
+      .then((result) => setBots(result.bots))
+      .catch((err: unknown) => {
+        // Log, don't swallow — but never break the sidebar over it. An empty Bots
+        // section is a survivable degradation; a thrown render is not.
+        console.error('[vibe-mistro:bots] could not list Bots:', err)
+      })
+  }, [])
+
+  useEffect(() => {
+    refreshBots()
+  }, [refreshBots])
+
+  return { bots, refreshBots }
+}

--- a/apps/desktop/src/renderer/src/connection/ConnectedWorkspace.tsx
+++ b/apps/desktop/src/renderer/src/connection/ConnectedWorkspace.tsx
@@ -6,6 +6,7 @@ import type {
   ThreadConnection,
   ThreadMeta,
 } from '../../../shared/ipc'
+import type { BotIdentity } from '../bots/BotHeader'
 import { ColdThread } from '../conversation/ColdThread'
 import { Conversation } from '../conversation/Conversation'
 import type { MessageSelection } from '../conversation/message-selection'
@@ -37,6 +38,7 @@ import type { SideThreadLifecycle } from '../side-panel/side-panel-store'
 export function ConnectedWorkspace({
   connection,
   activeThread,
+  activeBot,
   isLive,
   isActive,
   busy,
@@ -55,6 +57,13 @@ export function ConnectedWorkspace({
   connection: ThreadConnection
   /** The Thread App chose to show (its remembered active Thread for this Workspace). */
   activeThread: ThreadMeta
+  /**
+   * Who `activeThread` is when it belongs to a **Mistro Bot** (#446), else null.
+   * A Bot's conversation IS an ordinary Thread conversation (ADR-0027) — this only
+   * swaps the head for the Bot's identity and withdraws the agent-control pickers,
+   * because a Bot's behaviour is its profile and changing it means editing the Bot.
+   */
+  activeBot: BotIdentity | null
   /** Whether `activeThread` is hosted live on this session's agent (vs cold replay). */
   isLive: boolean
   /**
@@ -113,9 +122,14 @@ export function ConnectedWorkspace({
               sessionId: seedSessionId,
               title: activeThread.title,
             }}
-            modes={controls?.modes ?? null}
-            models={controls?.models ?? null}
-            reasoningEffort={controls?.reasoningEffort ?? null}
+            bot={activeBot}
+            // A Bot's behaviour is its profile (ADR-0027 decision 5), so it gets no
+            // Mode / Model / Reasoning-effort picker: the Mode axis is exactly where
+            // its persona is selected, and a picker there is a one-click way to
+            // silently switch off the personality the user configured.
+            modes={activeBot ? null : (controls?.modes ?? null)}
+            models={activeBot ? null : (controls?.models ?? null)}
+            reasoningEffort={activeBot ? null : (controls?.reasoningEffort ?? null)}
             onSetConfig={onSetConfig}
             onAuthExpired={onAuthExpired}
             onBound={onBound}

--- a/apps/desktop/src/renderer/src/conversation/Conversation.tsx
+++ b/apps/desktop/src/renderer/src/conversation/Conversation.tsx
@@ -17,6 +17,7 @@ import type {
   ThreadModes,
   ThreadReasoningEffort,
 } from '../../../shared/ipc'
+import { BotHeader, type BotIdentity } from '../bots/BotHeader'
 import { FileOpenProvider } from './file-open-context'
 import { isRejectOption } from './permission-option'
 import type { FileLink } from './file-link'
@@ -105,6 +106,7 @@ export interface LiveThread {
  */
 export function Conversation({
   thread,
+  bot = null,
   modes,
   models,
   reasoningEffort,
@@ -117,6 +119,14 @@ export function Conversation({
   skipInitialHydration = false,
 }: {
   thread: LiveThread
+  /**
+   * Who this Thread is, when it is a **Mistro Bot**'s conversation (#446) — the
+   * head renders its identity instead of the auto-generated Thread title, because a
+   * teammate's identity does not change with what you last asked it. Null (the
+   * default) for every ordinary Thread. Everything below the head is unchanged: a
+   * Bot's turn is an ordinary Thread turn (ADR-0027).
+   */
+  bot?: BotIdentity | null
   /** The connection's current Mode + options (#66) — display-from-session-state. */
   modes: ThreadModes | null
   /** The connection's current Model + options (#66). */
@@ -301,6 +311,13 @@ export function Conversation({
       if (e.rebound) dispatch({ type: 'agent-rebound' })
       if (e.controlFailures && e.controlFailures.length > 0) {
         dispatch({ type: 'system-notice', message: controlFailureNotice(e.controlFailures) })
+      }
+      // A Mistro Bot whose persona could NOT be selected on this session (#446).
+      // ADR-0027: failure is loud — a Bot that quietly answers as a plain agent is
+      // the one outcome the design forbids, so it says so in the transcript, where
+      // the answers it is about to give will appear.
+      if (e.botProfileError) {
+        dispatch({ type: 'system-notice', message: e.botProfileError })
       }
     })
   }, [thread.threadId])
@@ -558,11 +575,15 @@ export function Conversation({
     // for the FileChips streamdown renders far below in the assistant markdown.
     <FileOpenProvider value={openFile}>
       <div className="conv" ref={convRef}>
-        <div className="conv__head">
-          <span className="dot dot--ok" aria-hidden />
-          <span className="conv__title">{title}</span>
-          <span className="badge">connected</span>
-        </div>
+        {bot ? (
+          <BotHeader bot={bot} />
+        ) : (
+          <div className="conv__head">
+            <span className="dot dot--ok" aria-hidden />
+            <span className="conv__title">{title}</span>
+            <span className="badge">connected</span>
+          </div>
+        )}
 
         <UsageBar state={state} />
 

--- a/apps/desktop/src/renderer/src/search/SearchPalette.tsx
+++ b/apps/desktop/src/renderer/src/search/SearchPalette.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type JSX } from 'react'
-import { MessageSquare } from 'lucide-react'
+import { Bot, MessageSquare } from 'lucide-react'
 import type { SearchHit } from '../../../shared/ipc'
 import { formatRelativeTime } from '../shell/relative-time'
 import { setPendingJump } from './jump-store'
@@ -78,7 +78,7 @@ export function SearchPalette({
         <Command
           aria-label="Search threads"
           items={hits}
-          itemToStringValue={(hit: SearchHit) => hit.title ?? 'Untitled'}
+          itemToStringValue={(hit: SearchHit) => hit.botName ?? hit.title ?? 'Untitled'}
           value={query}
           onValueChange={setQuery}
         >
@@ -96,10 +96,25 @@ export function SearchPalette({
                   onMouseDown={(event) => event.preventDefault()}
                   onClick={() => selectHit(hit)}
                 >
-                  <MessageSquare className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+                  {/* A Mistro Bot's conversation is hidden from the sidebar's Thread
+                      list, so the palette is where it is found (#446) — and in the
+                      resting recents, it is one of the things switched to most. The
+                      marker is what tells the two kinds of row apart at a glance. */}
+                  {hit.botName ? (
+                    <Bot className="size-4 shrink-0 text-primary" aria-label="Bot" />
+                  ) : (
+                    <MessageSquare className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+                  )}
                   <span className="flex min-w-0 flex-1 flex-col">
                     <span className="flex min-w-0 items-center gap-1.5">
-                      <span className="truncate text-foreground">{hit.title ?? 'Untitled'}</span>
+                      <span className="truncate text-foreground">
+                        {hit.botName ?? hit.title ?? 'Untitled'}
+                      </span>
+                      {hit.botName && (
+                        <Badge variant="outline" className="shrink-0 px-1.5 py-0 text-[10px]">
+                          Bot
+                        </Badge>
+                      )}
                       {hit.archived && (
                         <Badge variant="outline" className="shrink-0 px-1.5 py-0 text-[10px]">
                           Archived

--- a/apps/desktop/src/renderer/src/shell/Shell.tsx
+++ b/apps/desktop/src/renderer/src/shell/Shell.tsx
@@ -72,7 +72,12 @@ export function Shell({
   nav: NavState
   /** Per-Workspace rolled-up live status, keyed by Workspace id (switcher badges). */
   workspaceFlags: Readonly<Record<string, WorkspaceFlags>>
-  /** The unified rows (cold + live) for the SELECTED Workspace — Bots already excluded. */
+  /**
+   * The unified rows (cold + live) for the SELECTED Workspace, exactly as App
+   * derived them — Mistro Bot rows INCLUDED. `WorkspaceNav` drops them per project
+   * (`partitionBots`) at the single point that renders a Thread list; anything new
+   * that reads these rows here must do the same.
+   */
   rows: UnifiedThreadRow[]
   /** The Bots, most-recently-active first, for the bounded section above Projects (#446). */
   botRows: BotSidebarRow[]

--- a/apps/desktop/src/renderer/src/shell/Shell.tsx
+++ b/apps/desktop/src/renderer/src/shell/Shell.tsx
@@ -4,6 +4,8 @@ import type { ListMetadataResult } from '../../../shared/ipc'
 import type { NavState } from './nav-reducer'
 import type { UnifiedThreadRow } from './unified-threads'
 import { WorkspaceNav, type ThreadRowActions, type WorkspaceFlags } from './workspace-nav'
+import { BotsSection } from '../bots/BotsSection'
+import type { BotSidebarRow } from '../bots/bot-rows'
 import { UpdateReadyChip } from './UpdateReadyChip'
 import {
   clampSidebarWidth,
@@ -44,11 +46,13 @@ export function Shell({
   nav,
   workspaceFlags,
   rows,
+  botRows,
   protectedThreadId,
   outlet,
   opening,
   onOpenProject,
   onNewThread,
+  onSelectBot,
   actions,
   onOpenSettings,
   onOpenSearch,
@@ -68,8 +72,10 @@ export function Shell({
   nav: NavState
   /** Per-Workspace rolled-up live status, keyed by Workspace id (switcher badges). */
   workspaceFlags: Readonly<Record<string, WorkspaceFlags>>
-  /** The unified rows (cold + live) for the SELECTED Workspace. */
+  /** The unified rows (cold + live) for the SELECTED Workspace — Bots already excluded. */
   rows: UnifiedThreadRow[]
+  /** The Bots, most-recently-active first, for the bounded section above Projects (#446). */
+  botRows: BotSidebarRow[]
   /** The connection's primary Thread (never deletable mid-connection), or null. */
   protectedThreadId: string | null
   /** The fully-computed conversation outlet (connection views / cold replay). */
@@ -80,6 +86,8 @@ export function Shell({
   onOpenProject: () => void
   /** Mint a New-thread draft on the selected Workspace's live agent. */
   onNewThread: () => void
+  /** Open a Bot's conversation in the outlet (#446) — an ordinary Thread select underneath. */
+  onSelectBot: (row: BotSidebarRow) => void
   /** The bundled per-Thread-row actions (select / new / delete / remove / flags / rename). */
   actions: ThreadRowActions
   /** Open the routed Settings page (#130) — from the account chip's menu. */
@@ -182,12 +190,21 @@ export function Shell({
             and account stay put while just the projects scroll. The INNER holds the
             resized width (not shrinking) so content slides under the clip on collapse. */}
         <div className="flex h-full flex-none flex-col gap-3 p-3" style={{ width }}>
-          <div className="flex flex-none flex-col gap-3">
+          <div className="flex min-h-0 flex-none flex-col gap-3">
             <PrimaryNav
               busy={opening}
               onNewThread={onNewThread}
               onOpenSearch={onOpenSearch}
               onOpenSkills={onOpenSkills}
+            />
+            {/* Bots sit ABOVE Projects and OUTSIDE the projects scroll region, with
+                their own bound + scrollbar (#446). That is the whole point: the
+                section can never grow past its cap, so Projects below stays reachable
+                however many teammates exist. */}
+            <BotsSection
+              rows={botRows}
+              selectedThreadId={nav.selectedThreadId}
+              onSelectBot={onSelectBot}
             />
           </div>
           <div className="min-h-0 flex-1 overflow-y-auto">

--- a/apps/desktop/src/renderer/src/shell/unified-threads.test.ts
+++ b/apps/desktop/src/renderer/src/shell/unified-threads.test.ts
@@ -4,6 +4,7 @@ import {
   isThreadDeletable,
   orderByPin,
   partitionArchived,
+  partitionBots,
   workspaceFlags,
   type UnifiedThreadRow,
 } from './unified-threads'
@@ -195,6 +196,51 @@ describe('partitionArchived (#133 split, order-preserving)', () => {
 
   it('handles an empty list', () => {
     expect(partitionArchived([])).toEqual({ active: [], archived: [] })
+  })
+})
+
+describe('partitionBots (#446 — hidden from the Thread list, visible in Search)', () => {
+  function row(id: string, botName?: string): UnifiedThreadRow {
+    return {
+      thread: { ...thread(id), ...(botName ? { bot: { name: botName } } : {}) },
+      live: false,
+      streaming: false,
+      needsAttention: false,
+    }
+  }
+
+  it('keeps every ordinary Thread in the list when there are no Bots', () => {
+    const { threads, bots } = partitionBots([row('a'), row('b')])
+    expect(threads.map((r) => r.thread.id)).toEqual(['a', 'b'])
+    expect(bots).toEqual([])
+  })
+
+  it('EXCLUDES a Bot from the Thread list — it has its own sidebar section', () => {
+    const { threads, bots } = partitionBots([row('a'), row('rex', 'Rex'), row('c')])
+    expect(threads.map((r) => r.thread.id)).toEqual(['a', 'c'])
+    expect(bots.map((r) => r.thread.id)).toEqual(['rex'])
+  })
+
+  it('preserves the incoming order in both halves', () => {
+    const rows = [row('a', 'Ada'), row('b'), row('c', 'Rex'), row('d')]
+    const { threads, bots } = partitionBots(rows)
+    expect(threads.map((r) => r.thread.id)).toEqual(['b', 'd'])
+    expect(bots.map((r) => r.thread.id)).toEqual(['a', 'c'])
+  })
+
+  it('treats an absent flag as an ordinary Thread', () => {
+    const { threads } = partitionBots([row('a', undefined), row('b')])
+    expect(threads.map((r) => r.thread.id)).toEqual(['a', 'b'])
+  })
+
+  it('does not mutate its input', () => {
+    const rows = [row('a'), row('rex', 'Rex')]
+    partitionBots(rows)
+    expect(rows.map((r) => r.thread.id)).toEqual(['a', 'rex'])
+  })
+
+  it('handles an empty list', () => {
+    expect(partitionBots([])).toEqual({ threads: [], bots: [] })
   })
 })
 

--- a/apps/desktop/src/renderer/src/shell/unified-threads.ts
+++ b/apps/desktop/src/renderer/src/shell/unified-threads.ts
@@ -97,6 +97,34 @@ export function partitionArchived(rows: UnifiedThreadRow[]): {
 }
 
 /**
+ * Split a Workspace's rows into the ones its Thread list SHOWS and the **Mistro
+ * Bot** rows it does not (#446, ADR-0027) — the sidebar half of "hidden from the
+ * Thread list, visible in Search". Sits beside `partitionArchived` deliberately:
+ * both are per-row presentation splits applied over the same derived rows, and
+ * this one is here — in the renderer, on a flag — rather than in the store,
+ * because `listMetadata` and `searchQuery` share one snapshot expression in main.
+ * Filtering there would delete Bots from Search too (PRD story 11).
+ *
+ * A Bot appears in its own bounded sidebar section instead. Both halves preserve
+ * the incoming order; pure (the input array is never mutated).
+ *
+ * Note that a DELETED Bot's Thread survives as an archived Thread whose record is
+ * gone — so it loses this flag and correctly reappears in the Archived section.
+ */
+export function partitionBots(rows: UnifiedThreadRow[]): {
+  threads: UnifiedThreadRow[]
+  bots: UnifiedThreadRow[]
+} {
+  const threads: UnifiedThreadRow[] = []
+  const bots: UnifiedThreadRow[] = []
+  for (const row of rows) {
+    if (row.thread.bot) bots.push(row)
+    else threads.push(row)
+  }
+  return { threads, bots }
+}
+
+/**
  * Whether a unified row may be deleted (pure — the safe-delete gate, TB6 / #48 /
  * #53). The hazard is tearing a session out from under a mid-turn agent. Now that
  * main pushes real per-Thread `streaming` for ALL live Threads (#53, not just the

--- a/apps/desktop/src/renderer/src/shell/unified-threads.ts
+++ b/apps/desktop/src/renderer/src/shell/unified-threads.ts
@@ -99,17 +99,15 @@ export function partitionArchived(rows: UnifiedThreadRow[]): {
 /**
  * Split a Workspace's rows into the ones its Thread list SHOWS and the **Mistro
  * Bot** rows it does not (#446, ADR-0027) — the sidebar half of "hidden from the
- * Thread list, visible in Search". Sits beside `partitionArchived` deliberately:
- * both are per-row presentation splits applied over the same derived rows, and
- * this one is here — in the renderer, on a flag — rather than in the store,
- * because `listMetadata` and `searchQuery` share one snapshot expression in main.
- * Filtering there would delete Bots from Search too (PRD story 11).
+ * Thread list, visible in Search", a Bot having its own bounded section instead.
  *
- * A Bot appears in its own bounded sidebar section instead. Both halves preserve
- * the incoming order; pure (the input array is never mutated).
+ * It sits beside `partitionArchived` deliberately: both are per-row presentation
+ * splits over the same derived rows. That the exclusion belongs HERE, on a flag,
+ * rather than in main's store is argued once at `main/bots/mark-bot-threads.ts`.
  *
- * Note that a DELETED Bot's Thread survives as an archived Thread whose record is
- * gone — so it loses this flag and correctly reappears in the Archived section.
+ * Both halves preserve the incoming order; pure (the input is never mutated).
+ * A DELETED Bot's Thread survives as an archived Thread whose record is gone — so
+ * it loses the flag and correctly reappears in the Archived section.
  */
 export function partitionBots(rows: UnifiedThreadRow[]): {
   threads: UnifiedThreadRow[]

--- a/apps/desktop/src/renderer/src/shell/workspace-nav/index.tsx
+++ b/apps/desktop/src/renderer/src/shell/workspace-nav/index.tsx
@@ -20,6 +20,7 @@ import {
   isThreadDeletable,
   orderByPin,
   partitionArchived,
+  partitionBots,
   type UnifiedThreadRow,
 } from '../unified-threads'
 import { getOpenProjects, setOpenProjects } from '../project-open-store'
@@ -282,10 +283,17 @@ function ProjectRow({
   // The "Remove project" confirmation dialog (Codex-style): a destructive, controlled
   // modal opened from this project's ⋯ menu. Confirming calls `actions.removeWorkspace`.
   const [confirmRemoveOpen, setConfirmRemoveOpen] = useState(false)
+  // Drop this project's Mistro Bots (#446) — a Bot has its own bounded sidebar
+  // section, so its Thread must not also appear here. This is the SIDEBAR half of
+  // "hidden from the Thread list, visible in Search": the exclusion lives here, on
+  // a per-row flag, and never in the store (which Search reads from the same
+  // expression). A deleted Bot loses the flag and correctly returns as an archived
+  // Thread below.
+  const { threads: threadRows } = partitionBots(rows)
   // Split archived rows out (#133) then float pinned rows to the top of the active
   // list (#132) — both pure post-processing over the derived rows (deriveUnifiedThreads
   // stays flag-agnostic). Archived rows fold into a collapsible section at the bottom.
-  const { active: activeRows, archived: archivedRows } = partitionArchived(rows)
+  const { active: activeRows, archived: archivedRows } = partitionArchived(threadRows)
   const mainRows = orderByPin(activeRows)
   // Cap the main list, PINNING the selected row so opening a thread that sorts below
   // the cap never hides its (highlighted) row (#113 review). Only the active project

--- a/apps/desktop/src/renderer/src/shell/workspace-nav/index.tsx
+++ b/apps/desktop/src/renderer/src/shell/workspace-nav/index.tsx
@@ -283,12 +283,10 @@ function ProjectRow({
   // The "Remove project" confirmation dialog (Codex-style): a destructive, controlled
   // modal opened from this project's ⋯ menu. Confirming calls `actions.removeWorkspace`.
   const [confirmRemoveOpen, setConfirmRemoveOpen] = useState(false)
-  // Drop this project's Mistro Bots (#446) — a Bot has its own bounded sidebar
-  // section, so its Thread must not also appear here. This is the SIDEBAR half of
-  // "hidden from the Thread list, visible in Search": the exclusion lives here, on
-  // a per-row flag, and never in the store (which Search reads from the same
-  // expression). A deleted Bot loses the flag and correctly returns as an archived
-  // Thread below.
+  // Drop this project's Mistro Bots (#446): a Bot has its own bounded sidebar
+  // section, so its Thread must not also appear here. This is the ONLY point that
+  // renders a Thread list — for the active project and every peeked one alike — so
+  // it is the only place the exclusion has to happen.
   const { threads: threadRows } = partitionBots(rows)
   // Split archived rows out (#133) then float pinned rows to the top of the active
   // list (#132) — both pure post-processing over the derived rows (deriveUnifiedThreads

--- a/apps/desktop/src/shared/ipc/search.ts
+++ b/apps/desktop/src/shared/ipc/search.ts
@@ -33,6 +33,18 @@ export interface SearchHit {
   title: string | null
   /** Archived Threads are searchable but badged (and hidden from resting recents). */
   archived: boolean
+  /**
+   * The **Mistro Bot**'s name when this hit is a Bot's conversation (#446), absent
+   * otherwise. Bots are hidden from the sidebar's Thread list but deliberately KEPT
+   * here — both in query results (PRD story 11: the longest-running conversations
+   * must not be a hole in Search) and in the resting recents (story 12: a switcher
+   * should list what you switch to most).
+   *
+   * The palette shows this INSTEAD of `title` and marks the row, because a Thread
+   * title is what Vibe made of the first prompt while the name is who the teammate
+   * is — and it is matched on, so searching a Bot by name finds it.
+   */
+  botName?: string
   /** Epoch-ms recency — the ranking tiebreak and the row's relative timestamp. */
   lastActiveAt: number
   /** One display line from the best-matching message (whitespace-collapsed, windowed). */

--- a/apps/desktop/src/shared/ipc/thread.ts
+++ b/apps/desktop/src/shared/ipc/thread.ts
@@ -86,6 +86,15 @@ export interface ThreadBoundEvent {
    * fallback state; the renderer surfaces a notice instead of failing silently.
    */
   controlFailures?: ThreadConfigAxis[]
+  /**
+   * A Mistro Bot's persona could NOT be selected on the session this bind produced
+   * (#446, ADR-0027): the profile the record names is not among the session's modes,
+   * or the validating `session/set_config_option` rejected it. Carries the
+   * human-readable reason, which the renderer weaves in as a system notice — a Bot
+   * that quietly answers as a plain agent is the one failure ADR-0027 forbids.
+   * Absent on every ordinary Thread and on a successful persona selection.
+   */
+  botProfileError?: string
 }
 
 /**
@@ -355,6 +364,26 @@ export interface ThreadMeta {
    * via `setThreadFlags`; split out by `partitionArchived`.
    */
   archived?: boolean
+  /**
+   * Present when this Thread is a **Mistro Bot**'s conversation (#446, ADR-0027) —
+   * one durable Thread that carries a teammate's identity and persona. Absent on
+   * every ordinary Thread, and NOT persisted on the Thread row: main derives it per
+   * reply by joining the `bots` table (`markBotThreads`), so the Bot record stays
+   * the single source of truth.
+   *
+   * It is a per-row FLAG, deliberately not a store-level filter, because
+   * `listMetadata` and `searchQuery` share one snapshot expression. Each side reads
+   * it differently: the sidebar's Thread list EXCLUDES these rows
+   * (`partitionBots` — a Bot has its own section), while Search KEEPS them and
+   * identifies them. Filtering in the store would delete Bots from Search too,
+   * which is exactly the hole PRD user story 11 exists to close.
+   *
+   * It carries the Bot's `name` because Search is the ONLY place a Bot's
+   * conversation can be found by text, and the Thread's own title is whatever Vibe
+   * auto-generated from the first prompt — so without the name, searching for the
+   * teammate you are looking for would miss it (PRD story 12).
+   */
+  bot?: { name: string }
 }
 
 /** A Workspace with its Threads nested, both most-recent-first — the cold list. */

--- a/apps/desktop/src/shared/ipc/thread.ts
+++ b/apps/desktop/src/shared/ipc/thread.ts
@@ -371,12 +371,10 @@ export interface ThreadMeta {
    * reply by joining the `bots` table (`markBotThreads`), so the Bot record stays
    * the single source of truth.
    *
-   * It is a per-row FLAG, deliberately not a store-level filter, because
-   * `listMetadata` and `searchQuery` share one snapshot expression. Each side reads
-   * it differently: the sidebar's Thread list EXCLUDES these rows
-   * (`partitionBots` — a Bot has its own section), while Search KEEPS them and
-   * identifies them. Filtering in the store would delete Bots from Search too,
-   * which is exactly the hole PRD user story 11 exists to close.
+   * A per-row FLAG rather than a store-level filter, read differently by each side:
+   * the sidebar's Thread list excludes these rows (`partitionBots`), Search keeps
+   * and identifies them. The reason it cannot be a filter is written down once, at
+   * `main/bots/mark-bot-threads.ts`.
    *
    * It carries the Bot's `name` because Search is the ONLY place a Bot's
    * conversation can be found by text, and the Thread's own title is whatever Vibe


### PR DESCRIPTION
Closes nothing — this is slice 2 of #444. Do not close #446 on merge; the user is smoke-testing.

## What this is

The first slice of **Mistro Bots** you can see: the bounded sidebar section, the Bot conversation in the outlet, the persona selection at bind, and the Thread-list / Search visibility split. Built on slice 1's record + profile projection (#445), which is untouched.

Create / edit / Start over / delete are slice 3 (#447) and deliberately absent.

## Acceptance criteria

| | Criterion | Status |
|---|---|---|
| ✅ | Bots section renders above Projects, bounded with its own scroll; Projects remains reachable with 20 Bots | **Met** — verified in the running app at 20 Bots (throwaway Playwright harness against the built app, isolated `VIBE_MISTRO_USER_DATA` + `VIBE_HOME`; harness deleted before commit). The list carries `max-height: 240px` + `overflow-y-auto` and sits in the sidebar's pinned top band, *outside* the Projects scroll region — so it is bounded structurally, not by luck. |
| ✅ | Rows show mark, name, last-active and unread dot; no truncation at default sidebar width | **Met** — the name is the only flexible column (`min-w-0 truncate`); mark, spinner, needs-you badge, timestamp and dot are all `flex-none`. Verified at the default width with 20 Bots. |
| ✅ | Selecting a Bot swaps the outlet to its conversation with a Bot header; the composer works as in any Thread | **Met** — selection routes through the ordinary `selectThreadInWorkspace`, so connect-if-needed, hosting, replay, the composer and the turn lifecycle are all unchanged. Only the head swaps (`BotHeader`: mark, name, `description · project`). Verified live against the scripted fake agent: prompt sent, reply streamed. |
| ✅ | Binding selects the Bot's profile through the validating config setter, and a rejection surfaces rather than silently no-opping | **Met** — `WorkspaceAgent.setMode` routes to `session/set_config_option` (`configId: "mode"`) whenever the session advertises it, which is the setter that rejects a bad id with `-32602`; `session/set_mode` would answer `{}` (#427). A missing profile is caught *before* the call (it is not among the session's modes) and a rejected one after; both are logged in main and pushed on `thread:bound` as `botProfileError`, which the conversation weaves in as a system notice. Verified live — the fake agent offers no `mistro-bot-*` profile, and the notice appears above the reply. |
| ✅ | Pure partition module excludes Bots from the Thread list while Search still finds them — unit-tested both ways | **Met** — `partitionBots` (renderer, beside `partitionArchived`) does the excluding; `markBotThreads` (main) marks and never drops. Tested from both ends in one file: the marked snapshot is asserted to be the *same shape* as the input, then fed straight into `searchThreads` to prove the Bot is still found by name, by prose, and in the resting recents. |
| ✅ | A ⌘K hit on text inside a Bot conversation opens that Bot | **Met** — the FTS prose projection needed no change (it keys on `threadId` alone) and the existing hit routing already selects the Thread, which now *is* the Bot. Covered by a prose-search unit test; the jump path is untouched. |
| ✅ | Bots appear in ⌘K's resting recents with a marker | **Met** — Bot icon + "Bot" badge, and the row reads the Bot's **name** rather than the Vibe-generated Thread title (see the judgment call below). Verified in the running palette. |
| ✅ | All four gates pass | **Met** — see below. |

## Gates

```
bun run lint       ✅
bun run typecheck  ✅
bun run build      ✅
bun run test       ✅  172 files, 1927 tests (46 new across the 4 new/extended suites)
```

## The one thing this slice could have got structurally wrong

I verified the claim in the ticket before writing anything: `listMetadata` and `searchQuery` both call `groupThreadsByWorkspace(deps.store.snapshot())`, so a filter in the store, in `snapshot()`, or in the grouper would delete Bots from Search as well as from the sidebar.

So there is no filter anywhere in main. `coldSnapshotWithBots` marks rows with `ThreadMeta.bot`, both handlers are served from it, and the two sides read the flag differently:

- sidebar → `partitionBots` drops those rows from the Thread list (they have their own section);
- Search → keeps every row and renders the identity.

The FTS prose projection was checked and needs no change at all.

## Decisions the ticket did not settle

1. **The flag carries the Bot's name, not just a boolean.** With a bare boolean, ⌘K listed the Bot under whatever title Vibe generated from its first prompt, and typing the Bot's name found nothing — Search being the *only* place a Bot's conversation is findable, that is a real hole in PRD stories 11/12. `ThreadMeta.bot` is therefore `{ name: string }` (presence is still the flag), the palette shows the name and matches on it. Say the word if you would rather have the bare flag.

2. **What "unread" means.** There are no read receipts in the app and inventing durable ones would be dishonest, so the dot is defined from signals that already exist: the Bot has been active since the last time you opened it (`lastActiveAt > seenAt`), or it is blocked on a permission. The seen times are renderer-only UI state in `localStorage` (`bot-seen-store.ts`), like the sidebar's fold state — losing them costs one stale dot. Opening a Bot clears it, including via a ⌘K hit.

3. **No Mode / Model / reasoning-effort picker on a Bot.** ADR-0027 decision 5, and not strictly in this slice's AC list — but the Mode axis is exactly where the persona is selected, so leaving the picker in would ship a one-click way to silently switch off the persona this slice just built. Done here rather than deferred.

4. **The section's `+` is omitted, not inert.** Per the brief, and because #447 owns the create form: a button that does nothing is worse than no button. The `+` lands with the form.

## Deliberately not done

- **Filtering Bot profiles out of ordinary Threads' Mode pickers** (PRD story 13). It is not in this slice's AC, and it is not reachable yet: with no create UI, a user cannot get a Bot profile into their `~/.vibe/agents/` through the app until #447.
- **`ColdThread` keeps its ordinary header.** A Bot selection auto-continues into a live conversation, so the cold view is a transient frame; giving it Bot chrome is noise for the width of one connect.
- **No screenshot baselines added to `e2e/`.** The visual verification was done with a throwaway harness and deleted; the prototype's captures on `proto/422-bots-view` remain the design record. Happy to add pinned baselines if you want the section defended against layout regressions.

## Files worth reading first

- `apps/desktop/src/main/bots/mark-bot-threads.ts` — the marking, and why it is not a filter
- `apps/desktop/src/main/bots/select-bot-profile.ts` — the persona plan + applier
- `apps/desktop/src/renderer/src/bots/bot-rows.ts` — ordering and the unread rule
- `apps/desktop/src/renderer/src/bots/BotsSection.tsx` — the bound
