### PR TITLE
Mistro Bots slice 3 — create, edit, Start over, delete, and the Remove-project hole (#447)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -36,6 +36,16 @@ Project. Its behaviour — Model, Mode, reasoning effort — comes from its prof
 editing the Bot, never by a per-Thread control (ADR-0027).
 _Avoid_: bot mode (**Mode** is the approval posture), agent (that's the `vibe-acp` child process),
 assistant, persona (a Bot is the conversation, not a reusable configuration — see #379 for presets).
+Its Project is chosen once, at creation, and never changes (ADR-0027 consequences).
+
+**Start over** (a Mistro Bot action):
+Retire a Bot's **ACP session** so its next prompt binds a fresh one. It is a pressure valve for a
+conversation that has gone bad, and it destroys nothing: the Bot keeps its name, colour, description
+and instructions, both generated profile files are untouched, and the whole transcript stays
+readable — only the agent's memory of it goes. Refused mid-turn (#447).
+_Avoid_: reset the Bot / clear history / wipe (nothing is cleared and no history is lost — say what
+goes: the agent stops remembering the conversation above), new thread (a Bot is ONE Thread; starting
+over keeps it).
 
 **ACP session**:
 The protocol-level handle returned by `session/new` and addressed by `session/*` methods. Lives only

--- a/apps/desktop/src/main/bots/register-ipc.ts
+++ b/apps/desktop/src/main/bots/register-ipc.ts
@@ -7,12 +7,15 @@ import {
   type BotsDeleteArgs,
   type BotsDeleteResult,
   type BotsListResult,
+  type BotsStartOverArgs,
+  type BotsStartOverResult,
   type BotsUpdateArgs,
   type BotWriteResult,
 } from '../../shared/ipc'
 import type { BotStoreApi } from '../persistence/bot-store-api'
 import { getShellEnv } from '../shell-env'
 import { createBot, deleteBot, listBots, updateBot, type BotLifecycleDeps } from './bot-lifecycle'
+import { startOverBot, type StartOverThreads } from './start-over'
 import { mintBotProfileId } from './profile-id'
 import { vibeProfileDirs } from './profile-dirs'
 import { nodeProfileFs } from './node-profile-fs'
@@ -30,9 +33,20 @@ import { removeBotProfile, writeBotProfile, type BotProfileFs } from './write-bo
 export interface BotsIpcDeps {
   bots: BotStoreApi
   /** The Thread half: a Bot's conversation is an ordinary Thread record. */
-  threads: BotLifecycleDeps['threads']
+  threads: BotLifecycleDeps['threads'] & StartOverThreads
   /** Overridable for tests; production uses the real `node:fs` binding. */
   fs?: BotProfileFs
+  /**
+   * Whether a turn is in flight on a Thread — main's `thread-status` registry,
+   * injected because it lives in `index.ts` beside the pool. Guards "Start over".
+   */
+  isStreaming: (threadId: string) => boolean
+  /**
+   * Best-effort close of a Thread's live ACP session on the warm agent hosting it
+   * (`bestEffortCloseFor` in `index.ts`, which owns the pool). Returns undefined
+   * when there is nothing to close.
+   */
+  closeThreadSession: (threadId: string) => (() => Promise<void>) | undefined
 }
 
 /**
@@ -41,7 +55,9 @@ export interface BotsIpcDeps {
  * shell on its first use, and registration runs before the first window — a Bot
  * write is never on the launch path, so the probe should not be either.
  */
-export function createBotLifecycleDeps(deps: BotsIpcDeps): BotLifecycleDeps {
+export function createBotLifecycleDeps(
+  deps: Pick<BotsIpcDeps, 'bots' | 'threads' | 'fs'>,
+): BotLifecycleDeps {
   const fs = deps.fs ?? nodeProfileFs
   const dirs = () => vibeProfileDirs(getShellEnv(), homedir())
   return {
@@ -73,5 +89,21 @@ export function registerBotsIpc(deps: BotsIpcDeps): void {
   ipcMain.handle(
     IPC.botsDelete,
     (_event, args: BotsDeleteArgs): Promise<BotsDeleteResult> => deleteBot(lifecycle, args),
+  )
+
+  ipcMain.handle(
+    IPC.botsStartOver,
+    (_event, args: BotsStartOverArgs): Promise<BotsStartOverResult> =>
+      startOverBot(
+        {
+          bots: deps.bots,
+          threads: deps.threads,
+          isStreaming: deps.isStreaming,
+          // Resolved per call: the hosting agent (and whether there is one at all)
+          // is live state, so it can only be read when the user actually asks.
+          closeSession: deps.closeThreadSession(args.threadId),
+        },
+        args,
+      ),
   )
 }

--- a/apps/desktop/src/main/bots/start-over.test.ts
+++ b/apps/desktop/src/main/bots/start-over.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { BotRecord } from '../../shared/ipc'
+import { startOverBot, type StartOverDeps } from './start-over'
+
+/**
+ * "Start over" (#447, ADR-0027). The tests are written around what it must NOT do:
+ * a pressure valve that quietly cost a user their teammate's name, its persona
+ * files or weeks of readable history would be the worst button in the app.
+ */
+
+const BOT: BotRecord = {
+  threadId: 'thread-rex',
+  workspaceId: 'ws-1',
+  profileId: 'mistro-bot-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+  name: 'Rex',
+  colour: '#e8734a',
+  description: 'Reviews my changes',
+  instructions: 'Be blunt about correctness.',
+  createdAt: 1,
+  updatedAt: 2,
+}
+
+interface Harness {
+  deps: StartOverDeps
+  cleared: string[]
+  closed: number
+  streaming: Set<string>
+  clearFailure: boolean
+  closeFailure: boolean
+}
+
+function harness(bot: BotRecord | null = BOT): Harness {
+  const h: Harness = {
+    cleared: [],
+    closed: 0,
+    streaming: new Set(),
+    clearFailure: false,
+    closeFailure: false,
+    deps: {} as StartOverDeps,
+  }
+  h.deps = {
+    bots: { get: (threadId) => (bot && bot.threadId === threadId ? bot : null) },
+    threads: {
+      clearThreadSession: async (id) => {
+        if (h.clearFailure) throw new Error('disk full')
+        h.cleared.push(id)
+      },
+    },
+    isStreaming: (threadId) => h.streaming.has(threadId),
+    closeSession: async () => {
+      h.closed += 1
+      if (h.closeFailure) throw new Error('agent gone')
+    },
+  }
+  return h
+}
+
+let errorSpy: ReturnType<typeof vi.spyOn>
+beforeEach(() => {
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+afterEach(() => {
+  errorSpy.mockRestore()
+})
+
+describe('startOverBot', () => {
+  it('retires the session cursor so the next prompt mints a fresh session', async () => {
+    const h = harness()
+    const result = await startOverBot(h.deps, { threadId: BOT.threadId })
+
+    expect(result).toEqual({ ok: true })
+    expect(h.cleared).toEqual([BOT.threadId])
+  })
+
+  it('closes the retired session on the warm agent that hosts it', async () => {
+    const h = harness()
+    await startOverBot(h.deps, { threadId: BOT.threadId })
+
+    expect(h.closed).toBe(1)
+  })
+
+  it('succeeds with no session to close (a cold Bot)', async () => {
+    const h = harness()
+    delete h.deps.closeSession
+    await expect(startOverBot(h.deps, { threadId: BOT.threadId })).resolves.toEqual({ ok: true })
+    expect(h.cleared).toEqual([BOT.threadId])
+  })
+
+  it('still succeeds when closing the retired session fails — the cursor is already gone', async () => {
+    const h = harness()
+    h.closeFailure = true
+
+    await expect(startOverBot(h.deps, { threadId: BOT.threadId })).resolves.toEqual({ ok: true })
+    expect(errorSpy).toHaveBeenCalled() // logged, never swallowed
+  })
+
+  it('refuses a Thread that is not a Bot', async () => {
+    const h = harness(null)
+    const result = await startOverBot(h.deps, { threadId: 'some-ordinary-thread' })
+
+    expect(result).toEqual({ ok: false, reason: 'notFound' })
+    expect(h.cleared).toEqual([])
+  })
+
+  it('refuses mid-turn — retiring a session under a running turn would strand it', async () => {
+    const h = harness()
+    h.streaming.add(BOT.threadId)
+
+    const result = await startOverBot(h.deps, { threadId: BOT.threadId })
+
+    expect(result).toEqual({ ok: false, reason: 'streaming' })
+    expect(h.cleared).toEqual([])
+    expect(h.closed).toBe(0)
+  })
+
+  it('reports a failed clear instead of closing a session the Thread would still resume', async () => {
+    const h = harness()
+    h.clearFailure = true
+
+    const result = await startOverBot(h.deps, { threadId: BOT.threadId })
+
+    expect(result).toEqual({ ok: false, reason: 'io' })
+    expect(h.closed).toBe(0)
+    expect(errorSpy).toHaveBeenCalled()
+  })
+
+  it('never touches the record or the profile files — the Bot keeps its identity', async () => {
+    // The deps this module is given carry NO profile writer and NO bot mutator, so
+    // "does not touch them" is enforced by the type, not by a spy. This test pins
+    // that the shape stays that way: `StartOverDeps` may only read the Bot.
+    const h = harness()
+    await startOverBot(h.deps, { threadId: BOT.threadId })
+
+    expect(Object.keys(h.deps).sort()).toEqual(['bots', 'closeSession', 'isStreaming', 'threads'])
+    expect(Object.keys(h.deps.bots)).toEqual(['get'])
+  })
+})

--- a/apps/desktop/src/main/bots/start-over.ts
+++ b/apps/desktop/src/main/bots/start-over.ts
@@ -1,0 +1,79 @@
+import type { BotsStartOverArgs, BotsStartOverResult } from '../../shared/ipc'
+import type { BotStoreApi } from '../persistence/bot-store-api'
+
+/**
+ * "Start over" on a **Mistro Bot** (#447, ADR-0027) — the pressure valve for a
+ * conversation that has gone bad.
+ *
+ * What it does is deliberately narrow: it retires the Bot's ACP session so the
+ * NEXT prompt mints a fresh one. What it must NOT touch is the interesting half,
+ * and this module exists so that list is stated once and pinned by tests:
+ *
+ * - **the record** — the Bot keeps its name, colour, description and instructions;
+ * - **the profile files** — the TOML and the prompt `.md` are never rewritten or
+ *   removed, so the persona the next session selects is the same persona;
+ * - **the transcript** — every earlier turn stays readable in our own log. The
+ *   agent will not remember it, the user still can, and the copy on the button
+ *   says exactly that.
+ *
+ * It is therefore NOT a delete: nothing that took work to write is destroyed. The
+ * only casualty is the agent-side context, which is what the user asked to lose.
+ *
+ * Pure over injected seams (store + agent), so the whole decision is testable with
+ * no SQLite, no pool and no home directory.
+ */
+
+export interface StartOverThreads {
+  /** Forget the Thread's session cursor. See `MetadataStoreApi.clearThreadSession`. */
+  clearThreadSession(id: string): Promise<void>
+}
+
+export interface StartOverDeps {
+  bots: Pick<BotStoreApi, 'get'>
+  threads: StartOverThreads
+  /**
+   * Whether a turn is in flight on this Thread (main's `thread-status` registry).
+   * Retiring the session under a running turn would strand it mid-stream, so this
+   * is the same authoritative guard `deleteThread` applies — the renderer disables
+   * the button too, but the click-race is real and main owns the truth.
+   */
+  isStreaming(threadId: string): boolean
+  /**
+   * Best-effort close of the retired ACP session on whichever warm agent hosts it.
+   * Optional: a cold Bot (no warm agent, or no session yet) has nothing to close.
+   * A failure here never fails the Start over — the cursor is already gone, and a
+   * lingering idle session costs nothing.
+   */
+  closeSession?: () => Promise<void>
+}
+
+export async function startOverBot(
+  deps: StartOverDeps,
+  args: BotsStartOverArgs,
+): Promise<BotsStartOverResult> {
+  const bot = deps.bots.get(args.threadId)
+  // Only a Bot has a Start over: an ordinary Thread's session cursor is not ours
+  // to retire from here, and a wrong id must never silently clear one.
+  if (!bot) return { ok: false, reason: 'notFound' }
+  if (deps.isStreaming(args.threadId)) return { ok: false, reason: 'streaming' }
+
+  // The cursor FIRST: it is the step that decides the outcome. If it fails, the
+  // Bot is exactly as it was and we say so, rather than closing a session the
+  // Thread would then try to resume.
+  try {
+    await deps.threads.clearThreadSession(args.threadId)
+  } catch (err) {
+    console.error(`[vibe-mistro:bots] could not start over ${args.threadId}:`, err)
+    return { ok: false, reason: 'io' }
+  }
+
+  if (deps.closeSession) {
+    try {
+      await deps.closeSession()
+    } catch (err) {
+      // Log, don't swallow — but never turn a completed Start over into a failure.
+      console.error(`[vibe-mistro:bots] could not close the retired session:`, err)
+    }
+  }
+  return { ok: true }
+}

--- a/apps/desktop/src/main/bots/validate-bot-profile.test.ts
+++ b/apps/desktop/src/main/bots/validate-bot-profile.test.ts
@@ -5,6 +5,8 @@ import {
   BOT_DESCRIPTION_MAX_LENGTH,
   BOT_INSTRUCTIONS_MAX_LENGTH,
   BOT_NAME_MAX_LENGTH,
+} from '../../shared/bot-limits'
+import {
   collectProblems,
   describeProblems,
   validateBotColour,

--- a/apps/desktop/src/main/bots/validate-bot-profile.ts
+++ b/apps/desktop/src/main/bots/validate-bot-profile.ts
@@ -1,3 +1,9 @@
+import {
+  BOT_COLOUR_MAX_LENGTH,
+  BOT_DESCRIPTION_MAX_LENGTH,
+  BOT_INSTRUCTIONS_MAX_LENGTH,
+  BOT_NAME_MAX_LENGTH,
+} from '../../shared/bot-limits'
 import type { BotProfileFiles, BotProfileSource } from './bot-profile'
 import { isMistroBotProfileId } from './profile-id'
 
@@ -53,14 +59,17 @@ const PROFILE_OVERRIDE_KEYS = new Set(['system_prompt_id'])
 /** `AgentSafety` (vibe/agents.py). Anything else raises on load and drops the profile. */
 const PROFILE_SAFETY_VALUES = new Set(['safe', 'neutral', 'destructive', 'yolo'])
 
-/** Long enough for any real teammate name; short enough to stay one sidebar line. */
-export const BOT_NAME_MAX_LENGTH = 60
-/** The mode `description` is one line in a picker, not prose. */
-export const BOT_DESCRIPTION_MAX_LENGTH = 200
-/** The persona proper. Generous — it is the whole personality — but not unbounded. */
-export const BOT_INSTRUCTIONS_MAX_LENGTH = 100_000
-/** A hex colour or a short token name; nothing legitimate needs more. */
-export const BOT_COLOUR_MAX_LENGTH = 32
+/**
+ * The field bounds moved to `shared/bot-limits` in #447 so the renderer's Bot form
+ * enforces the SAME numbers this validator does; re-exported here because this is
+ * still where they are ENFORCED, and every existing reader imports them from here.
+ */
+export {
+  BOT_COLOUR_MAX_LENGTH,
+  BOT_DESCRIPTION_MAX_LENGTH,
+  BOT_INSTRUCTIONS_MAX_LENGTH,
+  BOT_NAME_MAX_LENGTH,
+}
 
 /** `#abc` … `#aabbccdd`. */
 const BOT_COLOUR_HEX = /^#[0-9a-fA-F]{3,8}$/

--- a/apps/desktop/src/main/bots/validate-bot-profile.ts
+++ b/apps/desktop/src/main/bots/validate-bot-profile.ts
@@ -3,6 +3,7 @@ import {
   BOT_DESCRIPTION_MAX_LENGTH,
   BOT_INSTRUCTIONS_MAX_LENGTH,
   BOT_NAME_MAX_LENGTH,
+  hasBotControlCharacter,
 } from '../../shared/bot-limits'
 import type { BotProfileFiles, BotProfileSource } from './bot-profile'
 import { isMistroBotProfileId } from './profile-id'
@@ -59,17 +60,9 @@ const PROFILE_OVERRIDE_KEYS = new Set(['system_prompt_id'])
 /** `AgentSafety` (vibe/agents.py). Anything else raises on load and drops the profile. */
 const PROFILE_SAFETY_VALUES = new Set(['safe', 'neutral', 'destructive', 'yolo'])
 
-/**
- * The field bounds moved to `shared/bot-limits` in #447 so the renderer's Bot form
- * enforces the SAME numbers this validator does; re-exported here because this is
- * still where they are ENFORCED, and every existing reader imports them from here.
- */
-export {
-  BOT_COLOUR_MAX_LENGTH,
-  BOT_DESCRIPTION_MAX_LENGTH,
-  BOT_INSTRUCTIONS_MAX_LENGTH,
-  BOT_NAME_MAX_LENGTH,
-}
+// The bounds and the control-character rule live in `shared/bot-limits` (#447) so
+// the renderer's Bot form applies exactly what this validator enforces. Read them
+// from there — deliberately NOT re-exported here, so there is one import path.
 
 /** `#abc` … `#aabbccdd`. */
 const BOT_COLOUR_HEX = /^#[0-9a-fA-F]{3,8}$/
@@ -139,7 +132,7 @@ export function validateBotProfileSource(source: BotProfileSource): BotProfileVa
       field: 'name',
       message: `A name can be at most ${BOT_NAME_MAX_LENGTH} characters.`,
     })
-  } else if (hasControlCharacter(name)) {
+  } else if (hasBotControlCharacter(name)) {
     problems.push({ field: 'name', message: 'A name cannot contain line breaks or control characters.' })
   }
 
@@ -149,7 +142,7 @@ export function validateBotProfileSource(source: BotProfileSource): BotProfileVa
       field: 'description',
       message: `A description can be at most ${BOT_DESCRIPTION_MAX_LENGTH} characters.`,
     })
-  } else if (hasControlCharacter(description)) {
+  } else if (hasBotControlCharacter(description)) {
     // It becomes the mode's one-line `description` over ACP; a newline there
     // would break the line the picker renders.
     problems.push({
@@ -292,11 +285,3 @@ function unquote(value: string): string {
   return inner.replace(/\\(["\\])/g, '$1')
 }
 
-/** C0 controls (line breaks included) and DEL. */
-function hasControlCharacter(value: string): boolean {
-  for (const char of value) {
-    const code = char.codePointAt(0) ?? 0
-    if (code < 0x20 || code === 0x7f) return true
-  }
-  return false
-}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -944,7 +944,15 @@ function registerIpc(deps: MainDeps): void {
   })
   registerFilesIpc({ pool, cache: filesListCache })
   registerSkillsIpc()
-  registerBotsIpc({ bots: deps.bots, threads: deps.store })
+  registerBotsIpc({
+    bots: deps.bots,
+    threads: deps.store,
+    // "Start over" (#447) retires a live session, so it needs the same two live
+    // seams the delete path uses: the authoritative streaming guard and the warm
+    // agent that hosts the session being left behind.
+    isStreaming: (threadId) => threadStatus.statusFor(threadId).streaming,
+    closeThreadSession: (threadId) => bestEffortCloseFor(deps, threadId),
+  })
   // The same profile-file seam the Bot CRUD uses, reused by the Thread- and
   // Workspace-removal cleanup below so both paths refuse a foreign profile id
   // through exactly one gate (#445).

--- a/apps/desktop/src/main/persistence/metadata-store-api.ts
+++ b/apps/desktop/src/main/persistence/metadata-store-api.ts
@@ -26,6 +26,13 @@ export interface MetadataStoreApi {
   touchThread(id: string): Promise<void>
   setThreadFlags(id: string, flags: { pinned?: boolean; archived?: boolean }): Promise<void>
   setThreadTitle(id: string, title: string | null): Promise<boolean>
+  /**
+   * Forget a Thread's ACP session cursor, so its next prompt binds a FRESH session
+   * instead of resuming (#447, "Start over"). `upsertThread` cannot express this —
+   * it coalesces `input.sessionId ?? existing.session_id`, so a null there means
+   * "keep", never "clear". The Thread, its transcript and its flags are untouched.
+   */
+  clearThreadSession(id: string): Promise<void>
   deleteThread(id: string): Promise<void>
   removeWorkspace(id: string): Promise<string[]>
   findThreadIdBySessionId(sessionId: string | null | undefined): string | null

--- a/apps/desktop/src/main/persistence/sqlite-bot-store.test.ts
+++ b/apps/desktop/src/main/persistence/sqlite-bot-store.test.ts
@@ -220,6 +220,42 @@ describe('SqliteBotStore cascades', () => {
   })
 })
 
+describe('deleting a Bot keeps its conversation (#447, ADR-0027)', () => {
+  it('drops the Bot row and ARCHIVES its Thread rather than deleting it', async () => {
+    // The real stores, not the lifecycle's fakes: the guarantee that matters is
+    // that weeks of irreplaceable history survive the loss of a teammate, and that
+    // is a property of the ROWS. `deleteBot` performs exactly these two writes.
+    const f = openFixture()
+    const ids = await seedThread(f)
+    insertBot(f, ids)
+
+    expect(f.bots.delete(ids.threadId)).toBe(true)
+    await f.meta.setThreadFlags(ids.threadId, { archived: true })
+
+    expect(f.bots.get(ids.threadId)).toBeNull()
+    const thread = f.meta.snapshot().threads.find((t) => t.id === ids.threadId)
+    expect(thread).toBeDefined()
+    expect(thread?.archived).toBe(true)
+  })
+})
+
+describe('"Start over" retires only the session cursor (#447)', () => {
+  it('clears session_id and leaves the Thread, its title and its Bot row intact', async () => {
+    const f = openFixture()
+    const ws = await f.meta.upsertWorkspace({ dir: '/proj/start-over' })
+    const thread = await f.meta.upsertThread({ workspaceId: ws.id, sessionId: 'sess-old' })
+    await f.meta.setThreadTitle(thread.id, 'Weeks of history')
+    insertBot(f, { workspaceId: ws.id, threadId: thread.id })
+
+    await f.meta.clearThreadSession(thread.id)
+
+    const after = f.meta.snapshot().threads.find((t) => t.id === thread.id)
+    expect(after?.sessionId).toBeNull()
+    expect(after?.title).toBe('Weeks of history')
+    expect(f.bots.get(thread.id)?.name).toBe('Rex')
+  })
+})
+
 describe('SqliteBotStore on a LOCKED database', () => {
   function lockedFixture(): Fixture {
     // A db written by a NEWER build: bump user_version past our latest, reopen.

--- a/apps/desktop/src/main/persistence/sqlite-metadata-store.ts
+++ b/apps/desktop/src/main/persistence/sqlite-metadata-store.ts
@@ -177,6 +177,14 @@ export class SqliteMetadataStore implements MetadataStoreApi {
     return result.changes > 0
   }
 
+  async clearThreadSession(id: string): Promise<void> {
+    // "Start over" (#447): the row survives with its title, flags and timestamps —
+    // only the session cursor goes, so the next prompt takes `ensureBoundSession`'s
+    // DRAFT branch (one `session/new`) instead of resuming the retired session.
+    if (this.stateDb.locked) return
+    this.db.prepare('UPDATE threads SET session_id = NULL WHERE id = ?').run(id)
+  }
+
   async deleteThread(id: string): Promise<void> {
     if (this.stateDb.locked) return
     this.db.prepare('DELETE FROM threads WHERE id = ?').run(id)

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -58,6 +58,8 @@ import {
   type BotsDeleteArgs,
   type BotsDeleteResult,
   type BotsListResult,
+  type BotsStartOverArgs,
+  type BotsStartOverResult,
   type BotsUpdateArgs,
   type BotWriteResult,
   type SkillsListArgs,
@@ -169,6 +171,8 @@ const api = {
     ipcRenderer.invoke(IPC.botsUpdate, args),
   botsDelete: (args: BotsDeleteArgs): Promise<BotsDeleteResult> =>
     ipcRenderer.invoke(IPC.botsDelete, args),
+  botsStartOver: (args: BotsStartOverArgs): Promise<BotsStartOverResult> =>
+    ipcRenderer.invoke(IPC.botsStartOver, args),
   gitSubscribeStatus: (args: GitStatusSubscriptionArgs): Promise<void> =>
     ipcRenderer.invoke(IPC.gitSubscribeStatus, args),
   gitUnsubscribeStatus: (args: GitStatusSubscriptionArgs): Promise<void> =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -2,9 +2,6 @@ import { useEffect, useReducer, useRef, useState, type JSX, type ReactNode } fro
 import type {
   AuthMethod,
   BotRecord,
-  BotsCreateArgs,
-  BotsUpdateArgs,
-  BotWriteResult,
   ListMetadataResult,
   StartThreadResult,
   ThreadAgentControls,
@@ -95,11 +92,8 @@ import { useBots } from './bots/use-bots'
 import type { BotHeaderActions, BotIdentity } from './bots/BotHeader'
 import { BotFormView } from './bots/BotFormView'
 import type { BotFormTarget } from './bots/bot-form'
-import {
-  bumpConversationEpoch,
-  conversationViewKey,
-  initialConversationEpochs,
-} from './bots/conversation-reset'
+import { useBotLifecycle } from './bots/use-bot-lifecycle'
+import { conversationViewKey, initialConversationEpochs } from './bots/conversation-reset'
 import { EmptyState } from './shell/EmptyState'
 import { ColdOutlet, TransientOutlet } from './shell/Outlet'
 import { SettingsView } from './settings/SettingsView'
@@ -221,14 +215,17 @@ export function App(): JSX.Element {
   // When each Bot was last OPENED — renderer-only UI state (localStorage), the one
   // input the unread dot needs that nothing else in the app tracks.
   const [botsSeen, setBotsSeen] = useState(() => getBotsSeen(window.localStorage))
-  // WHICH Bot the outlet's form is for (#447) — create, or edit this one. The VIEW
-  // it renders in is nav state (`nav.view === 'bot-form'`); this is the payload,
-  // like Settings' account. Null until the form has been opened once.
-  const [botFormTarget, setBotFormTarget] = useState<BotFormTarget | null>(null)
   // How many times each Thread's live view has been reset by a "Start over" — the
   // key that remounts it, so it stops holding the retired session. See
   // `bots/conversation-reset.ts`.
   const [conversationEpochs, setConversationEpochs] = useState(initialConversationEpochs)
+  // The last refused Bot action, shown on that Bot's header until dismissed (#447
+  // review, D2): the confirm dialog closes on click, so this is the only place the
+  // user can learn that nothing happened. Keyed by Thread so it cannot leak onto a
+  // different Bot's header.
+  const [botActionError, setBotActionError] = useState<{ threadId: string; message: string } | null>(
+    null,
+  )
   // Restoration reconciliation must happen exactly once. Re-running it for live
   // state changes can race a just-bound Side Thread's metadata refresh or erase an
   // in-memory Draft (which intentionally has no metadata yet).
@@ -519,123 +516,21 @@ export function App(): JSX.Element {
     else void openProject()
   }
 
-  /**
-   * Open the Bot form in the outlet (#447): create (from the sidebar section's ＋ or
-   * its empty-state CTA) or edit (from a Bot's own header). The TARGET is App state
-   * and the VIEW is nav state — nav answers "what am I looking at", not "with what".
-   * Every ordinary navigation resets the view to `conversation`, so the form needs
-   * no closing of its own when the user clicks away.
-   */
-  function openBotForm(target: BotFormTarget): void {
-    setBotFormTarget(target)
-    navDispatch({ type: 'open-bot-form' })
-  }
-
-  /**
-   * Create a Bot. Main is the validator and the file writer, so this is a thin
-   * pass-through that refreshes the list on success — the form shows `problems`
-   * when main refuses, and stays open so nothing typed is lost.
-   *
-   * On success we land in the new Bot's conversation: it exists to be talked to,
-   * and leaving the user on an empty form after making one would be a dead end.
-   */
-  async function createBot(args: BotsCreateArgs): Promise<BotWriteResult> {
-    const result = await window.api.botsCreate(args)
-    if (!result.ok) return result
-    refreshBots()
-    // A Bot's Thread is durable from creation (CONTEXT.md's carve-out), so the cold
-    // list has a new row to pick up.
-    await refreshRecents()
-    openBotConversation(result.bot)
-    return result
-  }
-
-  /**
-   * Save an edit. A rename rewrites `display_name` and never the profile id, so the
-   * live session keeps the mode it has selected and the Bot keeps working across it
-   * (ADR-0027). New instructions ride the NEXT prompt's profile selection — nothing
-   * that has already been said is touched, which is what the form's helper says.
-   */
-  async function saveBot(args: BotsUpdateArgs): Promise<BotWriteResult> {
-    const result = await window.api.botsUpdate(args)
-    if (!result.ok) return result
-    refreshBots()
-    // The Bot mark on the Thread rows carries its NAME, so a rename has to re-read
-    // the cold list too or Search would still show the old one. The form closes
-    // itself on a successful write — App only navigates when it has somewhere to go.
-    await refreshRecents()
-    return result
-  }
-
-  /**
-   * Land on a just-created Bot's conversation, ready to talk to.
-   *
-   * The awkward half is the never-connected Project: `hostSelectedThread` resolves
-   * a cold Thread through `recents`, and the row for a Bot created seconds ago is
-   * not in THIS closure's `recents` (the refresh above updated state, not the value
-   * captured here). So the cold path is handed a meta built from the record itself
-   * — the Thread is durable from creation (CONTEXT.md's carve-out), so main can
-   * genuinely continue it.
-   */
-  function openBotConversation(bot: BotRecord): void {
-    if (connections[bot.workspaceId]?.status === undefined) {
-      void continueColdThread({
-        id: bot.threadId,
-        workspaceId: bot.workspaceId,
-        sessionId: null,
-        title: null,
-        createdAt: bot.createdAt,
-        lastActiveAt: bot.updatedAt,
-      })
-      return
-    }
-    selectThreadInWorkspace(bot.workspaceId, bot.threadId)
-  }
-
-  /**
-   * Delete a Bot: the identity goes, the conversation stays. Main drops the record
-   * and both profile files and ARCHIVES the Thread, so the row leaves the Bots
-   * section and reappears in its project's Archived section — nothing irreplaceable
-   * is destroyed. We land the user back on the (now ordinary) conversation.
-   */
-  async function deleteBot(bot: BotRecord): Promise<void> {
-    const result = await window.api.botsDelete({ threadId: bot.threadId })
-    if (!result.ok) {
-      console.error(`[vibe-mistro:bots] could not delete ${bot.threadId}`)
-      return
-    }
-    refreshBots()
-    await refreshRecents()
-    selectThreadInWorkspace(bot.workspaceId, bot.threadId)
-  }
-
-  /**
-   * "Start over" on a Bot (#447). Main retires the session cursor; the renderer has
-   * to stop using the session it is holding, which takes three steps that must land
-   * TOGETHER (they do — they are one post-await batch):
-   *
-   *  1. re-read the metadata, so the Thread's `sessionId` is the cleared one;
-   *  2. drop and re-host the Thread in the live set, clearing `bound` (which
-   *     otherwise wins over the record's cursor — `seedSessionId`);
-   *  3. bump the view epoch, which remounts `Conversation` so it re-seeds from the
-   *     now-null cursor instead of the session it bound at mount.
-   *
-   * The transcript is untouched throughout, and the remounted view replays it — the
-   * old conversation is still there to read, exactly as the confirm promised.
-   */
-  async function startOverBot(bot: BotIdentity, workspaceId: string): Promise<void> {
-    const result = await window.api.botsStartOver({ threadId: bot.threadId })
-    if (!result.ok) {
-      // Log, don't swallow. `streaming` is the only reason the user can act on, and
-      // the button is already disabled for it — this catches the click-race.
-      console.error(`[vibe-mistro:bots] start over refused (${bot.threadId}): ${result.reason}`)
-      return
-    }
-    await refreshRecents()
-    wtDispatch({ type: 'remove', workspaceId, threadId: bot.threadId })
-    wtDispatch({ type: 'open', workspaceId, threadId: bot.threadId })
-    setConversationEpochs((prev) => bumpConversationEpoch(prev, bot.threadId))
-  }
+  // The Mistro Bot lifecycle (#447): create / save / delete / Start over, behind
+  // the same kind of seam as `useWorkspaceActions` — each one reconciles several
+  // stores in a specific order, and Start over's order is load-bearing enough to
+  // be worth a test (`bots/use-bot-lifecycle.test.ts`).
+  const botLifecycle = useBotLifecycle({
+    connections,
+    navDispatch,
+    wtDispatch,
+    setConversationEpochs,
+    refreshBots,
+    refreshRecents,
+    selectThreadInWorkspace,
+    continueColdThread,
+    setActionError: setBotActionError,
+  })
 
   useEffect(() => {
     void runDetect()
@@ -956,11 +851,14 @@ export function App(): JSX.Element {
   function botActionsFor(bot: BotIdentity | null, workspaceId: string): BotHeaderActions | null {
     if (!bot) return null
     return {
-      onEdit: () => openBotForm({ mode: 'edit', threadId: bot.threadId }),
-      onStartOver: () => void startOverBot(bot, workspaceId),
+      onEdit: () => botLifecycle.openForm({ mode: 'edit', threadId: bot.threadId }),
+      onStartOver: () => void botLifecycle.startOver(bot, workspaceId),
       // Main refuses a mid-turn Start over (it would strand the running turn); the
       // button says so before the click rather than after it.
       busy: statuses[bot.threadId]?.streaming === true,
+      // Only THIS Bot's refusal, so a message can never appear on the wrong header.
+      error: botActionError?.threadId === bot.threadId ? botActionError.message : null,
+      onDismissError: () => setBotActionError(null),
     }
   }
 
@@ -1139,7 +1037,14 @@ export function App(): JSX.Element {
   // The Bot create/edit form (#447): a third routed outlet view under the SAME
   // keep-mounted contract — a Bot's conversation (or any other Workspace's turn)
   // keeps streaming underneath while its form is on screen, and Cancel returns to
-  // exactly what was there. Not a Bots page: no list, nothing to browse.
+  // exactly what was there. Not a Bots browsing view: no list, nothing to browse.
+  //
+  // An EDIT whose Bot no longer exists is not a form at all. A history entry can
+  // outlive its Bot (Edit → Delete → Back), and rendering it would show an empty
+  // "New Bot" offering to create one — a back arrow that proposes replacing the
+  // teammate you just deleted (#447 review, D1). Falling through leaves the
+  // conversation on screen, which is where Delete already landed the user.
+  const botFormTarget = resolveBotFormTarget(nav.botForm ?? null, bots)
   const inBotForm = nav.view === 'bot-form' && botFormTarget !== null
   const overlayView = inSettings || inSkills || inBotForm
   // Persistent missing-CLI banner (visibility is the pure `installBannerMessage`):
@@ -1202,15 +1107,20 @@ export function App(): JSX.Element {
       ) : inBotForm && botFormTarget ? (
         <div className="p-6">
           <BotFormView
-            // Keyed by the target so switching from create to edit (or between two
-            // Bots) starts a fresh form rather than re-seeding a mounted one.
-            key={botFormTarget.mode === 'edit' ? `edit:${botFormTarget.threadId}` : 'create'}
+            // Keyed by the WHOLE target so switching from create to edit, between
+            // two Bots, or between two Projects starts a fresh form rather than
+            // leaving a mounted one seeded from the target it opened with.
+            key={
+              botFormTarget.mode === 'edit'
+                ? `edit:${botFormTarget.threadId}`
+                : `create:${botFormTarget.workspaceId ?? ''}`
+            }
             target={botFormTarget}
             bots={bots}
             workspaces={recents}
-            onCreate={createBot}
-            onSave={saveBot}
-            onDelete={deleteBot}
+            onCreate={botLifecycle.createBot}
+            onSave={botLifecycle.saveBot}
+            onDelete={botLifecycle.deleteBot}
             onClose={() => navDispatch({ type: 'close-bot-form' })}
           />
         </div>
@@ -1397,7 +1307,9 @@ export function App(): JSX.Element {
         onSelectBot={selectBot}
         // The section's ＋ (and its empty-state CTA) — the create affordance that
         // works in EVERY state, including with a Bot conversation open (#447).
-        onCreateBot={() => openBotForm({ mode: 'create', workspaceId: nav.selectedWorkspaceId })}
+        onCreateBot={() =>
+          botLifecycle.openForm({ mode: 'create', workspaceId: nav.selectedWorkspaceId })
+        }
         actions={{
           selectThread: selectThreadInWorkspace,
           newThreadInWorkspace,
@@ -1454,6 +1366,23 @@ function liveMetasFor(
   // and an unmarked Bot is one `partitionBots` cannot drop from the Thread list
   // (#447 — see `markBotMeta`). A cold meta is returned untouched.
   return metas.map((meta) => markBotMeta(meta, bots))
+}
+
+/**
+ * The Bot form target to actually RENDER, or null (#447 review, D1).
+ *
+ * A create target always resolves — the form picks its Project. An edit target has
+ * to name a Bot that still exists: nav history can carry one whose record has since
+ * been deleted, and a form that silently degrades from "Edit Rex" to "New Bot" is
+ * the back arrow offering to replace the teammate you just removed.
+ */
+function resolveBotFormTarget(
+  target: BotFormTarget | null,
+  bots: readonly BotRecord[],
+): BotFormTarget | null {
+  if (!target) return null
+  if (target.mode === 'create') return target
+  return bots.some((bot) => bot.threadId === target.threadId) ? target : null
 }
 
 /** Synthesize the connection's auto-opened Thread meta (when the list lags). */

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useReducer, useRef, useState, type JSX, type ReactNode } from 'react'
 import type {
   AuthMethod,
+  BotRecord,
+  BotsCreateArgs,
+  BotsUpdateArgs,
+  BotWriteResult,
   ListMetadataResult,
   StartThreadResult,
   ThreadAgentControls,
@@ -85,10 +89,17 @@ import {
   type SideThreadLifecycle,
 } from './side-panel/side-panel-store'
 import { deriveUnifiedThreads, workspaceFlags, type UnifiedThreadRow } from './shell/unified-threads'
-import { botBeingRead, deriveBotRows, type BotSidebarRow } from './bots/bot-rows'
+import { botBeingRead, deriveBotRows, markBotMeta, type BotSidebarRow } from './bots/bot-rows'
 import { getBotsSeen, markBotSeen } from './bots/bot-seen-store'
 import { useBots } from './bots/use-bots'
-import type { BotIdentity } from './bots/BotHeader'
+import type { BotHeaderActions, BotIdentity } from './bots/BotHeader'
+import { BotFormView } from './bots/BotFormView'
+import type { BotFormTarget } from './bots/bot-form'
+import {
+  bumpConversationEpoch,
+  conversationViewKey,
+  initialConversationEpochs,
+} from './bots/conversation-reset'
 import { EmptyState } from './shell/EmptyState'
 import { ColdOutlet, TransientOutlet } from './shell/Outlet'
 import { SettingsView } from './settings/SettingsView'
@@ -206,10 +217,18 @@ export function App(): JSX.Element {
   // the Threads in `recents`, not from these records — a record moves on an edit,
   // a conversation moves on a turn, and the sidebar answers "who did I speak to
   // most recently" (PRD story 5).
-  const { bots } = useBots()
+  const { bots, refreshBots } = useBots()
   // When each Bot was last OPENED — renderer-only UI state (localStorage), the one
   // input the unread dot needs that nothing else in the app tracks.
   const [botsSeen, setBotsSeen] = useState(() => getBotsSeen(window.localStorage))
+  // WHICH Bot the outlet's form is for (#447) — create, or edit this one. The VIEW
+  // it renders in is nav state (`nav.view === 'bot-form'`); this is the payload,
+  // like Settings' account. Null until the form has been opened once.
+  const [botFormTarget, setBotFormTarget] = useState<BotFormTarget | null>(null)
+  // How many times each Thread's live view has been reset by a "Start over" — the
+  // key that remounts it, so it stops holding the retired session. See
+  // `bots/conversation-reset.ts`.
+  const [conversationEpochs, setConversationEpochs] = useState(initialConversationEpochs)
   // Restoration reconciliation must happen exactly once. Re-running it for live
   // state changes can race a just-bound Side Thread's metadata refresh or erase an
   // in-memory Draft (which intentionally has no metadata yet).
@@ -500,6 +519,124 @@ export function App(): JSX.Element {
     else void openProject()
   }
 
+  /**
+   * Open the Bot form in the outlet (#447): create (from the sidebar section's ＋ or
+   * its empty-state CTA) or edit (from a Bot's own header). The TARGET is App state
+   * and the VIEW is nav state — nav answers "what am I looking at", not "with what".
+   * Every ordinary navigation resets the view to `conversation`, so the form needs
+   * no closing of its own when the user clicks away.
+   */
+  function openBotForm(target: BotFormTarget): void {
+    setBotFormTarget(target)
+    navDispatch({ type: 'open-bot-form' })
+  }
+
+  /**
+   * Create a Bot. Main is the validator and the file writer, so this is a thin
+   * pass-through that refreshes the list on success — the form shows `problems`
+   * when main refuses, and stays open so nothing typed is lost.
+   *
+   * On success we land in the new Bot's conversation: it exists to be talked to,
+   * and leaving the user on an empty form after making one would be a dead end.
+   */
+  async function createBot(args: BotsCreateArgs): Promise<BotWriteResult> {
+    const result = await window.api.botsCreate(args)
+    if (!result.ok) return result
+    refreshBots()
+    // A Bot's Thread is durable from creation (CONTEXT.md's carve-out), so the cold
+    // list has a new row to pick up.
+    await refreshRecents()
+    openBotConversation(result.bot)
+    return result
+  }
+
+  /**
+   * Save an edit. A rename rewrites `display_name` and never the profile id, so the
+   * live session keeps the mode it has selected and the Bot keeps working across it
+   * (ADR-0027). New instructions ride the NEXT prompt's profile selection — nothing
+   * that has already been said is touched, which is what the form's helper says.
+   */
+  async function saveBot(args: BotsUpdateArgs): Promise<BotWriteResult> {
+    const result = await window.api.botsUpdate(args)
+    if (!result.ok) return result
+    refreshBots()
+    // The Bot mark on the Thread rows carries its NAME, so a rename has to re-read
+    // the cold list too or Search would still show the old one. The form closes
+    // itself on a successful write — App only navigates when it has somewhere to go.
+    await refreshRecents()
+    return result
+  }
+
+  /**
+   * Land on a just-created Bot's conversation, ready to talk to.
+   *
+   * The awkward half is the never-connected Project: `hostSelectedThread` resolves
+   * a cold Thread through `recents`, and the row for a Bot created seconds ago is
+   * not in THIS closure's `recents` (the refresh above updated state, not the value
+   * captured here). So the cold path is handed a meta built from the record itself
+   * — the Thread is durable from creation (CONTEXT.md's carve-out), so main can
+   * genuinely continue it.
+   */
+  function openBotConversation(bot: BotRecord): void {
+    if (connections[bot.workspaceId]?.status === undefined) {
+      void continueColdThread({
+        id: bot.threadId,
+        workspaceId: bot.workspaceId,
+        sessionId: null,
+        title: null,
+        createdAt: bot.createdAt,
+        lastActiveAt: bot.updatedAt,
+      })
+      return
+    }
+    selectThreadInWorkspace(bot.workspaceId, bot.threadId)
+  }
+
+  /**
+   * Delete a Bot: the identity goes, the conversation stays. Main drops the record
+   * and both profile files and ARCHIVES the Thread, so the row leaves the Bots
+   * section and reappears in its project's Archived section — nothing irreplaceable
+   * is destroyed. We land the user back on the (now ordinary) conversation.
+   */
+  async function deleteBot(bot: BotRecord): Promise<void> {
+    const result = await window.api.botsDelete({ threadId: bot.threadId })
+    if (!result.ok) {
+      console.error(`[vibe-mistro:bots] could not delete ${bot.threadId}`)
+      return
+    }
+    refreshBots()
+    await refreshRecents()
+    selectThreadInWorkspace(bot.workspaceId, bot.threadId)
+  }
+
+  /**
+   * "Start over" on a Bot (#447). Main retires the session cursor; the renderer has
+   * to stop using the session it is holding, which takes three steps that must land
+   * TOGETHER (they do — they are one post-await batch):
+   *
+   *  1. re-read the metadata, so the Thread's `sessionId` is the cleared one;
+   *  2. drop and re-host the Thread in the live set, clearing `bound` (which
+   *     otherwise wins over the record's cursor — `seedSessionId`);
+   *  3. bump the view epoch, which remounts `Conversation` so it re-seeds from the
+   *     now-null cursor instead of the session it bound at mount.
+   *
+   * The transcript is untouched throughout, and the remounted view replays it — the
+   * old conversation is still there to read, exactly as the confirm promised.
+   */
+  async function startOverBot(bot: BotIdentity, workspaceId: string): Promise<void> {
+    const result = await window.api.botsStartOver({ threadId: bot.threadId })
+    if (!result.ok) {
+      // Log, don't swallow. `streaming` is the only reason the user can act on, and
+      // the button is already disabled for it — this catches the click-race.
+      console.error(`[vibe-mistro:bots] start over refused (${bot.threadId}): ${result.reason}`)
+      return
+    }
+    await refreshRecents()
+    wtDispatch({ type: 'remove', workspaceId, threadId: bot.threadId })
+    wtDispatch({ type: 'open', workspaceId, threadId: bot.threadId })
+    setConversationEpochs((prev) => bumpConversationEpoch(prev, bot.threadId))
+  }
+
   useEffect(() => {
     void runDetect()
     void refreshRecents()
@@ -762,7 +899,7 @@ export function App(): JSX.Element {
       const wts = workspaceThreadStateFor(workspaceThreads, selectedWs)
       rows = deriveUnifiedThreads({
         cold,
-        live: liveMetasFor(conn, cold, wts),
+        live: liveMetasFor(conn, cold, wts, bots),
         liveThreadIds: wts?.live ?? new Set([conn.threadId]),
         statuses,
       })
@@ -811,6 +948,22 @@ export function App(): JSX.Element {
     }
   }
 
+  /**
+   * What the Bot header can DO (#447) — edit it, or start over. Assembled beside the
+   * identity and for the same reason: the conversation slice renders what it is
+   * handed and never reaches into the `bots` store itself.
+   */
+  function botActionsFor(bot: BotIdentity | null, workspaceId: string): BotHeaderActions | null {
+    if (!bot) return null
+    return {
+      onEdit: () => openBotForm({ mode: 'edit', threadId: bot.threadId }),
+      onStartOver: () => void startOverBot(bot, workspaceId),
+      // Main refuses a mid-turn Start over (it would strand the running turn); the
+      // button says so before the click rather than after it.
+      busy: statuses[bot.threadId]?.streaming === true,
+    }
+  }
+
   /** The connected view for a Workspace (the controlled outlet). `busy` is the
    *  Workspace's rolled-up streaming flag (#86) — threaded to the Changes panel so the
    *  commit affordance is disabled while a turn is in flight (the v1 guard). Sign-out now
@@ -820,7 +973,7 @@ export function App(): JSX.Element {
     const cold = threadsForWorkspace(recents, conn.workspaceId)
     const activeId = wts?.active ?? conn.threadId
     const activeThread =
-      [...liveMetasFor(conn, cold, wts), ...cold].find((t) => t.id === activeId) ?? synthConnectionMeta(conn)
+      [...liveMetasFor(conn, cold, wts, bots), ...cold].find((t) => t.id === activeId) ?? synthConnectionMeta(conn)
     // Route + seed via the same pure helpers the cold list uses: live-set membership
     // decides live-vs-cold; a session bound this session wins over the persisted cursor.
     const liveIds = wts?.live ?? new Set([conn.threadId])
@@ -931,6 +1084,10 @@ export function App(): JSX.Element {
         connection={conn}
         activeThread={activeThread}
         activeBot={botIdentityFor(activeThread.id)}
+        activeBotActions={botActionsFor(botIdentityFor(activeThread.id), conn.workspaceId)}
+        // Normally the Thread id; changed once by a "Start over" so the live view
+        // remounts and drops the session it is holding (#447).
+        conversationKey={conversationViewKey(activeThread.id, conversationEpochs)}
         isLive={isLive}
         isActive={isActive}
         busy={busy}
@@ -979,7 +1136,12 @@ export function App(): JSX.Element {
   // The Skills browser (#259): a sibling routed outlet view, same keep-mounted
   // contract as Settings — connected Workspaces hide (not unmount) beneath it.
   const inSkills = nav.view === 'skills'
-  const overlayView = inSettings || inSkills
+  // The Bot create/edit form (#447): a third routed outlet view under the SAME
+  // keep-mounted contract — a Bot's conversation (or any other Workspace's turn)
+  // keeps streaming underneath while its form is on screen, and Cancel returns to
+  // exactly what was there. Not a Bots page: no list, nothing to browse.
+  const inBotForm = nav.view === 'bot-form' && botFormTarget !== null
+  const overlayView = inSettings || inSkills || inBotForm
   // Persistent missing-CLI banner (visibility is the pure `installBannerMessage`):
   // spans the shell under the window chrome so a selected Workspace / open Thread
   // still surfaces the missing toolchain; suppressed where the fuller guidance is
@@ -1036,6 +1198,21 @@ export function App(): JSX.Element {
             navDispatch({ type: 'close-settings' })
           }}
         />
+        </div>
+      ) : inBotForm && botFormTarget ? (
+        <div className="p-6">
+          <BotFormView
+            // Keyed by the target so switching from create to edit (or between two
+            // Bots) starts a fresh form rather than re-seeding a mounted one.
+            key={botFormTarget.mode === 'edit' ? `edit:${botFormTarget.threadId}` : 'create'}
+            target={botFormTarget}
+            bots={bots}
+            workspaces={recents}
+            onCreate={createBot}
+            onSave={saveBot}
+            onDelete={deleteBot}
+            onClose={() => navDispatch({ type: 'close-bot-form' })}
+          />
         </div>
       ) : inSkills ? (
         <div className="p-6">
@@ -1218,6 +1395,9 @@ export function App(): JSX.Element {
         onOpenProject={() => void openProject()}
         onNewThread={startNewChat}
         onSelectBot={selectBot}
+        // The section's ＋ (and its empty-state CTA) — the create affordance that
+        // works in EVERY state, including with a Bot conversation open (#447).
+        onCreateBot={() => openBotForm({ mode: 'create', workspaceId: nav.selectedWorkspaceId })}
         actions={{
           selectThread: selectThreadInWorkspace,
           newThreadInWorkspace,
@@ -1251,6 +1431,7 @@ function liveMetasFor(
   conn: ThreadConnection,
   cold: ThreadMeta[],
   wts: WorkspaceThreadState | null,
+  bots: readonly BotRecord[],
 ): ThreadMeta[] {
   const byId = new Map(cold.map((t) => [t.id, t]))
   const ids = wts ? wts.live : new Set([conn.threadId])
@@ -1269,7 +1450,10 @@ function liveMetasFor(
         lastActiveAt: 0,
       })
   }
-  return metas
+  // Every meta main lists carries the Bot mark; the two synthesized above do not,
+  // and an unmarked Bot is one `partitionBots` cannot drop from the Thread list
+  // (#447 — see `markBotMeta`). A cold meta is returned untouched.
+  return metas.map((meta) => markBotMeta(meta, bots))
 }
 
 /** Synthesize the connection's auto-opened Thread meta (when the list lags). */

--- a/apps/desktop/src/renderer/src/bots/BotFormView.tsx
+++ b/apps/desktop/src/renderer/src/bots/BotFormView.tsx
@@ -1,0 +1,358 @@
+import { useId, useState, type JSX, type ReactNode } from 'react'
+import { Check, Trash2 } from 'lucide-react'
+import type {
+  BotRecord,
+  BotsCreateArgs,
+  BotsUpdateArgs,
+  BotWriteResult,
+  ListMetadataResult,
+} from '../../../shared/ipc'
+import {
+  BOT_COLOURS,
+  botCreateArgs,
+  botUpdateArgs,
+  initialBotFormValues,
+  isBotFormDirty,
+  validateBotForm,
+  type BotFormTarget,
+  type BotFormValues,
+} from './bot-form'
+import { BOT_NAME_MAX_LENGTH, BOT_DESCRIPTION_MAX_LENGTH } from '../../../shared/bot-limits'
+import { BotMark } from './BotMark'
+import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+import { Textarea } from '../ui/textarea'
+import { Menu, MenuContent, MenuRadioGroup, MenuRadioItem, MenuTrigger } from '../ui/menu'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog'
+import { cn } from '../lib/utils'
+
+/**
+ * Creating and editing a **Mistro Bot**, in the OUTLET (#447, ADR-0027 decision 4;
+ * prototyped as variant D on `proto/422-bots-view`).
+ *
+ * Not a dialog, and the reason is the instructions field: it is the whole
+ * personality, and a three-line box in a modal quietly contradicts its own helper
+ * text — it tells you to describe a teammate in a space that fits a sentence. The
+ * outlet gives it real width and real height, and the sidebar stays visible
+ * throughout, so opening the form never costs the user their place.
+ *
+ * Two things this form deliberately cannot do, both argued in `bot-form.ts`: move
+ * a Bot to another Project, and change its profile id. Everything else about a Bot
+ * is here — its behaviour IS this form, because a Bot has no Mode, Model or
+ * reasoning-effort picker (ADR-0027 decision 5).
+ */
+export function BotFormView({
+  target,
+  bots,
+  workspaces,
+  onCreate,
+  onSave,
+  onDelete,
+  onClose,
+}: {
+  target: BotFormTarget
+  /** Every Bot record — the edit target is looked up here, and seeds the colour. */
+  bots: readonly BotRecord[]
+  /** The Projects a Bot may live in. Empty = nothing to create a Bot in yet. */
+  workspaces: ListMetadataResult
+  /** Create a Bot. Resolves with main's typed result so `problems` can be shown. */
+  onCreate: (args: BotsCreateArgs) => Promise<BotWriteResult>
+  /** Save an edit. Same contract; never carries a Project or a profile id. */
+  onSave: (args: BotsUpdateArgs) => Promise<BotWriteResult>
+  /** Delete this Bot (edit only): the identity goes, the conversation is archived. */
+  onDelete: (bot: BotRecord) => Promise<void>
+  /** Leave the form — App returns the outlet to whatever was on screen. */
+  onClose: () => void
+}): JSX.Element {
+  const editing = target.mode === 'edit' ? (bots.find((b) => b.threadId === target.threadId) ?? null) : null
+  // Seeded ONCE per form open: the view is keyed by its target in App, so a switch
+  // from create to edit (or to another Bot) remounts rather than re-seeding.
+  const [values, setValues] = useState<BotFormValues>(() => initialBotFormValues({ target, bots }))
+  const [saving, setSaving] = useState(false)
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false)
+  // What MAIN refused, verbatim. Main is the validator (Vibe validates nothing we
+  // write), so its problems are shown rather than paraphrased.
+  const [problems, setProblems] = useState<string[]>([])
+  // Only complain about a field once the user has tried to submit — a form that
+  // shouts "A Bot needs a name" before the first keystroke is a form that nags.
+  const [showErrors, setShowErrors] = useState(false)
+  const fieldId = useId()
+
+  const errors = validateBotForm(values)
+  const invalid = Object.keys(errors).length > 0
+  const dirty = editing ? isBotFormDirty(values, editing) : true
+
+  function set<K extends keyof BotFormValues>(key: K, value: BotFormValues[K]): void {
+    setValues((prev) => ({ ...prev, [key]: value }))
+  }
+
+  async function submit(): Promise<void> {
+    setShowErrors(true)
+    if (invalid || saving) return
+    if (editing && !dirty) {
+      // Nothing changed: don't rewrite the profile files (and don't claim the
+      // "takes effect on your next message" promise) over a no-op.
+      onClose()
+      return
+    }
+    setSaving(true)
+    setProblems([])
+    const result = editing
+      ? await onSave(botUpdateArgs(editing.threadId, values))
+      : await onCreate(botCreateArgs(values))
+    setSaving(false)
+    if (result.ok) {
+      onClose()
+      return
+    }
+    setProblems(result.problems)
+  }
+
+  const projectName = workspaces.find((w) => w.id === values.workspaceId)?.displayName ?? null
+
+  return (
+    // Roomy, and capped at a readable measure — the instructions field is the point
+    // of the layout, so everything above it stays compact and it gets the height.
+    <div className="mx-auto flex w-full max-w-[720px] flex-col gap-5">
+      <header className="flex items-center gap-3">
+        <BotMark name={values.name || '?'} colour={values.colour} size={36} />
+        <div className="min-w-0 flex-1">
+          <h1 className="truncate text-[20px] font-semibold text-foreground">
+            {editing ? `Edit ${editing.name}` : 'New Bot'}
+          </h1>
+          <p className="text-[13px] text-muted-foreground">
+            {editing
+              ? 'A Bot keeps one conversation going. Editing it never changes what it has already said.'
+              : 'It lives in the project you pick and keeps one conversation there.'}
+          </p>
+        </div>
+      </header>
+
+      <Field label="Name" controlId={`${fieldId}-name`} error={showErrors ? errors.name : undefined}>
+        <Input
+          id={`${fieldId}-name`}
+          value={values.name}
+          maxLength={BOT_NAME_MAX_LENGTH}
+          placeholder="Rex"
+          autoFocus
+          onChange={(e) => set('name', e.target.value)}
+        />
+      </Field>
+
+      <Field label="Colour" error={showErrors ? errors.colour : undefined}>
+        <div className="flex items-center gap-2">
+          {BOT_COLOURS.map((colour) => (
+            <button
+              key={colour}
+              type="button"
+              aria-label={`Colour ${colour}`}
+              aria-pressed={values.colour === colour}
+              onClick={() => set('colour', colour)}
+              className={cn(
+                'flex size-7 items-center justify-center rounded-full outline-none transition-transform',
+                'hover:scale-110 focus-visible:ring-2 focus-visible:ring-primary',
+              )}
+              style={{ background: colour }}
+            >
+              {values.colour === colour && <Check className="size-4 text-white" aria-hidden />}
+            </button>
+          ))}
+        </div>
+      </Field>
+
+      <Field
+        label="Project"
+        error={showErrors ? errors.workspaceId : undefined}
+        hint={
+          editing
+            ? 'A Bot stays in the project it was made in — its conversation is about those files.'
+            : 'A Bot lives in one project and works on those files.'
+        }
+      >
+        {editing ? (
+          <div className="rounded-md border border-border bg-secondary px-3 py-2 text-[14px] text-muted-foreground">
+            {projectName ?? 'Unknown project'}
+          </div>
+        ) : workspaces.length === 0 ? (
+          <p className="rounded-md border border-border bg-secondary px-3 py-2 text-[13px] text-muted-foreground">
+            No projects yet — open one first. A Bot cannot exist without a project.
+          </p>
+        ) : (
+          <Menu>
+            <MenuTrigger
+              className="flex h-9 w-full items-center justify-between gap-2 rounded-md border border-border bg-background px-3 text-left text-sm text-foreground outline-none transition-colors hover:bg-primary/10 focus-visible:border-primary"
+              aria-label="Project"
+            >
+              <span className={cn('truncate', !projectName && 'text-muted-foreground')}>
+                {projectName ?? 'Pick a project'}
+              </span>
+            </MenuTrigger>
+            <MenuContent align="start" className="min-w-[260px]">
+              <MenuRadioGroup
+                value={values.workspaceId}
+                onValueChange={(value) => set('workspaceId', String(value))}
+              >
+                {workspaces.map((w) => (
+                  // `closeOnClick` is NOT base-ui's default for a radio item (it
+                  // assumes a menu you keep picking from). Picking a Project is one
+                  // choice and done — without this the menu stays open behind its
+                  // own inert backdrop and the rest of the form cannot be clicked.
+                  <MenuRadioItem key={w.id} value={w.id} closeOnClick>
+                    {w.displayName}
+                  </MenuRadioItem>
+                ))}
+              </MenuRadioGroup>
+            </MenuContent>
+          </Menu>
+        )}
+      </Field>
+
+      <Field
+        label="Description"
+        controlId={`${fieldId}-description`}
+        error={showErrors ? errors.description : undefined}
+        hint="One line, shown under the Bot's name. Optional."
+      >
+        <Input
+          id={`${fieldId}-description`}
+          value={values.description}
+          maxLength={BOT_DESCRIPTION_MAX_LENGTH}
+          placeholder="Reviews my changes before I open a PR"
+          onChange={(e) => set('description', e.target.value)}
+        />
+      </Field>
+
+      <Field
+        label="Instructions"
+        controlId={`${fieldId}-instructions`}
+        error={showErrors ? errors.instructions : undefined}
+        hint={
+          editing
+            ? 'This is the whole personality. It loads with every message, so an edit takes effect on your next message — it never rewrites what has already been said.'
+            : 'This is the whole personality. It is loaded with every message and survives everything the conversation does.'
+        }
+      >
+        {/* The field the whole layout exists for: real width, real height. */}
+        <Textarea
+          id={`${fieldId}-instructions`}
+          value={values.instructions}
+          rows={14}
+          className="min-h-[280px] resize-y font-normal"
+          placeholder={
+            'You review my changes before I open a PR. Be blunt about correctness, quiet about style.\n\n' +
+            'You already know this project: its conventions, its awkward corners, and what we decided last week.'
+          }
+          onChange={(e) => set('instructions', e.target.value)}
+        />
+      </Field>
+
+      {problems.length > 0 && (
+        // Main refused the write. Its messages are field-prefixed and specific —
+        // shown verbatim rather than collapsed into "something went wrong".
+        <ul className="flex flex-col gap-1 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-[13px] text-destructive">
+          {problems.map((problem) => (
+            <li key={problem}>{problem}</li>
+          ))}
+        </ul>
+      )}
+
+      <div className="flex items-center gap-2 border-t border-border pt-4">
+        {editing && (
+          <Button
+            variant="ghost"
+            className="mr-auto text-destructive hover:bg-destructive/10"
+            onClick={() => setConfirmDeleteOpen(true)}
+          >
+            <Trash2 className="size-3.5" aria-hidden />
+            Delete Bot
+          </Button>
+        )}
+        <div className={cn('flex gap-2', !editing && 'ml-auto')}>
+          <Button variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={() => void submit()} disabled={saving || (showErrors && invalid)}>
+            {saving ? 'Saving…' : editing ? 'Save changes' : 'Create Bot'}
+          </Button>
+        </div>
+      </div>
+
+      {/* Deleting a Bot destroys the IDENTITY, not the history (ADR-0027). The copy
+          has to carry that, or the button reads as "delete weeks of conversation". */}
+      {editing && (
+        <Dialog open={confirmDeleteOpen} onOpenChange={setConfirmDeleteOpen}>
+          <DialogContent className="max-w-md">
+            <DialogHeader>
+              <DialogTitle>Delete {editing.name}?</DialogTitle>
+              <DialogDescription>
+                This removes {editing.name} from the sidebar and deletes its profile. The
+                conversation is kept — it becomes an archived thread in{' '}
+                {projectName ?? 'its project'}, so nothing you have said is lost.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <DialogClose render={<Button variant="secondary" />}>Cancel</DialogClose>
+              <Button
+                variant="destructive"
+                onClick={() => {
+                  setConfirmDeleteOpen(false)
+                  void onDelete(editing)
+                }}
+              >
+                Delete Bot
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      )}
+    </div>
+  )
+}
+
+/**
+ * One labelled row of the form: label, control, then hint or error (never both).
+ *
+ * The label never WRAPS its control: two of these rows hold buttons (the colour
+ * swatches and the Project menu), and a wrapping label makes every click on the
+ * row fire the first one.
+ */
+function Field({
+  label,
+  controlId,
+  hint,
+  error,
+  children,
+}: {
+  label: string
+  /** The id of the field's single input, when it has one — associates the label. */
+  controlId?: string
+  hint?: string
+  error?: string
+  children: ReactNode
+}): JSX.Element {
+  return (
+    <div className="flex flex-col gap-1.5">
+      {controlId ? (
+        <label htmlFor={controlId} className="text-[13px] font-medium text-foreground">
+          {label}
+        </label>
+      ) : (
+        <span className="text-[13px] font-medium text-foreground">{label}</span>
+      )}
+      {children}
+      {error ? (
+        <span className="text-[12px] text-destructive">{error}</span>
+      ) : hint ? (
+        <span className="text-[12px] leading-relaxed text-muted-foreground">{hint}</span>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/bots/BotFormView.tsx
+++ b/apps/desktop/src/renderer/src/bots/BotFormView.tsx
@@ -35,8 +35,9 @@ import {
 import { cn } from '../lib/utils'
 
 /**
- * Creating and editing a **Mistro Bot**, in the OUTLET (#447, ADR-0027 decision 4;
- * prototyped as variant D on `proto/422-bots-view`).
+ * Creating and editing a **Mistro Bot**, in the OUTLET (#447; ADR-0027 decision 4
+ * as amended — no Bots BROWSING view, and create/edit is a transient outlet view
+ * with no list; prototyped as variant D on `proto/422-bots-view`).
  *
  * Not a dialog, and the reason is the instructions field: it is the whole
  * personality, and a three-line box in a modal quietly contradicts its own helper
@@ -67,8 +68,13 @@ export function BotFormView({
   onCreate: (args: BotsCreateArgs) => Promise<BotWriteResult>
   /** Save an edit. Same contract; never carries a Project or a profile id. */
   onSave: (args: BotsUpdateArgs) => Promise<BotWriteResult>
-  /** Delete this Bot (edit only): the identity goes, the conversation is archived. */
-  onDelete: (bot: BotRecord) => Promise<void>
+  /**
+   * Delete this Bot (edit only): the identity goes, the conversation is archived.
+   * Resolves with the problems to SHOW — empty on success. A failed delete leaves
+   * the form open saying so, rather than closing the confirm over a Bot that is
+   * still there (#447 review, D2).
+   */
+  onDelete: (bot: BotRecord) => Promise<string[]>
   /** Leave the form — App returns the outlet to whatever was on screen. */
   onClose: () => void
 }): JSX.Element {
@@ -304,7 +310,7 @@ export function BotFormView({
                 variant="destructive"
                 onClick={() => {
                   setConfirmDeleteOpen(false)
-                  void onDelete(editing)
+                  void onDelete(editing).then(setProblems)
                 }}
               >
                 Delete Bot

--- a/apps/desktop/src/renderer/src/bots/BotHeader.tsx
+++ b/apps/desktop/src/renderer/src/bots/BotHeader.tsx
@@ -1,5 +1,16 @@
-import type { JSX } from 'react'
+import { useState, type JSX } from 'react'
+import { Pencil, RotateCcw } from 'lucide-react'
 import { BotMark } from './BotMark'
+import { Button } from '../ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog'
 
 /**
  * Who this Bot is, as the conversation needs to render it (#446). Assembled by App
@@ -16,16 +27,39 @@ export interface BotIdentity {
 }
 
 /**
+ * What the header can DO to this Bot (#447). Separate from the identity because
+ * one is data and the other is behaviour, and because a Bot rendered without
+ * actions (any future read-only surface) must still render.
+ */
+export interface BotHeaderActions {
+  /** Open the Bot's form in the outlet. */
+  onEdit: () => void
+  /** Start over — retire the session and keep everything else. */
+  onStartOver: () => void
+  /**
+   * A turn is in flight. Start over is refused mid-turn (main re-checks), so the
+   * button says so before the click rather than after it.
+   */
+  busy: boolean
+}
+
+/**
  * The Bot conversation's header (#446, ADR-0027 decision 4), replacing the ordinary
- * Thread head. Mark, name, and one subtitle line: `description · project`.
+ * Thread head. Mark, name, one subtitle line (`description · project`), and the two
+ * things you can do to a teammate: edit it, or start over.
  *
  * A Thread's head shows its auto-generated title, which is the right answer for a
  * conversation and the wrong one for a teammate — a Bot's identity does not change
- * with what you last asked it. "Start over" belongs in this header too, but it is
- * slice 3 (#447), so the row is deliberately left with room for it rather than
- * carrying a button that cannot do its job yet.
+ * with what you last asked it.
  */
-export function BotHeader({ bot }: { bot: BotIdentity }): JSX.Element {
+export function BotHeader({
+  bot,
+  actions = null,
+}: {
+  bot: BotIdentity
+  actions?: BotHeaderActions | null
+}): JSX.Element {
+  const [confirmStartOverOpen, setConfirmStartOverOpen] = useState(false)
   return (
     <div className="flex items-center gap-3 border-b border-border pb-3">
       <BotMark name={bot.name} colour={bot.colour} size={28} />
@@ -35,6 +69,59 @@ export function BotHeader({ bot }: { bot: BotIdentity }): JSX.Element {
           {bot.description ? `${bot.description} · ${bot.projectName}` : bot.projectName}
         </div>
       </div>
+      {actions && (
+        <div className="flex flex-none items-center gap-1">
+          <Button variant="ghost" size="sm" onClick={actions.onEdit}>
+            <Pencil className="size-3.5" aria-hidden />
+            Edit
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={actions.busy}
+            title={
+              actions.busy
+                ? `Wait for ${bot.name} to finish this turn`
+                : `Keeps ${bot.name}'s name and instructions. The conversation above stays readable.`
+            }
+            onClick={() => setConfirmStartOverOpen(true)}
+          >
+            <RotateCcw className="size-3.5" aria-hidden />
+            Start over
+          </Button>
+        </div>
+      )}
+
+      {/* The copy is the whole point of this dialog. "Start over" sits one click from
+          weeks of conversation, so it has to say — before the click — that nothing is
+          deleted: the Bot keeps its name, its instructions and its profile, and every
+          earlier message stays readable. What is lost is the agent's MEMORY of them,
+          which is exactly what the user came here for. */}
+      {actions && (
+        <Dialog open={confirmStartOverOpen} onOpenChange={setConfirmStartOverOpen}>
+          <DialogContent className="max-w-md">
+            <DialogHeader>
+              <DialogTitle>Start over with {bot.name}?</DialogTitle>
+              <DialogDescription>
+                {bot.name} keeps its name, its instructions and everything you have already
+                said — the conversation above stays here to read. It just starts the next
+                message with a clear head, remembering none of it.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <DialogClose render={<Button variant="secondary" />}>Cancel</DialogClose>
+              <Button
+                onClick={() => {
+                  setConfirmStartOverOpen(false)
+                  actions.onStartOver()
+                }}
+              >
+                Start over
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      )}
     </div>
   )
 }

--- a/apps/desktop/src/renderer/src/bots/BotHeader.tsx
+++ b/apps/desktop/src/renderer/src/bots/BotHeader.tsx
@@ -1,5 +1,5 @@
 import { useState, type JSX } from 'react'
-import { Pencil, RotateCcw } from 'lucide-react'
+import { Pencil, RotateCcw, X } from 'lucide-react'
 import { BotMark } from './BotMark'
 import { Button } from '../ui/button'
 import {
@@ -41,6 +41,15 @@ export interface BotHeaderActions {
    * button says so before the click rather than after it.
    */
   busy: boolean
+  /**
+   * The last refusal, or null. This is the channel `shared/ipc/bots.ts` promises:
+   * the confirm dialog closes on click, so without it a refused Start over looks
+   * exactly like a successful one while the Bot keeps the session the user asked
+   * to leave behind (#447 review, D2).
+   */
+  error: string | null
+  /** Dismiss the message above — it is not an error state, just something to read. */
+  onDismissError: () => void
 }
 
 /**
@@ -61,34 +70,56 @@ export function BotHeader({
 }): JSX.Element {
   const [confirmStartOverOpen, setConfirmStartOverOpen] = useState(false)
   return (
-    <div className="flex items-center gap-3 border-b border-border pb-3">
-      <BotMark name={bot.name} colour={bot.colour} size={28} />
-      <div className="min-w-0 flex-1">
-        <div className="truncate text-[14px] font-semibold text-foreground">{bot.name}</div>
-        <div className="truncate text-[12px] text-muted-foreground">
-          {bot.description ? `${bot.description} · ${bot.projectName}` : bot.projectName}
+    <div className="flex flex-col gap-2 border-b border-border pb-3">
+      <div className="flex items-center gap-3">
+        <BotMark name={bot.name} colour={bot.colour} size={28} />
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-[14px] font-semibold text-foreground">{bot.name}</div>
+          <div className="truncate text-[12px] text-muted-foreground">
+            {bot.description ? `${bot.description} · ${bot.projectName}` : bot.projectName}
+          </div>
         </div>
+        {actions && (
+          <div className="flex flex-none items-center gap-1">
+            <Button variant="ghost" size="sm" onClick={actions.onEdit}>
+              <Pencil className="size-3.5" aria-hidden />
+              Edit
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={actions.busy}
+              title={
+                actions.busy
+                  ? `Wait for ${bot.name} to finish this turn`
+                  : `Keeps ${bot.name}'s name and instructions. The conversation above stays readable.`
+              }
+              onClick={() => setConfirmStartOverOpen(true)}
+            >
+              <RotateCcw className="size-3.5" aria-hidden />
+              Start over
+            </Button>
+          </div>
+        )}
       </div>
-      {actions && (
-        <div className="flex flex-none items-center gap-1">
-          <Button variant="ghost" size="sm" onClick={actions.onEdit}>
-            <Pencil className="size-3.5" aria-hidden />
-            Edit
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            disabled={actions.busy}
-            title={
-              actions.busy
-                ? `Wait for ${bot.name} to finish this turn`
-                : `Keeps ${bot.name}'s name and instructions. The conversation above stays readable.`
-            }
-            onClick={() => setConfirmStartOverOpen(true)}
+
+      {/* A refused action, said out loud. The confirm dialog has already closed by
+          the time main answers, so this is the only place the user can learn that
+          the Bot is still on the session they asked to leave behind. */}
+      {actions?.error && (
+        <div
+          role="status"
+          className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-[13px] text-destructive"
+        >
+          <span className="flex-1">{actions.error}</span>
+          <button
+            type="button"
+            aria-label="Dismiss"
+            className="flex-none rounded-sm px-1 text-destructive/70 outline-none hover:text-destructive focus-visible:text-destructive"
+            onClick={actions.onDismissError}
           >
-            <RotateCcw className="size-3.5" aria-hidden />
-            Start over
-          </Button>
+            <X className="size-3.5" aria-hidden />
+          </button>
         </div>
       )}
 

--- a/apps/desktop/src/renderer/src/bots/BotsSection.tsx
+++ b/apps/desktop/src/renderer/src/bots/BotsSection.tsx
@@ -5,6 +5,7 @@ import { BotMark } from './BotMark'
 import { LogoSnakeSpinner } from '../shell/logo-snake-spinner'
 import { formatRelativeTime } from '../shell/relative-time'
 import { Badge } from '../ui/badge'
+import { Button } from '../ui/button'
 import { IconButton } from '../ui/icon-button'
 import { cn } from '../lib/utils'
 
@@ -39,17 +40,19 @@ export function BotsSection({
   /** Open a Bot's conversation — App routes it through the ordinary Thread select. */
   onSelectBot: (row: BotSidebarRow) => void
   /**
-   * Open the create form. The section's ＋ is the create affordance that works in
-   * every state (the empty-state CTA only exists while there are no Bots), but the
-   * form itself is slice 3 (#447) — until it lands the ＋ is omitted rather than
-   * rendered inert, because a button that does nothing is worse than no button.
+   * Open the create form in the outlet (#447). The section's ＋ is the create
+   * affordance that works in EVERY state, and that is the load-bearing part: the
+   * empty-state CTA below exists only while there are no Bots, so without the ＋
+   * there would be no way to add a second one — a hole the prototype's capture spec
+   * caught rather than the eye.
+   *
+   * Still optional, because a surface that cannot create a Bot should render the
+   * section without a button that does nothing.
    */
   onCreateBot?: () => void
 }): JSX.Element | null {
   // Nothing to show and nothing to do: the section is absent rather than an empty
-  // block. Without the ＋ (slice 3) an empty section is a permanent, actionless
-  // header in EVERY existing user's sidebar — so it earns its space only once
-  // there are Bots, or once there is a way to make one.
+  // block — a permanent, actionless header in the sidebar earns no space.
   if (rows.length === 0 && !onCreateBot) return null
 
   // ONE Date.now() per render, injected into the pure formatter at each call site.
@@ -66,9 +69,19 @@ export function BotsSection({
       </div>
 
       {rows.length === 0 ? (
-        <p className="px-3 py-1 text-[13px] leading-relaxed text-muted-foreground">
-          No Bots yet. A Bot keeps one running conversation about one project.
-        </p>
+        // The empty state, with something to do (#447). It says what a Bot IS —
+        // the word alone means nothing on first sight — and offers the one action.
+        <div className="flex flex-col items-start gap-1.5 px-3 py-1">
+          <p className="text-[13px] leading-relaxed text-muted-foreground">
+            No Bots yet. A Bot keeps one running conversation about one project.
+          </p>
+          {onCreateBot && (
+            <Button variant="ghost" size="sm" className="-ml-2" onClick={onCreateBot}>
+              <Plus className="size-3.5" aria-hidden />
+              Create a Bot
+            </Button>
+          )}
+        </div>
       ) : (
         <ul
           // The bound itself. `overflow-y-auto` on the LIST (not the section) keeps

--- a/apps/desktop/src/renderer/src/bots/bot-action-messages.test.ts
+++ b/apps/desktop/src/renderer/src/bots/bot-action-messages.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import type { BotStartOverFailure } from '../../../shared/ipc'
+import { deleteBotFailureMessage, startOverFailureMessage } from './bot-action-messages'
+
+const REASONS: BotStartOverFailure[] = ['streaming', 'notFound', 'io']
+
+describe('startOverFailureMessage', () => {
+  it('has a message for every typed reason, naming the Bot', () => {
+    for (const reason of REASONS) {
+      const message = startOverFailureMessage(reason, 'Rex')
+      expect(message).toContain('Rex')
+      expect(message.length).toBeGreaterThan(20)
+    }
+  })
+
+  it('tells the user what to do about the reachable one (a mid-turn click race)', () => {
+    expect(startOverFailureMessage('streaming', 'Rex')).toMatch(/wait/i)
+  })
+
+  it('admits the Bot kept its old conversation when the write failed', () => {
+    // The one case where nothing on screen would otherwise differ from success.
+    expect(startOverFailureMessage('io', 'Rex')).toMatch(/still has its old conversation/i)
+  })
+})
+
+describe('deleteBotFailureMessage', () => {
+  it('says the Bot is untouched, so the user does not re-delete or assume it half-happened', () => {
+    const message = deleteBotFailureMessage('Rex')
+    expect(message).toContain('Rex')
+    expect(message).toMatch(/nothing was changed/i)
+  })
+})

--- a/apps/desktop/src/renderer/src/bots/bot-action-messages.ts
+++ b/apps/desktop/src/renderer/src/bots/bot-action-messages.ts
@@ -1,0 +1,37 @@
+import type { BotStartOverFailure } from '../../../shared/ipc'
+
+/**
+ * What to TELL the user when a Bot action is refused (#447 review, D2).
+ *
+ * The contract these exist to make true: `shared/ipc/bots.ts` says the typed
+ * failures are typed so the header can show what happened "instead of the Bot
+ * silently continuing on the session the user asked to leave behind". A console
+ * line is not that — the confirm dialog closes, nothing changes on screen, and a
+ * failed Start over is indistinguishable from a successful one.
+ *
+ * Pure and separate from the components because the interesting part is the
+ * WORDING: each reason has a different next action for the user, and a refusal
+ * that does not say what to do next is only marginally better than silence.
+ */
+
+/** The message for a refused "Start over", addressed to the user, by reason. */
+export function startOverFailureMessage(reason: BotStartOverFailure, botName: string): string {
+  switch (reason) {
+    case 'streaming':
+      // The reachable one: the button disables off a `thread:status` push, so a
+      // click landing in the gap gets here. Says exactly what to do.
+      return `${botName} is mid-turn. Wait for this answer to finish, then start over.`
+    case 'notFound':
+      // The record went away underneath us (deleted in another window).
+      return `${botName} is no longer a Bot, so there is no session to start over.`
+    case 'io':
+      // The one the user cannot predict — and the one where the Bot silently keeps
+      // its old session, so it must never pass unremarked.
+      return `Could not start over: ${botName} could not be saved. It still has its old conversation loaded.`
+  }
+}
+
+/** The message for a failed delete. The Bot is untouched — say so. */
+export function deleteBotFailureMessage(botName: string): string {
+  return `Could not delete ${botName}. Nothing was changed — the Bot and its files are still there.`
+}

--- a/apps/desktop/src/renderer/src/bots/bot-destruction.test.ts
+++ b/apps/desktop/src/renderer/src/bots/bot-destruction.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import type { ThreadMeta } from '../../../shared/ipc'
+import type { UnifiedThreadRow } from '../shell/unified-threads'
+import {
+  botNamesInRows,
+  botNamesInThreads,
+  describeBotDestruction,
+  formatBotNames,
+} from './bot-destruction'
+
+function meta(id: string, botName?: string): ThreadMeta {
+  return {
+    id,
+    workspaceId: 'ws-1',
+    sessionId: null,
+    title: null,
+    createdAt: 0,
+    lastActiveAt: 0,
+    ...(botName ? { bot: { name: botName } } : {}),
+  }
+}
+
+function row(id: string, botName?: string): UnifiedThreadRow {
+  return { thread: meta(id, botName), live: false, streaming: false, needsAttention: false }
+}
+
+describe('botNamesInRows', () => {
+  it('names only the Bot rows, in row order', () => {
+    expect(botNamesInRows([row('a'), row('rex', 'Rex'), row('b'), row('ada', 'Ada')])).toEqual([
+      'Rex',
+      'Ada',
+    ])
+  })
+
+  it('is empty for a project with no Bots', () => {
+    expect(botNamesInRows([row('a'), row('b')])).toEqual([])
+  })
+})
+
+describe('botNamesInThreads', () => {
+  it('reads the same flag off raw metas', () => {
+    expect(botNamesInThreads([meta('a'), meta('rex', 'Rex')])).toEqual(['Rex'])
+  })
+})
+
+describe('formatBotNames', () => {
+  it('reads as a sentence at every size', () => {
+    expect(formatBotNames(['Rex'])).toBe('Rex')
+    expect(formatBotNames(['Rex', 'Ada'])).toBe('Rex and Ada')
+    expect(formatBotNames(['Rex', 'Ada', 'Kim'])).toBe('Rex, Ada and Kim')
+  })
+
+  it('counts the rest rather than turning the confirm into a list', () => {
+    expect(formatBotNames(['Rex', 'Ada', 'Kim', 'Lou', 'Max'])).toBe('Rex, Ada, Kim and 2 more')
+  })
+})
+
+describe('describeBotDestruction', () => {
+  it('says nothing when the project has no Bots', () => {
+    expect(describeBotDestruction([])).toBeNull()
+  })
+
+  it('names the Bot and admits it cannot be recovered', () => {
+    const text = describeBotDestruction(['Rex'])
+    expect(text).toContain('1 Bot')
+    expect(text).toContain('Rex')
+    expect(text).toContain('cannot be recovered')
+  })
+
+  it('pluralises', () => {
+    expect(describeBotDestruction(['Rex', 'Ada'])).toContain('2 Bots')
+  })
+})

--- a/apps/desktop/src/renderer/src/bots/bot-destruction.test.ts
+++ b/apps/desktop/src/renderer/src/bots/bot-destruction.test.ts
@@ -50,8 +50,19 @@ describe('formatBotNames', () => {
     expect(formatBotNames(['Rex', 'Ada', 'Kim'])).toBe('Rex, Ada and Kim')
   })
 
+  it('names all four rather than saying "and 1 more" — the boundary the cap exists for', () => {
+    expect(formatBotNames(['Rex', 'Ada', 'Kim', 'Lou'])).toBe('Rex, Ada, Kim and Lou')
+  })
+
   it('counts the rest rather than turning the confirm into a list', () => {
     expect(formatBotNames(['Rex', 'Ada', 'Kim', 'Lou', 'Max'])).toBe('Rex, Ada, Kim and 2 more')
+  })
+
+  it('never emits "and 1 more" at any size', () => {
+    const names = Array.from({ length: 12 }, (_, i) => `Bot ${i + 1}`)
+    for (let count = 1; count <= names.length; count += 1) {
+      expect(formatBotNames(names.slice(0, count))).not.toContain('and 1 more')
+    }
   })
 })
 

--- a/apps/desktop/src/renderer/src/bots/bot-destruction.ts
+++ b/apps/desktop/src/renderer/src/bots/bot-destruction.ts
@@ -1,0 +1,63 @@
+import type { ThreadMeta } from '../../../shared/ipc'
+import type { UnifiedThreadRow } from '../shell/unified-threads'
+
+/**
+ * What "Remove project" is about to destroy, in words (#447, ADR-0027 —
+ * *destruction is honest*).
+ *
+ * Removing a Workspace drops every Thread under it, which cascades away its Bots
+ * and (since #445) deletes their generated profile files. That is the right
+ * behaviour and the wrong silence: a routine cleanup can take teammates the user
+ * forgot lived there, and unlike a Thread a Bot is not recoverable from anywhere
+ * else. So the confirm names them.
+ *
+ * Pure, and separated from the dialog because the interesting part is the
+ * SENTENCE — one Bot reads differently from four, and "and 1 more" is a bug.
+ */
+
+/** Cap the names actually spelled out; beyond it the rest are counted. */
+const NAMED_BOT_LIMIT = 3
+
+/**
+ * The Bot names among a project's sidebar rows, in row order.
+ *
+ * The `bot` flag is main's per-row mark (`markBotThreads`), which is why this
+ * works for a peeked project as well as the selected one: both render rows built
+ * from the same bot-marked metadata.
+ */
+export function botNamesInRows(rows: readonly UnifiedThreadRow[]): string[] {
+  return rows.map((row) => row.thread.bot?.name).filter((name): name is string => Boolean(name))
+}
+
+/** The same read over raw metas, for callers that have not derived rows yet. */
+export function botNamesInThreads(threads: readonly ThreadMeta[]): string[] {
+  return threads.map((thread) => thread.bot?.name).filter((name): name is string => Boolean(name))
+}
+
+/**
+ * The sentence the confirm dialog adds when a project has Bots — or null when it
+ * has none, so the existing copy is untouched in the common case.
+ *
+ * It states the destruction in the terms ADR-0027 uses: the identity goes (the
+ * teammate and its generated profile files), the conversation survives. Naming
+ * beyond three would turn a confirm into a list, so the rest are counted.
+ */
+export function describeBotDestruction(names: readonly string[]): string | null {
+  if (names.length === 0) return null
+  const noun = names.length === 1 ? 'Bot' : 'Bots'
+  return (
+    `This also deletes ${names.length} ${noun} — ${formatBotNames(names)}. ` +
+    `Their conversations are removed with the project; the ${names.length === 1 ? 'Bot' : 'Bots'} ` +
+    `cannot be recovered.`
+  )
+}
+
+/** `Rex`, `Rex and Ada`, `Rex, Ada and Kim`, `Rex, Ada, Kim and 2 more`. */
+export function formatBotNames(names: readonly string[]): string {
+  if (names.length <= NAMED_BOT_LIMIT) {
+    if (names.length <= 1) return names[0] ?? ''
+    return `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`
+  }
+  const shown = names.slice(0, NAMED_BOT_LIMIT).join(', ')
+  return `${shown} and ${names.length - NAMED_BOT_LIMIT} more`
+}

--- a/apps/desktop/src/renderer/src/bots/bot-destruction.ts
+++ b/apps/desktop/src/renderer/src/bots/bot-destruction.ts
@@ -15,7 +15,13 @@ import type { UnifiedThreadRow } from '../shell/unified-threads'
  * SENTENCE — one Bot reads differently from four, and "and 1 more" is a bug.
  */
 
-/** Cap the names actually spelled out; beyond it the rest are counted. */
+/**
+ * Cap the names actually spelled out; beyond it the rest are counted.
+ *
+ * The +1 in {@link formatBotNames} is the point: with a cap of three, FOUR Bots
+ * would read "Rex, Ada, Kim and 1 more" — a sentence that spends more characters
+ * hiding a name than printing it. So the cap only bites when it saves at least two.
+ */
 const NAMED_BOT_LIMIT = 3
 
 /**
@@ -38,9 +44,11 @@ export function botNamesInThreads(threads: readonly ThreadMeta[]): string[] {
  * The sentence the confirm dialog adds when a project has Bots — or null when it
  * has none, so the existing copy is untouched in the common case.
  *
- * It states the destruction in the terms ADR-0027 uses: the identity goes (the
- * teammate and its generated profile files), the conversation survives. Naming
- * beyond three would turn a confirm into a list, so the rest are counted.
+ * This is the **Remove project** copy, and it is deliberately harsher than the
+ * delete-a-Bot copy: deleting a Bot keeps its conversation as an archived Thread,
+ * but removing the project removes every Thread under it, so the conversations go
+ * too. The sentence has to say the thing that is actually true here, because this
+ * is the path where something irreplaceable is lost.
  */
 export function describeBotDestruction(names: readonly string[]): string | null {
   if (names.length === 0) return null
@@ -52,9 +60,15 @@ export function describeBotDestruction(names: readonly string[]): string | null 
   )
 }
 
-/** `Rex`, `Rex and Ada`, `Rex, Ada and Kim`, `Rex, Ada, Kim and 2 more`. */
+/**
+ * `Rex`, `Rex and Ada`, `Rex, Ada and Kim`, `Rex, Ada, Kim and Lou`,
+ * `Rex, Ada, Kim and 2 more`.
+ *
+ * Four names are all printed: a remainder of one is worth less than the name it
+ * replaces. Five or more fall back to the count.
+ */
 export function formatBotNames(names: readonly string[]): string {
-  if (names.length <= NAMED_BOT_LIMIT) {
+  if (names.length <= NAMED_BOT_LIMIT + 1) {
     if (names.length <= 1) return names[0] ?? ''
     return `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`
   }

--- a/apps/desktop/src/renderer/src/bots/bot-form.test.ts
+++ b/apps/desktop/src/renderer/src/bots/bot-form.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest'
+import type { BotRecord } from '../../../shared/ipc'
+import {
+  BOT_COLOURS,
+  botCreateArgs,
+  botUpdateArgs,
+  canSubmitBotForm,
+  DEFAULT_BOT_COLOUR,
+  initialBotFormValues,
+  isBotFormDirty,
+  nextBotColour,
+  validateBotForm,
+  type BotFormValues,
+} from './bot-form'
+import {
+  BOT_DESCRIPTION_MAX_LENGTH,
+  BOT_INSTRUCTIONS_MAX_LENGTH,
+  BOT_NAME_MAX_LENGTH,
+} from '../../../shared/bot-limits'
+
+function bot(overrides: Partial<BotRecord> = {}): BotRecord {
+  return {
+    threadId: 'thread-rex',
+    workspaceId: 'ws-1',
+    profileId: 'mistro-bot-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    name: 'Rex',
+    colour: '#e8734a',
+    description: 'Reviews my diffs',
+    instructions: 'Be blunt about correctness.',
+    createdAt: 1,
+    updatedAt: 2,
+    ...overrides,
+  }
+}
+
+function values(overrides: Partial<BotFormValues> = {}): BotFormValues {
+  return {
+    name: 'Rex',
+    colour: DEFAULT_BOT_COLOUR,
+    workspaceId: 'ws-1',
+    description: '',
+    instructions: '',
+    ...overrides,
+  }
+}
+
+describe('initialBotFormValues', () => {
+  it('seeds a create from the selected Project', () => {
+    const v = initialBotFormValues({ target: { mode: 'create', workspaceId: 'ws-7' }, bots: [] })
+    expect(v).toMatchObject({ name: '', workspaceId: 'ws-7', instructions: '' })
+  })
+
+  it('seeds a create with no Project selected as an unpicked Project, not a guess', () => {
+    const v = initialBotFormValues({ target: { mode: 'create', workspaceId: null }, bots: [] })
+    expect(v.workspaceId).toBe('')
+    expect(canSubmitBotForm(v)).toBe(false)
+  })
+
+  it('seeds an edit from the record, Project included', () => {
+    const v = initialBotFormValues({ target: { mode: 'edit', threadId: 'thread-rex' }, bots: [bot()] })
+    expect(v).toEqual({
+      name: 'Rex',
+      colour: '#e8734a',
+      workspaceId: 'ws-1',
+      description: 'Reviews my diffs',
+      instructions: 'Be blunt about correctness.',
+    })
+  })
+
+  it('falls back to an empty form when the record has vanished under it', () => {
+    const v = initialBotFormValues({ target: { mode: 'edit', threadId: 'gone' }, bots: [bot()] })
+    expect(v.name).toBe('')
+  })
+})
+
+describe('nextBotColour', () => {
+  it('picks the first unused palette colour so two new Bots never look alike', () => {
+    expect(nextBotColour([])).toBe(BOT_COLOURS[0])
+    expect(nextBotColour([bot({ colour: BOT_COLOURS[0] })])).toBe(BOT_COLOURS[1])
+  })
+
+  it('falls back to the default once every colour is taken', () => {
+    const all = BOT_COLOURS.map((colour, i) => bot({ threadId: `t-${i}`, colour }))
+    expect(nextBotColour(all)).toBe(DEFAULT_BOT_COLOUR)
+  })
+})
+
+describe('validateBotForm', () => {
+  it('accepts a name and a Project with nothing else', () => {
+    expect(validateBotForm(values())).toEqual({})
+    expect(canSubmitBotForm(values())).toBe(true)
+  })
+
+  it('requires a name', () => {
+    expect(validateBotForm(values({ name: '   ' })).name).toBeDefined()
+  })
+
+  it('requires a Project — a Bot cannot exist without one', () => {
+    expect(validateBotForm(values({ workspaceId: '' })).workspaceId).toBeDefined()
+  })
+
+  it('applies the SAME bounds main enforces', () => {
+    expect(validateBotForm(values({ name: 'x'.repeat(BOT_NAME_MAX_LENGTH + 1) })).name).toBeDefined()
+    expect(validateBotForm(values({ name: 'x'.repeat(BOT_NAME_MAX_LENGTH) })).name).toBeUndefined()
+    expect(
+      validateBotForm(values({ description: 'x'.repeat(BOT_DESCRIPTION_MAX_LENGTH + 1) })).description,
+    ).toBeDefined()
+    expect(
+      validateBotForm(values({ instructions: 'x'.repeat(BOT_INSTRUCTIONS_MAX_LENGTH + 1) })).instructions,
+    ).toBeDefined()
+  })
+
+  it('refuses a line break in the name or the description — both are one-liners on the wire', () => {
+    expect(validateBotForm(values({ name: 'Rex\nthe reviewer' })).name).toBeDefined()
+    expect(validateBotForm(values({ description: 'one\ntwo' })).description).toBeDefined()
+  })
+
+  it('allows multi-line instructions — the persona is prose', () => {
+    expect(validateBotForm(values({ instructions: 'line one\n\nline two' }))).toEqual({})
+  })
+})
+
+describe('the payloads', () => {
+  it('trims the one-line fields but never the instructions', () => {
+    const v = values({ name: '  Rex  ', description: '  Reviews  ', instructions: '  keep\n  me  ' })
+    expect(botCreateArgs(v)).toEqual({
+      workspaceId: 'ws-1',
+      name: 'Rex',
+      colour: DEFAULT_BOT_COLOUR,
+      description: 'Reviews',
+      instructions: '  keep\n  me  ',
+    })
+  })
+
+  it('never sends a Project or a profile id on an update', () => {
+    const args = botUpdateArgs('thread-rex', values())
+    expect(Object.keys(args).sort()).toEqual([
+      'colour',
+      'description',
+      'instructions',
+      'name',
+      'threadId',
+    ])
+  })
+})
+
+describe('isBotFormDirty', () => {
+  it('is false for an untouched edit', () => {
+    const b = bot()
+    expect(isBotFormDirty(initialBotFormValues({ target: { mode: 'edit', threadId: b.threadId }, bots: [b] }), b)).toBe(
+      false,
+    )
+  })
+
+  it('sees a rename, a recolour, and an instructions edit', () => {
+    const b = bot()
+    const from = initialBotFormValues({ target: { mode: 'edit', threadId: b.threadId }, bots: [b] })
+    expect(isBotFormDirty({ ...from, name: 'Rexi' }, b)).toBe(true)
+    expect(isBotFormDirty({ ...from, colour: '#4a90d9' }, b)).toBe(true)
+    expect(isBotFormDirty({ ...from, instructions: 'Be kind.' }, b)).toBe(true)
+  })
+
+  it('ignores whitespace-only changes to the one-line fields', () => {
+    const b = bot()
+    const from = initialBotFormValues({ target: { mode: 'edit', threadId: b.threadId }, bots: [b] })
+    expect(isBotFormDirty({ ...from, name: '  Rex  ' }, b)).toBe(false)
+  })
+})

--- a/apps/desktop/src/renderer/src/bots/bot-form.ts
+++ b/apps/desktop/src/renderer/src/bots/bot-form.ts
@@ -1,0 +1,203 @@
+import type { BotRecord, BotsCreateArgs, BotsUpdateArgs } from '../../../shared/ipc'
+import {
+  BOT_COLOUR_MAX_LENGTH,
+  BOT_DESCRIPTION_MAX_LENGTH,
+  BOT_INSTRUCTIONS_MAX_LENGTH,
+  BOT_NAME_MAX_LENGTH,
+} from '../../../shared/bot-limits'
+
+/**
+ * The Bot create/edit form, as data (#447, ADR-0027). Pure — no React, no IPC — so
+ * what the form ACCEPTS, what it REFUSES and what it SENDS are settled in a unit
+ * test rather than by clicking through the app.
+ *
+ * The division of labour with main is deliberate. Main is the validator: it refuses
+ * a record that would project a profile Vibe silently ignores, and its `problems`
+ * are shown verbatim. This module is the SAME bounds one step earlier, so the two
+ * can never disagree and so the user learns about a 61-character name while typing
+ * it instead of after a round trip.
+ *
+ * Two things it will not do:
+ * - **Move a Bot between Projects.** `BotsUpdateArgs` has no `workspaceId` and that
+ *   is not an oversight: the live ACP session is bound to one `cwd`, so a Bot that
+ *   changed Project mid-conversation would be answering about files it has never
+ *   seen. The Project is chosen once, at creation.
+ * - **Change the profile id.** It is not a form field at all — a rename rewrites
+ *   `display_name` only, because the running session has that id selected as its
+ *   mode (ADR-0027).
+ */
+
+/** Which shape the outlet's form is in — and, for an edit, whose Bot it is. */
+export type BotFormTarget =
+  | { mode: 'create'; workspaceId: string | null }
+  | { mode: 'edit'; threadId: string }
+
+/** The four fields the form edits, plus the Project a create must pick. */
+export interface BotFormValues {
+  name: string
+  colour: string
+  /** The Project. Fixed after creation — see the module note. */
+  workspaceId: string
+  description: string
+  instructions: string
+}
+
+/** Per-field messages, keyed by the field that is at fault. Empty = submittable. */
+export type BotFormErrors = Partial<Record<keyof BotFormValues, string>>
+
+/**
+ * The default mark colour for a new Bot, and the palette the form offers. Hex, so
+ * it renders identically wherever the mark appears and passes `validateBotColour`.
+ * Six is enough to tell teammates apart at a glance without turning the form into
+ * a colour picker.
+ */
+export const BOT_COLOURS = ['#e8734a', '#4a90d9', '#3fa87a', '#b26bd6', '#d94a6a', '#c9a227'] as const
+
+export const DEFAULT_BOT_COLOUR = BOT_COLOURS[0]
+
+/**
+ * The form's starting values. A create seeds the Project from the current
+ * selection (the Bot you are most likely to want is one for the project you are
+ * looking at) and picks the colour least recently used, so two Bots made in a row
+ * do not look alike. An edit seeds every field from the record.
+ */
+export function initialBotFormValues(args: {
+  target: BotFormTarget
+  bots: readonly BotRecord[]
+}): BotFormValues {
+  const target = args.target
+  if (target.mode === 'edit') {
+    const bot = args.bots.find((b) => b.threadId === target.threadId)
+    if (bot) {
+      return {
+        name: bot.name,
+        colour: bot.colour,
+        workspaceId: bot.workspaceId,
+        description: bot.description,
+        instructions: bot.instructions,
+      }
+    }
+    // A record that vanished under the form (deleted in another window): fall
+    // through to an empty create-shaped form rather than rendering stale values.
+    return emptyValues('')
+  }
+  return {
+    ...emptyValues(target.workspaceId ?? ''),
+    colour: nextBotColour(args.bots),
+  }
+}
+
+/**
+ * The colour a new Bot gets: the first palette entry no existing Bot is using, or
+ * — once every colour is taken — the one belonging to the oldest Bot, so the cycle
+ * repeats in a stable order instead of at random.
+ */
+export function nextBotColour(bots: readonly BotRecord[]): string {
+  const taken = new Set(bots.map((bot) => bot.colour))
+  return BOT_COLOURS.find((colour) => !taken.has(colour)) ?? DEFAULT_BOT_COLOUR
+}
+
+/**
+ * What is wrong with these values, per field. The bounds are `shared/bot-limits`,
+ * the same ones main enforces.
+ *
+ * `description` and `instructions` are optional by design: a Bot with nothing to
+ * say is a product question, not a broken profile (the writer still creates the
+ * `.md`, so the profile loads). `workspaceId` is not optional — a Bot cannot exist
+ * without a Project (ADR-0027 decision 2).
+ */
+export function validateBotForm(values: BotFormValues): BotFormErrors {
+  const errors: BotFormErrors = {}
+  const name = values.name.trim()
+  if (!name) errors.name = 'A Bot needs a name.'
+  else if (name.length > BOT_NAME_MAX_LENGTH) {
+    errors.name = `A name can be at most ${BOT_NAME_MAX_LENGTH} characters.`
+  } else if (hasControlCharacter(name)) {
+    errors.name = 'A name cannot contain line breaks.'
+  }
+
+  if (!values.workspaceId) errors.workspaceId = 'A Bot lives in a project — pick one.'
+
+  if (!values.colour) errors.colour = 'A Bot needs a colour.'
+  else if (values.colour.length > BOT_COLOUR_MAX_LENGTH) {
+    errors.colour = `A colour can be at most ${BOT_COLOUR_MAX_LENGTH} characters.`
+  }
+
+  const description = values.description.trim()
+  if (description.length > BOT_DESCRIPTION_MAX_LENGTH) {
+    errors.description = `A description can be at most ${BOT_DESCRIPTION_MAX_LENGTH} characters.`
+  } else if (hasControlCharacter(description)) {
+    // It becomes the mode's one-line `description` over ACP.
+    errors.description = 'A description is one line — no line breaks.'
+  }
+
+  if (values.instructions.length > BOT_INSTRUCTIONS_MAX_LENGTH) {
+    errors.instructions = `Instructions can be at most ${BOT_INSTRUCTIONS_MAX_LENGTH} characters.`
+  }
+  return errors
+}
+
+/** Whether the form may be submitted at all. */
+export function canSubmitBotForm(values: BotFormValues): boolean {
+  return Object.keys(validateBotForm(values)).length === 0
+}
+
+/** The `bots:create` payload for these values. Trimmed exactly as main will store it. */
+export function botCreateArgs(values: BotFormValues): BotsCreateArgs {
+  return {
+    workspaceId: values.workspaceId,
+    name: values.name.trim(),
+    colour: values.colour,
+    description: values.description.trim(),
+    instructions: values.instructions,
+  }
+}
+
+/**
+ * The `bots:update` payload for these values. Carries every editable field (main
+ * merges by presence, and sending all four keeps the record and the profile files
+ * one write apart) — but never `workspaceId` and never a profile id, neither of
+ * which the contract accepts.
+ */
+export function botUpdateArgs(threadId: string, values: BotFormValues): BotsUpdateArgs {
+  return {
+    threadId,
+    name: values.name.trim(),
+    colour: values.colour,
+    description: values.description.trim(),
+    instructions: values.instructions,
+  }
+}
+
+/**
+ * Whether an edit changed anything worth writing. Used to keep Save honest: a
+ * no-op edit should not rewrite the profile files (and so should not claim the
+ * "takes effect on your next message" promise either).
+ */
+export function isBotFormDirty(values: BotFormValues, bot: BotRecord): boolean {
+  return (
+    values.name.trim() !== bot.name ||
+    values.colour !== bot.colour ||
+    values.description.trim() !== bot.description ||
+    values.instructions !== bot.instructions
+  )
+}
+
+function emptyValues(workspaceId: string): BotFormValues {
+  return {
+    name: '',
+    colour: DEFAULT_BOT_COLOUR,
+    workspaceId,
+    description: '',
+    instructions: '',
+  }
+}
+
+/** C0 controls (line breaks included) and DEL — the same rule main applies. */
+function hasControlCharacter(value: string): boolean {
+  for (const char of value) {
+    const code = char.codePointAt(0) ?? 0
+    if (code < 0x20 || code === 0x7f) return true
+  }
+  return false
+}

--- a/apps/desktop/src/renderer/src/bots/bot-form.ts
+++ b/apps/desktop/src/renderer/src/bots/bot-form.ts
@@ -4,6 +4,7 @@ import {
   BOT_DESCRIPTION_MAX_LENGTH,
   BOT_INSTRUCTIONS_MAX_LENGTH,
   BOT_NAME_MAX_LENGTH,
+  hasBotControlCharacter,
 } from '../../../shared/bot-limits'
 
 /**
@@ -13,9 +14,12 @@ import {
  *
  * The division of labour with main is deliberate. Main is the validator: it refuses
  * a record that would project a profile Vibe silently ignores, and its `problems`
- * are shown verbatim. This module is the SAME bounds one step earlier, so the two
- * can never disagree and so the user learns about a 61-character name while typing
- * it instead of after a round trip.
+ * are shown verbatim. This module applies the rules BOTH sides share
+ * (`shared/bot-limits` — the four bounds and the control-character rule) one step
+ * earlier, so the user learns about a 61-character name while typing it instead of
+ * after a round trip. Main still checks more than this does — `validateBotColour`'s
+ * hex/token pattern has no counterpart here, because the form only ever emits
+ * palette entries — so a refusal it alone catches lands in the `problems` strip.
  *
  * Two things it will not do:
  * - **Move a Bot between Projects.** `BotsUpdateArgs` has no `workspaceId` and that
@@ -88,9 +92,11 @@ export function initialBotFormValues(args: {
 }
 
 /**
- * The colour a new Bot gets: the first palette entry no existing Bot is using, or
- * — once every colour is taken — the one belonging to the oldest Bot, so the cycle
- * repeats in a stable order instead of at random.
+ * The colour a new Bot gets: the first palette entry no existing Bot is using, so
+ * two Bots made in a row never look alike. Once every colour is taken it falls back
+ * to the default and colours simply repeat — a duplicate is a cosmetic collision
+ * between teammates you can already tell apart by name, and the user can pick any
+ * other swatch in the form.
  */
 export function nextBotColour(bots: readonly BotRecord[]): string {
   const taken = new Set(bots.map((bot) => bot.colour))
@@ -112,7 +118,7 @@ export function validateBotForm(values: BotFormValues): BotFormErrors {
   if (!name) errors.name = 'A Bot needs a name.'
   else if (name.length > BOT_NAME_MAX_LENGTH) {
     errors.name = `A name can be at most ${BOT_NAME_MAX_LENGTH} characters.`
-  } else if (hasControlCharacter(name)) {
+  } else if (hasBotControlCharacter(name)) {
     errors.name = 'A name cannot contain line breaks.'
   }
 
@@ -126,7 +132,7 @@ export function validateBotForm(values: BotFormValues): BotFormErrors {
   const description = values.description.trim()
   if (description.length > BOT_DESCRIPTION_MAX_LENGTH) {
     errors.description = `A description can be at most ${BOT_DESCRIPTION_MAX_LENGTH} characters.`
-  } else if (hasControlCharacter(description)) {
+  } else if (hasBotControlCharacter(description)) {
     // It becomes the mode's one-line `description` over ACP.
     errors.description = 'A description is one line — no line breaks.'
   }
@@ -191,13 +197,4 @@ function emptyValues(workspaceId: string): BotFormValues {
     description: '',
     instructions: '',
   }
-}
-
-/** C0 controls (line breaks included) and DEL — the same rule main applies. */
-function hasControlCharacter(value: string): boolean {
-  for (const char of value) {
-    const code = char.codePointAt(0) ?? 0
-    if (code < 0x20 || code === 0x7f) return true
-  }
-  return false
 }

--- a/apps/desktop/src/renderer/src/bots/bot-rows.test.ts
+++ b/apps/desktop/src/renderer/src/bots/bot-rows.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import type { BotRecord, ListMetadataResult } from '../../../shared/ipc'
 import type { ThreadStatusMap } from '../conversation/thread-status'
-import { botBeingRead, deriveBotRows, isBotUnread } from './bot-rows'
+import { botBeingRead, deriveBotRows, isBotUnread, markBotMeta } from './bot-rows'
 import { getBotsSeen, markBotSeen } from './bot-seen-store'
 
 function bot(name: string, threadId: string, updatedAt = 100): BotRecord {
@@ -227,5 +227,31 @@ describe('isBotUnread', () => {
 
   it('is never unread while it is the Bot on screen', () => {
     expect(isBotUnread({ lastActiveAt: 99, seenAt: 0, needsAttention: true, selected: true })).toBe(false)
+  })
+})
+
+describe('markBotMeta (#447 — the renderer-synthesized meta)', () => {
+  const meta = {
+    id: 't-rex',
+    workspaceId: 'ws-1',
+    sessionId: null,
+    title: null,
+    createdAt: 0,
+    lastActiveAt: 0,
+  }
+
+  it('marks a synthesized live meta so the Thread list can still drop it', () => {
+    // Without this a just-created Bot appears TWICE in the sidebar: once in the
+    // Bots section, once as an untitled row in its project's Thread list.
+    expect(markBotMeta(meta, [bot('Rex', 't-rex')])).toMatchObject({ bot: { name: 'Rex' } })
+  })
+
+  it('leaves an ordinary Thread untouched, by identity', () => {
+    expect(markBotMeta(meta, [bot('Rex', 't-other')])).toBe(meta)
+  })
+
+  it('leaves an already-marked meta untouched, by identity', () => {
+    const marked = { ...meta, bot: { name: 'Rex' } }
+    expect(markBotMeta(marked, [bot('Renamed', 't-rex')])).toBe(marked)
   })
 })

--- a/apps/desktop/src/renderer/src/bots/bot-rows.ts
+++ b/apps/desktop/src/renderer/src/bots/bot-rows.ts
@@ -1,4 +1,4 @@
-import type { BotRecord, ListMetadataResult } from '../../../shared/ipc'
+import type { BotRecord, ListMetadataResult, ThreadMeta } from '../../../shared/ipc'
 import type { ThreadStatusMap } from '../conversation/thread-status'
 
 /**
@@ -126,6 +126,28 @@ export function deriveBotRows(args: {
   return rows.sort(
     (a, b) => b.lastActiveAt - a.lastActiveAt || a.bot.name.localeCompare(b.bot.name),
   )
+}
+
+/**
+ * Carry the per-row **Bot** mark onto a meta the RENDERER synthesized (#447, the
+ * deferred #446 finding). Main marks every meta it lists (`markBotThreads`), but
+ * App synthesizes metas for live Threads that are not in the cold list yet — a
+ * just-created Bot before the metadata refresh lands, or the connection's own
+ * auto-opened Thread. Those arrive unmarked, and an unmarked Bot is a Bot that
+ * `partitionBots` cannot drop: its Thread shows up in the project's Thread list,
+ * as an untitled duplicate of the row already in the Bots section.
+ *
+ * Unreachable before this slice (nothing created a Bot while its Workspace was
+ * connected); reachable the moment the create form exists, which is why it is
+ * fixed here rather than there.
+ *
+ * Same shape as main's marker: it MARKS and never drops, and a meta that already
+ * carries the flag (or belongs to no Bot) is returned untouched.
+ */
+export function markBotMeta(meta: ThreadMeta, bots: readonly BotRecord[]): ThreadMeta {
+  if (meta.bot) return meta
+  const bot = bots.find((candidate) => candidate.threadId === meta.id)
+  return bot ? { ...meta, bot: { name: bot.name } } : meta
 }
 
 /** Every listed Thread's `lastActiveAt`, keyed by Thread id. */

--- a/apps/desktop/src/renderer/src/bots/conversation-reset.test.ts
+++ b/apps/desktop/src/renderer/src/bots/conversation-reset.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import {
+  bumpConversationEpoch,
+  conversationViewKey,
+  initialConversationEpochs,
+} from './conversation-reset'
+
+describe('conversationViewKey', () => {
+  it('is the plain Thread id until a Start over — nothing else may remount', () => {
+    expect(conversationViewKey('t1', initialConversationEpochs)).toBe('t1')
+  })
+
+  it('changes exactly once per Start over', () => {
+    const once = bumpConversationEpoch(initialConversationEpochs, 't1')
+    const twice = bumpConversationEpoch(once, 't1')
+    expect(conversationViewKey('t1', once)).not.toBe('t1')
+    expect(conversationViewKey('t1', twice)).not.toBe(conversationViewKey('t1', once))
+  })
+
+  it('leaves the key of every other Thread alone', () => {
+    const epochs = bumpConversationEpoch(initialConversationEpochs, 't1')
+    expect(conversationViewKey('t2', epochs)).toBe('t2')
+  })
+})
+
+describe('bumpConversationEpoch', () => {
+  it('does not mutate the map it is given', () => {
+    const before = initialConversationEpochs
+    bumpConversationEpoch(before, 't1')
+    expect(before).toEqual({})
+  })
+})

--- a/apps/desktop/src/renderer/src/bots/conversation-reset.ts
+++ b/apps/desktop/src/renderer/src/bots/conversation-reset.ts
@@ -1,0 +1,43 @@
+/**
+ * The renderer half of "Start over" (#447, ADR-0027).
+ *
+ * Main retires the Bot's session cursor; the live view has to stop using the
+ * session it already holds. `Conversation` seeds its bound session ONCE, at mount
+ * (`useState(thread.sessionId)` mirrored into a ref, so the event subscription
+ * reads it without re-subscribing) — a deliberate design that also means a prop
+ * change cannot un-bind it. If the mounted view kept that session, the very next
+ * prompt would reuse the conversation the user just asked to leave behind.
+ *
+ * So Start over REMOUNTS the live view, by changing the key it is rendered under.
+ * That is the whole mechanism, and it is safe precisely because the transcript is
+ * durable: a remounted Conversation replays the Thread's history from our own log
+ * (`conversation/replay.ts`), so the old turns are still there to read — which is
+ * exactly what Start over promises.
+ *
+ * Renderer-session-only by design: an epoch survives no restart, and needs to
+ * survive none. After a relaunch the Thread's persisted `sessionId` is already
+ * null, so the fresh mount seeds a draft with no help from here.
+ */
+
+/** How many times each Thread's live view has been reset this session. */
+export type ConversationEpochs = Readonly<Record<string, number>>
+
+export const initialConversationEpochs: ConversationEpochs = {}
+
+/** Record one Start over on a Thread. Pure; returns a new map. */
+export function bumpConversationEpoch(
+  epochs: ConversationEpochs,
+  threadId: string,
+): ConversationEpochs {
+  return { ...epochs, [threadId]: (epochs[threadId] ?? 0) + 1 }
+}
+
+/**
+ * The React key the Thread's live view is rendered under. Stable for a Thread
+ * that has never started over (so nothing remounts in the ordinary case) and
+ * different afterwards (so the view is rebuilt exactly once per Start over).
+ */
+export function conversationViewKey(threadId: string, epochs: ConversationEpochs): string {
+  const epoch = epochs[threadId] ?? 0
+  return epoch === 0 ? threadId : `${threadId}#${epoch}`
+}

--- a/apps/desktop/src/renderer/src/bots/use-bot-lifecycle.test.ts
+++ b/apps/desktop/src/renderer/src/bots/use-bot-lifecycle.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { BotRecord } from '../../../shared/ipc'
+import { useBotLifecycle, type BotLifecycleDeps } from './use-bot-lifecycle'
+
+/**
+ * The Bot lifecycle choreography (#447). Driven directly, with fake dispatchers and
+ * a stubbed `window.api` — the same shape as `use-workspace-actions.test.ts`.
+ *
+ * The test that earns the seam is the Start-over ORDER: every step is recorded into
+ * one log, so "refresh the metadata BEFORE re-hosting and remounting" is asserted
+ * rather than assumed. Get it wrong and the remounted view re-seeds the session the
+ * user just asked to leave behind — which no type and no reviewer would catch.
+ */
+
+const BOT: BotRecord = {
+  threadId: 'thread-rex',
+  workspaceId: 'ws-1',
+  profileId: 'mistro-bot-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+  name: 'Rex',
+  colour: '#e8734a',
+  description: '',
+  instructions: '',
+  createdAt: 10,
+  updatedAt: 20,
+}
+
+interface Harness {
+  deps: BotLifecycleDeps
+  log: string[]
+  errors: Array<{ threadId: string; message: string } | null>
+}
+
+function harness(overrides: Partial<BotLifecycleDeps> = {}): Harness {
+  const log: string[] = []
+  const errors: Harness['errors'] = []
+  const deps: BotLifecycleDeps = {
+    connections: { 'ws-1': { status: 'connected' } as never },
+    navDispatch: vi.fn((action) => log.push(`nav:${action.type}`)),
+    wtDispatch: vi.fn((action) => log.push(`wt:${action.type}`)),
+    setConversationEpochs: vi.fn(() => log.push('epoch:bump')),
+    refreshBots: vi.fn(() => log.push('refresh:bots')),
+    refreshRecents: vi.fn(async () => {
+      log.push('refresh:recents')
+    }),
+    selectThreadInWorkspace: vi.fn(() => log.push('select:thread')),
+    continueColdThread: vi.fn(async () => {
+      log.push('continue:cold')
+    }),
+    setActionError: vi.fn((error) => {
+      errors.push(error)
+      if (error) log.push('error:shown')
+    }),
+    ...overrides,
+  }
+  return { deps, log, errors }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('startOver', () => {
+  it('refreshes the metadata BEFORE re-hosting and remounting', async () => {
+    vi.stubGlobal('window', { api: { botsStartOver: vi.fn(async () => ({ ok: true })) } })
+    const h = harness()
+
+    await useBotLifecycle(h.deps).startOver({ threadId: BOT.threadId, name: BOT.name }, 'ws-1')
+
+    // The cleared cursor must be in `recents` before anything re-seeds from it, and
+    // `remove` (which drops the bound session) must precede `open`.
+    expect(h.log).toEqual(['refresh:recents', 'wt:remove', 'wt:open', 'epoch:bump'])
+  })
+
+  it('shows a refusal instead of changing anything', async () => {
+    vi.stubGlobal('window', {
+      api: { botsStartOver: vi.fn(async () => ({ ok: false, reason: 'streaming' })) },
+    })
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const h = harness()
+
+    await useBotLifecycle(h.deps).startOver({ threadId: BOT.threadId, name: BOT.name }, 'ws-1')
+
+    expect(h.log).toEqual(['error:shown'])
+    expect(h.errors.at(-1)).toEqual({
+      threadId: BOT.threadId,
+      message: expect.stringContaining('Rex'),
+    })
+    expect(errorSpy).toHaveBeenCalled() // logged AND surfaced, not one or the other
+  })
+
+  it('clears a previous refusal when the user tries again', async () => {
+    vi.stubGlobal('window', { api: { botsStartOver: vi.fn(async () => ({ ok: true })) } })
+    const h = harness()
+
+    await useBotLifecycle(h.deps).startOver({ threadId: BOT.threadId, name: BOT.name }, 'ws-1')
+
+    expect(h.errors[0]).toBeNull()
+  })
+})
+
+describe('createBot', () => {
+  it('opens the new Bot through the ordinary selection on a connected Project', async () => {
+    vi.stubGlobal('window', {
+      api: { botsCreate: vi.fn(async () => ({ ok: true, bot: BOT })) },
+    })
+    const h = harness()
+
+    const result = await useBotLifecycle(h.deps).createBot({
+      workspaceId: 'ws-1',
+      name: 'Rex',
+      colour: '#e8734a',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(h.log).toEqual(['refresh:bots', 'refresh:recents', 'select:thread'])
+  })
+
+  it('continues a never-connected Project on the Bot\'s own Thread', async () => {
+    // The row is not in the caller's captured metadata yet, so the cold path is
+    // handed a meta built from the record instead of looking one up.
+    vi.stubGlobal('window', {
+      api: { botsCreate: vi.fn(async () => ({ ok: true, bot: BOT })) },
+    })
+    const h = harness({ connections: {} })
+
+    await useBotLifecycle(h.deps).createBot({ workspaceId: 'ws-1', name: 'Rex', colour: '#e8734a' })
+
+    expect(h.log).toEqual(['refresh:bots', 'refresh:recents', 'continue:cold'])
+    expect(h.deps.continueColdThread).toHaveBeenCalledWith(
+      expect.objectContaining({ id: BOT.threadId, workspaceId: 'ws-1', sessionId: null }),
+    )
+  })
+
+  it('changes nothing when main refuses, so the form can keep what was typed', async () => {
+    vi.stubGlobal('window', {
+      api: {
+        botsCreate: vi.fn(async () => ({ ok: false, reason: 'invalid', problems: ['name: nope'] })),
+      },
+    })
+    const h = harness()
+
+    const result = await useBotLifecycle(h.deps).createBot({
+      workspaceId: 'ws-1',
+      name: '',
+      colour: '#e8734a',
+    })
+
+    expect(result).toEqual({ ok: false, reason: 'invalid', problems: ['name: nope'] })
+    expect(h.log).toEqual([])
+  })
+})
+
+describe('saveBot', () => {
+  it('re-reads both lists so the rename lands in the sidebar and in Search', async () => {
+    vi.stubGlobal('window', {
+      api: { botsUpdate: vi.fn(async () => ({ ok: true, bot: { ...BOT, name: 'Rexi' } })) },
+    })
+    const h = harness()
+
+    await useBotLifecycle(h.deps).saveBot({ threadId: BOT.threadId, name: 'Rexi' })
+
+    expect(h.log).toEqual(['refresh:bots', 'refresh:recents'])
+  })
+})
+
+describe('deleteBot', () => {
+  it('lands back on the now-ordinary conversation and reports no problems', async () => {
+    vi.stubGlobal('window', { api: { botsDelete: vi.fn(async () => ({ ok: true })) } })
+    const h = harness()
+
+    const problems = await useBotLifecycle(h.deps).deleteBot(BOT)
+
+    expect(problems).toEqual([])
+    expect(h.log).toEqual(['refresh:bots', 'refresh:recents', 'select:thread'])
+  })
+
+  it('returns something to SHOW when the delete fails, and changes nothing', async () => {
+    vi.stubGlobal('window', { api: { botsDelete: vi.fn(async () => ({ ok: false })) } })
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const h = harness()
+
+    const problems = await useBotLifecycle(h.deps).deleteBot(BOT)
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0]).toContain('Rex')
+    expect(h.log).toEqual([])
+    expect(errorSpy).toHaveBeenCalled()
+  })
+})
+
+describe('openForm', () => {
+  it('carries the target INTO nav, so a history entry knows which form it was', () => {
+    const h = harness()
+    useBotLifecycle(h.deps).openForm({ mode: 'edit', threadId: BOT.threadId })
+
+    expect(h.deps.navDispatch).toHaveBeenCalledWith({
+      type: 'open-bot-form',
+      target: { mode: 'edit', threadId: BOT.threadId },
+    })
+  })
+})

--- a/apps/desktop/src/renderer/src/bots/use-bot-lifecycle.ts
+++ b/apps/desktop/src/renderer/src/bots/use-bot-lifecycle.ts
@@ -1,0 +1,184 @@
+import type { Dispatch, SetStateAction } from 'react'
+import type {
+  BotRecord,
+  BotsCreateArgs,
+  BotsUpdateArgs,
+  BotWriteResult,
+  ThreadMeta,
+} from '../../../shared/ipc'
+import type { ConnectionMap } from '../connection/connections'
+import type { WorkspaceThreadsAction } from '../connection/workspace-threads'
+import type { NavAction } from '../shell/nav-reducer'
+import { deleteBotFailureMessage, startOverFailureMessage } from './bot-action-messages'
+import { bumpConversationEpoch, type ConversationEpochs } from './conversation-reset'
+import type { BotFormTarget } from './bot-form'
+
+/**
+ * The **Mistro Bot** lifecycle mutations (#447), extracted from App for the same
+ * reason `use-workspace-actions.ts` was: each one reconciles SEVERAL stores in a
+ * specific order, and behind this seam the choreography is drivable with fake
+ * dispatchers instead of being closed over App's hooks.
+ *
+ * "Start over" is why this seam earns its keep. Its three renderer steps are
+ * genuinely order-dependent — and one of them is invisible (`wt remove` exists
+ * only to drop `bound[threadId]`, because a session bound this session WINS over
+ * the record's cursor in `seedSessionId`). A reader reordering them would see
+ * nothing wrong; a test does.
+ *
+ * Every mutation calls main FIRST and reconciles local state only on an ok result,
+ * so the UI never drops something main still holds — and every refusal comes back
+ * as something to SHOW, never as a console line alone (#447 review, D2).
+ */
+
+export interface BotLifecycleDeps {
+  /** The per-Workspace connection registry — decides how a new Bot is opened. */
+  connections: ConnectionMap
+  navDispatch: Dispatch<NavAction>
+  wtDispatch: Dispatch<WorkspaceThreadsAction>
+  setConversationEpochs: Dispatch<SetStateAction<ConversationEpochs>>
+  /** Re-read the Bot records (`bots:list`) after a write. */
+  refreshBots: () => void
+  /** Re-read the cold Workspace/Thread list. Awaited where ordering matters. */
+  refreshRecents: () => Promise<void>
+  /** Select a Thread the ordinary way (connect-if-needed, host, replay). */
+  selectThreadInWorkspace: (workspaceId: string, threadId: string) => void
+  /** Connect a cold Workspace ON a specific Thread (the `continueThreadId` path). */
+  continueColdThread: (thread: ThreadMeta) => Promise<void>
+  /** Show a refusal on the Bot's header — the channel `shared/ipc/bots.ts` promises. */
+  setActionError: (error: { threadId: string; message: string } | null) => void
+}
+
+export interface BotLifecycle {
+  openForm(target: BotFormTarget): void
+  createBot(args: BotsCreateArgs): Promise<BotWriteResult>
+  saveBot(args: BotsUpdateArgs): Promise<BotWriteResult>
+  /** Resolves with the problems to SHOW in the form — empty on success. */
+  deleteBot(bot: BotRecord): Promise<string[]>
+  startOver(bot: { threadId: string; name: string }, workspaceId: string): Promise<void>
+}
+
+export function useBotLifecycle(deps: BotLifecycleDeps): BotLifecycle {
+  /**
+   * Land on a Bot's conversation, ready to talk to.
+   *
+   * The awkward half is the never-connected Project: `hostSelectedThread` resolves
+   * a cold Thread through the metadata list, and a Bot created seconds ago is not
+   * in the caller's captured copy of it (the refresh updated state, not that
+   * value). So the cold path is handed a meta built from the RECORD — a Bot's
+   * Thread is durable from creation (CONTEXT.md's carve-out), so main can
+   * genuinely continue it.
+   */
+  function openBotConversation(bot: BotRecord): void {
+    if (deps.connections[bot.workspaceId]?.status === undefined) {
+      void deps.continueColdThread({
+        id: bot.threadId,
+        workspaceId: bot.workspaceId,
+        sessionId: null,
+        title: null,
+        createdAt: bot.createdAt,
+        lastActiveAt: bot.updatedAt,
+      })
+      return
+    }
+    deps.selectThreadInWorkspace(bot.workspaceId, bot.threadId)
+  }
+
+  return {
+    /**
+     * Open the Bot form in the outlet: create (the sidebar section's ＋ or its
+     * empty-state CTA) or edit (a Bot's own header). The target travels IN nav
+     * state, so a history entry describes which form it was (#447 review, D1).
+     */
+    openForm(target) {
+      deps.navDispatch({ type: 'open-bot-form', target })
+    },
+
+    /**
+     * Create a Bot. Main is the validator and the file writer, so this is a thin
+     * pass-through that refreshes the list on success — the form shows `problems`
+     * when main refuses, and stays open so nothing typed is lost.
+     *
+     * On success we land in the new Bot's conversation: it exists to be talked to,
+     * and leaving the user on an empty form after making one would be a dead end.
+     */
+    async createBot(args) {
+      const result = await window.api.botsCreate(args)
+      if (!result.ok) return result
+      deps.refreshBots()
+      // A Bot's Thread is durable from creation, so the cold list has a new row.
+      await deps.refreshRecents()
+      openBotConversation(result.bot)
+      return result
+    },
+
+    /**
+     * Save an edit. A rename rewrites `display_name` and never the profile id, so
+     * the live session keeps the mode it has selected and the Bot keeps working
+     * across it (ADR-0027). New instructions ride the NEXT prompt's profile
+     * selection — nothing already said is touched, which is what the form promises.
+     */
+    async saveBot(args) {
+      const result = await window.api.botsUpdate(args)
+      if (!result.ok) return result
+      deps.refreshBots()
+      // The Bot mark on the Thread rows carries its NAME, so a rename has to
+      // re-read the cold list too or Search would still show the old one. The form
+      // closes itself on a successful write — we only navigate when there is
+      // somewhere to go.
+      await deps.refreshRecents()
+      return result
+    },
+
+    /**
+     * Delete a Bot: the identity goes, the conversation stays. Main drops the
+     * record and both profile files and ARCHIVES the Thread, so the row leaves the
+     * Bots section and reappears in its project's Archived section — nothing
+     * irreplaceable is destroyed. We land the user back on the (now ordinary)
+     * conversation. A refusal comes back as a message for the form to show.
+     */
+    async deleteBot(bot) {
+      const result = await window.api.botsDelete({ threadId: bot.threadId })
+      if (!result.ok) {
+        console.error(`[vibe-mistro:bots] could not delete ${bot.threadId}`)
+        return [deleteBotFailureMessage(bot.name)]
+      }
+      deps.refreshBots()
+      await deps.refreshRecents()
+      deps.selectThreadInWorkspace(bot.workspaceId, bot.threadId)
+      return []
+    },
+
+    /**
+     * "Start over". Main retires the session cursor; the renderer then has to stop
+     * using the session it is holding, in this order:
+     *
+     *  1. re-read the metadata, so the Thread's `sessionId` IS the cleared one —
+     *     before anything re-seeds from it;
+     *  2. `remove` then `open`, which drops `bound[threadId]` (a session bound this
+     *     session wins over the record's cursor in `seedSessionId`) and re-hosts;
+     *  3. bump the view epoch, which remounts `Conversation` so it re-seeds from
+     *     the now-null cursor instead of the session it bound at mount.
+     *
+     * All three land in one post-await batch, so the remount never sees a
+     * half-updated world. The transcript is untouched throughout and the remounted
+     * view replays it — the old conversation is still there to read, exactly as the
+     * confirm promised.
+     */
+    async startOver(bot, workspaceId) {
+      deps.setActionError(null)
+      const result = await window.api.botsStartOver({ threadId: bot.threadId })
+      if (!result.ok) {
+        console.error(`[vibe-mistro:bots] start over refused (${bot.threadId}): ${result.reason}`)
+        deps.setActionError({
+          threadId: bot.threadId,
+          message: startOverFailureMessage(result.reason, bot.name),
+        })
+        return
+      }
+      await deps.refreshRecents()
+      deps.wtDispatch({ type: 'remove', workspaceId, threadId: bot.threadId })
+      deps.wtDispatch({ type: 'open', workspaceId, threadId: bot.threadId })
+      deps.setConversationEpochs((prev) => bumpConversationEpoch(prev, bot.threadId))
+    },
+  }
+}

--- a/apps/desktop/src/renderer/src/connection/ConnectedWorkspace.tsx
+++ b/apps/desktop/src/renderer/src/connection/ConnectedWorkspace.tsx
@@ -6,7 +6,7 @@ import type {
   ThreadConnection,
   ThreadMeta,
 } from '../../../shared/ipc'
-import type { BotIdentity } from '../bots/BotHeader'
+import type { BotHeaderActions, BotIdentity } from '../bots/BotHeader'
 import { ColdThread } from '../conversation/ColdThread'
 import { Conversation } from '../conversation/Conversation'
 import type { MessageSelection } from '../conversation/message-selection'
@@ -39,6 +39,8 @@ export function ConnectedWorkspace({
   connection,
   activeThread,
   activeBot,
+  activeBotActions,
+  conversationKey,
   isLive,
   isActive,
   busy,
@@ -64,6 +66,16 @@ export function ConnectedWorkspace({
    * because a Bot's behaviour is its profile and changing it means editing the Bot.
    */
   activeBot: BotIdentity | null
+  /** Edit / Start over for that Bot's header (#447); null for an ordinary Thread. */
+  activeBotActions: BotHeaderActions | null
+  /**
+   * The key the LIVE view is mounted under (#447). Normally the Thread id, exactly
+   * as before; after a "Start over" it changes once, which remounts `Conversation`
+   * so it drops the session it bound at mount and seeds the now-cleared cursor —
+   * see `bots/conversation-reset.ts`. Never derive this from the session id: it
+   * changes on every bind, and remounting mid-turn would drop a streaming view.
+   */
+  conversationKey: string
   /** Whether `activeThread` is hosted live on this session's agent (vs cold replay). */
   isLive: boolean
   /**
@@ -113,7 +125,7 @@ export function ConnectedWorkspace({
       <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col gap-3 p-6">
         {isLive ? (
           <Conversation
-            key={activeThread.id}
+            key={conversationKey}
             thread={{
               agentId: connection.agentId,
               threadId: activeThread.id,
@@ -123,6 +135,7 @@ export function ConnectedWorkspace({
               title: activeThread.title,
             }}
             bot={activeBot}
+            botActions={activeBotActions}
             // A Bot's behaviour is its profile (ADR-0027 decision 5), so it gets no
             // Mode / Model / Reasoning-effort picker: the Mode axis is exactly where
             // its persona is selected, and a picker there is a one-click way to

--- a/apps/desktop/src/renderer/src/conversation/Conversation.tsx
+++ b/apps/desktop/src/renderer/src/conversation/Conversation.tsx
@@ -17,7 +17,7 @@ import type {
   ThreadModes,
   ThreadReasoningEffort,
 } from '../../../shared/ipc'
-import { BotHeader, type BotIdentity } from '../bots/BotHeader'
+import { BotHeader, type BotHeaderActions, type BotIdentity } from '../bots/BotHeader'
 import { FileOpenProvider } from './file-open-context'
 import { isRejectOption } from './permission-option'
 import type { FileLink } from './file-link'
@@ -107,6 +107,7 @@ export interface LiveThread {
 export function Conversation({
   thread,
   bot = null,
+  botActions = null,
   modes,
   models,
   reasoningEffort,
@@ -127,6 +128,12 @@ export function Conversation({
    * Bot's turn is an ordinary Thread turn (ADR-0027).
    */
   bot?: BotIdentity | null
+  /**
+   * Edit / Start over for a Bot's header (#447), supplied by App beside the
+   * identity. Null for an ordinary Thread and for any surface that renders a Bot
+   * without offering to change it.
+   */
+  botActions?: BotHeaderActions | null
   /** The connection's current Mode + options (#66) — display-from-session-state. */
   modes: ThreadModes | null
   /** The connection's current Model + options (#66). */
@@ -576,7 +583,7 @@ export function Conversation({
     <FileOpenProvider value={openFile}>
       <div className="conv" ref={convRef}>
         {bot ? (
-          <BotHeader bot={bot} />
+          <BotHeader bot={bot} actions={botActions} />
         ) : (
           <div className="conv__head">
             <span className="dot dot--ok" aria-hidden />

--- a/apps/desktop/src/renderer/src/shell/Shell.tsx
+++ b/apps/desktop/src/renderer/src/shell/Shell.tsx
@@ -53,6 +53,7 @@ export function Shell({
   onOpenProject,
   onNewThread,
   onSelectBot,
+  onCreateBot,
   actions,
   onOpenSettings,
   onOpenSearch,
@@ -93,6 +94,8 @@ export function Shell({
   onNewThread: () => void
   /** Open a Bot's conversation in the outlet (#446) — an ordinary Thread select underneath. */
   onSelectBot: (row: BotSidebarRow) => void
+  /** Open the Bot create form in the outlet (#447) — the section's ＋ and its empty-state CTA. */
+  onCreateBot: () => void
   /** The bundled per-Thread-row actions (select / new / delete / remove / flags / rename). */
   actions: ThreadRowActions
   /** Open the routed Settings page (#130) — from the account chip's menu. */
@@ -210,6 +213,7 @@ export function Shell({
               rows={botRows}
               selectedThreadId={nav.selectedThreadId}
               onSelectBot={onSelectBot}
+              onCreateBot={onCreateBot}
             />
           </div>
           <div className="min-h-0 flex-1 overflow-y-auto">

--- a/apps/desktop/src/renderer/src/shell/nav-history.ts
+++ b/apps/desktop/src/renderer/src/shell/nav-history.ts
@@ -1,4 +1,10 @@
-import { initialNavState, navReducer, type NavAction, type NavState } from './nav-reducer'
+import {
+  initialNavState,
+  navReducer,
+  sameBotFormTarget,
+  type NavAction,
+  type NavState,
+} from './nav-reducer'
 
 /**
  * Browser-style back/forward over shell navigation: a pure history wrapper around
@@ -95,6 +101,9 @@ function areNavStatesEqual(a: NavState, b: NavState): boolean {
   return (
     a.selectedWorkspaceId === b.selectedWorkspaceId &&
     a.selectedThreadId === b.selectedThreadId &&
-    a.view === b.view
+    a.view === b.view &&
+    // The form's target is part of "what am I looking at" (#447): two `bot-form`
+    // entries editing different Bots are different places.
+    sameBotFormTarget(a.botForm ?? null, b.botForm ?? null)
   )
 }

--- a/apps/desktop/src/renderer/src/shell/nav-reducer.test.ts
+++ b/apps/desktop/src/renderer/src/shell/nav-reducer.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { findSelectedThread, initialNavState, navReducer, type NavState } from './nav-reducer'
+import {
+  findSelectedThread,
+  initialNavState,
+  navReducer,
+  type NavAction,
+  type NavState,
+} from './nav-reducer'
 import type { ListMetadataResult, ThreadMeta } from '../../../shared/ipc'
 
 /**
@@ -123,27 +129,61 @@ describe('navReducer', () => {
   })
 
   describe('Bot form view (#447)', () => {
+    const editRex: NavAction = { type: 'open-bot-form', target: { mode: 'edit', threadId: 't-rex' } }
+
     it('open-bot-form / close-bot-form mirror the Settings contract, preserving the selection', () => {
       // The selection MUST survive: the form is opened from a Bot's own
       // conversation ("Edit"), and Cancel has to land back on it.
       const start: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 't1', view: 'conversation' }
-      const open = navReducer(start, { type: 'open-bot-form' })
-      expect(open).toEqual({ selectedWorkspaceId: 'w1', selectedThreadId: 't1', view: 'bot-form' })
-      expect(navReducer(open, { type: 'open-bot-form' })).toBe(open) // referential no-op
+      const open = navReducer(start, editRex)
+      expect(open).toEqual({
+        selectedWorkspaceId: 'w1',
+        selectedThreadId: 't1',
+        view: 'bot-form',
+        botForm: { mode: 'edit', threadId: 't-rex' },
+      })
+      expect(navReducer(open, editRex)).toBe(open) // referential no-op: same form
+      // Closing DROPS the payload: a stale target must not travel with a view that
+      // is not showing a form.
       expect(navReducer(open, { type: 'close-bot-form' })).toEqual(start)
     })
 
-    it('selecting a Bot from the sidebar leaves the form', () => {
-      const start: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: null, view: 'bot-form' }
-      const next = navReducer(start, { type: 'select-thread', workspaceId: 'w1', threadId: 't-rex' })
-      expect(next).toEqual({ selectedWorkspaceId: 'w1', selectedThreadId: 't-rex', view: 'conversation' })
+    it('carries WHICH form it is, so two edits are two different places (#447 D1)', () => {
+      // Without the payload in nav, Back from "Edit Ada" would restore the view with
+      // whatever target was set last — showing Ada's form under Rex's history entry.
+      const start: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 't1', view: 'conversation' }
+      const rex = navReducer(start, editRex)
+      const ada = navReducer(rex, { type: 'open-bot-form', target: { mode: 'edit', threadId: 't-ada' } })
+      expect(ada).not.toBe(rex)
+      expect(ada.botForm).toEqual({ mode: 'edit', threadId: 't-ada' })
+    })
+
+    it('drops the target on every route back to a conversation', () => {
+      // A stale target must never travel into a history entry that shows no form.
+      const start: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: null, view: 'conversation' }
+      const open = navReducer(start, editRex)
+      expect(navReducer(open, { type: 'select-thread', workspaceId: 'w1', threadId: 't-rex' })).toEqual({
+        selectedWorkspaceId: 'w1',
+        selectedThreadId: 't-rex',
+        view: 'conversation',
+      })
+      for (const action of [
+        { type: 'select-workspace', workspaceId: 'w2' },
+        { type: 'select-workspace', workspaceId: 'w1' },
+        { type: 'open-settings' },
+        { type: 'open-skills' },
+        { type: 'close-bot-form' },
+      ] satisfies NavAction[]) {
+        expect(navReducer(open, action).botForm ?? null).toBeNull()
+      }
     })
 
     it('the ＋ works from Settings or Skills — the form swaps in directly', () => {
+      const create: NavAction = { type: 'open-bot-form', target: { mode: 'create', workspaceId: 'w1' } }
       const fromSkills: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: null, view: 'skills' }
-      expect(navReducer(fromSkills, { type: 'open-bot-form' }).view).toBe('bot-form')
+      expect(navReducer(fromSkills, create).view).toBe('bot-form')
       const fromSettings: NavState = { ...fromSkills, view: 'settings' }
-      expect(navReducer(fromSettings, { type: 'open-bot-form' }).view).toBe('bot-form')
+      expect(navReducer(fromSettings, create).view).toBe('bot-form')
     })
   })
 })

--- a/apps/desktop/src/renderer/src/shell/nav-reducer.test.ts
+++ b/apps/desktop/src/renderer/src/shell/nav-reducer.test.ts
@@ -121,6 +121,31 @@ describe('navReducer', () => {
       expect(navReducer(start, { type: 'open-settings' }).view).toBe('settings')
     })
   })
+
+  describe('Bot form view (#447)', () => {
+    it('open-bot-form / close-bot-form mirror the Settings contract, preserving the selection', () => {
+      // The selection MUST survive: the form is opened from a Bot's own
+      // conversation ("Edit"), and Cancel has to land back on it.
+      const start: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: 't1', view: 'conversation' }
+      const open = navReducer(start, { type: 'open-bot-form' })
+      expect(open).toEqual({ selectedWorkspaceId: 'w1', selectedThreadId: 't1', view: 'bot-form' })
+      expect(navReducer(open, { type: 'open-bot-form' })).toBe(open) // referential no-op
+      expect(navReducer(open, { type: 'close-bot-form' })).toEqual(start)
+    })
+
+    it('selecting a Bot from the sidebar leaves the form', () => {
+      const start: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: null, view: 'bot-form' }
+      const next = navReducer(start, { type: 'select-thread', workspaceId: 'w1', threadId: 't-rex' })
+      expect(next).toEqual({ selectedWorkspaceId: 'w1', selectedThreadId: 't-rex', view: 'conversation' })
+    })
+
+    it('the ＋ works from Settings or Skills — the form swaps in directly', () => {
+      const fromSkills: NavState = { selectedWorkspaceId: 'w1', selectedThreadId: null, view: 'skills' }
+      expect(navReducer(fromSkills, { type: 'open-bot-form' }).view).toBe('bot-form')
+      const fromSettings: NavState = { ...fromSkills, view: 'settings' }
+      expect(navReducer(fromSettings, { type: 'open-bot-form' }).view).toBe('bot-form')
+    })
+  })
 })
 
 describe('findSelectedThread (cold-outlet derivation)', () => {

--- a/apps/desktop/src/renderer/src/shell/nav-reducer.ts
+++ b/apps/desktop/src/renderer/src/shell/nav-reducer.ts
@@ -16,11 +16,18 @@ export interface NavState {
   /**
    * WHICH top-level outlet view is showing (#130). `'settings'` swaps the outlet for
    * the on-demand Settings page (env/CLI status + future settings); `'skills'` for
-   * the Skills browser (#259) — both leave the Workspace/Thread selection intact so
-   * closing returns to the same conversation. Any `select-workspace` / `select-thread`
-   * (picking a project or thread from the sidebar) resets it to `'conversation'`.
+   * the Skills browser (#259); `'bot-form'` for creating or editing a **Mistro Bot**
+   * (#447) — all leave the Workspace/Thread selection intact so closing returns to
+   * the same conversation. Any `select-workspace` / `select-thread` (picking a
+   * project or thread from the sidebar) resets it to `'conversation'`.
+   *
+   * `'bot-form'` is NOT the "Bots page" ADR-0027 rules out: there is no list column
+   * and no way to browse Bots in it — it is a transient form the sidebar's ＋ (or a
+   * Bot's Edit) opens and Cancel/Save closes. WHICH Bot it is editing is App state,
+   * not nav state, for the same reason Settings' account payload is: nav answers
+   * "what am I looking at", not "with what data".
    */
-  view: 'conversation' | 'settings' | 'skills'
+  view: 'conversation' | 'settings' | 'skills' | 'bot-form'
 }
 
 export type NavAction =
@@ -30,6 +37,8 @@ export type NavAction =
   | { type: 'close-settings' }
   | { type: 'open-skills' }
   | { type: 'close-skills' }
+  | { type: 'open-bot-form' }
+  | { type: 'close-bot-form' }
   | { type: 'clear' }
 
 export const initialNavState: NavState = {
@@ -71,8 +80,14 @@ export function navReducer(state: NavState, action: NavAction): NavState {
     case 'open-skills':
       // Swap the outlet for the Skills browser (#259) — same contract as Settings.
       return state.view === 'skills' ? state : { ...state, view: 'skills' }
+    case 'open-bot-form':
+      // Swap the outlet for the Bot create/edit form (#447) — same contract again:
+      // the selection is preserved, so Cancel returns to what was on screen (a Bot's
+      // own conversation, when the form was opened from its Edit).
+      return state.view === 'bot-form' ? state : { ...state, view: 'bot-form' }
     case 'close-settings':
     case 'close-skills':
+    case 'close-bot-form':
       // Return to the conversation view, PRESERVING the current selection.
       return state.view === 'conversation' ? state : { ...state, view: 'conversation' }
     case 'clear':

--- a/apps/desktop/src/renderer/src/shell/nav-reducer.ts
+++ b/apps/desktop/src/renderer/src/shell/nav-reducer.ts
@@ -1,4 +1,5 @@
 import type { ListMetadataResult, ThreadMeta } from '../../../shared/ipc'
+import type { BotFormTarget } from '../bots/bot-form'
 
 /**
  * Shell navigation state (ADR-0006 decision 2): WHICH Workspace and Thread the
@@ -21,13 +22,25 @@ export interface NavState {
    * the same conversation. Any `select-workspace` / `select-thread` (picking a
    * project or thread from the sidebar) resets it to `'conversation'`.
    *
-   * `'bot-form'` is NOT the "Bots page" ADR-0027 rules out: there is no list column
-   * and no way to browse Bots in it — it is a transient form the sidebar's ＋ (or a
-   * Bot's Edit) opens and Cancel/Save closes. WHICH Bot it is editing is App state,
-   * not nav state, for the same reason Settings' account payload is: nav answers
-   * "what am I looking at", not "with what data".
+   * `'bot-form'` is NOT the Bots BROWSING view ADR-0027 rules out (decision 4, as
+   * amended by #447): there is no list column, no nav row, and no way to browse Bots
+   * in it — it is a transient form the sidebar's ＋ (or a Bot's Edit) opens and
+   * Cancel/Save closes.
    */
   view: 'conversation' | 'settings' | 'skills' | 'bot-form'
+  /**
+   * WHICH Bot the form is for, when `view === 'bot-form'`; null otherwise.
+   *
+   * It lives in nav state rather than beside it because the view travels through
+   * nav HISTORY, and a payload that does not travel with it produces a back arrow
+   * that restores the form pointing at whatever was edited last — or at a Bot that
+   * has since been deleted, which then reads as an offer to create a new one (#447
+   * review, D1). Keep the two together and the history entry is self-describing.
+   *
+   * Optional so the many `view: 'conversation'` literals around the app (and their
+   * tests) stay literal: absent means the same as null — no form.
+   */
+  botForm?: BotFormTarget | null
 }
 
 export type NavAction =
@@ -37,7 +50,7 @@ export type NavAction =
   | { type: 'close-settings' }
   | { type: 'open-skills' }
   | { type: 'close-skills' }
-  | { type: 'open-bot-form' }
+  | { type: 'open-bot-form'; target: BotFormTarget }
   | { type: 'close-bot-form' }
   | { type: 'clear' }
 
@@ -56,7 +69,7 @@ export function navReducer(state: NavState, action: NavAction): NavState {
       // but the same-Workspace path stays a referential no-op when ALREADY in the
       // conversation view, so re-selecting the current project never re-renders.
       if (state.selectedWorkspaceId === action.workspaceId) {
-        return state.view === 'conversation' ? state : { ...state, view: 'conversation' }
+        return state.view === 'conversation' ? state : toConversation(state)
       }
       return { selectedWorkspaceId: action.workspaceId, selectedThreadId: null, view: 'conversation' }
     case 'select-thread':
@@ -72,27 +85,62 @@ export function navReducer(state: NavState, action: NavAction): NavState {
       ) {
         return state
       }
-      return { selectedWorkspaceId: action.workspaceId, selectedThreadId: action.threadId, view: 'conversation' }
+      return {
+        selectedWorkspaceId: action.workspaceId,
+        selectedThreadId: action.threadId,
+        view: 'conversation',
+      }
     case 'open-settings':
       // Swap the outlet for the Settings page, PRESERVING the current selection.
       // Referential no-op when already in Settings (uniform with select-workspace).
-      return state.view === 'settings' ? state : { ...state, view: 'settings' }
+      return state.view === 'settings' ? state : { ...withoutBotForm(state), view: 'settings' }
     case 'open-skills':
       // Swap the outlet for the Skills browser (#259) — same contract as Settings.
-      return state.view === 'skills' ? state : { ...state, view: 'skills' }
+      return state.view === 'skills' ? state : { ...withoutBotForm(state), view: 'skills' }
     case 'open-bot-form':
       // Swap the outlet for the Bot create/edit form (#447) — same contract again:
       // the selection is preserved, so Cancel returns to what was on screen (a Bot's
-      // own conversation, when the form was opened from its Edit).
-      return state.view === 'bot-form' ? state : { ...state, view: 'bot-form' }
+      // own conversation, when the form was opened from its Edit). Re-opening the
+      // SAME form is a referential no-op, so the ＋ pressed twice records one move.
+      return state.view === 'bot-form' && sameBotFormTarget(state.botForm ?? null, action.target)
+        ? state
+        : { ...state, view: 'bot-form', botForm: action.target }
     case 'close-settings':
     case 'close-skills':
     case 'close-bot-form':
       // Return to the conversation view, PRESERVING the current selection.
-      return state.view === 'conversation' ? state : { ...state, view: 'conversation' }
+      return state.view === 'conversation' ? state : toConversation(state)
     case 'clear':
       return initialNavState
   }
+}
+
+/**
+ * Back to the conversation view, DROPPING the form payload with it — a `botForm`
+ * left behind would travel into history entries that are not showing a form.
+ *
+ * The key is removed rather than nulled: absent is the canonical "no form", so a
+ * state that never had one is indistinguishable from one that left it.
+ */
+function toConversation(state: NavState): NavState {
+  return { ...withoutBotForm(state), view: 'conversation' }
+}
+
+/** The state minus its form payload (same ref when it has none). */
+function withoutBotForm(state: NavState): NavState {
+  if (state.botForm === undefined) return state
+  return {
+    selectedWorkspaceId: state.selectedWorkspaceId,
+    selectedThreadId: state.selectedThreadId,
+    view: state.view,
+  }
+}
+
+/** Whether two form targets address the same thing (value equality, for no-ops). */
+export function sameBotFormTarget(a: BotFormTarget | null, b: BotFormTarget | null): boolean {
+  if (a === null || b === null) return a === b
+  if (a.mode === 'edit') return b.mode === 'edit' && a.threadId === b.threadId
+  return b.mode === 'create' && a.workspaceId === b.workspaceId
 }
 
 /**

--- a/apps/desktop/src/renderer/src/shell/workspace-nav/index.tsx
+++ b/apps/desktop/src/renderer/src/shell/workspace-nav/index.tsx
@@ -23,6 +23,7 @@ import {
   partitionBots,
   type UnifiedThreadRow,
 } from '../unified-threads'
+import { botNamesInRows, describeBotDestruction } from '../../bots/bot-destruction'
 import { getOpenProjects, setOpenProjects } from '../project-open-store'
 import { getSortOrder, setSortOrder, sortWorkspaces, type WorkspaceSortOrder } from '../workspace-sort'
 import { normalizeRename } from '../rename'
@@ -287,7 +288,11 @@ function ProjectRow({
   // section, so its Thread must not also appear here. This is the ONLY point that
   // renders a Thread list — for the active project and every peeked one alike — so
   // it is the only place the exclusion has to happen.
-  const { threads: threadRows } = partitionBots(rows)
+  const { threads: threadRows, bots: botRows } = partitionBots(rows)
+  // …and the same split answers what "Remove project" is about to destroy (#447):
+  // the rows are built from main's bot-marked metadata, for a peeked project as
+  // much as for the selected one, so the confirm can name them without a new prop.
+  const doomedBots = describeBotDestruction(botNamesInRows(botRows))
   // Split archived rows out (#133) then float pinned rows to the top of the active
   // list (#132) — both pure post-processing over the derived rows (deriveUnifiedThreads
   // stays flag-agnostic). Archived rows fold into a collapsible section at the bottom.
@@ -379,6 +384,13 @@ function ProjectRow({
             <DialogDescription>
               This removes the project from vibe-mistro. Files on disk will not be deleted.
             </DialogDescription>
+            {/* Destruction is honest (ADR-0027): a routine cleanup must not quietly
+                take teammates the user forgot lived here. Main deletes their
+                generated profile files with them (`cleanRemovedBots`); this is the
+                half that says so BEFORE the click. */}
+            {doomedBots && (
+              <p className="text-[13px] leading-relaxed text-destructive">{doomedBots}</p>
+            )}
           </DialogHeader>
           <DialogFooter>
             <DialogClose render={<Button variant="secondary" />}>Cancel</DialogClose>

--- a/apps/desktop/src/shared/bot-limits.ts
+++ b/apps/desktop/src/shared/bot-limits.ts
@@ -1,0 +1,21 @@
+/**
+ * The bounds of a **Mistro Bot** record's editable fields (#445/#447, ADR-0027) —
+ * shared because BOTH sides need them and they must agree.
+ *
+ * Main is the validator (`main/bots/validate-bot-profile.ts`): Vibe validates
+ * nothing we write, so the record is refused there before a profile is projected.
+ * The renderer's form needs the SAME numbers to say "too long" while you type
+ * instead of after a round trip — a form whose limit disagrees with the validator
+ * is a form that lets you write something it then refuses.
+ *
+ * Node/DOM-free like everything under `shared/`.
+ */
+
+/** Long enough for any real teammate name; short enough to stay one sidebar line. */
+export const BOT_NAME_MAX_LENGTH = 60
+/** The mode `description` is one line in a picker, not prose. */
+export const BOT_DESCRIPTION_MAX_LENGTH = 200
+/** The persona proper. Generous — it is the whole personality — but not unbounded. */
+export const BOT_INSTRUCTIONS_MAX_LENGTH = 100_000
+/** A hex colour or a short token name; nothing legitimate needs more. */
+export const BOT_COLOUR_MAX_LENGTH = 32

--- a/apps/desktop/src/shared/bot-limits.ts
+++ b/apps/desktop/src/shared/bot-limits.ts
@@ -1,12 +1,12 @@
 /**
- * The bounds of a **Mistro Bot** record's editable fields (#445/#447, ADR-0027) —
- * shared because BOTH sides need them and they must agree.
+ * The field rules of a **Mistro Bot** record (#445/#447, ADR-0027) — the bounds and
+ * the character rule, shared because BOTH sides apply them and they must agree.
  *
  * Main is the validator (`main/bots/validate-bot-profile.ts`): Vibe validates
  * nothing we write, so the record is refused there before a profile is projected.
- * The renderer's form needs the SAME numbers to say "too long" while you type
- * instead of after a round trip — a form whose limit disagrees with the validator
- * is a form that lets you write something it then refuses.
+ * The renderer's form applies the SAME rules while you type, so it can never let
+ * you write something the validator then refuses. Anything both sides check lives
+ * here rather than in two copies that nothing prevents from drifting.
  *
  * Node/DOM-free like everything under `shared/`.
  */
@@ -19,3 +19,19 @@ export const BOT_DESCRIPTION_MAX_LENGTH = 200
 export const BOT_INSTRUCTIONS_MAX_LENGTH = 100_000
 /** A hex colour or a short token name; nothing legitimate needs more. */
 export const BOT_COLOUR_MAX_LENGTH = 32
+
+/**
+ * Whether a value carries a C0 control character (line breaks included) or DEL.
+ *
+ * The rule behind the rule: `name` and `description` are ONE-LINE values on the
+ * wire — `display_name` and the mode `description` Vibe renders in a picker — so a
+ * newline in either breaks the line that renders it. `instructions` is prose and
+ * is deliberately not checked against this.
+ */
+export function hasBotControlCharacter(value: string): boolean {
+  for (const char of value) {
+    const code = char.codePointAt(0) ?? 0
+    if (code < 0x20 || code === 0x7f) return true
+  }
+  return false
+}

--- a/apps/desktop/src/shared/ipc/bots.ts
+++ b/apps/desktop/src/shared/ipc/bots.ts
@@ -25,6 +25,13 @@ export const botsChannels = {
   botsUpdate: 'bots:update',
   /** Delete a Bot: destroy the identity + its profile files, ARCHIVE its Thread. */
   botsDelete: 'bots:delete',
+  /**
+   * "Start over" (#447): retire the Bot's ACP session so its NEXT prompt mints a
+   * fresh one. A pressure valve, not a delete — the record, both profile files and
+   * the whole transcript are untouched, so the Bot keeps its name, its persona and
+   * a readable history of everything it has already said.
+   */
+  botsStartOver: 'bots:start-over',
 } as const
 
 /**
@@ -117,3 +124,22 @@ export type BotWriteResult =
 export interface BotsDeleteResult {
   ok: boolean
 }
+
+/** Args for `bots:start-over`. Addressed by the Bot's durable Thread, like every Bot op. */
+export interface BotsStartOverArgs {
+  threadId: string
+}
+
+/**
+ * Why a "Start over" was refused. `notFound` = that Thread is not a Bot;
+ * `streaming` = a turn is in flight, and retiring the session under a running turn
+ * would strand it; `io` = the session cursor could not be cleared.
+ */
+export type BotStartOverFailure = 'notFound' | 'streaming' | 'io'
+
+/**
+ * The reply to `bots:start-over`. Typed failure rather than a throw, like every
+ * other Bot write — the header shows what happened instead of the Bot silently
+ * continuing on the session the user asked to leave behind.
+ */
+export type BotsStartOverResult = { ok: true } | { ok: false; reason: BotStartOverFailure }

--- a/docs/adr/0027-mistro-bots-durable-thread-backed-by-agent-profile.md
+++ b/docs/adr/0027-mistro-bots-durable-thread-backed-by-agent-profile.md
@@ -47,8 +47,14 @@ Five parts, each load-bearing:
    generated, and can rebuild them. Profile ids are `mistro-bot-<uuid>`: generated, immutable, and
    therefore incapable of shadowing a builtin mode.
 4. **Sidebar-native.** Bots occupy a bounded, scrollable section above Projects; selecting one swaps
-   the outlet to its conversation exactly as a Thread does. There is **no Bots page and no fourth
-   outlet view**. A Bot is hidden from its Project's Thread list but findable in Search.
+   the outlet to its conversation exactly as a Thread does. There is **no Bots page and no Bots
+   BROWSING view** — nothing reachable from a nav row, and nothing that lists Bots outside the
+   sidebar. *(Amended in #447, which built the create/edit form: **create and edit are a transient
+   outlet view** — `nav.view === 'bot-form'`, with no list, no nav row and no way to reach it except
+   the section's ＋ or a Bot's Edit, cleared by any selection. The original wording said "no fourth
+   outlet view", which would have forbidden the roomy form the same design requires; the thing it
+   meant to forbid — the top-level `view: 'bots'` with its second list column, killed in #422 — is
+   still forbidden.)* A Bot is hidden from its Project's Thread list but findable in Search.
 5. **A Bot's behaviour is its profile.** Model, Mode and reasoning effort are all changed by editing
    the Bot, never by a per-Thread control — so none of the three pickers appear on a Bot.
 
@@ -84,6 +90,22 @@ glossary; the invariant still holds for every Thread a user starts by hand.
 **Deleting a Bot keeps its conversation** as an archived Thread and destroys only the identity. The
 "Remove project" path must gain the same cleanup — today it drops Threads silently and would orphan
 profile files, which would keep appearing as modes for Bots that no longer exist.
+
+**The Bots empty state lives in the sidebar section, not the outlet** (#447). The PRD sketched
+"nothing selected → a roomy empty state" in the outlet, which was written before the outlet's other
+two states were weighed against it: the app already has an idle hero there, and a Bots-specific
+outlet state would be a Bots surface by another name — the thing decision 4 exists to avoid — while
+also being unavailable for **Edit**, where a Bot is selected. So the empty state is the section's
+own (one line explaining what a Bot is, plus a Create CTA), and the section's ＋ is the create
+affordance in every other state.
+
+**A Bot's Project is chosen once and cannot be changed** (#447). Decision 2 says a Bot cannot exist
+*without* a Project; this is the stronger consequence the create/edit form made concrete. The live
+ACP session is bound to one `cwd`, and a Bot's whole value is that it knows *this* project — one
+that changed Project mid-conversation would answer about files it has never seen, with weeks of
+history implying otherwise. `BotsUpdateArgs` therefore carries no `workspaceId`, and the edit form
+shows the Project read-only, saying why rather than merely locking it. Moving a Bot means making a
+new one.
 
 **Vibe validates nothing we write.** Unknown keys in a profile TOML are silently ignored — a typo'd
 override loads, works, and quietly lacks the setting. Since we generate these files, we validate them.


### PR DESCRIPTION
Closes nothing on its own — slice 3 of #444 (ADR-0027). Do not close #447 from here.

## What this adds

**Create and edit, in the outlet.** Nothing about a Bot is editable in a modal: the
instructions field is the whole personality, so it gets a 280px-minimum textarea in a
720px column, and the sidebar stays mounted throughout. The form carries name, colour,
Project and instructions (plus the one-line description that becomes the mode's
`description`). Editing shows the Project read-only — `BotsUpdateArgs` has no
`workspaceId`, and a Bot that changed Project mid-conversation would be answering about
files it has never seen.

**The section's ＋ works in every state**, including with a Bot conversation open; the
empty state (restored by passing `onCreateBot`, the seam slice 2 left) carries the CTA
that only exists while the list is empty.

**"Start over"** — `bots:start-over`. Main retires the Thread's session cursor
(`clearThreadSession`, which `upsertThread` cannot express) and best-effort closes the
retired session; the record, both profile files and the transcript are untouched, and a
mid-turn request is refused (main re-checks `thread-status`, the button disables). The
renderer remounts the live view under a new key, because `Conversation` seeds its bound
session once at mount by design — and since the transcript is durable, the remount
replays it, so the old conversation is still readable. The confirm says all of that.

**Delete** destroys the identity and keeps the history: record + both files gone, Thread
archived, row moves to the project's Archived section.

**"Remove project" names the Bots it will destroy.** Main already deleted their profile
files (#445); this is the UI half. The names come from `partitionBots` over the rows the
list already renders, so a peeked project works too.

**Deferred #446 finding, fixed:** `liveMetasFor` synthesized metas without the Bot mark.
Unreachable until this slice; now a just-created Bot would otherwise appear twice in the
sidebar. `markBotMeta` mirrors main's marker (marks, never drops).

## Acceptance criteria

- [x] Create and edit render in the outlet with an instructions field that has genuine width; the sidebar stays visible
- [x] The Bots section's ＋ opens the create form from **any** state, including with a Bot conversation open
- [x] Editing instructions takes effect on the next turn, and the UI says when it takes effect (never implying it rewrites history) — the field's helper text on an edit, plus a no-op save that does not rewrite the files at all
- [x] A rename updates `display_name` in the TOML and never the profile id; the running Bot keeps working across it — smoke-verified: same file, new `display_name`
- [x] "Start over" mints a fresh session, keeps name/instructions/profile, leaves the old transcript readable, and its copy says so
- [x] Deleting a Bot removes both profile files and the sidebar row, and its Thread becomes archived rather than deleted — store-tested (`sqlite-bot-store.test.ts`) and smoke-verified
- [x] "Remove project" names the Bots it will destroy in the confirm, and deletes their profile files; no orphaned TOML survives — the naming is pure + tested (`bot-destruction.test.ts`), the deletion is #445's `cleanRemovedBots` (already tested)
- [x] All four gates pass — lint, typecheck, build, **1982 tests** (176 files)

## Tests

Pure modules with colocated tests, per convention: `bot-form.ts` (bounds shared with main's
validator through the new `shared/bot-limits`, payload shapes, dirty check),
`bot-destruction.ts` (which Bots, and the sentence), `conversation-reset.ts` (the view key),
`main/bots/start-over.ts` (refusals, best-effort close, and a test that pins the deps shape
so the module cannot grow the ability to touch the record or the files), plus store tests for
delete-keeps-the-conversation and start-over-keeps-everything-else.

No DOM tests (node environment). The surfaces were verified in the built app with a throwaway
Playwright harness against the fake agent, under an isolated `VIBE_MISTRO_USER_DATA` **and**
`VIBE_HOME` — create → TOML written → sidebar row → ＋ with a Bot open → rename (same profile
id) → a real turn → Start over (transcript still readable) → Remove-project naming → delete
(files gone, Thread archived, transcript intact). The harness is deleted.

## Decisions the ticket did not settle

- **A fourth outlet view.** The form is `nav.view === 'bot-form'`, with the target in App
  state. That is not the "Bots page" ADR-0027 rules out — no list, nothing to browse — but it
  is a new value in the nav union, so it is called out here.
- **The "nothing selected" empty state** is the sidebar section's (restored, with its CTA).
  The app's idle hero was left alone rather than hijacked for Bots.
- **A Project cannot be changed after creation** (see above). The form shows it read-only.

## Note for the reviewer

`MenuRadioItem` does not close its menu on click (base-ui default `closeOnClick: false`),
which leaves the popup open behind an inert backdrop. The Project picker passes
`closeOnClick`. The pre-existing Projects **sort** menu (`workspace-nav`) has the same
quirk and was left alone — out of scope here.

Expect a rebase: #448 lands from the same base and also touches `App.tsx`.
