### PR TITLE
feat: Mistro Bots slice 4 — durable persona across restart, loud failure, and control suppression (#448)

### DIFF
--- a/apps/desktop/src/main/acp/agent-controls.test.ts
+++ b/apps/desktop/src/main/acp/agent-controls.test.ts
@@ -4,6 +4,7 @@ import {
   extractThreadControls,
   hasConfigOption,
   missingControlAxes,
+  readModeDiscovery,
 } from './agent-controls'
 
 /** The verbatim 2.24.1 `session/new` shape (acp-capture §14.0) — no `models` block. */
@@ -194,5 +195,21 @@ describe('missingControlAxes', () => {
       missingControlAxes(extractThreadControls({ modes: MODES_2_24, configOptions: [{ id: 'thinking' }] })),
     ).toEqual(['model', 'reasoningEffort'])
     expect(missingControlAxes(extractThreadControls({}))).toEqual(['mode', 'model', 'reasoningEffort'])
+  })
+})
+
+describe('readModeDiscovery', () => {
+  it('reads the advertised mode ids as a stamped registry reading', () => {
+    const controls = extractThreadControls({ configOptions: CONFIG_OPTIONS_2_24 })
+    expect(readModeDiscovery(controls, 4_242)).toEqual({
+      modeIds: MODES_2_24.availableModes.map((mode) => mode.id),
+      observedAt: 4_242,
+    })
+  })
+
+  it('is null when the session advertises no modes at all', () => {
+    // An agent with no mode axis says nothing about which agent profiles exist,
+    // and must never be mistaken for one that offers modes and lacks ours (#448).
+    expect(readModeDiscovery(extractThreadControls({}), 1)).toBeNull()
   })
 })

--- a/apps/desktop/src/main/acp/agent-controls.ts
+++ b/apps/desktop/src/main/acp/agent-controls.ts
@@ -160,6 +160,37 @@ function extractReasoningEffort(configOptions: unknown): ThreadReasoningEffort |
 }
 
 /**
+ * One reading of the agent's agent-profile registry: the mode ids a session
+ * result advertised, and WHEN we read them (#448).
+ *
+ * The timestamp is load-bearing, not diagnostics. Vibe re-scans `~/.vibe/agents/`
+ * per session (acp-capture §14.6), so a mode list is a snapshot of the registry at
+ * that instant — and a Mistro Bot created or repaired AFTER it is legitimately
+ * absent from it. Without the reading's age, "not in the list" would accuse every
+ * Bot made on an already-warm agent of having a broken profile.
+ */
+export interface ModeDiscovery {
+  /** Every `availableModes[].id` the session reported — builtins and profiles alike. */
+  modeIds: string[]
+  /** Epoch-ms when the session reported them (i.e. when Vibe last scanned). */
+  observedAt: number
+}
+
+/**
+ * Read a controls bundle as a registry reading, or null when the session
+ * advertised no modes at all — an agent that offers no mode axis says nothing
+ * about which profiles exist, and must not be mistaken for one that offers modes
+ * and lacks ours.
+ */
+export function readModeDiscovery(
+  controls: ThreadAgentControls,
+  observedAt: number,
+): ModeDiscovery | null {
+  if (!controls.modes) return null
+  return { modeIds: controls.modes.availableModes.map((mode) => mode.id), observedAt }
+}
+
+/**
  * The axes this session advertises NOTHING for — our drift tripwire (#427). Every
  * agent we support offers all three, so a non-empty result means the agent stopped
  * advertising what we expect (a renamed field, a removed block) and the matching

--- a/apps/desktop/src/main/bots/assess-bot-profile.test.ts
+++ b/apps/desktop/src/main/bots/assess-bot-profile.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { assessBotProfile } from './assess-bot-profile'
+
+const PROFILE = 'mistro-bot-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+const WRITTEN = 1_000
+
+describe('assessBotProfile', () => {
+  it('is HEALTHY when a later scan lists the profile', () => {
+    expect(
+      assessBotProfile({
+        profileId: PROFILE,
+        profileWrittenAt: WRITTEN,
+        discovery: { modeIds: ['ask', 'plan', PROFILE], observedAt: WRITTEN + 1 },
+      }),
+    ).toEqual({ kind: 'healthy' })
+  })
+
+  it('is MISSING when a later scan lists only builtins — the profile file is gone', () => {
+    const status = assessBotProfile({
+      profileId: PROFILE,
+      profileWrittenAt: WRITTEN,
+      discovery: { modeIds: ['ask', 'plan', 'accept-edits'], observedAt: WRITTEN + 1 },
+    })
+    expect(status.kind).toBe('missing')
+    // The banner names the profile, so the reason must travel with the id.
+    expect(status).toMatchObject({ profileId: PROFILE })
+  })
+
+  it('does not distinguish a malformed profile from a deleted one — both are absent', () => {
+    // Vibe drops an unreadable TOML at scan with only a log line (#424), so the
+    // ONLY evidence either way is that the id is not in the list.
+    const status = assessBotProfile({
+      profileId: PROFILE,
+      profileWrittenAt: WRITTEN,
+      discovery: { modeIds: ['ask'], observedAt: WRITTEN + 5_000 },
+    })
+    expect(status.kind).toBe('missing')
+  })
+
+  it('is UNKNOWN when the agent has never reported modes', () => {
+    expect(
+      assessBotProfile({ profileId: PROFILE, profileWrittenAt: WRITTEN, discovery: null }),
+    ).toEqual({ kind: 'unknown' })
+  })
+
+  it('is UNKNOWN when the only scan PREDATES the profile write', () => {
+    // Creating (or rebuilding) a Bot on an already-warm agent: the registry was
+    // scanned before the file existed, so its absence proves nothing.
+    expect(
+      assessBotProfile({
+        profileId: PROFILE,
+        profileWrittenAt: WRITTEN,
+        discovery: { modeIds: ['ask', 'plan'], observedAt: WRITTEN - 1 },
+      }),
+    ).toEqual({ kind: 'unknown' })
+  })
+
+  it('is UNKNOWN on a same-millisecond tie — an unorderable pair accuses nobody', () => {
+    expect(
+      assessBotProfile({
+        profileId: PROFILE,
+        profileWrittenAt: WRITTEN,
+        discovery: { modeIds: ['ask'], observedAt: WRITTEN },
+      }),
+    ).toEqual({ kind: 'unknown' })
+  })
+
+  it('checks freshness FIRST, so even a stale affirmative reading is UNKNOWN', () => {
+    // Pinned deliberately: the answer only ever drives a banner, and `unknown`
+    // and `healthy` both mean "say nothing" — so the rule stays one comparison
+    // rather than growing a second, cleverer path for the affirmative case.
+    expect(
+      assessBotProfile({
+        profileId: PROFILE,
+        profileWrittenAt: WRITTEN,
+        discovery: { modeIds: [PROFILE], observedAt: WRITTEN - 1 },
+      }),
+    ).toEqual({ kind: 'unknown' })
+  })
+})

--- a/apps/desktop/src/main/bots/assess-bot-profile.ts
+++ b/apps/desktop/src/main/bots/assess-bot-profile.ts
@@ -1,0 +1,63 @@
+import type { BotProfileStatus } from '../../shared/ipc'
+import type { ModeDiscovery } from '../acp/agent-controls'
+
+/**
+ * Is a Mistro Bot's persona still there? (#448, ADR-0027 "failure is loud")
+ *
+ * This is the OPEN-path half of the persona check. Slice 2 decides the same
+ * question on a bind (`select-bot-profile.ts`), but a bind only happens on a
+ * prompt — and a Bot whose profile file was hand-deleted must be told on OPEN,
+ * before the user has typed anything into what looks like their teammate.
+ *
+ * The question is answered by DIFFING the expected `profileId` against the mode
+ * ids the agent last advertised, never by sending something and reading the
+ * error. Vibe drops an unreadable or malformed profile at registry scan with a
+ * log line and no wire signal (#424, acp-capture §14.6), so a broken profile and
+ * an absent one look identical from here: the absence IS the evidence.
+ *
+ * The decision is pure so that the genuinely hard part — *when does absence mean
+ * broken, and when does it merely mean "not scanned yet"?* — is settled in a unit
+ * test rather than against a live binary.
+ */
+
+export interface BotProfileAssessment {
+  /** The `mistro-bot-<uuid>` the Bot record names. */
+  profileId: string
+  /** When the profile files were last written — the record's `updatedAt`. */
+  profileWrittenAt: number
+  /** The agent's latest registry reading, or null when it has none yet. */
+  discovery: ModeDiscovery | null
+}
+
+/**
+ * Decide what to tell the user about a Bot's persona.
+ *
+ * Three answers, and the third is the one that keeps the banner honest:
+ *
+ * - **healthy** — the agent lists the profile as a mode; it will be selected on
+ *   the next bind.
+ * - **unknown** — we have no reading, or none NEWER than the last write to the
+ *   profile files. Creating a Bot on an already-warm agent lands here (the
+ *   registry was scanned before the file existed), and so does the instant after
+ *   a rebuild. Saying nothing is correct: the next session re-scans, and slice
+ *   2's bind-time check is the backstop.
+ * - **missing** — the agent scanned AFTER we wrote, and still does not list it.
+ *   The file is gone, unreadable, or malformed.
+ *
+ * Ties (`observedAt === profileWrittenAt`) read as `unknown`: both stamps are
+ * coarse epoch-ms and a scan in the same millisecond as the write cannot be
+ * ordered, so the failure direction is the quiet one.
+ */
+export function assessBotProfile(input: BotProfileAssessment): BotProfileStatus {
+  const { profileId, profileWrittenAt, discovery } = input
+  if (!discovery) return { kind: 'unknown' }
+  if (discovery.observedAt <= profileWrittenAt) return { kind: 'unknown' }
+  if (discovery.modeIds.includes(profileId)) return { kind: 'healthy' }
+  return {
+    kind: 'missing',
+    profileId,
+    reason:
+      'Vibe no longer lists it as an agent profile — the file under ~/.vibe/agents/ ' +
+      'is missing, unreadable, or malformed.',
+  }
+}

