### PR TITLE
docs: never paste Vibe's implementation into public artifacts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,12 @@ durable fold snapshot + fold only the entry tail → full fold through the same 
 - Log, don't swallow — surface failures to the renderer even when a flow is best-effort.
 - ACP param field names: verify against the live `vibe-acp` binary as each method is implemented;
   don't hardcode unverified shapes. Protocol reference: `docs/vibe-acp-protocol.md`, `docs/acp-capture.md`.
+- **This repository is PUBLIC, and `mistral-vibe` is not ours to reproduce.** Capture and document what
+  Vibe does on the **wire** — request/response shapes, error codes, observed behaviour — freely; that is
+  the contract we consume. Never paste Vibe's **implementation** into anything that leaves this machine:
+  no function bodies, no constant definitions, no internal file/line citations, in tracked files, issues,
+  PRs or comments. Describe the mechanism in your own words and say how to re-verify it against the
+  binary. This applies to subagents and probes too — say it in their prompt, because they cannot infer it.
 
 ## Reference docs
 


### PR DESCRIPTION
One rule, added to the ACP conventions in `CLAUDE.md`.

**Why now:** a research probe posted verbatim `mistral-vibe` function bodies and a constant definition into issue comments on this repo — which is public. The comments have been deleted and replaced with redacted versions that keep every finding, and two unpushed `research/*` branches carrying the same content in `docs/acp-capture.md` were scrubbed. Nothing else left the machine, and the merged capture doc was always clean.

**The gap was in the instructions, not the agent.** Every probe prompt asked for findings to be posted publicly and appended to a tracked doc; none said the repo is public or that Vibe's implementation must not be quoted. The distinction that matters:

- **Wire behaviour is ours to document** — request/response shapes, error codes, what we observed. That is the contract we consume and it is why `docs/acp-capture.md` exists.
- **Vibe's implementation is not** — function bodies, constant definitions, internal file/line citations.

The rule calls out subagents explicitly, because they cannot infer it from the repo and will otherwise do the natural thing.