--- a/apps/desktop/src/main/bots/assess-bot-profile.ts
+++ b/apps/desktop/src/main/bots/assess-bot-profile.ts
@@ -20,6 +20,18 @@ import type { ModeDiscovery } from '../acp/agent-controls'
  * test rather than against a live binary.
  */
 
+/**
+ * Why a profile the agent does not list is absent — ONE wording for both paths.
+ *
+ * The bind-time check (`select-bot-profile.ts`) and this open-time one answer the
+ * same question about the same file, and the notice one raises now also raises the
+ * other's banner. Two descriptions of one broken profile would read as two
+ * different problems.
+ */
+export const BOT_PROFILE_ABSENT_REASON =
+  'Vibe does not list it as an agent profile — the file under ~/.vibe/agents/ is ' +
+  'missing, unreadable, or malformed.'
+
 export interface BotProfileAssessment {
   /** The `mistro-bot-<uuid>` the Bot record names. */
   profileId: string
@@ -50,14 +62,14 @@ export interface BotProfileAssessment {
  */
 export function assessBotProfile(input: BotProfileAssessment): BotProfileStatus {
   const { profileId, profileWrittenAt, discovery } = input
+  // An agent that has advertised no modes at all arrives here as a null reading and
+  // reads as `unknown` — DELIBERATELY unlike the bind-time check, which calls the
+  // same condition `missing`. The asymmetry is what each side holds: a bind has a
+  // session result in hand and is about to prompt it, while this may be asking
+  // before any session ever reported anything. Both comments point at each other so
+  // a later edit to one is not read as a bug against the other.
   if (!discovery) return { kind: 'unknown' }
   if (discovery.observedAt <= profileWrittenAt) return { kind: 'unknown' }
   if (discovery.modeIds.includes(profileId)) return { kind: 'healthy' }
-  return {
-    kind: 'missing',
-    profileId,
-    reason:
-      'Vibe no longer lists it as an agent profile — the file under ~/.vibe/agents/ ' +
-      'is missing, unreadable, or malformed.',
-  }
+  return { kind: 'missing', profileId, reason: BOT_PROFILE_ABSENT_REASON }
 }

--- a/apps/desktop/src/main/bots/bot-lifecycle.test.ts
+++ b/apps/desktop/src/main/bots/bot-lifecycle.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import type { BotRecord } from '../../shared/ipc'
 import type { BotInsert, BotPatch, BotStoreApi } from '../persistence/bot-store-api'
-import { createBot, deleteBot, listBots, updateBot, type BotLifecycleDeps } from './bot-lifecycle'
+import {
+  createBot,
+  deleteBot,
+  listBots,
+  rebuildBotProfile,
+  updateBot,
+  type BotLifecycleDeps,
+} from './bot-lifecycle'
 import type { BotProfileSource } from './bot-profile'
 import type { WriteBotProfileResult } from './write-bot-profile'
 
@@ -314,5 +321,65 @@ describe('listBots', () => {
     const h = harness()
     await createBot(h.deps, { workspaceId: 'ws-1', name: 'Rex', colour: '#fff' })
     expect(listBots(h.deps).map((b) => b.name)).toEqual(['Rex'])
+  })
+})
+
+describe('rebuildBotProfile', () => {
+  it('re-writes the profile files from the record, persona and id intact', async () => {
+    const h = harness()
+    const created = await createBot(h.deps, {
+      workspaceId: 'ws-1',
+      name: 'Rex',
+      colour: '#fff',
+      instructions: 'You know this project.',
+    })
+    if (!created.ok) throw new Error('setup failed')
+    h.written.length = 0
+
+    const rebuilt = await rebuildBotProfile(h.deps, { threadId: created.bot.threadId })
+
+    expect(rebuilt.ok).toBe(true)
+    expect(h.written).toEqual([
+      {
+        // The id the live session selected as a mode is NEVER re-minted.
+        profileId: created.bot.profileId,
+        name: 'Rex',
+        description: '',
+        instructions: 'You know this project.',
+      },
+    ])
+  })
+
+  it('re-stamps updatedAt, so the open-path check stops accusing the profile', async () => {
+    // `assessBotProfile` only calls a profile missing when the agent's registry
+    // reading is NEWER than the last write — so a rebuild must move that stamp.
+    const h = harness()
+    const created = await createBot(h.deps, { workspaceId: 'ws-1', name: 'Rex', colour: '#fff' })
+    if (!created.ok) throw new Error('setup failed')
+
+    const rebuilt = await rebuildBotProfile(h.deps, { threadId: created.bot.threadId })
+
+    if (!rebuilt.ok) throw new Error('rebuild failed')
+    expect(rebuilt.bot.updatedAt).toBeGreaterThan(created.bot.updatedAt)
+  })
+
+  it('reports a write failure instead of claiming a repair', async () => {
+    const h = harness()
+    const created = await createBot(h.deps, { workspaceId: 'ws-1', name: 'Rex', colour: '#fff' })
+    if (!created.ok) throw new Error('setup failed')
+    h.writeResult = { ok: false, reason: 'io', problems: ['EACCES'] }
+
+    const rebuilt = await rebuildBotProfile(h.deps, { threadId: created.bot.threadId })
+
+    expect(rebuilt).toEqual({ ok: false, reason: 'io', problems: ['EACCES'] })
+  })
+
+  it('refuses an unknown Bot — there is no record to rebuild from', async () => {
+    const h = harness()
+    expect(await rebuildBotProfile(h.deps, { threadId: 'nope' })).toEqual({
+      ok: false,
+      reason: 'notFound',
+      problems: ['No such Bot.'],
+    })
   })
 })

--- a/apps/desktop/src/main/bots/bot-lifecycle.ts
+++ b/apps/desktop/src/main/bots/bot-lifecycle.ts
@@ -3,6 +3,7 @@ import type {
   BotsCreateArgs,
   BotsDeleteArgs,
   BotsDeleteResult,
+  BotsRebuildProfileArgs,
   BotsUpdateArgs,
   BotWriteResult,
 } from '../../shared/ipc'
@@ -194,6 +195,28 @@ export async function deleteBot(
     console.error('[vibe-mistro:bots] could not archive the deleted Bot Thread:', err)
   }
   return { ok: removed }
+}
+
+/**
+ * Rebuild a Bot's profile files from its record (#448) — the repair the
+ * missing-persona banner offers.
+ *
+ * It is `updateBot` with nothing to change, and that is the point: the record is
+ * the source of truth and the files are a projection of it (ADR-0027), so
+ * "rebuild" is that projection run again rather than a second, parallel writer
+ * that could drift from the one the form uses. It also re-stamps `updatedAt`,
+ * which is what tells the open-path check (`assessBotProfile`) that the agent's
+ * registry reading now predates the files and has nothing left to accuse.
+ *
+ * It does NOT restore the persona on a session that is already running: a live
+ * session resolved its profile at `session/new` and is unaffected by the files
+ * either way (acp-capture §14.6). The next bind selects it.
+ */
+export async function rebuildBotProfile(
+  deps: BotLifecycleDeps,
+  args: BotsRebuildProfileArgs,
+): Promise<BotWriteResult> {
+  return updateBot(deps, { threadId: args.threadId })
 }
 
 /** Every Bot, for `bots:list`. */

--- a/apps/desktop/src/main/bots/register-ipc.ts
+++ b/apps/desktop/src/main/bots/register-ipc.ts
@@ -3,17 +3,29 @@ import { randomUUID } from 'node:crypto'
 import { homedir } from 'node:os'
 import {
   IPC,
+  type BotProfileStatus,
   type BotsCreateArgs,
   type BotsDeleteArgs,
   type BotsDeleteResult,
   type BotsListResult,
+  type BotsProfileStatusArgs,
+  type BotsRebuildProfileArgs,
   type BotsUpdateArgs,
   type BotWriteResult,
 } from '../../shared/ipc'
+import { mintBotProfileId } from '../../shared/bot-profile-id'
+import type { ModeDiscovery } from '../acp/agent-controls'
 import type { BotStoreApi } from '../persistence/bot-store-api'
 import { getShellEnv } from '../shell-env'
-import { createBot, deleteBot, listBots, updateBot, type BotLifecycleDeps } from './bot-lifecycle'
-import { mintBotProfileId } from './profile-id'
+import { assessBotProfile } from './assess-bot-profile'
+import {
+  createBot,
+  deleteBot,
+  listBots,
+  rebuildBotProfile,
+  updateBot,
+  type BotLifecycleDeps,
+} from './bot-lifecycle'
 import { vibeProfileDirs } from './profile-dirs'
 import { nodeProfileFs } from './node-profile-fs'
 import { removeBotProfile, writeBotProfile, type BotProfileFs } from './write-bot-profile'
@@ -33,6 +45,15 @@ export interface BotsIpcDeps {
   threads: BotLifecycleDeps['threads']
   /** Overridable for tests; production uses the real `node:fs` binding. */
   fs?: BotProfileFs
+  /**
+   * The Workspace agent's latest agent-profile registry reading (#448), by
+   * `agentId` — the wire evidence the open-path persona check diffs against.
+   * Injected because the pool lives in `index.ts`; it awaits the Workspace's
+   * eager primary session (ADR-0012) so a Bot opened the instant its Project
+   * connects gets a real answer rather than a shrug. Null when the agent is gone
+   * or never opened a session.
+   */
+  discoverModes?: (agentId: string) => Promise<ModeDiscovery | null>
 }
 
 /**
@@ -73,5 +94,36 @@ export function registerBotsIpc(deps: BotsIpcDeps): void {
   ipcMain.handle(
     IPC.botsDelete,
     (_event, args: BotsDeleteArgs): Promise<BotsDeleteResult> => deleteBot(lifecycle, args),
+  )
+
+  // The OPEN-path persona check (#448). Slice 2 decides the same question on a
+  // bind, but a bind needs a prompt — and ADR-0027's "failure is loud" means the
+  // user is told when the Bot OPENS, before typing into what looks like their
+  // teammate. Thin by design: the answer is `assessBotProfile`'s.
+  ipcMain.handle(
+    IPC.botsProfileStatus,
+    async (_event, args: BotsProfileStatusArgs): Promise<BotProfileStatus> => {
+      const bot = deps.bots.get(args.threadId)
+      if (!bot) return { kind: 'unknown' } // an ordinary Thread, or a deleted Bot
+      const discovery = deps.discoverModes ? await deps.discoverModes(args.agentId) : null
+      const status = assessBotProfile({
+        profileId: bot.profileId,
+        profileWrittenAt: bot.updatedAt,
+        discovery,
+      })
+      if (status.kind === 'missing') {
+        console.error(
+          `[vibe-mistro:bots] ${bot.name} (${args.threadId}): persona ${status.profileId} ` +
+            `is not among the agent's modes — ${status.reason}`,
+        )
+      }
+      return status
+    },
+  )
+
+  ipcMain.handle(
+    IPC.botsRebuildProfile,
+    (_event, args: BotsRebuildProfileArgs): Promise<BotWriteResult> =>
+      rebuildBotProfile(lifecycle, args),
   )
 }

--- a/apps/desktop/src/main/bots/register-ipc.ts
+++ b/apps/desktop/src/main/bots/register-ipc.ts
@@ -39,21 +39,35 @@ import { removeBotProfile, writeBotProfile, type BotProfileFs } from './write-bo
  * sees, so the profiles land where Vibe will look for them.
  */
 
+/**
+ * What the Bot LIFECYCLE needs — no agent, so main's Workspace/Thread cleanup
+ * paths can build the same profile-file seam without one.
+ */
 export interface BotsIpcDeps {
   bots: BotStoreApi
   /** The Thread half: a Bot's conversation is an ordinary Thread record. */
   threads: BotLifecycleDeps['threads']
   /** Overridable for tests; production uses the real `node:fs` binding. */
   fs?: BotProfileFs
+}
+
+/**
+ * What REGISTERING the handlers additionally needs. `discoverModes` is required
+ * rather than optional on purpose (#448): it is the only evidence the loud-failure
+ * check has, so wiring that could be forgotten would turn the whole feature into a
+ * permanent `unknown` — the app failing silently about failing silently. A missing
+ * source must be a type error at the call site, not a shrug at runtime.
+ */
+export interface BotsRegistrarDeps extends BotsIpcDeps {
   /**
-   * The Workspace agent's latest agent-profile registry reading (#448), by
-   * `agentId` — the wire evidence the open-path persona check diffs against.
-   * Injected because the pool lives in `index.ts`; it awaits the Workspace's
-   * eager primary session (ADR-0012) so a Bot opened the instant its Project
-   * connects gets a real answer rather than a shrug. Null when the agent is gone
-   * or never opened a session.
+   * The Workspace agent's latest agent-profile registry reading, by `agentId` —
+   * the wire evidence the open-path persona check diffs against. Injected because
+   * the pool lives in `index.ts`; it awaits the Workspace's eager primary session
+   * (ADR-0012) so a Bot opened the instant its Project connects gets a real answer
+   * rather than a shrug. Null when the agent is gone or never opened a session —
+   * the one legitimate "nothing to report".
    */
-  discoverModes?: (agentId: string) => Promise<ModeDiscovery | null>
+  discoverModes: (agentId: string) => Promise<ModeDiscovery | null>
 }
 
 /**
@@ -76,7 +90,7 @@ export function createBotLifecycleDeps(deps: BotsIpcDeps): BotLifecycleDeps {
   }
 }
 
-export function registerBotsIpc(deps: BotsIpcDeps): void {
+export function registerBotsIpc(deps: BotsRegistrarDeps): void {
   const lifecycle = createBotLifecycleDeps(deps)
 
   ipcMain.handle(IPC.botsList, (): BotsListResult => ({ bots: listBots(lifecycle) }))
@@ -105,7 +119,7 @@ export function registerBotsIpc(deps: BotsIpcDeps): void {
     async (_event, args: BotsProfileStatusArgs): Promise<BotProfileStatus> => {
       const bot = deps.bots.get(args.threadId)
       if (!bot) return { kind: 'unknown' } // an ordinary Thread, or a deleted Bot
-      const discovery = deps.discoverModes ? await deps.discoverModes(args.agentId) : null
+      const discovery = await deps.discoverModes(args.agentId)
       const status = assessBotProfile({
         profileId: bot.profileId,
         profileWrittenAt: bot.updatedAt,

--- a/apps/desktop/src/main/bots/select-bot-profile.test.ts
+++ b/apps/desktop/src/main/bots/select-bot-profile.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi } from 'vitest'
 import type { ThreadAgentControls } from '../../shared/ipc'
-import { applyBotProfile, planBotProfileSelection } from './select-bot-profile'
+import {
+  applyBotProfile,
+  mayClaimPreopenedSession,
+  planBotProfileSelection,
+} from './select-bot-profile'
 
 const PROFILE = 'mistro-bot-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
 
@@ -14,6 +18,32 @@ function controls(currentModeId: string, ids: string[]): ThreadAgentControls {
     reasoningEffort: null,
   }
 }
+
+describe('mayClaimPreopenedSession', () => {
+  it('lets an ordinary Thread take the eager primary session, always', () => {
+    expect(mayClaimPreopenedSession(null, controls('ask', ['ask']))).toBe(true)
+    expect(mayClaimPreopenedSession(null, null)).toBe(true)
+  })
+
+  it('lets a Bot take it when that session advertises the persona', () => {
+    expect(mayClaimPreopenedSession(PROFILE, controls('ask', ['ask', PROFILE]))).toBe(true)
+  })
+
+  it('makes a Bot MINT instead when the primary session predates its profile', () => {
+    // The silent-failure sequence this exists to break: connect a Project, create
+    // a Bot, prompt it. The primary session was scanned before the profile file
+    // existed, so binding to it would leave the Bot unable to wear its persona for
+    // the whole run — every later turn reuses that session and skips re-selection.
+    expect(mayClaimPreopenedSession(PROFILE, controls('ask', ['ask', 'plan']))).toBe(false)
+  })
+
+  it('makes a Bot mint when there is no primary session to judge', () => {
+    expect(mayClaimPreopenedSession(PROFILE, null)).toBe(false)
+    expect(
+      mayClaimPreopenedSession(PROFILE, { modes: null, models: null, reasoningEffort: null }),
+    ).toBe(false)
+  })
+})
 
 describe('planBotProfileSelection', () => {
   it('does nothing for an ordinary Thread', () => {

--- a/apps/desktop/src/main/bots/select-bot-profile.ts
+++ b/apps/desktop/src/main/bots/select-bot-profile.ts
@@ -1,4 +1,5 @@
 import type { ThreadAgentControls } from '../../shared/ipc'
+import { BOT_PROFILE_ABSENT_REASON } from './assess-bot-profile'
 
 /**
  * Selecting a Mistro Bot's persona on the session its Thread just bound to (#446,
@@ -23,11 +24,37 @@ export type BotProfilePlan =
   | { kind: 'select'; profileId: string }
   /**
    * The session does not offer this profile as a mode. Vibe re-scans `~/.vibe/agents/`
-   * on every `session/new`, so an absent profile means the FILE is gone or unreadable
-   * — not a timing race. Sending it anyway would earn a `-32602`; reporting it is
-   * strictly more useful, and slice 4 turns this into the rebuild banner.
+   * on every `session/new` AND every `session/load` (acp-capture §14.6), so a profile
+   * absent from a FRESH session result means the FILE is gone or unreadable — not a
+   * timing race. Sending it anyway would earn a `-32602`; reporting it is strictly
+   * more useful, and it is what raises the rebuild banner (#448).
    */
   | { kind: 'missing'; profileId: string; reason: string }
+
+/**
+ * May a Bot's first prompt bind to the Workspace's eager PRIMARY session (ADR-0012),
+ * or must it mint a fresh one?
+ *
+ * ADR-0012 opens one `session/new` at connect and lets a draft's first prompt claim
+ * it instead of minting a second. That is right for every ordinary Thread and wrong
+ * for a Bot created AFTER the connect: the primary session's mode list was built by
+ * a registry scan that predates the profile, so the persona can never be selected on
+ * it — and the Bot would answer its whole first conversation as a plain agent, which
+ * is exactly the silent failure ADR-0027 forbids. A fresh `session/new` re-scans
+ * (acp-capture §14.6), so minting one is the fix, at the cost of one extra session in
+ * the one case that needs it.
+ *
+ * Null `primaryControls` (no primary session opened, or a best-effort failure) also
+ * declines: we cannot show the persona is selectable there, and for a Bot the safe
+ * direction is the fresh scan.
+ */
+export function mayClaimPreopenedSession(
+  profileId: string | null,
+  primaryControls: ThreadAgentControls | null,
+): boolean {
+  if (!profileId) return true // an ordinary Thread always takes ADR-0012's session
+  return primaryControls?.modes?.availableModes.some((mode) => mode.id === profileId) ?? false
+}
 
 /**
  * Decide what this bind owes the Bot's persona.
@@ -36,7 +63,8 @@ export type BotProfilePlan =
  * produced a fresh `session/new` / `session/load` result, and null on a plain reuse
  * of an already-hosted session. A reuse is `satisfied`: the session was bound
  * earlier in this same run, which is precisely when the persona was already
- * selected on it.
+ * selected on it. That holds because `mayClaimPreopenedSession` above keeps a Bot
+ * off any session that could not host its persona in the first place.
  */
 export function planBotProfileSelection(
   profileId: string | null,
@@ -46,6 +74,12 @@ export function planBotProfileSelection(
   if (!controls) return { kind: 'satisfied' } // reuse — selected on the earlier bind
   const modes = controls.modes
   if (!modes) {
+    // DELIBERATE divergence from the open-path check (`assess-bot-profile.ts`),
+    // which reads the same condition as `unknown` and stays quiet. The difference
+    // is what each side is holding: here we have a session result in hand and are
+    // about to prompt it, so "this session cannot carry the persona" is a fact
+    // about the turn the user is starting. There, an agent that has reported no
+    // modes has told us nothing about which profiles exist.
     return {
       kind: 'missing',
       profileId,
@@ -54,11 +88,10 @@ export function planBotProfileSelection(
   }
   if (modes.currentModeId === profileId) return { kind: 'satisfied' }
   if (!modes.availableModes.some((mode) => mode.id === profileId)) {
-    return {
-      kind: 'missing',
-      profileId,
-      reason: 'Vibe does not list it as an agent profile — its profile file is missing or unreadable',
-    }
+    // The SAME condition the banner reports, so it uses the same words — one
+    // broken profile must not be described two ways by the notice and the banner
+    // the notice raises.
+    return { kind: 'missing', profileId, reason: BOT_PROFILE_ABSENT_REASON }
   }
   return { kind: 'select', profileId }
 }

--- a/apps/desktop/src/main/bots/validate-bot-profile.ts
+++ b/apps/desktop/src/main/bots/validate-bot-profile.ts
@@ -1,5 +1,5 @@
 import type { BotProfileFiles, BotProfileSource } from './bot-profile'
-import { isMistroBotProfileId } from './profile-id'
+import { isMistroBotProfileId } from '../../shared/bot-profile-id'
 
 /**
  * The validation Vibe will not do for us (#424, #445; ADR-0027).

--- a/apps/desktop/src/main/bots/write-bot-profile.ts
+++ b/apps/desktop/src/main/bots/write-bot-profile.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path'
 import { projectBotProfile, type BotProfileSource } from './bot-profile'
-import { isMistroBotProfileId } from './profile-id'
+import { isMistroBotProfileId } from '../../shared/bot-profile-id'
 import type { VibeProfileDirs } from './profile-dirs'
 import {
   collectProblems,

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -110,7 +110,11 @@ import { registerSkillsIpc } from './skills/register-ipc'
 import { createBotLifecycleDeps, registerBotsIpc } from './bots/register-ipc'
 import { cleanRemovedBots } from './bots/clean-removed-bots'
 import { botNamesByThread, markBotThreads } from './bots/mark-bot-threads'
-import { applyBotProfile, planBotProfileSelection } from './bots/select-bot-profile'
+import {
+  applyBotProfile,
+  mayClaimPreopenedSession,
+  planBotProfileSelection,
+} from './bots/select-bot-profile'
 import type { ModeDiscovery } from './acp/agent-controls'
 import { SqliteBotStore } from './persistence/sqlite-bot-store'
 import type { BotStoreApi } from './persistence/bot-store-api'
@@ -715,11 +719,24 @@ async function runPromptTurn(
     // event tees to the ACTIVE Thread when several share an agent — refreshed every
     // prompt (last-write-wins, and only the active Thread prompts at a time).
     deps.bridge.bind(args.agentId, args.threadId)
+    // Is this Thread a Mistro Bot, and which persona does it own? Resolved BEFORE
+    // the bind, because it decides which session the bind may use (#448).
+    const botProfileId = deps.bots.get(args.threadId)?.profileId ?? null
     // A draft's first prompt (sessionId null) claims the Workspace's eager primary
     // session (ADR-0012), so it binds to that instead of minting a SECOND
     // `session/new`; consumed once, so a second concurrent draft mints its own.
     // Never claimed for a reopened/already-bound Thread (those aren't case (i)).
-    const preopened = args.sessionId === null ? (agent.consumePrimarySession() ?? undefined) : undefined
+    //
+    // A Bot declines that session unless it ADVERTISES the Bot's persona (#448): a
+    // Bot created after the Workspace connected is absent from the primary
+    // session's registry scan, so binding to it would give the Bot a session that
+    // can never wear its persona — silently, for the rest of the run (every later
+    // turn reuses that session and re-selection is skipped). Minting a fresh
+    // `session/new` re-scans and costs one extra session in that case alone.
+    const preopened =
+      args.sessionId === null && mayClaimPreopenedSession(botProfileId, agent.primarySessionControls)
+        ? (agent.consumePrimarySession() ?? undefined)
+        : undefined
     const bound = await ensureBoundSession({
       agent,
       store: deps.store,
@@ -759,10 +776,10 @@ async function runPromptTurn(
     //
     // `setMode` routes through the VALIDATING `session/set_config_option` (a bogus
     // id is rejected with -32602), never `session/set_mode`, which answers a bad id
-    // with `{}` — a silent no-op indistinguishable from success (#427). A failure
-    // is reported, never swallowed: a Bot that quietly answers with no persona is
-    // the one failure ADR-0027 forbids.
-    const botProfileId = deps.bots.get(args.threadId)?.profileId ?? null
+    // with `{}` — a silent no-op indistinguishable from success (#427) — on every
+    // 2.24.x binary, all of which advertise the `mode` config option. A failure is
+    // reported, never swallowed: a Bot that quietly answers with no persona is the
+    // one failure ADR-0027 forbids.
     const profileOutcome = await applyBotProfile(
       agent,
       sessionId,

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -111,6 +111,7 @@ import { createBotLifecycleDeps, registerBotsIpc } from './bots/register-ipc'
 import { cleanRemovedBots } from './bots/clean-removed-bots'
 import { botNamesByThread, markBotThreads } from './bots/mark-bot-threads'
 import { applyBotProfile, planBotProfileSelection } from './bots/select-bot-profile'
+import type { ModeDiscovery } from './acp/agent-controls'
 import { SqliteBotStore } from './persistence/sqlite-bot-store'
 import type { BotStoreApi } from './persistence/bot-store-api'
 import { registerEditorsIpc } from './editors/register-ipc'
@@ -511,6 +512,26 @@ function bestEffortCloseFor(deps: MainDeps, threadId: string): (() => Promise<vo
   return async () => {
     for (const agent of pool.agents()) await agent.closeSession(sessionId)
   }
+}
+
+/**
+ * The agent's latest agent-profile registry reading (#448) — what the open-path
+ * Bot persona check diffs against, resolved from the pool by `agentId`.
+ *
+ * It first ensures the Workspace's eager primary session (ADR-0012) — idempotent
+ * and already time-bounded — so a Bot opened the moment its Project connects gets
+ * a real reading instead of `unknown`. Best-effort: an agent that cannot open a
+ * session simply has nothing to report, which is a shrug, never an accusation.
+ */
+async function discoverModes(agentId: string): Promise<ModeDiscovery | null> {
+  const agent = pool.get(agentId)
+  if (!agent) return null
+  try {
+    await agent.openPrimarySession()
+  } catch {
+    // Already best-effort inside; a failure just leaves the reading as it was.
+  }
+  return agent.modeDiscovery
 }
 
 /**
@@ -944,7 +965,7 @@ function registerIpc(deps: MainDeps): void {
   })
   registerFilesIpc({ pool, cache: filesListCache })
   registerSkillsIpc()
-  registerBotsIpc({ bots: deps.bots, threads: deps.store })
+  registerBotsIpc({ bots: deps.bots, threads: deps.store, discoverModes })
   // The same profile-file seam the Bot CRUD uses, reused by the Thread- and
   // Workspace-removal cleanup below so both paths refuse a foreign profile id
   // through exactly one gate (#445).

--- a/apps/desktop/src/main/workspace-agent.ts
+++ b/apps/desktop/src/main/workspace-agent.ts
@@ -546,6 +546,12 @@ export class WorkspaceAgent extends EventEmitter {
   async openThread(): Promise<ThreadInfo> {
     if (!this.initialized) throw new WorkspaceAgentError('Agent is not initialized; call start() first.')
 
+    // Stamped BEFORE the round-trip (#448): Vibe scans `~/.vibe/agents/` while
+    // serving this request, so the reading describes the registry as of NOW, not as
+    // of the reply. Stamping on arrival would overstate its freshness and could let
+    // a profile written during the round-trip be judged missing by a list that
+    // legitimately predates it.
+    const askedAt = Date.now()
     let result: SessionNewResult
     try {
       result = await this.client.request<SessionNewResult>('session/new', {
@@ -556,7 +562,7 @@ export class WorkspaceAgent extends EventEmitter {
       throw this.mapErrorAndCacheAuth(err)
     }
 
-    const controls = this.readControls(result, 'session/new')
+    const controls = this.readControls(result, 'session/new', askedAt)
     const thread: ThreadInfo = {
       sessionId: result.sessionId,
       // `session/new` returns no title in the capture — the Thread title arrives
@@ -667,6 +673,7 @@ export class WorkspaceAgent extends EventEmitter {
       throw new WorkspaceAgentError('Agent is not initialized; call start() first.')
     }
     this.loadingSessions.add(sessionId)
+    const askedAt = Date.now() // see `openThread` — stamped before the scan happens
     try {
       const result = await this.client.request<SessionNewResult>('session/load', {
         sessionId,
@@ -677,7 +684,7 @@ export class WorkspaceAgent extends EventEmitter {
         // The `session/load` result omits `sessionId` (acp-capture §9) — keep ours.
         sessionId,
         title: result.title ?? null,
-        ...this.readControls({ ...result, sessionId }, 'session/load'),
+        ...this.readControls({ ...result, sessionId }, 'session/load', askedAt),
       }
       this.threads.set(sessionId, thread)
       return thread
@@ -801,11 +808,18 @@ export class WorkspaceAgent extends EventEmitter {
    * there was silent — a renamed field just made a picker disappear — so an axis we
    * expect but no longer get must at least leave a trace in the main-process log.
    */
-  private readControls(result: SessionNewResult, method: string): ThreadAgentControls {
+  private readControls(
+    result: SessionNewResult,
+    method: string,
+    observedAt: number,
+  ): ThreadAgentControls {
     const controls = extractThreadControls(result)
-    // Every `session/new` and `session/load` result carries a FRESH registry scan
-    // (acp-capture §14.6), so this is the one place a reading is taken.
-    this.modeDiscoveryValue = readModeDiscovery(controls, Date.now()) ?? this.modeDiscoveryValue
+    // Every `session/new` AND every `session/load` result carries a FRESH registry
+    // scan — verified against 2.24.1 for #448: a profile written after the process
+    // started appears in a later `session/load` from the SAME process (extending
+    // acp-capture §14.6, which only established rescan-per-`session/new`). So this
+    // is the one place a reading is taken, and both methods may take one.
+    this.modeDiscoveryValue = readModeDiscovery(controls, observedAt) ?? this.modeDiscoveryValue
     const advertised = new Set(
       [MODE_CONFIG_ID, MODEL_CONFIG_ID, REASONING_EFFORT_CONFIG_ID].filter((id) =>
         hasConfigOption(result.configOptions, id),

--- a/apps/desktop/src/main/workspace-agent.ts
+++ b/apps/desktop/src/main/workspace-agent.ts
@@ -6,6 +6,8 @@ import {
   extractThreadControls,
   hasConfigOption,
   missingControlAxes,
+  readModeDiscovery,
+  type ModeDiscovery,
 } from './acp/agent-controls'
 import { AcpClient, type SpawnFn } from './acp/client'
 import { handleFsReadTextFile, type ReadTextFn } from './acp/fs-read'
@@ -155,6 +157,15 @@ export class WorkspaceAgent extends EventEmitter {
   private readonly sessionConfigIds = new Map<string, Set<string>>()
   /** Axes we have already warned are unadvertised — warn once per agent, not per session. */
   private readonly driftWarnedAxes = new Set<ThreadConfigAxis>()
+  /**
+   * The most recent reading of Vibe's agent-profile registry (#448): the mode ids
+   * the last `session/new` / `session/load` advertised, and when. This is the ONLY
+   * wire evidence that a Mistro Bot's profile still exists — a broken profile is
+   * dropped at scan with no error to catch (acp-capture §14.6) — so it is kept per
+   * agent rather than per session, and stays readable after the session is
+   * consumed or closed.
+   */
+  private modeDiscoveryValue: ModeDiscovery | null = null
   /** `agentInfo.version` from `initialize` (acp-capture §1) — for drift diagnostics. */
   private agentVersionValue: string | null = null
   /**
@@ -615,6 +626,16 @@ export class WorkspaceAgent extends EventEmitter {
   }
 
   /**
+   * The agent's latest agent-profile registry reading (#448) — the mode ids the
+   * last session result advertised, and when. Null until this agent has opened or
+   * loaded one session; a spawn that never got that far simply has nothing to say
+   * about a Bot's persona, which is exactly what `unknown` is for.
+   */
+  get modeDiscovery(): ModeDiscovery | null {
+    return this.modeDiscoveryValue
+  }
+
+  /**
    * Claim the unconsumed primary session for a Draft's FIRST prompt (ADR-0012 #2),
    * marking it consumed so a second concurrent Draft mints its own session instead.
    * Returns the primary `ThreadInfo` exactly once, then null (none open, or already
@@ -782,6 +803,9 @@ export class WorkspaceAgent extends EventEmitter {
    */
   private readControls(result: SessionNewResult, method: string): ThreadAgentControls {
     const controls = extractThreadControls(result)
+    // Every `session/new` and `session/load` result carries a FRESH registry scan
+    // (acp-capture §14.6), so this is the one place a reading is taken.
+    this.modeDiscoveryValue = readModeDiscovery(controls, Date.now()) ?? this.modeDiscoveryValue
     const advertised = new Set(
       [MODE_CONFIG_ID, MODEL_CONFIG_ID, REASONING_EFFORT_CONFIG_ID].filter((id) =>
         hasConfigOption(result.configOptions, id),

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -58,7 +58,10 @@ import {
   type BotsDeleteArgs,
   type BotsDeleteResult,
   type BotsListResult,
+  type BotsProfileStatusArgs,
+  type BotsRebuildProfileArgs,
   type BotsUpdateArgs,
+  type BotProfileStatus,
   type BotWriteResult,
   type SkillsListArgs,
   type SkillsListResult,
@@ -169,6 +172,10 @@ const api = {
     ipcRenderer.invoke(IPC.botsUpdate, args),
   botsDelete: (args: BotsDeleteArgs): Promise<BotsDeleteResult> =>
     ipcRenderer.invoke(IPC.botsDelete, args),
+  botsProfileStatus: (args: BotsProfileStatusArgs): Promise<BotProfileStatus> =>
+    ipcRenderer.invoke(IPC.botsProfileStatus, args),
+  botsRebuildProfile: (args: BotsRebuildProfileArgs): Promise<BotWriteResult> =>
+    ipcRenderer.invoke(IPC.botsRebuildProfile, args),
   gitSubscribeStatus: (args: GitStatusSubscriptionArgs): Promise<void> =>
     ipcRenderer.invoke(IPC.gitSubscribeStatus, args),
   gitUnsubscribeStatus: (args: GitStatusSubscriptionArgs): Promise<void> =>

--- a/apps/desktop/src/renderer/src/bots/BotProfileBanner.tsx
+++ b/apps/desktop/src/renderer/src/bots/BotProfileBanner.tsx
@@ -1,0 +1,69 @@
+import type { JSX } from 'react'
+import { CircleCheck, TriangleAlert } from 'lucide-react'
+import { Button } from '../ui/button'
+import { CodeText } from '../ui/code-text'
+import type { BotProfileHealth } from './use-bot-profile-health'
+
+/**
+ * The missing-persona banner (#448, ADR-0027 "failure is loud"): a strip at the
+ * top of a Bot's conversation, naming the profile Vibe no longer offers and
+ * offering to rebuild it from the Bot record.
+ *
+ * It exists because the alternative is the one outcome the design forbids — a
+ * Bot that keeps its name, its row and its history while quietly answering as a
+ * plain agent. It names the profile id (not just "something is wrong") because
+ * the file it is about is the user's to inspect, under `~/.vibe/agents/`.
+ *
+ * The confirmation is deliberately unexcited about what a rebuild achieves: the
+ * files are back, but a running session resolved its profile when it opened
+ * (acp-capture §14.6), so the persona returns when the conversation next binds.
+ */
+export function BotProfileBanner({
+  botName,
+  health,
+}: {
+  /** The teammate this is about — the banner speaks about a Bot, not a Thread. */
+  botName: string
+  health: BotProfileHealth
+}): JSX.Element | null {
+  if (health.missing) {
+    return (
+      <div
+        role="alert"
+        className="flex flex-none items-center gap-2.5 rounded-lg border border-destructive/35 bg-destructive/10 px-3 py-2 text-[13px] text-foreground"
+      >
+        <TriangleAlert className="size-4 flex-none text-destructive" aria-hidden />
+        <span className="min-w-0 flex-1">
+          {botName} has lost its persona: <CodeText text={health.missing.profileId} />{' '}
+          {health.missing.reason} Until it is rebuilt, {botName} answers with Vibe&rsquo;s default
+          instructions.
+          {health.rebuildError && <> Rebuild failed: {health.rebuildError}</>}
+        </span>
+        <Button
+          variant="outline"
+          size="xs"
+          className="flex-none"
+          onClick={health.rebuild}
+          disabled={health.rebuilding}
+        >
+          {health.rebuilding ? 'Rebuilding…' : 'Rebuild persona'}
+        </Button>
+      </div>
+    )
+  }
+  if (health.rebuilt) {
+    return (
+      <div
+        role="status"
+        className="flex flex-none items-center gap-2.5 rounded-lg border border-border bg-muted/40 px-3 py-2 text-[13px] text-foreground"
+      >
+        <CircleCheck className="size-4 flex-none text-muted-foreground" aria-hidden />
+        <span className="min-w-0 flex-1">
+          {botName}&rsquo;s persona was rebuilt from its Bot record. It takes effect the next time
+          this conversation resumes.
+        </span>
+      </div>
+    )
+  }
+  return null
+}

--- a/apps/desktop/src/renderer/src/bots/BotProfileBanner.tsx
+++ b/apps/desktop/src/renderer/src/bots/BotProfileBanner.tsx
@@ -14,9 +14,12 @@ import type { BotProfileHealth } from './use-bot-profile-health'
  * plain agent. It names the profile id (not just "something is wrong") because
  * the file it is about is the user's to inspect, under `~/.vibe/agents/`.
  *
- * The confirmation is deliberately unexcited about what a rebuild achieves: the
- * files are back, but a running session resolved its profile when it opened
- * (acp-capture §14.6), so the persona returns when the conversation next binds.
+ * Both halves of the copy are pinned to acp-capture §14.6, which says a session
+ * ALREADY RUNNING is unaffected by the profile files either way — it resolved the
+ * persona when it opened. So the warning does not claim the Bot is answering
+ * without its persona right now (it may well not be), and the confirmation does
+ * not claim a rebuild put one back into a session that is already under way.
+ * Both speak about the next session this conversation opens.
  */
 export function BotProfileBanner({
   botName,
@@ -34,9 +37,10 @@ export function BotProfileBanner({
       >
         <TriangleAlert className="size-4 flex-none text-destructive" aria-hidden />
         <span className="min-w-0 flex-1">
-          {botName} has lost its persona: <CodeText text={health.missing.profileId} />{' '}
-          {health.missing.reason} Until it is rebuilt, {botName} answers with Vibe&rsquo;s default
-          instructions.
+          {botName}&rsquo;s persona is no longer available:{' '}
+          <CodeText text={health.missing.profileId} /> {health.missing.reason} A conversation
+          already under way keeps the persona it started with; from its next session onwards,{' '}
+          {botName} answers with Vibe&rsquo;s default instructions.
           {health.rebuildError && <> Rebuild failed: {health.rebuildError}</>}
         </span>
         <Button
@@ -59,8 +63,9 @@ export function BotProfileBanner({
       >
         <CircleCheck className="size-4 flex-none text-muted-foreground" aria-hidden />
         <span className="min-w-0 flex-1">
-          {botName}&rsquo;s persona was rebuilt from its Bot record. It takes effect the next time
-          this conversation resumes.
+          {botName}&rsquo;s persona was rebuilt from its Bot record. It is selected again the next
+          time this conversation opens a session with Vibe — your next message, unless one is
+          already running, in which case when the app next starts.
         </span>
       </div>
     )

--- a/apps/desktop/src/renderer/src/bots/use-bot-profile-health.ts
+++ b/apps/desktop/src/renderer/src/bots/use-bot-profile-health.ts
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { BotProfileStatus } from '../../../shared/ipc'
+
+/**
+ * Is the open Bot's persona still there, and can it be repaired? (#448)
+ *
+ * ADR-0027 says failure is LOUD: a Bot whose profile file went missing must open
+ * with a banner naming the profile and offering a rebuild — never silently, and
+ * never as a plain Thread. Slice 2 answers the same question on a bind, but a
+ * bind needs a prompt; this asks on OPEN, before the user has typed a word into
+ * what still looks like their teammate.
+ *
+ * Main does the diffing (`assess-bot-profile.ts`) against the agent's advertised
+ * modes; this hook only owns the asking, the repair round-trip, and the
+ * stale-answer guard. It is inert for an ordinary Thread (`threadId` null).
+ */
+export interface BotProfileHealth {
+  /** The persona the agent no longer offers, or null when there is nothing to say. */
+  missing: { profileId: string; reason: string } | null
+  /** A repair landed this session — the banner turns into its confirmation. */
+  rebuilt: boolean
+  /** A repair is in flight (the button is disabled meanwhile). */
+  rebuilding: boolean
+  /** The repair itself failed — shown in place of the confirmation. */
+  rebuildError: string | null
+  /** Rebuild the profile files from the Bot record. */
+  rebuild: () => void
+  /** Re-ask, e.g. after a bind reported the persona could not be selected. */
+  recheck: () => void
+}
+
+export function useBotProfileHealth(
+  threadId: string | null,
+  agentId: string,
+): BotProfileHealth {
+  const [status, setStatus] = useState<BotProfileStatus>({ kind: 'unknown' })
+  const [rebuilt, setRebuilt] = useState(false)
+  const [rebuilding, setRebuilding] = useState(false)
+  const [rebuildError, setRebuildError] = useState<string | null>(null)
+  // Every answer carries the request that asked for it: switching Bots (or a
+  // rebuild's re-check) must never be overwritten by a slower earlier reply.
+  const askId = useRef(0)
+
+  const recheck = useCallback(() => {
+    if (!threadId) return
+    const asked = ++askId.current
+    void window.api
+      .botsProfileStatus({ threadId, agentId })
+      .then((next) => {
+        if (asked === askId.current) setStatus(next)
+      })
+      .catch((err: unknown) => {
+        // Log, don't swallow — but a failed CHECK is not evidence of a failed
+        // persona, so it must not raise a banner accusing one.
+        console.error('[vibe-mistro:bots] could not check the Bot persona:', err)
+      })
+  }, [threadId, agentId])
+
+  useEffect(() => {
+    setRebuilt(false)
+    setRebuildError(null)
+    setStatus({ kind: 'unknown' })
+    recheck()
+  }, [recheck])
+
+  const rebuild = useCallback(() => {
+    if (!threadId) return
+    setRebuilding(true)
+    setRebuildError(null)
+    void window.api
+      .botsRebuildProfile({ threadId })
+      .then((result) => {
+        if (result.ok) {
+          setRebuilt(true)
+          // The files are back, but a session that is already running resolved its
+          // profile when it opened and is unaffected either way (acp-capture
+          // §14.6) — so re-checking is how the accusation is withdrawn, not how
+          // the persona returns. It returns on the next bind.
+          recheck()
+        } else {
+          setRebuildError(result.problems.join(' ') || 'The persona could not be rebuilt.')
+        }
+      })
+      .catch((err: unknown) => {
+        console.error('[vibe-mistro:bots] could not rebuild the Bot persona:', err)
+        setRebuildError(err instanceof Error ? err.message : String(err))
+      })
+      .finally(() => setRebuilding(false))
+  }, [threadId, recheck])
+
+  return {
+    missing: status.kind === 'missing' ? { profileId: status.profileId, reason: status.reason } : null,
+    rebuilt,
+    rebuilding,
+    rebuildError,
+    rebuild,
+    recheck,
+  }
+}

--- a/apps/desktop/src/renderer/src/conversation/AgentControls.tsx
+++ b/apps/desktop/src/renderer/src/conversation/AgentControls.tsx
@@ -8,6 +8,7 @@ import type {
 } from '../../../shared/ipc'
 import { Menu, MenuContent, MenuItem, MenuTrigger } from '../ui/menu'
 import { cn } from '../lib/utils'
+import { modesWithoutBotProfiles } from './ordinary-modes'
 
 /**
  * The composer's agent-controls (#66): Mode / Model / Reasoning-effort pickers,
@@ -22,9 +23,12 @@ import { cn } from '../lib/utils'
  * streams (a pre-prompt draft is NOT processing, so its pickers are live: #75 lets the
  * user pre-select before a session exists, and App caches the pick to apply on the
  * first bind). The row renders nothing when the agent advertises no axes at all.
+ *
+ * One deliberate subtraction from session state: Mistro Bot personas are filtered
+ * out of the Mode list (`modesWithoutBotProfiles`, ADR-0007's recorded amendment).
  */
 export function AgentControls({
-  modes,
+  modes: sessionModes,
   models,
   reasoningEffort,
   disabled,
@@ -36,6 +40,11 @@ export function AgentControls({
   disabled: boolean
   onSetConfig: (axis: ThreadConfigAxis, value: string) => void
 }): JSX.Element | null {
+  // Mistro Bot personas are agent profiles, and Vibe publishes every profile as a
+  // selectable mode — so an ordinary Thread's approval-posture list would fill up
+  // with the user's teammates (#448). Filtered HERE, at the one component that
+  // renders a Mode picker, so no caller can route around it.
+  const modes = modesWithoutBotProfiles(sessionModes)
   if (!modes && !models && !reasoningEffort) return null
   return (
     // min-w-0 + no wrap: in a narrow composer the chips SHRINK (labels truncate, see

--- a/apps/desktop/src/renderer/src/conversation/Conversation.tsx
+++ b/apps/desktop/src/renderer/src/conversation/Conversation.tsx
@@ -18,6 +18,8 @@ import type {
   ThreadReasoningEffort,
 } from '../../../shared/ipc'
 import { BotHeader, type BotIdentity } from '../bots/BotHeader'
+import { BotProfileBanner } from '../bots/BotProfileBanner'
+import { useBotProfileHealth } from '../bots/use-bot-profile-health'
 import { FileOpenProvider } from './file-open-context'
 import { isRejectOption } from './permission-option'
 import type { FileLink } from './file-link'
@@ -182,6 +184,15 @@ export function Conversation({
   const stateRef = useRef(state)
   stateRef.current = state
 
+  // Is this Bot's persona still on the agent? (#448) Asked on OPEN — the bind-time
+  // check needs a prompt, and a Bot whose profile file went missing must say so
+  // before the user types into what still looks like their teammate. Inert
+  // for an ordinary Thread. `recheck` is mirrored into a ref so the `thread:bound`
+  // subscription below can re-ask without re-subscribing.
+  const botHealth = useBotProfileHealth(bot?.threadId ?? null, thread.agentId)
+  const recheckBotProfileRef = useRef(botHealth.recheck)
+  recheckBotProfileRef.current = botHealth.recheck
+
   // The follow-up queue for THIS Thread (#105, ADR-0009): submitting while a turn
   // streams enqueues here (the queue lives in a module store ABOVE this remount, so
   // it survives a Thread switch), and every turn-end auto-flushes one message.
@@ -318,6 +329,10 @@ export function Conversation({
       // the answers it is about to give will appear.
       if (e.botProfileError) {
         dispatch({ type: 'system-notice', message: e.botProfileError })
+        // ...and re-ask the open-path check, so the SAME failure also raises the
+        // banner with its rebuild button (#448). A notice explains; the banner
+        // repairs — a Bot that lost its persona mid-conversation deserves both.
+        recheckBotProfileRef.current()
       }
     })
   }, [thread.threadId])
@@ -576,7 +591,18 @@ export function Conversation({
     <FileOpenProvider value={openFile}>
       <div className="conv" ref={convRef}>
         {bot ? (
-          <BotHeader bot={bot} />
+          <>
+            <BotHeader bot={bot} />
+            {/* Loud failure (ADR-0027): a Bot whose persona Vibe no longer offers
+                says so at the top of its own conversation, with the repair. The
+                wrapper is gated too, so a healthy Bot adds no empty row to the
+                column's gap. */}
+            {(botHealth.missing || botHealth.rebuilt) && (
+              <div className="conv-measure">
+                <BotProfileBanner botName={bot.name} health={botHealth} />
+              </div>
+            )}
+          </>
         ) : (
           <div className="conv__head">
             <span className="dot dot--ok" aria-hidden />

--- a/apps/desktop/src/renderer/src/conversation/ordinary-modes.test.ts
+++ b/apps/desktop/src/renderer/src/conversation/ordinary-modes.test.ts
@@ -35,6 +35,10 @@ describe('modesWithoutBotProfiles', () => {
     expect(modesWithoutBotProfiles(original)).toBe(original)
   })
 
+  it('reports NO axis when every advertised mode is a Bot — never an empty menu', () => {
+    expect(modesWithoutBotProfiles(modes(BOT_A, [BOT_A, BOT_B]))).toBeNull()
+  })
+
   it('passes null through — an agent that advertises no modes still shows no picker', () => {
     expect(modesWithoutBotProfiles(null)).toBeNull()
   })

--- a/apps/desktop/src/renderer/src/conversation/ordinary-modes.test.ts
+++ b/apps/desktop/src/renderer/src/conversation/ordinary-modes.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import type { ThreadModes } from '../../../shared/ipc'
+import { modesWithoutBotProfiles } from './ordinary-modes'
+
+const BOT_A = 'mistro-bot-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+const BOT_B = 'mistro-bot-11111111-2222-3333-4444-555555555555'
+
+function modes(currentModeId: string, ids: string[]): ThreadModes {
+  return { currentModeId, availableModes: ids.map((id) => ({ id, name: id })) }
+}
+
+describe('modesWithoutBotProfiles', () => {
+  it('drops every Bot persona from the picker', () => {
+    const filtered = modesWithoutBotProfiles(modes('ask', ['ask', BOT_A, 'plan', BOT_B]))
+    expect(filtered?.availableModes.map((m) => m.id)).toEqual(['ask', 'plan'])
+  })
+
+  it('leaves the builtin modes and the current value untouched', () => {
+    const builtins = ['ask', 'plan', 'accept-edits', 'auto-approve', 'explore', 'lean']
+    const filtered = modesWithoutBotProfiles(modes('plan', [...builtins, BOT_A]))
+    expect(filtered?.availableModes.map((m) => m.id)).toEqual(builtins)
+    expect(filtered?.currentModeId).toBe('plan')
+  })
+
+  it('never touches a hand-written profile of the user’s', () => {
+    // The ownership test is the minted `mistro-bot-<uuid>` shape, so a profile a
+    // human wrote — including a near-miss — stays in their own picker.
+    const foreign = ['reviewer', 'mistro-bot-not-a-uuid', 'MISTRO-BOT-AAAAAAAA']
+    const filtered = modesWithoutBotProfiles(modes('ask', ['ask', ...foreign]))
+    expect(filtered?.availableModes.map((m) => m.id)).toEqual(['ask', ...foreign])
+  })
+
+  it('returns the SAME object when there is nothing to filter', () => {
+    const original = modes('ask', ['ask', 'plan'])
+    expect(modesWithoutBotProfiles(original)).toBe(original)
+  })
+
+  it('passes null through — an agent that advertises no modes still shows no picker', () => {
+    expect(modesWithoutBotProfiles(null)).toBeNull()
+  })
+})

--- a/apps/desktop/src/renderer/src/conversation/ordinary-modes.ts
+++ b/apps/desktop/src/renderer/src/conversation/ordinary-modes.ts
@@ -24,9 +24,14 @@ import type { ThreadModes } from '../../../shared/ipc'
 export function modesWithoutBotProfiles(modes: ThreadModes | null): ThreadModes | null {
   if (!modes) return null
   const availableModes = modes.availableModes.filter((mode) => !isMistroBotProfileId(mode.id))
-  // Same-length: return the SAME object, so a picker that memoizes on identity
-  // (the overwhelmingly common case — a user with no Bots) re-renders no more
-  // than it did before this filter existed.
+  // Nothing was filtered — the overwhelmingly common case, a user with no Bots.
+  // Hand back the SAME object rather than a copy: a cheap fast path, not a
+  // memoization guarantee (a user WITH Bots does get a fresh object per call).
   if (availableModes.length === modes.availableModes.length) return modes
+  // Everything was filtered: a picker with nothing to pick is not a control, so
+  // report the axis as unadvertised rather than rendering an empty menu. Only
+  // reachable if an agent ever advertises no builtins at all — the function is
+  // total either way.
+  if (availableModes.length === 0) return null
   return { ...modes, availableModes }
 }

--- a/apps/desktop/src/renderer/src/conversation/ordinary-modes.ts
+++ b/apps/desktop/src/renderer/src/conversation/ordinary-modes.ts
@@ -1,0 +1,32 @@
+import { isMistroBotProfileId } from '../../../shared/bot-profile-id'
+import type { ThreadModes } from '../../../shared/ipc'
+
+/**
+ * Keep Mistro Bot personas out of an ordinary Thread's Mode picker (#448,
+ * ADR-0027 / the ADR-0007 amendment).
+ *
+ * A Bot's persona is a Vibe agent profile, and every profile is published over
+ * ACP as a selectable mode — so without this every Bot a user owns would appear
+ * in every Thread's approval-posture list, beside `ask` and `plan`. Hiding them
+ * Vibe-side is impossible: `_is_primary_mode` re-derives from `build_mode_state`,
+ * so the presentation filter IS the authorization gate (#424). The filter is
+ * therefore client-side and deliberate.
+ *
+ * It is a departure from display-from-session-state, recorded in ADR-0007: the
+ * principle forbids INVENTING or STALING state, not presenting a known subset.
+ * Nothing here fabricates a mode, and the ids removed are only ever ones we
+ * minted ourselves — `mistro-bot-<uuid>` is a mechanical test, not a heuristic,
+ * so a hand-written profile of the user's is never touched.
+ *
+ * A Bot's OWN conversation never reaches this: it is handed no modes at all
+ * (`ConnectedWorkspace`), because a Bot's behaviour is its profile.
+ */
+export function modesWithoutBotProfiles(modes: ThreadModes | null): ThreadModes | null {
+  if (!modes) return null
+  const availableModes = modes.availableModes.filter((mode) => !isMistroBotProfileId(mode.id))
+  // Same-length: return the SAME object, so a picker that memoizes on identity
+  // (the overwhelmingly common case — a user with no Bots) re-renders no more
+  // than it did before this filter existed.
+  if (availableModes.length === modes.availableModes.length) return modes
+  return { ...modes, availableModes }
+}

--- a/apps/desktop/src/shared/bot-profile-id.test.ts
+++ b/apps/desktop/src/shared/bot-profile-id.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { randomUUID } from 'node:crypto'
-import { MISTRO_BOT_PROFILE_PREFIX, isMistroBotProfileId, mintBotProfileId } from './profile-id'
+import { MISTRO_BOT_PROFILE_PREFIX, isMistroBotProfileId, mintBotProfileId } from './bot-profile-id'
 
 describe('mintBotProfileId', () => {
   it('prefixes a uuid and produces an id we recognise as ours', () => {

--- a/apps/desktop/src/shared/bot-profile-id.ts
+++ b/apps/desktop/src/shared/bot-profile-id.ts
@@ -16,6 +16,12 @@
  *   is FOREIGN — a hand-written profile the user owns — and we never read,
  *   rewrite or delete it. The prefix + uuid shape is a mechanical check, not a
  *   heuristic, so there is nothing to get wrong at the boundary.
+ *
+ * It lives in `shared/` (Node- and DOM-free, like `thread-control-intent.ts`)
+ * because BOTH sides ask the ownership question: main gates every profile-file
+ * read, write and delete on it, and the renderer uses it to keep Bot profiles out
+ * of ordinary Threads' Mode pickers (#448). One regex, two consumers — a second
+ * copy in the renderer is exactly the drift this shape exists to prevent.
  */
 
 /** The reserved prefix. Everything after it is a uuid. */

--- a/apps/desktop/src/shared/ipc/bots.ts
+++ b/apps/desktop/src/shared/ipc/bots.ts
@@ -25,6 +25,19 @@ export const botsChannels = {
   botsUpdate: 'bots:update',
   /** Delete a Bot: destroy the identity + its profile files, ARCHIVE its Thread. */
   botsDelete: 'bots:delete',
+  /**
+   * Is this Bot's persona still there? (#448) Asked when the Bot is OPENED —
+   * before any prompt — because "the profile file went missing" must never be
+   * discovered by the Bot silently answering as a plain agent. See
+   * {@link BotProfileStatus}.
+   */
+  botsProfileStatus: 'bots:profile-status',
+  /**
+   * Re-write a Bot's profile files from its record — the banner's repair action.
+   * The record is the source of truth and the files are a projection (ADR-0027),
+   * so a rebuild is just that projection run again.
+   */
+  botsRebuildProfile: 'bots:rebuild-profile',
 } as const
 
 /**
@@ -116,4 +129,35 @@ export type BotWriteResult =
 /** The reply to `bots:delete`. Best-effort: `ok:false` means nothing was removed. */
 export interface BotsDeleteResult {
   ok: boolean
+}
+
+/** Args for `bots:profile-status`: which Bot, and on which Workspace agent. */
+export interface BotsProfileStatusArgs {
+  threadId: string
+  /** The Workspace agent whose advertised modes answer the question. */
+  agentId: string
+}
+
+/**
+ * Whether a Bot's persona is still selectable on its Workspace's agent (#448).
+ *
+ * Answered by DIFFING the Bot's expected `profileId` against the modes the agent
+ * last advertised, never by waiting for an error: a broken profile (hand-deleted
+ * TOML, malformed TOML, missing prompt `.md`) is indistinguishable from an absent
+ * one over the wire — Vibe drops it at registry scan with only a log line (#424,
+ * acp-capture §14.6). The absence IS the signal.
+ *
+ * `unknown` is the deliberate third answer, and the reason this is not a boolean:
+ * the app must not accuse a profile it has no fresh reading for. No agent, no
+ * session yet, or a profile WRITTEN since the last registry scan (creating a Bot
+ * on an already-warm agent) all land here, and say nothing to the user.
+ */
+export type BotProfileStatus =
+  | { kind: 'healthy' }
+  | { kind: 'unknown' }
+  | { kind: 'missing'; profileId: string; reason: string }
+
+/** Args for `bots:rebuild-profile`: the Bot whose files to re-project. */
+export interface BotsRebuildProfileArgs {
+  threadId: string
 }

--- a/docs/acp-capture.md
+++ b/docs/acp-capture.md
@@ -697,6 +697,15 @@ With a live session already switched to `zz-probe-bot`:
 picked up by the next Thread. The failure mode to design for is the opposite one: a mode id we cached
 per-Thread can vanish from `availableModes` between sessions, and re-asserting it will fail *silently*.
 
+**Addendum (captured 2026-08-21 for #448, vibe-acp 2.24.1): `session/load` re-scans too.** The
+`session/load` observation in §14.5 was taken from a *fresh process*, so it could not tell a rescan
+from a process-start cache. Probed directly, in ONE long-running process: `session/new` (no custom
+profile on disk) → prompt → write `~/.vibe/agents/<id>.toml` + the prompt `.md` → `session/load` of
+that same session ⇒ the load result **does** list the newly written profile in `availableModes` (a
+control `session/new` in the same process agreed). ⇒ **every** session result — new or load — carries
+a scan of the registry as it is at that moment, which is what lets a client treat an absent profile
+id as evidence the file is gone rather than as a stale list.
+
 ### 14.7 Safety note on the probe
 
 The probe answers every `session/request_permission` with `reject_once` and refuses

--- a/docs/adr/0007-agent-controls-vibe-owned-sticky-per-thread.md
+++ b/docs/adr/0007-agent-controls-vibe-owned-sticky-per-thread.md
@@ -62,6 +62,33 @@ reflection, re-assert after resume) is unchanged. What changed underneath it:
 - Both drifts failed **silently** (a hidden picker, a dead setter). `missingControlAxes` now logs any
   axis the agent stops advertising, so the next drift leaves a trace instead of vanishing.
 
+## Amendment (#448, ADR-0027, 2026-08-21) — Mistro Bot profiles are filtered out of the Mode picker
+
+A **Mistro Bot**'s persona is a Vibe agent profile we generate, and Vibe publishes *every*
+`AgentType.AGENT` profile as a selectable mode. Left alone, every Bot a user owns would appear in
+every ordinary Thread's Mode picker, beside `ask` and `plan` — a list of approval postures filling up
+with teammates. Hiding them Vibe-side is impossible: `_is_primary_mode` re-derives from
+`build_mode_state`, so the presentation filter **is** the authorization gate (probed, #424).
+
+So the Mode picker **omits every `mistro-bot-<uuid>` id** — client-side and deliberate
+(`src/renderer/src/conversation/ordinary-modes.ts`, applied in `AgentControls`). This is a departure
+from display-from-session-state, and it is recorded here rather than assumed: the principle forbids
+**inventing** or **staling** state, not presenting a known subset. Nothing is fabricated, nothing goes
+stale, and the ids removed are only ever ones we minted — the `mistro-bot-<uuid>` shape is a
+mechanical ownership test, so a hand-written profile of the user's is never hidden from them.
+
+Two related consequences of the same design, for the reader who arrives here from the picker:
+
+- A **Bot's own** conversation shows no Mode, Model or reasoning-effort picker at all. Its persona is
+  selected on the Mode axis, so a Mode picker would offer `plan` as a peer of the personality — and
+  picking it would silently switch the Bot off while it kept its name, row and history.
+- The re-assert-after-resume choreography above is **in-memory by design**, which is right for a
+  Thread and not enough for a Bot: a cold restart has no cache. A Bot's `profile_id` is therefore
+  durable in our store and re-asserted on every bind through the **validating** config setter
+  (`src/main/bots/select-bot-profile.ts`), never `session/set_mode`, whose silent no-op would leave a
+  nameless agent wearing a teammate's name. When the profile is absent from the session's advertised
+  modes, the app says so (banner + rebuild) instead of quietly proceeding.
+
 ## Considered alternatives
 
 - **Persist the selection per-Thread in our metadata (committed on the thread +

--- a/docs/adr/0007-agent-controls-vibe-owned-sticky-per-thread.md
+++ b/docs/adr/0007-agent-controls-vibe-owned-sticky-per-thread.md
@@ -84,10 +84,17 @@ Two related consequences of the same design, for the reader who arrives here fro
   picking it would silently switch the Bot off while it kept its name, row and history.
 - The re-assert-after-resume choreography above is **in-memory by design**, which is right for a
   Thread and not enough for a Bot: a cold restart has no cache. A Bot's `profile_id` is therefore
-  durable in our store and re-asserted on every bind through the **validating** config setter
-  (`src/main/bots/select-bot-profile.ts`), never `session/set_mode`, whose silent no-op would leave a
-  nameless agent wearing a teammate's name. When the profile is absent from the session's advertised
-  modes, the app says so (banner + rebuild) instead of quietly proceeding.
+  durable in our store and re-asserted on **every bind that produces a fresh session result** — a
+  mint, a re-bind, or a `session/load` resume (`src/main/bots/select-bot-profile.ts`). A plain reuse
+  of a session already bound this run is skipped, which is only safe because a Bot never binds to a
+  session that could not host its persona in the first place (it declines the eager primary session
+  unless that session advertises the profile). The re-assertion goes through `WorkspaceAgent.setMode`,
+  which prefers the **validating** `session/set_config_option` wherever the session advertises the
+  `mode` config option — every 2.24.x binary does, and 2.24 is our floor. The qualifier matters: the
+  same method falls back to `session/set_mode` for a session that advertises no such option, and that
+  method's silent no-op on an unknown id would leave a nameless agent wearing a teammate's name. When
+  the profile is absent from the session's advertised modes, the app says so (banner + rebuild)
+  instead of quietly proceeding.
 
 ## Considered alternatives
 

--- a/docs/adr/0027-mistro-bots-durable-thread-backed-by-agent-profile.md
+++ b/docs/adr/0027-mistro-bots-durable-thread-backed-by-agent-profile.md
@@ -85,6 +85,16 @@ glossary; the invariant still holds for every Thread a user starts by hand.
 "Remove project" path must gain the same cleanup — today it drops Threads silently and would orphan
 profile files, which would keep appearing as modes for Bots that no longer exist.
 
+**Failure is loud** (stated in PRD #444, recorded here because the code cites this ADR for it, #448).
+A Bot whose profile is missing or malformed opens with a banner naming it and offering a rebuild from
+the record — never silently, and never as a plain Thread. The outcome this forbids is specific: a Bot
+that keeps its name, its sidebar row and its history while answering as a nameless agent. Two things
+follow from it in the implementation. A Bot never binds to a session that cannot host its persona (the
+eager primary session predates a Bot created after connect), because binding to one would make exactly
+that outcome permanent for the run. And a broken profile is detected by DIFFING the expected
+`profile_id` against the session's advertised modes rather than by waiting for an error, since Vibe
+drops a bad profile at registry scan with only a log line (#424) — the absence is the whole signal.
+
 **Vibe validates nothing we write.** Unknown keys in a profile TOML are silently ignored — a typo'd
 override loads, works, and quietly lacks the setting. Since we generate these files, we validate them.
 


### PR DESCRIPTION
Closes nothing yet — this is slice 4 of #444 (see #448).

## What this is

The slice that makes a Bot survive a restart and fail loudly. Most of the durable-persona
machinery landed in slice 2; the piece that was genuinely missing is the **trigger on the open
path**, plus the banner and the picker filter.

## The trigger gap (the substance of the slice)

Slice 2's `select-bot-profile.ts` decides whether a Bot's persona can be selected — but it runs
inside `runPromptTurn` and its error ships on `thread:bound`, i.e. **only on a prompt**. The
acceptance criterion says a broken profile *opens* the Bot with a banner. So this adds the second
trigger:

- **`bots:profile-status`** (new IPC), asked when a Bot's conversation mounts.
- Main answers by **diffing the record's `profile_id` against the modes the agent last advertised**
  — never by sending something and reading the error. Vibe drops a missing/malformed profile at
  registry scan with a log line and no wire signal (#424), so absence is the only evidence there is.
- The reading itself is taken in `WorkspaceAgent.readControls` — the one place every fresh
  `session/new` / `session/load` scan lands — and **stamped with a time**, because its age is what
  makes it usable: `assessBotProfile` reports `missing` only when the scan is NEWER than the last
  write to the profile files. A scan older than the write (creating a Bot on an already-warm agent,
  or the instant after a rebuild) is `unknown` and accuses nobody.

## Acceptance criteria

- [x] **A Bot reopened after a full app restart re-asserts its profile and answers in persona.**
  Verified live against vibe-acp 2.24.1 in an **isolated `VIBE_HOME`** (the real `~/.vibe` never
  read or written), across two processes: `session/load` came back on `accept-edits` (Mode does not
  survive a resume), the resumed session still **advertised** the Bot profile, the re-assertion
  through `session/set_config_option` succeeded, and the agent answered with the persona's sentinel.
  The harness was deleted before committing.
- [x] **Re-assertion goes through the validating config setter; a rejection surfaces.**
  `WorkspaceAgent.setMode` → `session/set_config_option` (slice 2's path, unchanged). Confirmed live:
  the deleted profile is rejected `-32602 "Unsupported config option mode='mistro-bot-…'"`, never
  the `{}` silent no-op of `session/set_mode`.
- [x] **A missing or malformed profile opens the Bot with a banner naming it, offering a rebuild.**
  `BotProfileBanner` + `use-bot-profile-health`; rebuild goes through `bots:rebuild-profile` →
  `rebuildBotProfile`, which re-projects the files from the record and re-stamps `updatedAt`.
  *Caveat, stated in the UI copy:* a rebuild does **not** restore the persona on a session that is
  already running — a live session resolved its profile at `session/new` and is unaffected by the
  files either way (acp-capture §14.6). It takes effect on the next bind, and the confirmation says
  exactly that rather than implying otherwise.
- [x] **Detection is a diff against advertised modes, not an error.** `assessBotProfile`, unit-tested
  including the malformed-is-indistinguishable-from-deleted case.
- [x] **No Model, Mode or reasoning-effort picker on a Bot.** Verified — slice 2 already withdraws all
  three in `ConnectedWorkspace`; not rebuilt.
- [x] **Bot profiles are absent from every ordinary Thread's Mode picker; builtins unaffected.**
  `modesWithoutBotProfiles`, applied in `AgentControls` — the single component that renders a Mode
  picker, so ordinary Threads and Side Threads are both covered. Unit-tested against a stubbed mode
  list, including that a hand-written profile of the user's is never hidden.
- [x] **ADR-0007 gains the amendment line about the filter.**
- [x] **All four gates pass** — lint, typecheck, build, 1955 tests.

## Decisions I had to make that the ticket did not settle

- **`unknown` as a third answer.** A boolean check would accuse every Bot created on a warm agent.
  The freshness rule is the load-bearing part of the pure module and is where the tests concentrate.
- **The open-path check awaits the eager primary session** (`openPrimarySession`, idempotent and
  already time-bounded) instead of the renderer polling for a reading to appear.
- **`profile-id.ts` moved to `shared/`** so the renderer filter and main's profile-file gate share one
  regex instead of two copies.

## Notes for review

- `App.tsx` is untouched: the health check hangs off `Conversation`, which already receives the Bot
  identity and the `agentId` — so this should not conflict with #447.
- The bind-time failure now also raises the banner (a notice explains; the banner repairs).
