### PR TITLE
feat: Routines slice 1 — the Routine record, the schedule value, and the arithmetic both directions share (#467)

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -118,6 +118,9 @@ import {
 import type { ModeDiscovery } from './acp/agent-controls'
 import { SqliteBotStore } from './persistence/sqlite-bot-store'
 import type { BotStoreApi } from './persistence/bot-store-api'
+import { registerRoutinesIpc } from './routines/register-ipc'
+import { SqliteRoutineStore } from './persistence/sqlite-routine-store'
+import type { RoutineStoreApi } from './persistence/routine-store-api'
 import { registerEditorsIpc } from './editors/register-ipc'
 import { createTerminalManager, registerTerminalIpc } from './terminal/register-ipc'
 import { registerBrowserIpc } from './browser/register-ipc'
@@ -444,6 +447,8 @@ interface MainDeps {
   attachments: AttachmentStore | null
   /** The Mistro Bot records (#445, ADR-0027), on the same state database. */
   bots: BotStoreApi
+  /** The Routine records (#467, ADR-0028), keyed to their Bot. */
+  routines: RoutineStoreApi
 }
 
 /**
@@ -993,6 +998,9 @@ function registerIpc(deps: MainDeps): void {
     isStreaming: (threadId) => threadStatus.statusFor(threadId).streaming,
     closeThreadSession: (threadId) => bestEffortCloseFor(deps, threadId),
   })
+  // Routine CRUD (#467). Read-only on the Bot store: a Routine can only ever be
+  // attached to a Bot, and nothing in this slice fires one.
+  registerRoutinesIpc({ routines: deps.routines, bots: deps.bots })
   // The same profile-file seam the Bot CRUD uses, reused by the Thread- and
   // Workspace-removal cleanup below so both paths refuse a foreign profile id
   // through exactly one gate (#445).
@@ -1608,7 +1616,10 @@ app.whenReady().then(async () => {
   // metadata and transcript stores — a Bot IS a Thread, so its row cascades
   // with the Thread and the Workspace and can never be left dangling.
   const bots = new SqliteBotStore({ stateDb })
-  const deps: MainDeps = { store, transcript, bridge, attachments, stateDb, bots }
+  // A Routine belongs to a Bot (#467, ADR-0028) and its row cascades with the Bot
+  // row, so it rides the same database for the same reason.
+  const routines = new SqliteRoutineStore({ stateDb })
+  const deps: MainDeps = { store, transcript, bridge, attachments, stateDb, bots, routines }
 
   // Daily rotating backup of state.sqlite (ADR-0019, #298) — scheduled off the
   // launch path, best-effort, and never on the non-durable memory fallback

--- a/apps/desktop/src/main/persistence/routine-store-api.ts
+++ b/apps/desktop/src/main/persistence/routine-store-api.ts
@@ -1,0 +1,80 @@
+import type { RoutineOutcome, RoutineRecord } from '../../shared/ipc'
+import type { RoutineSchedule } from '../../shared/schedule'
+
+/**
+ * The public surface of the **Routine** store (#467, ADR-0028) — the seam every
+ * Routine flow in main types against, mirroring `BotStoreApi` exactly (which
+ * itself mirrors `MetadataStoreApi` / `TranscriptStoreApi`). One implementation
+ * today (`SqliteRoutineStore`, on the same `state.sqlite` as everything else);
+ * the interface exists so the lifecycle and the IPC handlers can be tested
+ * without a database.
+ *
+ * SYNCHRONOUS on purpose, like `BotStoreApi`: `node:sqlite` is synchronous and
+ * there is no legacy engine behind this seam.
+ *
+ * Best-effort like every other store here: a write that cannot land LOGS and
+ * reports failure (`null` / `false`) rather than throwing into the live flow —
+ * which for Routines matters twice over, since the flow that writes here is a
+ * turn nobody is watching.
+ */
+
+/** A new Routine's row values. The id is minted by the caller, never by the renderer. */
+export interface RoutineInsert {
+  id: string
+  /** The Bot this Routine belongs to. Must name a Bot row (the FK). */
+  threadId: string
+  name: string
+  prompt: string
+  schedule: RoutineSchedule
+  allowedCommands: string[]
+  /** A Routine is created ACTIVE (ADR-0028 part 7); the field exists for restores. */
+  active: boolean
+}
+
+/**
+ * The editable half of a Routine. `threadId` is deliberately absent: a Routine
+ * belongs to the Bot whose conversation it reports into, so moving one would
+ * strand its reports away from the history that makes them readable.
+ */
+export interface RoutinePatch {
+  name?: string
+  prompt?: string
+  schedule?: RoutineSchedule
+  allowedCommands?: string[]
+  active?: boolean
+}
+
+/**
+ * The run outcome, written by the firer (slice 2) after every turn — success or
+ * failure, one rule with no exceptions (ADR-0028 part 5).
+ *
+ * `lastError` is cleared by an `ok`, so a Routine that recovered does not keep
+ * showing the failure it recovered from.
+ */
+export interface RoutineRunResult {
+  lastRunAt: number
+  lastOutcome: RoutineOutcome
+  /** The fixable message behind a `failed` / `blocked` run; omitted for `ok`. */
+  lastError?: string | null
+}
+
+export interface RoutineStoreApi {
+  /** Every Routine, oldest first, across every Bot. Empty on a locked database. */
+  list(): RoutineRecord[]
+  /** One Bot's Routines, oldest first — creation order, which is the authoring list's order. */
+  listByBot(threadId: string): RoutineRecord[]
+  /** One Routine by id, or null. */
+  get(id: string): RoutineRecord | null
+  /**
+   * Insert a Routine row. Returns null when the write could not land (logged) —
+   * including when the Bot already holds `MAX_ROUTINES_PER_BOT` of them, which
+   * this store enforces as a data invariant so no writer can get past it.
+   */
+  insert(input: RoutineInsert): RoutineRecord | null
+  /** Patch a Routine in place. Returns null for an unknown id or a failed write. */
+  update(id: string, patch: RoutinePatch): RoutineRecord | null
+  /** Record how a run ended. Returns null for an unknown id or a failed write. */
+  recordRun(id: string, result: RoutineRunResult): RoutineRecord | null
+  /** Drop a Routine row. Idempotent; false = nothing removed. */
+  delete(id: string): boolean
+}

--- a/apps/desktop/src/main/persistence/sqlite-routine-store.test.ts
+++ b/apps/desktop/src/main/persistence/sqlite-routine-store.test.ts
@@ -1,0 +1,341 @@
+import { describe, it, expect, afterAll, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { MAX_ROUTINES_PER_BOT } from '../../shared/routine-limits'
+import type { RoutineSchedule } from '../../shared/schedule'
+import { openStateDb, readUserVersion, type StateDb } from './sqlite-db'
+import { SqliteMetadataStore } from './sqlite-metadata-store'
+import { SqliteBotStore } from './sqlite-bot-store'
+import { SqliteRoutineStore } from './sqlite-routine-store'
+import { STATE_MIGRATIONS } from './state-migrations'
+
+/**
+ * The Routine store (#467, ADR-0028) on the same `state.sqlite` as everything
+ * else — mirroring `sqlite-bot-store.test.ts`: `:memory:` databases for
+ * behaviour, a temp-dir file where reopen durability is the point.
+ */
+
+const dir = mkdtempSync(join(tmpdir(), 'vibe-sqlite-routines-'))
+afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+const DAILY: RoutineSchedule = { kind: 'daily', at: '09:00', timezone: 'America/New_York' }
+
+interface Fixture {
+  stateDb: StateDb
+  meta: SqliteMetadataStore
+  bots: SqliteBotStore
+  routines: SqliteRoutineStore
+}
+
+function openFixture(path = ':memory:', now?: () => number): Fixture {
+  const stateDb = openStateDb({ path, migrations: STATE_MIGRATIONS })
+  const clock = now ? { now } : {}
+  return {
+    stateDb,
+    meta: new SqliteMetadataStore({ stateDb }),
+    bots: new SqliteBotStore({ stateDb, ...clock }),
+    routines: new SqliteRoutineStore({ stateDb, ...clock }),
+  }
+}
+
+/** A Workspace + a Thread + the Bot row a Routine hangs off. */
+async function seedBot(f: Fixture, dirPath = '/proj/alpha', name = 'Rex') {
+  const ws = await f.meta.upsertWorkspace({ dir: dirPath })
+  const thread = await f.meta.upsertThread({ workspaceId: ws.id })
+  f.bots.insert({
+    threadId: thread.id,
+    workspaceId: ws.id,
+    profileId: `mistro-bot-${thread.id}`,
+    name,
+    colour: '#e8734a',
+    description: '',
+    instructions: '',
+  })
+  return { workspaceId: ws.id, threadId: thread.id }
+}
+
+function insertRoutine(
+  f: Fixture,
+  threadId: string,
+  id = 'routine-1',
+  overrides: Partial<{ name: string; schedule: RoutineSchedule; allowedCommands: string[] }> = {},
+) {
+  return f.routines.insert({
+    id,
+    threadId,
+    name: overrides.name ?? 'Morning triage',
+    prompt: 'Triage this repo’s issues and say what changed.',
+    schedule: overrides.schedule ?? DAILY,
+    allowedCommands: overrides.allowedCommands ?? ['gh issue list --state open'],
+    active: true,
+  })
+}
+
+describe('the routines migration', () => {
+  it('brings a fresh database to the latest user_version with a routines table', () => {
+    const f = openFixture()
+    expect(readUserVersion(f.stateDb.db)).toBe(STATE_MIGRATIONS[STATE_MIGRATIONS.length - 1].id)
+    expect(() => f.stateDb.db.prepare('SELECT * FROM routines').all()).not.toThrow()
+  })
+
+  it('is appended, never reordered — ids stay strictly increasing from 1', () => {
+    expect(STATE_MIGRATIONS.map((m) => m.id)).toEqual(STATE_MIGRATIONS.map((_, i) => i + 1))
+  })
+
+  it('has NO next-run column — the next fire is derived, never stored (ADR-0028 part 6)', () => {
+    const f = openFixture()
+    const columns = (
+      f.stateDb.db.prepare('PRAGMA table_info(routines)').all() as unknown as { name: string }[]
+    ).map((column) => column.name)
+    expect(columns).not.toContain('next_run_at')
+    expect(columns).toEqual(
+      expect.arrayContaining(['last_run_at', 'last_outcome', 'last_error', 'active']),
+    )
+  })
+})
+
+describe('SqliteRoutineStore round-trip', () => {
+  it('persists a Routine and reads it back through a new instance', async () => {
+    const path = join(dir, 'roundtrip.sqlite')
+    const f = openFixture(path)
+    const bot = await seedBot(f)
+    insertRoutine(f, bot.threadId)
+
+    const reopened = openFixture(path)
+    const [routine] = reopened.routines.list()
+    expect(routine).toMatchObject({
+      id: 'routine-1',
+      threadId: bot.threadId,
+      name: 'Morning triage',
+      schedule: DAILY,
+      allowedCommands: ['gh issue list --state open'],
+      active: true,
+      lastRunAt: null,
+      lastOutcome: null,
+      lastError: null,
+    })
+  })
+
+  it('round-trips a weekly schedule with its weekday intact', async () => {
+    const weekly: RoutineSchedule = {
+      kind: 'weekly',
+      at: '17:00',
+      weekday: 5,
+      timezone: 'Europe/Berlin',
+    }
+    const f = openFixture()
+    const bot = await seedBot(f)
+    insertRoutine(f, bot.threadId, 'weekly-1', { schedule: weekly })
+    expect(f.routines.get('weekly-1')?.schedule).toEqual(weekly)
+  })
+
+  it('stamps createdAt/updatedAt from the injected clock', async () => {
+    let clock = 1000
+    const f = openFixture(':memory:', () => clock)
+    const bot = await seedBot(f)
+    expect(insertRoutine(f, bot.threadId)).toMatchObject({ createdAt: 1000, updatedAt: 1000 })
+
+    clock = 2000
+    expect(f.routines.update('routine-1', { name: 'Renamed' })).toMatchObject({
+      createdAt: 1000,
+      updatedAt: 2000,
+    })
+  })
+})
+
+describe('SqliteRoutineStore CRUD', () => {
+  it('lists one Bot’s Routines oldest-first, and only that Bot’s', async () => {
+    let clock = 1000
+    const f = openFixture(':memory:', () => clock)
+    const a = await seedBot(f, '/proj/a', 'Rex')
+    insertRoutine(f, a.threadId, 'a1', { name: 'First' })
+    clock = 2000
+    insertRoutine(f, a.threadId, 'a2', { name: 'Second' })
+    clock = 3000
+    const b = await seedBot(f, '/proj/b', 'Scribe')
+    insertRoutine(f, b.threadId, 'b1', { name: 'Other' })
+
+    expect(f.routines.listByBot(a.threadId).map((r) => r.name)).toEqual(['First', 'Second'])
+    expect(f.routines.listByBot(b.threadId).map((r) => r.name)).toEqual(['Other'])
+    expect(f.routines.listByBot('nope')).toEqual([])
+    expect(f.routines.list()).toHaveLength(3)
+  })
+
+  it('patches only the fields given', async () => {
+    const f = openFixture()
+    const bot = await seedBot(f)
+    insertRoutine(f, bot.threadId)
+
+    const paused = f.routines.update('routine-1', { active: false })
+    expect(paused).toMatchObject({
+      active: false,
+      name: 'Morning triage',
+      schedule: DAILY,
+      allowedCommands: ['gh issue list --state open'],
+    })
+    expect(f.routines.get('routine-1')?.active).toBe(false)
+  })
+
+  it('records how a run ended, and clears the failure a success recovered from', async () => {
+    const f = openFixture()
+    const bot = await seedBot(f)
+    insertRoutine(f, bot.threadId)
+
+    const blocked = f.routines.recordRun('routine-1', {
+      lastRunAt: 1700,
+      lastOutcome: 'blocked',
+      lastError: 'rm -rf build is not an allowed command',
+    })
+    expect(blocked).toMatchObject({
+      lastRunAt: 1700,
+      lastOutcome: 'blocked',
+      lastError: 'rm -rf build is not an allowed command',
+    })
+
+    const recovered = f.routines.recordRun('routine-1', { lastRunAt: 1800, lastOutcome: 'ok' })
+    expect(recovered).toMatchObject({ lastRunAt: 1800, lastOutcome: 'ok', lastError: null })
+  })
+
+  it('reports an unknown Routine rather than throwing', async () => {
+    const f = openFixture()
+    expect(f.routines.get('nope')).toBeNull()
+    expect(f.routines.update('nope', { active: false })).toBeNull()
+    expect(f.routines.recordRun('nope', { lastRunAt: 1, lastOutcome: 'ok' })).toBeNull()
+    expect(f.routines.delete('nope')).toBe(false)
+  })
+
+  it('deletes one Routine and leaves the Bot and its other Routines standing', async () => {
+    const f = openFixture()
+    const bot = await seedBot(f)
+    insertRoutine(f, bot.threadId, 'keep', { name: 'Keep' })
+    insertRoutine(f, bot.threadId, 'drop', { name: 'Drop' })
+
+    expect(f.routines.delete('drop')).toBe(true)
+    expect(f.routines.listByBot(bot.threadId).map((r) => r.name)).toEqual(['Keep'])
+    expect(f.bots.get(bot.threadId)?.name).toBe('Rex')
+  })
+
+  it('refuses a Routine on a Thread that is not a Bot (the FK), reported not thrown', async () => {
+    const f = openFixture()
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const ws = await f.meta.upsertWorkspace({ dir: '/proj/plain' })
+    const plain = await f.meta.upsertThread({ workspaceId: ws.id })
+    expect(insertRoutine(f, plain.id)).toBeNull()
+    expect(insertRoutine(f, 'ghost-thread', 'ghost')).toBeNull()
+    spy.mockRestore()
+  })
+
+  it('skips a row whose stored schedule is unreadable rather than inventing one', async () => {
+    const f = openFixture()
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const bot = await seedBot(f)
+    insertRoutine(f, bot.threadId, 'good')
+    insertRoutine(f, bot.threadId, 'garbled')
+    // Only a hand-edited database produces this; the store must not carry it.
+    f.stateDb.db.prepare('UPDATE routines SET schedule = ? WHERE id = ?').run('{oops', 'garbled')
+
+    expect(f.routines.list().map((r) => r.id)).toEqual(['good'])
+    expect(f.routines.get('garbled')).toBeNull()
+    spy.mockRestore()
+  })
+})
+
+describe(`the ${MAX_ROUTINES_PER_BOT}-per-Bot cap (ADR-0028 part 1)`, () => {
+  it(`accepts ${MAX_ROUTINES_PER_BOT} and refuses the next one`, async () => {
+    const f = openFixture()
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const bot = await seedBot(f)
+    for (let i = 0; i < MAX_ROUTINES_PER_BOT; i += 1) {
+      expect(insertRoutine(f, bot.threadId, `r${i}`, { name: `Routine ${i}` })).not.toBeNull()
+    }
+    expect(insertRoutine(f, bot.threadId, 'one-too-many')).toBeNull()
+    expect(f.routines.listByBot(bot.threadId)).toHaveLength(MAX_ROUTINES_PER_BOT)
+    spy.mockRestore()
+  })
+
+  it('counts per Bot, not globally, and frees a slot when one is deleted', async () => {
+    const f = openFixture()
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const a = await seedBot(f, '/proj/a', 'Rex')
+    const b = await seedBot(f, '/proj/b', 'Scribe')
+    for (let i = 0; i < MAX_ROUTINES_PER_BOT; i += 1) insertRoutine(f, a.threadId, `a${i}`)
+
+    // A different Bot is unaffected by the first one being full.
+    expect(insertRoutine(f, b.threadId, 'b0')).not.toBeNull()
+    expect(insertRoutine(f, a.threadId, 'a-extra')).toBeNull()
+
+    f.routines.delete('a0')
+    expect(insertRoutine(f, a.threadId, 'a-extra')).not.toBeNull()
+    spy.mockRestore()
+  })
+})
+
+describe('SqliteRoutineStore cascades', () => {
+  it('drops a Bot’s Routines when the BOT is deleted (the Thread survives)', async () => {
+    const f = openFixture()
+    const bot = await seedBot(f)
+    insertRoutine(f, bot.threadId)
+
+    // `bots:delete` drops the Bot row and archives the Thread — the Routines
+    // must go with the teammate, not linger on the archived conversation.
+    expect(f.bots.delete(bot.threadId)).toBe(true)
+    expect(f.routines.list()).toEqual([])
+    expect(f.meta.snapshot().threads.map((t) => t.id)).toContain(bot.threadId)
+  })
+
+  it('drops them with the Thread', async () => {
+    const f = openFixture()
+    const bot = await seedBot(f)
+    insertRoutine(f, bot.threadId)
+
+    await f.meta.deleteThread(bot.threadId)
+    expect(f.routines.list()).toEqual([])
+  })
+
+  it('drops them with the WORKSPACE, leaving another Project’s untouched', async () => {
+    const f = openFixture()
+    const doomed = await seedBot(f, '/proj/doomed', 'Rex')
+    const kept = await seedBot(f, '/proj/kept', 'Scribe')
+    insertRoutine(f, doomed.threadId, 'doomed-1')
+    insertRoutine(f, kept.threadId, 'kept-1')
+
+    await f.meta.removeWorkspace(doomed.workspaceId)
+    expect(f.routines.list().map((r) => r.id)).toEqual(['kept-1'])
+  })
+})
+
+describe('SqliteRoutineStore on a LOCKED database', () => {
+  function lockedFixture(): Fixture {
+    const path = join(dir, 'locked.sqlite')
+    const seeded = openStateDb({ path, migrations: STATE_MIGRATIONS })
+    seeded.db.exec(`PRAGMA user_version = ${STATE_MIGRATIONS.length + 50}`)
+    seeded.close()
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const fixture = openFixture(path)
+    spy.mockRestore()
+    return fixture
+  }
+
+  it('presents empty and writes nothing — a Routine that cannot be read must not fire', () => {
+    const f = lockedFixture()
+    expect(f.stateDb.locked).toBe(true)
+    expect(f.routines.list()).toEqual([])
+    expect(f.routines.listByBot('t')).toEqual([])
+    expect(f.routines.get('r')).toBeNull()
+    expect(
+      f.routines.insert({
+        id: 'r',
+        threadId: 't',
+        name: 'Morning triage',
+        prompt: 'go',
+        schedule: DAILY,
+        allowedCommands: [],
+        active: true,
+      }),
+    ).toBeNull()
+    expect(f.routines.update('r', { active: false })).toBeNull()
+    expect(f.routines.recordRun('r', { lastRunAt: 1, lastOutcome: 'ok' })).toBeNull()
+    expect(f.routines.delete('r')).toBe(false)
+  })
+})

--- a/apps/desktop/src/main/persistence/sqlite-routine-store.ts
+++ b/apps/desktop/src/main/persistence/sqlite-routine-store.ts
@@ -1,0 +1,296 @@
+import type { RoutineOutcome, RoutineRecord } from '../../shared/ipc'
+import { MAX_ROUTINES_PER_BOT } from '../../shared/routine-limits'
+import { isRoutineSchedule } from '../../shared/schedule'
+import type {
+  RoutineInsert,
+  RoutinePatch,
+  RoutineRunResult,
+  RoutineStoreApi,
+} from './routine-store-api'
+import type { StateDb } from './sqlite-db'
+
+/**
+ * The **Routine** store on SQLite (#467, ADR-0028) — the `routines` table behind
+ * `RoutineStoreApi`, on the SAME `state.sqlite` as the metadata, transcript and
+ * Bot stores (never split-brain).
+ *
+ * A Routine row is keyed to its **Bot** and cascades with it, so deleting a Bot,
+ * deleting its Thread or removing its Workspace can never leave a schedule
+ * pointing at a teammate that is gone.
+ *
+ * LOCKED state (db written by a newer build, `openStateDb`): reads present EMPTY
+ * and every mutation is a no-op, mirroring `SqliteBotStore` — a Routine that
+ * cannot be read is a Routine that must not fire.
+ *
+ * Best-effort per ADR-0019: a failing statement is logged and reported as a
+ * failed write (`null` / `false`); it never rejects into the live flow.
+ */
+
+interface RoutineRow {
+  id: string
+  thread_id: string
+  name: string
+  prompt: string
+  schedule: string
+  allowed_commands: string
+  active: number
+  last_run_at: number | null
+  last_outcome: string | null
+  last_error: string | null
+  created_at: number
+  updated_at: number
+}
+
+const OUTCOMES: readonly RoutineOutcome[] = ['ok', 'failed', 'blocked', 'deferred']
+
+export interface SqliteRoutineStoreDeps {
+  stateDb: StateDb
+  now?: () => number
+}
+
+export class SqliteRoutineStore implements RoutineStoreApi {
+  private readonly stateDb: StateDb
+  private readonly now: () => number
+
+  constructor(deps: SqliteRoutineStoreDeps) {
+    this.stateDb = deps.stateDb
+    this.now = deps.now ?? Date.now
+  }
+
+  private get db() {
+    return this.stateDb.db
+  }
+
+  list(): RoutineRecord[] {
+    if (this.stateDb.locked) return []
+    try {
+      const rows = this.db
+        .prepare('SELECT * FROM routines ORDER BY created_at, rowid')
+        .all() as unknown as RoutineRow[]
+      return readable(rows)
+    } catch (err) {
+      console.error('[SqliteRoutineStore] list failed:', err)
+      return []
+    }
+  }
+
+  listByBot(threadId: string): RoutineRecord[] {
+    if (this.stateDb.locked) return []
+    try {
+      const rows = this.db
+        .prepare('SELECT * FROM routines WHERE thread_id = ? ORDER BY created_at, rowid')
+        .all(threadId) as unknown as RoutineRow[]
+      return readable(rows)
+    } catch (err) {
+      console.error('[SqliteRoutineStore] listByBot failed:', err)
+      return []
+    }
+  }
+
+  get(id: string): RoutineRecord | null {
+    if (this.stateDb.locked) return null
+    try {
+      const row = this.db.prepare('SELECT * FROM routines WHERE id = ?').get(id) as
+        | RoutineRow
+        | undefined
+      return row ? routineFromRow(row) : null
+    } catch (err) {
+      console.error('[SqliteRoutineStore] get failed:', err)
+      return null
+    }
+  }
+
+  insert(input: RoutineInsert): RoutineRecord | null {
+    if (this.stateDb.locked) return null
+    // The cap is enforced HERE as well as in the lifecycle (which owns the
+    // message the user reads), because it is a property of the data rather than
+    // of one code path: a Bot is single-threaded, so the deferral queue that
+    // forms when Routines collide is what this bounds (ADR-0028 part 1).
+    if (this.countForBot(input.threadId) >= MAX_ROUTINES_PER_BOT) {
+      console.error(
+        `[SqliteRoutineStore] refusing a ${MAX_ROUTINES_PER_BOT + 1}th routine on Bot ${input.threadId}`,
+      )
+      return null
+    }
+    const ts = this.now()
+    const record: RoutineRecord = {
+      ...input,
+      lastRunAt: null,
+      lastOutcome: null,
+      lastError: null,
+      createdAt: ts,
+      updatedAt: ts,
+    }
+    try {
+      this.db
+        .prepare(
+          `INSERT INTO routines (id, thread_id, name, prompt, schedule, allowed_commands, active,
+                                 last_run_at, last_outcome, last_error, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, ?, ?)`,
+        )
+        .run(
+          record.id,
+          record.threadId,
+          record.name,
+          record.prompt,
+          JSON.stringify(record.schedule),
+          JSON.stringify(record.allowedCommands),
+          record.active ? 1 : 0,
+          record.createdAt,
+          record.updatedAt,
+        )
+      return record
+    } catch (err) {
+      // A `threadId` that is not a Bot (the FK), a duplicate id, or a broken
+      // disk — logged, reported, never thrown into the create flow.
+      console.error('[SqliteRoutineStore] insert failed:', err)
+      return null
+    }
+  }
+
+  update(id: string, patch: RoutinePatch): RoutineRecord | null {
+    if (this.stateDb.locked) return null
+    const existing = this.get(id)
+    if (!existing) return null
+    const next: RoutineRecord = {
+      ...existing,
+      name: patch.name ?? existing.name,
+      prompt: patch.prompt ?? existing.prompt,
+      schedule: patch.schedule ?? existing.schedule,
+      allowedCommands: patch.allowedCommands ?? existing.allowedCommands,
+      active: patch.active ?? existing.active,
+      updatedAt: this.now(),
+    }
+    try {
+      this.db
+        .prepare(
+          `UPDATE routines SET name = ?, prompt = ?, schedule = ?, allowed_commands = ?,
+                               active = ?, updated_at = ?
+           WHERE id = ?`,
+        )
+        .run(
+          next.name,
+          next.prompt,
+          JSON.stringify(next.schedule),
+          JSON.stringify(next.allowedCommands),
+          next.active ? 1 : 0,
+          next.updatedAt,
+          id,
+        )
+      return next
+    } catch (err) {
+      console.error('[SqliteRoutineStore] update failed:', err)
+      return null
+    }
+  }
+
+  recordRun(id: string, result: RoutineRunResult): RoutineRecord | null {
+    if (this.stateDb.locked) return null
+    const existing = this.get(id)
+    if (!existing) return null
+    // A successful run clears the failure it recovered from; anything else keeps
+    // the detail that makes it fixable.
+    const lastError =
+      result.lastOutcome === 'ok' ? null : (result.lastError ?? existing.lastError ?? null)
+    const next: RoutineRecord = {
+      ...existing,
+      lastRunAt: result.lastRunAt,
+      lastOutcome: result.lastOutcome,
+      lastError,
+      updatedAt: this.now(),
+    }
+    try {
+      this.db
+        .prepare(
+          `UPDATE routines SET last_run_at = ?, last_outcome = ?, last_error = ?, updated_at = ?
+           WHERE id = ?`,
+        )
+        .run(next.lastRunAt, next.lastOutcome, next.lastError, next.updatedAt, id)
+      return next
+    } catch (err) {
+      console.error('[SqliteRoutineStore] recordRun failed:', err)
+      return null
+    }
+  }
+
+  delete(id: string): boolean {
+    if (this.stateDb.locked) return false
+    try {
+      return this.db.prepare('DELETE FROM routines WHERE id = ?').run(id).changes > 0
+    } catch (err) {
+      console.error('[SqliteRoutineStore] delete failed:', err)
+      return false
+    }
+  }
+
+  /** How many Routines this Bot already holds — the cap's own reading. */
+  private countForBot(threadId: string): number {
+    try {
+      const row = this.db
+        .prepare('SELECT COUNT(*) AS n FROM routines WHERE thread_id = ?')
+        .get(threadId) as { n?: number } | undefined
+      return typeof row?.n === 'number' ? row.n : 0
+    } catch (err) {
+      console.error('[SqliteRoutineStore] count failed:', err)
+      // Unreadable means unbounded, and unbounded is the one answer the cap
+      // exists to prevent — so a failed count refuses the insert.
+      return MAX_ROUTINES_PER_BOT
+    }
+  }
+}
+
+/**
+ * The rows that can be carried as records. A row whose `schedule` JSON is not a
+ * schedule is LOGGED and left out: it can be neither fired nor rendered, and
+ * inventing a schedule for it would be worse than admitting it is unreadable.
+ * Only a hand-edited database produces one.
+ */
+function readable(rows: RoutineRow[]): RoutineRecord[] {
+  const records: RoutineRecord[] = []
+  for (const row of rows) {
+    const record = routineFromRow(row)
+    if (record) records.push(record)
+  }
+  return records
+}
+
+function routineFromRow(row: RoutineRow): RoutineRecord | null {
+  const schedule = parseJson(row.schedule)
+  if (!isRoutineSchedule(schedule)) {
+    console.error(`[SqliteRoutineStore] routine ${row.id} has an unreadable schedule; skipping it`)
+    return null
+  }
+  return {
+    id: row.id,
+    threadId: row.thread_id,
+    name: row.name,
+    prompt: row.prompt,
+    schedule,
+    allowedCommands: parseCommands(row.allowed_commands),
+    active: row.active !== 0,
+    lastRunAt: row.last_run_at,
+    lastOutcome: isOutcome(row.last_outcome) ? row.last_outcome : null,
+    lastError: row.last_error,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+/** The allowed commands, or none — an unreadable list must never widen into one. */
+function parseCommands(json: string): string[] {
+  const parsed = parseJson(json)
+  if (!Array.isArray(parsed)) return []
+  return parsed.filter((entry): entry is string => typeof entry === 'string')
+}
+
+function parseJson(json: string): unknown {
+  try {
+    return JSON.parse(json)
+  } catch {
+    return null
+  }
+}
+
+function isOutcome(value: string | null): value is RoutineOutcome {
+  return value !== null && (OUTCOMES as readonly string[]).includes(value)
+}

--- a/apps/desktop/src/main/persistence/state-migrations.ts
+++ b/apps/desktop/src/main/persistence/state-migrations.ts
@@ -172,4 +172,46 @@ export const STATE_MIGRATIONS: readonly Migration[] = [
       `)
     },
   },
+  {
+    id: 6,
+    name: 'routines',
+    up: (db) => {
+      // A Routine (#467, ADR-0028): a named schedule attached to a Mistro Bot.
+      //
+      // `thread_id` references `bots`, NOT `threads`, and that is the load-bearing
+      // choice here: a Routine belongs to a BOT (ADR-0028 part 1), so the row must
+      // go when the Bot does — and `bots:delete` keeps the Thread (it archives the
+      // conversation), so a `threads` reference would leave Routines behind for a
+      // teammate that no longer exists. The cascade still reaches all the way out,
+      // because `bots` itself cascades from `threads` and from `workspaces`.
+      //
+      // `schedule` and `allowed_commands` are JSON: the schedule is a structured
+      // value whose `kind` discriminator must admit a future `cron` variant with
+      // NO migration (ADR-0028 part 2), and the allowed commands are a list. Both
+      // are read and written whole, never queried into, so a column each would buy
+      // nothing and cost a migration per variant.
+      //
+      // There is NO `next_run_at` column, deliberately: a stored next-fire is a
+      // value somebody must remember to rewrite, which is the exact failure mode
+      // the derivation in `shared/schedule` exists to remove (ADR-0028 part 6).
+      db.exec(`
+        CREATE TABLE routines (
+          id               TEXT PRIMARY KEY,
+          thread_id        TEXT NOT NULL REFERENCES bots(thread_id) ON DELETE CASCADE,
+          name             TEXT NOT NULL,
+          prompt           TEXT NOT NULL,
+          schedule         TEXT NOT NULL,
+          allowed_commands TEXT NOT NULL,
+          active           INTEGER NOT NULL,
+          last_run_at      INTEGER,
+          last_outcome     TEXT,
+          last_error       TEXT,
+          created_at       INTEGER NOT NULL,
+          updated_at       INTEGER NOT NULL
+        );
+
+        CREATE INDEX idx_routines_thread ON routines(thread_id, created_at);
+      `)
+    },
+  },
 ]

--- a/apps/desktop/src/main/routines/register-ipc.ts
+++ b/apps/desktop/src/main/routines/register-ipc.ts
@@ -1,0 +1,67 @@
+import { ipcMain } from 'electron'
+import { randomUUID } from 'node:crypto'
+import {
+  IPC,
+  type RoutinesCreateArgs,
+  type RoutinesDeleteArgs,
+  type RoutinesDeleteResult,
+  type RoutinesListArgs,
+  type RoutinesListResult,
+  type RoutinesUpdateArgs,
+  type RoutineWriteResult,
+} from '../../shared/ipc'
+import type { BotStoreApi } from '../persistence/bot-store-api'
+import type { RoutineStoreApi } from '../persistence/routine-store-api'
+import {
+  createRoutine,
+  deleteRoutine,
+  listRoutines,
+  updateRoutine,
+  type RoutineLifecycleDeps,
+} from './routine-lifecycle'
+
+/**
+ * The Routine CRUD handlers (#467, ADR-0028), registered beside their modules
+ * like the bots / git / files registrars. Thin wrappers: every decision lives in
+ * `routine-lifecycle.ts` and the pure validator under it.
+ *
+ * Nothing here fires anything. The scheduler, the headless turn and the
+ * missed-run detector are later slices; this registrar only lets a Routine be
+ * written down.
+ */
+
+export interface RoutinesIpcDeps {
+  routines: RoutineStoreApi
+  /** Read-only Bot access: a Routine can only ever be attached to a Bot. */
+  bots: Pick<BotStoreApi, 'get'>
+}
+
+export function registerRoutinesIpc(deps: RoutinesIpcDeps): void {
+  const lifecycle: RoutineLifecycleDeps = {
+    routines: deps.routines,
+    bots: deps.bots,
+    mintRoutineId: () => randomUUID(),
+  }
+
+  ipcMain.handle(
+    IPC.routinesList,
+    (_event, args: RoutinesListArgs = {}): RoutinesListResult => ({
+      routines: listRoutines(lifecycle, args),
+    }),
+  )
+
+  ipcMain.handle(
+    IPC.routinesCreate,
+    (_event, args: RoutinesCreateArgs): RoutineWriteResult => createRoutine(lifecycle, args),
+  )
+
+  ipcMain.handle(
+    IPC.routinesUpdate,
+    (_event, args: RoutinesUpdateArgs): RoutineWriteResult => updateRoutine(lifecycle, args),
+  )
+
+  ipcMain.handle(
+    IPC.routinesDelete,
+    (_event, args: RoutinesDeleteArgs): RoutinesDeleteResult => deleteRoutine(lifecycle, args),
+  )
+}

--- a/apps/desktop/src/main/routines/routine-lifecycle.test.ts
+++ b/apps/desktop/src/main/routines/routine-lifecycle.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect } from 'vitest'
+import type { BotRecord, RoutineRecord } from '../../shared/ipc'
+import { MAX_ROUTINES_PER_BOT } from '../../shared/routine-limits'
+import { machineTimezone, type RoutineSchedule } from '../../shared/schedule'
+import type {
+  RoutineInsert,
+  RoutinePatch,
+  RoutineRunResult,
+  RoutineStoreApi,
+} from '../persistence/routine-store-api'
+import {
+  createRoutine,
+  deleteRoutine,
+  listRoutines,
+  updateRoutine,
+  type RoutineLifecycleDeps,
+} from './routine-lifecycle'
+
+/**
+ * The Routine CRUD orchestration (#467), against fakes — no Electron, no SQLite.
+ * What is asserted here is the DECISIONS: what is refused, what is defaulted,
+ * and what the user is told.
+ */
+
+const DAILY: RoutineSchedule = { kind: 'daily', at: '09:00', timezone: 'America/New_York' }
+const BOT_THREAD = 'thread-bot'
+
+/** An in-memory `RoutineStoreApi` that behaves like the SQLite one, cap included. */
+class FakeRoutineStore implements RoutineStoreApi {
+  readonly rows: RoutineRecord[] = []
+  failWrites = false
+
+  list(): RoutineRecord[] {
+    return [...this.rows]
+  }
+  listByBot(threadId: string): RoutineRecord[] {
+    return this.rows.filter((row) => row.threadId === threadId)
+  }
+  get(id: string): RoutineRecord | null {
+    return this.rows.find((row) => row.id === id) ?? null
+  }
+  insert(input: RoutineInsert): RoutineRecord | null {
+    if (this.failWrites) return null
+    if (this.listByBot(input.threadId).length >= MAX_ROUTINES_PER_BOT) return null
+    const record: RoutineRecord = {
+      ...input,
+      lastRunAt: null,
+      lastOutcome: null,
+      lastError: null,
+      createdAt: 1000,
+      updatedAt: 1000,
+    }
+    this.rows.push(record)
+    return record
+  }
+  update(id: string, patch: RoutinePatch): RoutineRecord | null {
+    if (this.failWrites) return null
+    const index = this.rows.findIndex((row) => row.id === id)
+    if (index < 0) return null
+    const next = { ...this.rows[index], ...patch, updatedAt: 2000 }
+    this.rows[index] = next
+    return next
+  }
+  recordRun(id: string, result: RoutineRunResult): RoutineRecord | null {
+    const index = this.rows.findIndex((row) => row.id === id)
+    if (index < 0) return null
+    const next = { ...this.rows[index], ...result, lastError: result.lastError ?? null }
+    this.rows[index] = next
+    return next
+  }
+  delete(id: string): boolean {
+    const index = this.rows.findIndex((row) => row.id === id)
+    if (index < 0) return false
+    this.rows.splice(index, 1)
+    return true
+  }
+}
+
+function makeDeps(botThreads: string[] = [BOT_THREAD]) {
+  const routines = new FakeRoutineStore()
+  let minted = 0
+  const deps: RoutineLifecycleDeps = {
+    routines,
+    bots: {
+      get: (threadId: string) =>
+        botThreads.includes(threadId) ? ({ threadId } as BotRecord) : null,
+    },
+    mintRoutineId: () => `routine-${(minted += 1)}`,
+  }
+  return { deps, routines }
+}
+
+const createArgs = (over: Partial<Parameters<typeof createRoutine>[1]> = {}) => ({
+  threadId: BOT_THREAD,
+  name: 'Morning triage',
+  prompt: 'Triage this repo’s issues and say what changed.',
+  schedule: DAILY,
+  ...over,
+})
+
+describe('createRoutine', () => {
+  it('mints an id, stores the record and creates it ACTIVE (ADR-0028 part 7)', () => {
+    const { deps } = makeDeps()
+    const result = createRoutine(deps, createArgs())
+    expect(result).toMatchObject({
+      ok: true,
+      routine: { id: 'routine-1', threadId: BOT_THREAD, active: true, schedule: DAILY },
+    })
+  })
+
+  it('defaults the allowed commands to EMPTY — never seeded from anything', () => {
+    const { deps } = makeDeps()
+    const result = createRoutine(deps, createArgs())
+    expect(result.ok && result.routine.allowedCommands).toEqual([])
+  })
+
+  it('normalizes the allowed commands it is given', () => {
+    const { deps } = makeDeps()
+    const result = createRoutine(
+      deps,
+      createArgs({ allowedCommands: [' git status ', 'git status', ''] }),
+    )
+    expect(result.ok && result.routine.allowedCommands).toEqual(['git status'])
+  })
+
+  it('stores the MACHINE’s zone when none was given, and never consults it again', () => {
+    const { deps } = makeDeps()
+    const schedule = { kind: 'daily', at: '09:00' } as unknown as RoutineSchedule
+    const result = createRoutine(deps, createArgs({ schedule }))
+    expect(result.ok && result.routine.schedule.timezone).toBe(machineTimezone())
+  })
+
+  it('refuses a Thread that is not a Bot — a Routine belongs to a Bot', () => {
+    const { deps, routines } = makeDeps()
+    const result = createRoutine(deps, createArgs({ threadId: 'thread-plain' }))
+    expect(result).toMatchObject({ ok: false, reason: 'notFound' })
+    expect(routines.rows).toEqual([])
+  })
+
+  it('refuses an unschedulable routine BEFORE anything is written, and says why', () => {
+    const { deps, routines } = makeDeps()
+    const schedule = { kind: 'daily', at: '9am', timezone: 'UTC' } as unknown as RoutineSchedule
+    const result = createRoutine(deps, createArgs({ name: '', schedule }))
+    expect(result).toMatchObject({ ok: false, reason: 'invalid' })
+    expect(result.ok === false && result.problems.join(' ')).toMatch(/name|schedule\.at/)
+    expect(routines.rows).toEqual([])
+  })
+
+  it(`refuses the ${MAX_ROUTINES_PER_BOT + 1}th routine on one Bot, with a message`, () => {
+    const { deps } = makeDeps()
+    for (let i = 0; i < MAX_ROUTINES_PER_BOT; i += 1) {
+      expect(createRoutine(deps, createArgs({ name: `Routine ${i}` })).ok).toBe(true)
+    }
+    const result = createRoutine(deps, createArgs({ name: 'One too many' }))
+    expect(result).toMatchObject({ ok: false, reason: 'capped' })
+    expect(result.ok === false && result.problems[0]).toContain(String(MAX_ROUTINES_PER_BOT))
+  })
+
+  it('reports a failed write as io rather than throwing', () => {
+    const { deps, routines } = makeDeps()
+    routines.failWrites = true
+    expect(createRoutine(deps, createArgs())).toMatchObject({ ok: false, reason: 'io' })
+  })
+})
+
+describe('updateRoutine', () => {
+  it('patches only what it is given', () => {
+    const { deps } = makeDeps()
+    createRoutine(deps, createArgs())
+    const result = updateRoutine(deps, { id: 'routine-1', name: 'Renamed' })
+    expect(result).toMatchObject({
+      ok: true,
+      routine: { name: 'Renamed', schedule: DAILY, prompt: createArgs().prompt },
+    })
+  })
+
+  it('pauses and resumes — the prompt survives, which is the point of pausing', () => {
+    const { deps } = makeDeps()
+    createRoutine(deps, createArgs())
+    const paused = updateRoutine(deps, { id: 'routine-1', active: false })
+    expect(paused).toMatchObject({ ok: true, routine: { active: false, prompt: createArgs().prompt } })
+    expect(updateRoutine(deps, { id: 'routine-1', active: true })).toMatchObject({
+      ok: true,
+      routine: { active: true },
+    })
+  })
+
+  it('validates the MERGED record, not just the patch', () => {
+    const { deps } = makeDeps()
+    createRoutine(deps, createArgs())
+    expect(updateRoutine(deps, { id: 'routine-1', name: '  ' })).toMatchObject({
+      ok: false,
+      reason: 'invalid',
+    })
+    const schedule = { kind: 'weekly', at: '09:00', timezone: 'UTC' } as unknown as RoutineSchedule
+    expect(updateRoutine(deps, { id: 'routine-1', schedule })).toMatchObject({
+      ok: false,
+      reason: 'invalid',
+    })
+  })
+
+  it('reports an unknown routine', () => {
+    const { deps } = makeDeps()
+    expect(updateRoutine(deps, { id: 'nope', name: 'x' })).toMatchObject({
+      ok: false,
+      reason: 'notFound',
+    })
+  })
+})
+
+describe('listRoutines and deleteRoutine', () => {
+  it('lists every routine, or one Bot’s', () => {
+    const { deps } = makeDeps([BOT_THREAD, 'thread-other'])
+    createRoutine(deps, createArgs({ name: 'A' }))
+    createRoutine(deps, createArgs({ threadId: 'thread-other', name: 'B' }))
+
+    expect(listRoutines(deps).map((r) => r.name)).toEqual(['A', 'B'])
+    expect(listRoutines(deps, { threadId: 'thread-other' }).map((r) => r.name)).toEqual(['B'])
+  })
+
+  it('deletes by id and reports an unknown one', () => {
+    const { deps } = makeDeps()
+    createRoutine(deps, createArgs())
+    expect(deleteRoutine(deps, { id: 'routine-1' })).toEqual({ ok: true })
+    expect(deleteRoutine(deps, { id: 'routine-1' })).toEqual({ ok: false })
+  })
+})

--- a/apps/desktop/src/main/routines/routine-lifecycle.ts
+++ b/apps/desktop/src/main/routines/routine-lifecycle.ts
@@ -1,0 +1,162 @@
+import type {
+  RoutineRecord,
+  RoutinesCreateArgs,
+  RoutinesDeleteArgs,
+  RoutinesDeleteResult,
+  RoutinesListArgs,
+  RoutinesUpdateArgs,
+  RoutineWriteResult,
+} from '../../shared/ipc'
+import { MAX_ROUTINES_PER_BOT } from '../../shared/routine-limits'
+import { machineTimezone, type RoutineSchedule } from '../../shared/schedule'
+import type { BotStoreApi } from '../persistence/bot-store-api'
+import type { RoutineStoreApi } from '../persistence/routine-store-api'
+import {
+  collectRoutineProblems,
+  describeRoutineProblems,
+  normalizeAllowedCommands,
+  validateRoutineFields,
+  validateRoutineSchedule,
+} from './validate-routine'
+
+/**
+ * Create / edit / delete a **Routine** (#467, ADR-0028) — the orchestration the
+ * `routines:*` handlers are thin wrappers around, with every dependency injected
+ * so the whole lifecycle is testable without Electron or SQLite.
+ *
+ * The invariant these functions hold: **a stored Routine is one that can be
+ * scheduled.** A Routine runs unattended, so a record that cannot compute a next
+ * run is not a slightly-wrong row — it is a Bot that silently never reports. So
+ * the order is always *validate → persist*, and a refusal is typed and carries
+ * the message that says how to fix it.
+ *
+ * Best-effort per ADR-0019: nothing here rejects into the live flow.
+ */
+
+export interface RoutineLifecycleDeps {
+  routines: RoutineStoreApi
+  /**
+   * The Bot half, read-only. A Routine belongs to a **Bot** (ADR-0028 part 1),
+   * and an ordinary Thread has no persona, no continuing conversation to report
+   * into, and nothing the reports could be compared against — so attaching one
+   * to a plain Thread is refused here as well as by the row's foreign key.
+   */
+  bots: Pick<BotStoreApi, 'get'>
+  /** Mint the Routine's id — injected so tests are deterministic. */
+  mintRoutineId: () => string
+}
+
+/** Every Routine, or one Bot's, for `routines:list`. */
+export function listRoutines(
+  deps: Pick<RoutineLifecycleDeps, 'routines'>,
+  args: RoutinesListArgs = {},
+): RoutineRecord[] {
+  return args.threadId ? deps.routines.listByBot(args.threadId) : deps.routines.list()
+}
+
+/**
+ * Create a Routine on a Bot. Created ACTIVE (ADR-0028 part 7): a Routine created
+ * in a state where it silently does nothing is the failure family this whole
+ * design exists to remove.
+ */
+export function createRoutine(
+  deps: RoutineLifecycleDeps,
+  args: RoutinesCreateArgs,
+): RoutineWriteResult {
+  const schedule = withStoredTimezone(args.schedule)
+  const allowedCommands = normalizeAllowedCommands(args.allowedCommands ?? [])
+
+  const problems = describeRoutineProblems([
+    ...collectRoutineProblems(
+      validateRoutineFields({ name: args.name, prompt: args.prompt, allowedCommands }),
+    ),
+    ...collectRoutineProblems(validateRoutineSchedule(schedule)),
+  ])
+  if (problems.length) return { ok: false, reason: 'invalid', problems }
+
+  if (!deps.bots.get(args.threadId)) {
+    return {
+      ok: false,
+      reason: 'notFound',
+      problems: ['threadId: a routine belongs to a Bot, and that is not one.'],
+    }
+  }
+
+  // The cap, read here so the refusal carries a message. The store enforces the
+  // same bound as a data invariant — this is the half a person reads.
+  if (deps.routines.listByBot(args.threadId).length >= MAX_ROUTINES_PER_BOT) {
+    return {
+      ok: false,
+      reason: 'capped',
+      problems: [`A Bot can have at most ${MAX_ROUTINES_PER_BOT} routines.`],
+    }
+  }
+
+  const record = deps.routines.insert({
+    id: deps.mintRoutineId(),
+    threadId: args.threadId,
+    name: args.name.trim(),
+    prompt: args.prompt,
+    schedule,
+    allowedCommands,
+    active: true,
+  })
+  if (!record) return { ok: false, reason: 'io', problems: ['Could not save the routine.'] }
+  return { ok: true, routine: record }
+}
+
+/**
+ * Edit a Routine in place — including pausing it, which is an ordinary
+ * `active: false` patch rather than a second verb. A paused Routine keeps its
+ * prompt, which is the whole point of pausing rather than deleting (PRD story 6).
+ */
+export function updateRoutine(
+  deps: Pick<RoutineLifecycleDeps, 'routines'>,
+  args: RoutinesUpdateArgs,
+): RoutineWriteResult {
+  const existing = deps.routines.get(args.id)
+  if (!existing) return { ok: false, reason: 'notFound', problems: ['No such routine.'] }
+
+  const schedule = args.schedule ? withStoredTimezone(args.schedule) : existing.schedule
+  const allowedCommands = normalizeAllowedCommands(args.allowedCommands ?? existing.allowedCommands)
+  const name = args.name ?? existing.name
+  const prompt = args.prompt ?? existing.prompt
+
+  const problems = describeRoutineProblems([
+    ...collectRoutineProblems(validateRoutineFields({ name, prompt, allowedCommands })),
+    ...collectRoutineProblems(validateRoutineSchedule(schedule)),
+  ])
+  if (problems.length) return { ok: false, reason: 'invalid', problems }
+
+  const record = deps.routines.update(args.id, {
+    name: name.trim(),
+    prompt,
+    schedule,
+    allowedCommands,
+    ...(args.active === undefined ? {} : { active: args.active }),
+  })
+  if (!record) return { ok: false, reason: 'io', problems: ['Could not save the routine.'] }
+  return { ok: true, routine: record }
+}
+
+/** Delete a Routine. The Bot, its conversation and its other Routines are untouched. */
+export function deleteRoutine(
+  deps: Pick<RoutineLifecycleDeps, 'routines'>,
+  args: RoutinesDeleteArgs,
+): RoutinesDeleteResult {
+  return { ok: deps.routines.delete(args.id) }
+}
+
+/**
+ * Fill in an absent timezone with the MACHINE's, once, at the write.
+ *
+ * ADR-0028 part 2: the zone is stored, never followed. Reading it here is the
+ * only moment the machine's own zone is consulted — from then on the Routine
+ * carries it, so a flight does not silently reschedule the morning.
+ */
+function withStoredTimezone(schedule: RoutineSchedule): RoutineSchedule {
+  if (schedule && typeof schedule === 'object' && !schedule.timezone) {
+    return { ...schedule, timezone: machineTimezone() }
+  }
+  return schedule
+}

--- a/apps/desktop/src/main/routines/validate-routine.test.ts
+++ b/apps/desktop/src/main/routines/validate-routine.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ALLOWED_COMMAND_MAX_LENGTH,
+  MAX_ALLOWED_COMMANDS,
+  ROUTINE_NAME_MAX_LENGTH,
+  ROUTINE_PROMPT_MAX_LENGTH,
+} from '../../shared/routine-limits'
+import type { RoutineSchedule } from '../../shared/schedule'
+import {
+  collectRoutineProblems,
+  describeRoutineProblems,
+  normalizeAllowedCommands,
+  validateRoutineFields,
+  validateRoutineSchedule,
+} from './validate-routine'
+
+/**
+ * The rules that keep an unattended Routine from being stored in a state where
+ * it silently never reports (#467, ADR-0028).
+ */
+
+const fields = (over: Partial<{ name: string; prompt: string; allowedCommands: string[] }> = {}) =>
+  validateRoutineFields({
+    name: 'Morning triage',
+    prompt: 'Triage this repo’s issues and say what changed.',
+    allowedCommands: [],
+    ...over,
+  })
+
+const problemFields = (result: ReturnType<typeof validateRoutineFields>) =>
+  collectRoutineProblems(result).map((problem) => problem.field)
+
+describe('validateRoutineFields', () => {
+  it('accepts a plain routine with no allowed commands — empty is the default', () => {
+    expect(fields()).toEqual({ ok: true })
+  })
+
+  it('requires a name (ADR-0028 part 7: a list of identical schedules is unreadable)', () => {
+    expect(problemFields(fields({ name: '' }))).toEqual(['name'])
+    expect(problemFields(fields({ name: '   ' }))).toEqual(['name'])
+  })
+
+  it('bounds the name and refuses line breaks in it', () => {
+    expect(problemFields(fields({ name: 'x'.repeat(ROUTINE_NAME_MAX_LENGTH + 1) }))).toEqual(['name'])
+    expect(problemFields(fields({ name: 'Morning\ntriage' }))).toEqual(['name'])
+    expect(fields({ name: 'x'.repeat(ROUTINE_NAME_MAX_LENGTH) })).toEqual({ ok: true })
+  })
+
+  it('requires a prompt — a blank one would report daily that it had nothing to ask', () => {
+    expect(problemFields(fields({ prompt: '  ' }))).toEqual(['prompt'])
+    expect(problemFields(fields({ prompt: 'x'.repeat(ROUTINE_PROMPT_MAX_LENGTH + 1) }))).toEqual([
+      'prompt',
+    ])
+  })
+
+  it('checks the SHAPE of each allowed command', () => {
+    expect(fields({ allowedCommands: ['gh issue list --state open', 'git status'] })).toEqual({
+      ok: true,
+    })
+    expect(problemFields(fields({ allowedCommands: [''] }))).toEqual(['allowedCommands'])
+    expect(problemFields(fields({ allowedCommands: ['a'.repeat(ALLOWED_COMMAND_MAX_LENGTH + 1)] }))).toEqual(
+      ['allowedCommands'],
+    )
+    // Two invocations in one entry: only one of them would ever be read.
+    expect(problemFields(fields({ allowedCommands: ['git status\nrm -rf /'] }))).toEqual([
+      'allowedCommands',
+    ])
+    expect(
+      problemFields(fields({ allowedCommands: Array(MAX_ALLOWED_COMMANDS + 1).fill('git status') })),
+    ).toEqual(['allowedCommands'])
+  })
+
+  it('reports every problem at once, so a form shows them together', () => {
+    const result = fields({ name: '', prompt: '', allowedCommands: [''] })
+    expect(problemFields(result).sort()).toEqual(['allowedCommands', 'name', 'prompt'])
+    expect(describeRoutineProblems(collectRoutineProblems(result))[0]).toMatch(/^name: /)
+  })
+})
+
+describe('validateRoutineSchedule', () => {
+  it('accepts the three kinds', () => {
+    const zone = 'America/New_York'
+    expect(validateRoutineSchedule({ kind: 'daily', at: '09:00', timezone: zone })).toEqual({ ok: true })
+    expect(validateRoutineSchedule({ kind: 'weekdays', at: '09:00', timezone: zone })).toEqual({
+      ok: true,
+    })
+    expect(
+      validateRoutineSchedule({ kind: 'weekly', at: '17:00', weekday: 5, timezone: zone }),
+    ).toEqual({ ok: true })
+  })
+
+  it('refuses a malformed time of day', () => {
+    const bad = { kind: 'daily', at: '9am', timezone: 'UTC' } as unknown as RoutineSchedule
+    expect(collectRoutineProblems(validateRoutineSchedule(bad)).map((p) => p.field)).toEqual([
+      'schedule.at',
+    ])
+  })
+
+  it('refuses a weekly schedule with no weekday to key on', () => {
+    const bad = { kind: 'weekly', at: '09:00', timezone: 'UTC' } as unknown as RoutineSchedule
+    expect(collectRoutineProblems(validateRoutineSchedule(bad)).map((p) => p.field)).toEqual([
+      'schedule.weekday',
+    ])
+  })
+
+  it('refuses an unknown kind — a cron variant is a future branch, not a free-for-all', () => {
+    const bad = { kind: 'hourly', at: '09:00', timezone: 'UTC' } as unknown as RoutineSchedule
+    expect(collectRoutineProblems(validateRoutineSchedule(bad)).map((p) => p.field)).toEqual([
+      'schedule.kind',
+    ])
+  })
+
+  it('refuses a timezone Intl does not know, and a missing one', () => {
+    expect(
+      collectRoutineProblems(
+        validateRoutineSchedule({ kind: 'daily', at: '09:00', timezone: 'Mars/Olympus_Mons' }),
+      ).map((p) => p.field),
+    ).toEqual(['schedule.timezone'])
+    expect(
+      collectRoutineProblems(
+        validateRoutineSchedule({ kind: 'daily', at: '09:00', timezone: '' }),
+      ).map((p) => p.field),
+    ).toEqual(['schedule.timezone'])
+  })
+})
+
+describe('normalizeAllowedCommands', () => {
+  it('trims, drops blanks and duplicates, and keeps the order', () => {
+    expect(
+      normalizeAllowedCommands(['  git status ', '', 'gh issue list', 'git status', '   ']),
+    ).toEqual(['git status', 'gh issue list'])
+  })
+
+  it('leaves the invocation itself alone — only the surrounding whitespace goes', () => {
+    expect(normalizeAllowedCommands([' gh issue list --state open '])).toEqual([
+      'gh issue list --state open',
+    ])
+  })
+})

--- a/apps/desktop/src/main/routines/validate-routine.ts
+++ b/apps/desktop/src/main/routines/validate-routine.ts
@@ -1,0 +1,180 @@
+import { hasBotControlCharacter } from '../../shared/bot-limits'
+import {
+  ALLOWED_COMMAND_MAX_LENGTH,
+  MAX_ALLOWED_COMMANDS,
+  ROUTINE_NAME_MAX_LENGTH,
+  ROUTINE_PROMPT_MAX_LENGTH,
+} from '../../shared/routine-limits'
+import { isRoutineSchedule, isSupportedTimezone, parseTimeOfDay } from '../../shared/schedule'
+import type { RoutineSchedule } from '../../shared/schedule'
+
+/**
+ * What a **Routine** must be before it is stored (#467, ADR-0028) — pure, so
+ * every rule is a unit test rather than a form's behaviour.
+ *
+ * The rules exist because a Routine runs when NOBODY IS WATCHING. A Bot with a
+ * malformed schedule is a Bot that silently never reports; a Routine with no
+ * name is a row nobody can tell from the one beside it, and ADR-0028 part 4's
+ * failure messages already assume a name exists. So a Routine that cannot
+ * schedule is refused at the write, loudly, rather than accepted and left inert.
+ *
+ * The **allowed commands** are checked for SHAPE only here — one literal
+ * invocation per entry, bounded, no line breaks. Matching an agent's requested
+ * command against them (whole-string, refusing redirects, pipes and
+ * substitutions unless listed verbatim) is the answering path's job in a later
+ * slice, and belongs beside the thing that answers.
+ */
+
+/** One reason a Routine was refused, addressed to the user. */
+export interface RoutineProblem {
+  /** The record field at fault (`name`, `schedule.at`, `allowedCommands`, …). */
+  field: string
+  message: string
+}
+
+export type RoutineValidation = { ok: true } | { ok: false; problems: RoutineProblem[] }
+
+/** The `when`: is this something `nextRunAfter` can compute with? */
+export function validateRoutineSchedule(schedule: RoutineSchedule): RoutineValidation {
+  const problems: RoutineProblem[] = []
+  if (!isRoutineSchedule(schedule)) {
+    // Say WHICH part is wrong — "invalid schedule" is what the user already knows.
+    const candidate = (schedule ?? {}) as Partial<RoutineSchedule> & { weekday?: unknown }
+    if (!candidate.kind || !['daily', 'weekdays', 'weekly'].includes(candidate.kind)) {
+      problems.push({
+        field: 'schedule.kind',
+        message: `"${String(candidate.kind)}" is not a schedule kind (daily, weekdays or weekly).`,
+      })
+    }
+    if (typeof candidate.at !== 'string' || parseTimeOfDay(candidate.at) === null) {
+      problems.push({
+        field: 'schedule.at',
+        message: `"${String(candidate.at)}" is not a time of day (HH:MM, 24-hour).`,
+      })
+    }
+    if (candidate.kind === 'weekly' && !isWeekday(candidate.weekday)) {
+      problems.push({
+        field: 'schedule.weekday',
+        message: 'A weekly routine needs a weekday (0 = Sunday … 6 = Saturday).',
+      })
+    }
+    if (typeof candidate.timezone !== 'string' || !candidate.timezone) {
+      problems.push({ field: 'schedule.timezone', message: 'A schedule needs a timezone.' })
+    }
+  }
+  // The zone is checked separately from the structure: it is the one field whose
+  // validity depends on the ICU this build carries, and a Routine is STORED with
+  // it (ADR-0028 part 2) — so a name Intl cannot resolve must never be written,
+  // or 09:00 quietly means nothing at all.
+  if (typeof schedule?.timezone === 'string' && schedule.timezone && !isSupportedTimezone(schedule.timezone)) {
+    problems.push({
+      field: 'schedule.timezone',
+      message: `"${schedule.timezone}" is not an IANA timezone this app knows.`,
+    })
+  }
+  return problems.length ? { ok: false, problems } : { ok: true }
+}
+
+/** What a Routine record must carry, whatever it is scheduled for. */
+export function validateRoutineFields(input: {
+  name: string
+  prompt: string
+  allowedCommands: string[]
+}): RoutineValidation {
+  const problems: RoutineProblem[] = []
+
+  const name = input.name.trim()
+  if (!name) {
+    problems.push({ field: 'name', message: 'A routine needs a name.' })
+  } else if (name.length > ROUTINE_NAME_MAX_LENGTH) {
+    problems.push({
+      field: 'name',
+      message: `A name can be at most ${ROUTINE_NAME_MAX_LENGTH} characters.`,
+    })
+  } else if (hasBotControlCharacter(name)) {
+    // The same one-line rule the Bot record uses (`shared/bot-limits`), for the
+    // same reason: this name is a row in a list, not prose.
+    problems.push({
+      field: 'name',
+      message: 'A name cannot contain line breaks or control characters.',
+    })
+  }
+
+  const prompt = input.prompt.trim()
+  if (!prompt) {
+    // A routine with nothing to say would fire a blank turn on a schedule, and
+    // ADR-0028 part 5 says every routine turn writes an entry — so this one would
+    // report, daily, that it had nothing to ask.
+    problems.push({ field: 'prompt', message: 'A routine needs a prompt to send.' })
+  } else if (prompt.length > ROUTINE_PROMPT_MAX_LENGTH) {
+    problems.push({
+      field: 'prompt',
+      message: `A prompt can be at most ${ROUTINE_PROMPT_MAX_LENGTH} characters.`,
+    })
+  }
+
+  if (!Array.isArray(input.allowedCommands)) {
+    problems.push({ field: 'allowedCommands', message: 'Allowed commands must be a list.' })
+  } else if (input.allowedCommands.length > MAX_ALLOWED_COMMANDS) {
+    problems.push({
+      field: 'allowedCommands',
+      message: `A routine can list at most ${MAX_ALLOWED_COMMANDS} allowed commands.`,
+    })
+  } else {
+    for (const command of input.allowedCommands) {
+      if (typeof command !== 'string' || !command.trim()) {
+        problems.push({ field: 'allowedCommands', message: 'An allowed command cannot be blank.' })
+      } else if (command.length > ALLOWED_COMMAND_MAX_LENGTH) {
+        problems.push({
+          field: 'allowedCommands',
+          message: `An allowed command can be at most ${ALLOWED_COMMAND_MAX_LENGTH} characters.`,
+        })
+      } else if (hasBotControlCharacter(command)) {
+        // A line break inside "one invocation" is two invocations, and only one
+        // of them would ever be read by whoever authored the list.
+        problems.push({
+          field: 'allowedCommands',
+          message: `"${command}" spans more than one line; list one invocation per entry.`,
+        })
+      }
+    }
+  }
+
+  return problems.length ? { ok: false, problems } : { ok: true }
+}
+
+/**
+ * The allowed commands as they are STORED: trimmed, blanks dropped, duplicates
+ * dropped, order kept.
+ *
+ * Trimming at the write is deliberate — #458 found leading and trailing
+ * whitespace between an entry and the invocation it was meant to authorise, and
+ * a list whose entries differ from what the user meant to type is a list that
+ * answers questions nobody asked.
+ */
+export function normalizeAllowedCommands(commands: string[]): string[] {
+  const seen = new Set<string>()
+  const normalized: string[] = []
+  for (const command of commands) {
+    if (typeof command !== 'string') continue
+    const trimmed = command.trim()
+    if (!trimmed || seen.has(trimmed)) continue
+    seen.add(trimmed)
+    normalized.push(trimmed)
+  }
+  return normalized
+}
+
+/** The problems of a validation, or none. Handy for merging + for messages. */
+export function collectRoutineProblems(result: RoutineValidation): RoutineProblem[] {
+  return result.ok ? [] : result.problems
+}
+
+/** Render problems as the `problems: string[]` the IPC reply carries. */
+export function describeRoutineProblems(problems: RoutineProblem[]): string[] {
+  return problems.map((problem) => `${problem.field}: ${problem.message}`)
+}
+
+function isWeekday(value: unknown): boolean {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 && value <= 6
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -65,6 +65,13 @@ import {
   type BotsUpdateArgs,
   type BotProfileStatus,
   type BotWriteResult,
+  type RoutinesCreateArgs,
+  type RoutinesDeleteArgs,
+  type RoutinesDeleteResult,
+  type RoutinesListArgs,
+  type RoutinesListResult,
+  type RoutinesUpdateArgs,
+  type RoutineWriteResult,
   type SkillsListArgs,
   type SkillsListResult,
   type SkillsReadArgs,
@@ -180,6 +187,14 @@ const api = {
     ipcRenderer.invoke(IPC.botsProfileStatus, args),
   botsRebuildProfile: (args: BotsRebuildProfileArgs): Promise<BotWriteResult> =>
     ipcRenderer.invoke(IPC.botsRebuildProfile, args),
+  routinesList: (args: RoutinesListArgs = {}): Promise<RoutinesListResult> =>
+    ipcRenderer.invoke(IPC.routinesList, args),
+  routinesCreate: (args: RoutinesCreateArgs): Promise<RoutineWriteResult> =>
+    ipcRenderer.invoke(IPC.routinesCreate, args),
+  routinesUpdate: (args: RoutinesUpdateArgs): Promise<RoutineWriteResult> =>
+    ipcRenderer.invoke(IPC.routinesUpdate, args),
+  routinesDelete: (args: RoutinesDeleteArgs): Promise<RoutinesDeleteResult> =>
+    ipcRenderer.invoke(IPC.routinesDelete, args),
   gitSubscribeStatus: (args: GitStatusSubscriptionArgs): Promise<void> =>
     ipcRenderer.invoke(IPC.gitSubscribeStatus, args),
   gitUnsubscribeStatus: (args: GitStatusSubscriptionArgs): Promise<void> =>

--- a/apps/desktop/src/shared/ipc/index.ts
+++ b/apps/desktop/src/shared/ipc/index.ts
@@ -23,6 +23,7 @@ import { skillsChannels } from './skills'
 import { appUpdateChannels } from './app-update'
 import { themeChannels } from './theme'
 import { botsChannels } from './bots'
+import { routinesChannels } from './routines'
 
 /**
  * The one typed channel map. ONE exported object — the channel names are the wire
@@ -44,6 +45,7 @@ export const IPC = {
   ...appUpdateChannels,
   ...themeChannels,
   ...botsChannels,
+  ...routinesChannels,
 } as const
 
 export * from './core'
@@ -60,3 +62,4 @@ export * from './skills'
 export * from './app-update'
 export * from './theme'
 export * from './bots'
+export * from './routines'

--- a/apps/desktop/src/shared/ipc/routines.ts
+++ b/apps/desktop/src/shared/ipc/routines.ts
@@ -1,0 +1,158 @@
+import type { RoutineSchedule } from '../schedule'
+
+/**
+ * Routines domain of the shared IPC contract (#467, ADR-0028): the CRUD surface
+ * over a **Routine** — a named schedule attached to a **Mistro Bot** which, when
+ * due, runs ONE headless prompt turn into that Bot's existing conversation and
+ * reports there.
+ *
+ * This slice is the record, its schedule value and its store. The firing, the
+ * scheduler and the authoring surfaces are later slices; nothing here runs
+ * anything.
+ *
+ * `RoutineSchedule` and the arithmetic over it live in `shared/schedule` and are
+ * deliberately NOT re-exported here, so there is one import path for the value
+ * both the firer and the detector compute with.
+ *
+ * Keep this file free of Node/DOM imports so both sides can consume it.
+ */
+
+/** The routines channel entries, merged into the single `IPC` const in `./index`. */
+export const routinesChannels = {
+  /** Every Routine, or one Bot's — see {@link RoutinesListArgs}. */
+  routinesList: 'routines:list',
+  /** Create a Routine on a Bot. Refused past {@link MAX_ROUTINES_PER_BOT}. */
+  routinesCreate: 'routines:create',
+  /** Edit a Routine in place, including pausing it (`active: false`). */
+  routinesUpdate: 'routines:update',
+  /** Delete a Routine. The Bot and its conversation are untouched. */
+  routinesDelete: 'routines:delete',
+} as const
+
+/**
+ * How a Routine's last run ended (ADR-0028 part 6). Deliberately NOT a place for
+ * *missed*, *late* or *never*: those are comparisons between the schedule and
+ * `lastRunAt`, derived at launch by a detector that shares no code with the
+ * firing path — because the case worth catching is the one where no code ran at
+ * all, and a flag nobody set is indistinguishable from a flag nobody needed.
+ *
+ * - `ok` — the turn ran and ended.
+ * - `failed` — it could not run, or it broke (sign-in expired, no agent, …).
+ * - `blocked` — an **allowed commands** denial cancelled the turn.
+ * - `deferred` — the Bot was busy, so this slot was given up. Recorded on the
+ *   Routine and never written into the conversation.
+ */
+export type RoutineOutcome = 'ok' | 'failed' | 'blocked' | 'deferred'
+
+/**
+ * One Routine, as persisted.
+ *
+ * `threadId` names the **Bot** it belongs to — a Bot IS one continuing Thread
+ * (ADR-0027), so that is the whole address. The row cascades with the Bot, and
+ * with the Bot's Thread and Workspace behind it.
+ *
+ * **There is no `nextRunAt` field, deliberately** (ADR-0028 part 6). A stored
+ * next-fire is a value somebody must remember to rewrite; the next run is a pure
+ * function of the schedule (`nextRunAfter`), so it is computed wherever it is
+ * shown and can never go stale.
+ */
+export interface RoutineRecord {
+  /** Ours, minted by main. */
+  id: string
+  /** The Bot this Routine belongs to and reports into. */
+  threadId: string
+  /** Required and non-empty: a list of identical schedules is unreadable. */
+  name: string
+  /** The prompt the headless turn sends, verbatim. */
+  prompt: string
+  /** The `when`. A structured value, never a cron string — see `shared/schedule`. */
+  schedule: RoutineSchedule
+  /**
+   * The **allowed commands**: literal invocations this Routine may run
+   * unattended. EMPTY by default, and never seeded from what the Bot has already
+   * run while you watched (ADR-0028 part 4). Matching them is slice 3's job.
+   */
+  allowedCommands: string[]
+  /**
+   * False = paused. A paused Routine has no missed runs: resuming sets a fresh
+   * baseline rather than accruing a fortnight of catch-up.
+   */
+  active: boolean
+  /** When the last run STARTED, or null if it has never run. */
+  lastRunAt: number | null
+  /** How that run ended, or null if it has never run. */
+  lastOutcome: RoutineOutcome | null
+  /** The failure detail behind a `failed` / `blocked` outcome — the fixable message. */
+  lastError: string | null
+  createdAt: number
+  updatedAt: number
+}
+
+/** Args for `routines:list`. Omit `threadId` for every Bot's Routines. */
+export interface RoutinesListArgs {
+  /** One Bot's Routines, oldest first. */
+  threadId?: string
+}
+
+/** The `routines:list` reply. */
+export interface RoutinesListResult {
+  routines: RoutineRecord[]
+}
+
+/**
+ * Args for `routines:create`. Main mints the `id`, and defaults an omitted
+ * `schedule.timezone` to the machine's — read ONCE, at creation, and then stored
+ * (ADR-0028 part 2), so a Routine keeps meaning the 09:00 you chose after you
+ * travel.
+ *
+ * A Routine is created ACTIVE; there is no `active` here on purpose. One created
+ * in a state where it silently does nothing is the failure family this design
+ * exists to remove.
+ */
+export interface RoutinesCreateArgs {
+  /** The Bot to attach it to. Must BE a Bot — an ordinary Thread is refused. */
+  threadId: string
+  name: string
+  prompt: string
+  schedule: RoutineSchedule
+  /** Defaults to empty: a Routine may run nothing until you say what it may run. */
+  allowedCommands?: string[]
+}
+
+/** Args for `routines:update`. Omitted fields are left alone. */
+export interface RoutinesUpdateArgs {
+  id: string
+  name?: string
+  prompt?: string
+  schedule?: RoutineSchedule
+  allowedCommands?: string[]
+  /** Pause (`false`) or resume (`true`). */
+  active?: boolean
+}
+
+/** Args for `routines:delete`. */
+export interface RoutinesDeleteArgs {
+  id: string
+}
+
+/**
+ * Why a Routine write was refused. `invalid` = the record would not schedule
+ * (bad time, unknown zone, no name); `notFound` = no such Routine, or its
+ * `threadId` is not a Bot; `capped` = the Bot already holds
+ * {@link MAX_ROUTINES_PER_BOT}; `io` = the row could not be written.
+ */
+export type RoutineWriteFailure = 'invalid' | 'notFound' | 'capped' | 'io'
+
+/**
+ * The reply to `routines:create` / `routines:update`. Failure is LOUD and typed
+ * rather than thrown, like every Bot write: `problems` carries the
+ * human-readable messages the form shows.
+ */
+export type RoutineWriteResult =
+  | { ok: true; routine: RoutineRecord }
+  | { ok: false; reason: RoutineWriteFailure; problems: string[] }
+
+/** The reply to `routines:delete`. Best-effort: `ok:false` means nothing was removed. */
+export interface RoutinesDeleteResult {
+  ok: boolean
+}

--- a/apps/desktop/src/shared/routine-limits.ts
+++ b/apps/desktop/src/shared/routine-limits.ts
@@ -1,0 +1,39 @@
+/**
+ * The field rules of a **Routine** record (#467, ADR-0028) — the bounds BOTH
+ * sides apply, kept here for the same reason `bot-limits.ts` exists: main is the
+ * validator (`main/routines/validate-routine.ts`) and the authoring form (slice
+ * 5) applies the same rules while you type, so neither can let through something
+ * the other refuses.
+ *
+ * Node/DOM-free like everything under `shared/`.
+ */
+
+/**
+ * How many Routines one Mistro Bot may hold (ADR-0028 part 1).
+ *
+ * NOT a resource bound. A Bot is a single continuing conversation, so Routines
+ * due at the same moment defer against one another — the cap bounds the deferral
+ * queue that forms, and the queue is the thing that gets unreadable, not the
+ * rows.
+ */
+export const MAX_ROUTINES_PER_BOT = 5
+
+/** A Routine is NAMED (ADR-0028 part 7); long enough to say what it does. */
+export const ROUTINE_NAME_MAX_LENGTH = 60
+
+/**
+ * The prompt the headless turn sends. Generous — it is a whole instruction, and
+ * a Routine's prompt carries the context nobody is there to supply — but bounded
+ * so a runaway paste cannot become a row nothing can render.
+ */
+export const ROUTINE_PROMPT_MAX_LENGTH = 20_000
+
+/** One **allowed command** is a literal invocation, not a script. */
+export const ALLOWED_COMMAND_MAX_LENGTH = 500
+
+/**
+ * How many allowed commands one Routine may list. A list past this is not a
+ * permission answer any more; it is a posture, and ADR-0028 part 4 has no
+ * postures.
+ */
+export const MAX_ALLOWED_COMMANDS = 50

--- a/apps/desktop/src/shared/schedule.test.ts
+++ b/apps/desktop/src/shared/schedule.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect } from 'vitest'
+import {
+  expectedLastDue,
+  isRoutineSchedule,
+  isSupportedTimezone,
+  machineTimezone,
+  nextRunAfter,
+  parseTimeOfDay,
+  type RoutineSchedule,
+} from './schedule'
+
+/**
+ * The load-bearing suite of the Routines slice (#467, ADR-0028 parts 2 and 6).
+ *
+ * The firer asks `nextRunAfter`; the detector asks `expectedLastDue`, and the two
+ * share no code anywhere ABOVE this module — which is only safe if they agree
+ * about time. "They agree" is the round-trip property at the bottom of this file,
+ * and everything downstream of this slice assumes it.
+ *
+ * Instants are written as UTC ISO strings so the wall clock a rule is about and
+ * the instant it resolves to are both visible in the assertion.
+ */
+
+const at = (iso: string) => Date.parse(iso)
+const iso = (instant: number | null) => (instant === null ? null : new Date(instant).toISOString())
+
+const NY = 'America/New_York'
+const BERLIN = 'Europe/Berlin'
+const SYDNEY = 'Australia/Sydney'
+
+describe('parseTimeOfDay', () => {
+  it('accepts a zero-padded 24-hour wall clock', () => {
+    expect(parseTimeOfDay('00:00')).toEqual({ hours: 0, minutes: 0 })
+    expect(parseTimeOfDay('09:05')).toEqual({ hours: 9, minutes: 5 })
+    expect(parseTimeOfDay('23:59')).toEqual({ hours: 23, minutes: 59 })
+  })
+
+  it('refuses everything else — a malformed time must never become a guessed one', () => {
+    for (const bad of ['', '9:05', '24:00', '23:60', '09:5', '0905', 'noon', '09:05:00', '-1:00']) {
+      expect(parseTimeOfDay(bad)).toBeNull()
+    }
+  })
+})
+
+describe('isSupportedTimezone', () => {
+  it('accepts IANA names Intl knows, and refuses the rest', () => {
+    expect(isSupportedTimezone('UTC')).toBe(true)
+    expect(isSupportedTimezone(NY)).toBe(true)
+    expect(isSupportedTimezone(SYDNEY)).toBe(true)
+    expect(isSupportedTimezone('Mars/Olympus_Mons')).toBe(false)
+    expect(isSupportedTimezone('')).toBe(false)
+  })
+
+  it('reports the machine zone as usable — it is what a new Routine defaults to', () => {
+    expect(isSupportedTimezone(machineTimezone())).toBe(true)
+  })
+})
+
+describe('isRoutineSchedule — the guard stored rows are read through', () => {
+  it('accepts each kind, and weekly only with a weekday', () => {
+    expect(isRoutineSchedule({ kind: 'daily', at: '09:00', timezone: 'UTC' })).toBe(true)
+    expect(isRoutineSchedule({ kind: 'weekdays', at: '23:59', timezone: NY })).toBe(true)
+    expect(isRoutineSchedule({ kind: 'weekly', at: '09:00', weekday: 0, timezone: NY })).toBe(true)
+    expect(isRoutineSchedule({ kind: 'weekly', at: '09:00', timezone: NY })).toBe(false)
+    expect(isRoutineSchedule({ kind: 'weekly', at: '09:00', weekday: 7, timezone: NY })).toBe(false)
+  })
+
+  it('refuses an unknown kind, a malformed time and a missing zone', () => {
+    expect(isRoutineSchedule({ kind: 'cron', at: '09:00', timezone: 'UTC' })).toBe(false)
+    expect(isRoutineSchedule({ kind: 'daily', at: '9:00', timezone: 'UTC' })).toBe(false)
+    expect(isRoutineSchedule({ kind: 'daily', at: '09:00', timezone: '' })).toBe(false)
+    expect(isRoutineSchedule(null)).toBe(false)
+    expect(isRoutineSchedule('daily')).toBe(false)
+  })
+
+  it('does NOT ask Intl about the zone — an unknown zone stays readable and editable', () => {
+    // Structure only: the row must list, so the user can fix or delete it. The
+    // schedule simply computes no next run until then.
+    const schedule = { kind: 'daily', at: '09:00', timezone: 'Mars/Olympus_Mons' }
+    expect(isRoutineSchedule(schedule)).toBe(true)
+    expect(nextRunAfter(schedule as RoutineSchedule, 0)).toBeNull()
+  })
+})
+
+describe('nextRunAfter across the three kinds', () => {
+  it('fires daily at the local wall clock', () => {
+    const schedule: RoutineSchedule = { kind: 'daily', at: '09:00', timezone: NY }
+    // 2026-06-15 is a Monday; NY is on EDT (-04:00) in June.
+    expect(iso(nextRunAfter(schedule, at('2026-06-15T08:00:00Z')))).toBe('2026-06-15T13:00:00.000Z')
+    // Past today's slot, so tomorrow's.
+    expect(iso(nextRunAfter(schedule, at('2026-06-15T14:00:00Z')))).toBe('2026-06-16T13:00:00.000Z')
+  })
+
+  it('fires on weekdays only, skipping the weekend in the schedule’s OWN zone', () => {
+    const schedule: RoutineSchedule = { kind: 'weekdays', at: '09:00', timezone: NY }
+    // Friday 2026-06-19 after the slot -> Monday 2026-06-22, not Saturday.
+    expect(iso(nextRunAfter(schedule, at('2026-06-19T14:00:00Z')))).toBe('2026-06-22T13:00:00.000Z')
+    // Sunday -> Monday.
+    expect(iso(nextRunAfter(schedule, at('2026-06-21T00:00:00Z')))).toBe('2026-06-22T13:00:00.000Z')
+  })
+
+  it('fires weekly on its own weekday (0 = Sunday)', () => {
+    const friday: RoutineSchedule = { kind: 'weekly', at: '17:00', weekday: 5, timezone: NY }
+    // Monday 2026-06-15 -> Friday 2026-06-19 17:00 EDT.
+    expect(iso(nextRunAfter(friday, at('2026-06-15T08:00:00Z')))).toBe('2026-06-19T21:00:00.000Z')
+    // On the day, past the slot -> next week.
+    expect(iso(nextRunAfter(friday, at('2026-06-19T22:00:00Z')))).toBe('2026-06-26T21:00:00.000Z')
+
+    const sunday: RoutineSchedule = { kind: 'weekly', at: '08:00', weekday: 0, timezone: NY }
+    expect(iso(nextRunAfter(sunday, at('2026-06-15T08:00:00Z')))).toBe('2026-06-21T12:00:00.000Z')
+  })
+
+  it('is STRICTLY after — asked at a fire instant it answers with the NEXT one', () => {
+    const schedule: RoutineSchedule = { kind: 'daily', at: '09:00', timezone: NY }
+    const fire = at('2026-06-15T13:00:00Z')
+    expect(iso(nextRunAfter(schedule, fire))).toBe('2026-06-16T13:00:00.000Z')
+  })
+
+  it('answers null for a malformed time or a zone Intl does not know', () => {
+    expect(nextRunAfter({ kind: 'daily', at: '9:00', timezone: NY }, 0)).toBeNull()
+    expect(nextRunAfter({ kind: 'daily', at: '09:00', timezone: 'Mars/Olympus_Mons' }, 0)).toBeNull()
+    expect(expectedLastDue({ kind: 'daily', at: '25:00', timezone: NY }, 0)).toBeNull()
+    expect(expectedLastDue({ kind: 'daily', at: '09:00', timezone: '' }, 0)).toBeNull()
+  })
+})
+
+describe('expectedLastDue — the backwards computation the detector runs (ADR-0028 part 6)', () => {
+  it('answers the most recent slot at or before now', () => {
+    const schedule: RoutineSchedule = { kind: 'daily', at: '09:00', timezone: NY }
+    expect(iso(expectedLastDue(schedule, at('2026-06-15T14:00:00Z')))).toBe('2026-06-15T13:00:00.000Z')
+    // Before today's slot -> yesterday's.
+    expect(iso(expectedLastDue(schedule, at('2026-06-15T08:00:00Z')))).toBe('2026-06-14T13:00:00.000Z')
+  })
+
+  it('is INCLUSIVE of now — a fire instant is its own last-due', () => {
+    const schedule: RoutineSchedule = { kind: 'daily', at: '09:00', timezone: NY }
+    const fire = at('2026-06-15T13:00:00Z')
+    expect(expectedLastDue(schedule, fire)).toBe(fire)
+  })
+
+  it('reaches back over a closed weekend for a weekdays routine (PRD story 8)', () => {
+    const schedule: RoutineSchedule = { kind: 'weekdays', at: '09:00', timezone: NY }
+    // Laptop opened Monday 08:00 local: the last due was FRIDAY, not the weekend.
+    expect(iso(expectedLastDue(schedule, at('2026-06-22T12:00:00Z')))).toBe('2026-06-19T13:00:00.000Z')
+  })
+
+  it('reaches back a whole week for a weekly routine', () => {
+    const schedule: RoutineSchedule = { kind: 'weekly', at: '17:00', weekday: 5, timezone: NY }
+    expect(iso(expectedLastDue(schedule, at('2026-06-25T00:00:00Z')))).toBe('2026-06-19T21:00:00.000Z')
+  })
+})
+
+describe('the stored timezone is what decides (ADR-0028 part 2)', () => {
+  it('gives the same schedule different instants in different zones', () => {
+    const from = at('2026-06-15T00:00:00Z')
+    const inNy = nextRunAfter({ kind: 'daily', at: '09:00', timezone: NY }, from)
+    const inBerlin = nextRunAfter({ kind: 'daily', at: '09:00', timezone: BERLIN }, from)
+    const inUtc = nextRunAfter({ kind: 'daily', at: '09:00', timezone: 'UTC' }, from)
+    expect(iso(inNy)).toBe('2026-06-15T13:00:00.000Z')
+    expect(iso(inBerlin)).toBe('2026-06-15T07:00:00.000Z')
+    expect(iso(inUtc)).toBe('2026-06-15T09:00:00.000Z')
+  })
+})
+
+describe('DST rule 1 — a REPEATED hour fires at the FIRST occurrence', () => {
+  it('New York, autumn: 01:30 exists twice on 2026-11-01, and the earlier one wins', () => {
+    const schedule: RoutineSchedule = { kind: 'daily', at: '01:30', timezone: NY }
+    // 02:00 EDT -> 01:00 EST at 06:00Z. 01:30 EDT = 05:30Z; 01:30 EST = 06:30Z.
+    expect(iso(nextRunAfter(schedule, at('2026-11-01T00:00:00Z')))).toBe('2026-11-01T05:30:00.000Z')
+    expect(iso(expectedLastDue(schedule, at('2026-11-01T12:00:00Z')))).toBe('2026-11-01T05:30:00.000Z')
+  })
+
+  it('Berlin, autumn: 02:30 exists twice on 2026-10-25, and the earlier one wins', () => {
+    const schedule: RoutineSchedule = { kind: 'daily', at: '02:30', timezone: BERLIN }
+    // 03:00 CEST -> 02:00 CET at 01:00Z. 02:30 CEST = 00:30Z; 02:30 CET = 01:30Z.
+    expect(iso(nextRunAfter(schedule, at('2026-10-24T23:00:00Z')))).toBe('2026-10-25T00:30:00.000Z')
+  })
+
+  it('Sydney, autumn (southern hemisphere): 02:30 twice on 2026-04-05', () => {
+    const schedule: RoutineSchedule = { kind: 'daily', at: '02:30', timezone: SYDNEY }
+    // 03:00 AEDT -> 02:00 AEST at 2026-04-04T16:00Z. 02:30 AEDT = 15:30Z the day before.
+    expect(iso(nextRunAfter(schedule, at('2026-04-04T12:00:00Z')))).toBe('2026-04-04T15:30:00.000Z')
+  })
+})
+
+describe('DST rule 3 — at most once per scheduled slot', () => {
+  it('does not fire again in the second pass of a repeated hour', () => {
+    const schedule: RoutineSchedule = { kind: 'daily', at: '01:30', timezone: NY }
+    const fired = at('2026-11-01T05:30:00Z') // the first 01:30
+    // The second 01:30 (06:30Z) is NOT a slot — the next one is the following day.
+    expect(iso(nextRunAfter(schedule, fired))).toBe('2026-11-02T06:30:00.000Z')
+  })
+
+  it('and the detector agrees: mid-repeat, the last due is still the first occurrence', () => {
+    const schedule: RoutineSchedule = { kind: 'daily', at: '01:30', timezone: NY }
+    // Asked between the two 01:30s, the last due is the first one, never the second.
+    expect(iso(expectedLastDue(schedule, at('2026-11-01T06:45:00Z')))).toBe(
+      '2026-11-01T05:30:00.000Z',
+    )
+  })
+})
+
+describe('DST rule 2 — a SKIPPED hour fires at the next valid local time', () => {
+  it('New York, spring: 02:30 does not exist on 2026-03-08, so 03:00 local fires', () => {
+    const schedule: RoutineSchedule = { kind: 'daily', at: '02:30', timezone: NY }
+    // 02:00 EST -> 03:00 EDT at 07:00Z; 07:00Z reads 03:00 local, the first valid time.
+    expect(iso(nextRunAfter(schedule, at('2026-03-08T00:00:00Z')))).toBe('2026-03-08T07:00:00.000Z')
+    expect(iso(expectedLastDue(schedule, at('2026-03-08T12:00:00Z')))).toBe(
+      '2026-03-08T07:00:00.000Z',
+    )
+  })
+
+  it('Berlin, spring: 02:30 does not exist on 2026-03-29, so 03:00 local fires', () => {
+    const schedule: RoutineSchedule = { kind: 'daily', at: '02:30', timezone: BERLIN }
+    // 02:00 CET -> 03:00 CEST at 01:00Z.
+    expect(iso(nextRunAfter(schedule, at('2026-03-28T23:00:00Z')))).toBe('2026-03-29T01:00:00.000Z')
+  })
+
+  it('Sydney, spring (southern hemisphere): 02:30 does not exist on 2026-10-04', () => {
+    const schedule: RoutineSchedule = { kind: 'daily', at: '02:30', timezone: SYDNEY }
+    // 02:00 AEST -> 03:00 AEDT at 2026-10-03T16:00Z.
+    expect(iso(nextRunAfter(schedule, at('2026-10-03T12:00:00Z')))).toBe('2026-10-03T16:00:00.000Z')
+  })
+
+  it('still fires exactly once on the day the hour was skipped', () => {
+    const schedule: RoutineSchedule = { kind: 'daily', at: '02:30', timezone: NY }
+    const fired = at('2026-03-08T07:00:00Z')
+    expect(iso(nextRunAfter(schedule, fired))).toBe('2026-03-09T06:30:00.000Z')
+  })
+})
+
+describe('the round-trip property — the firer and the detector agree', () => {
+  /**
+   * THE test of this slice. `nextRunAfter` produces a fire instant; feeding that
+   * instant back to `expectedLastDue` must return it unchanged. If it ever did
+   * not, the detector would either see a run it had already recorded as missed,
+   * or miss one that never happened — and every downstream slice believes it.
+   */
+  const zones = ['UTC', NY, BERLIN, SYDNEY, 'Asia/Kolkata', 'Pacific/Chatham']
+  const times = ['00:00', '01:30', '02:30', '09:00', '23:59']
+  const probes = [
+    // Ordinary instants, plus both DST transitions in every direction above.
+    '2026-01-01T00:00:00Z',
+    '2026-03-08T06:59:00Z',
+    '2026-03-08T07:01:00Z',
+    '2026-03-29T00:30:00Z',
+    '2026-04-04T15:45:00Z',
+    '2026-06-15T11:11:11Z',
+    '2026-10-03T15:59:00Z',
+    '2026-10-25T00:45:00Z',
+    '2026-11-01T06:15:00Z',
+    '2026-12-31T23:59:59Z',
+  ]
+
+  it('holds for every kind, zone, time and probe instant', () => {
+    for (const timezone of zones) {
+      for (const time of times) {
+        const schedules: RoutineSchedule[] = [
+          { kind: 'daily', at: time, timezone },
+          { kind: 'weekdays', at: time, timezone },
+          { kind: 'weekly', at: time, weekday: 3, timezone },
+          { kind: 'weekly', at: time, weekday: 0, timezone },
+        ]
+        for (const schedule of schedules) {
+          for (const probe of probes) {
+            const fire = nextRunAfter(schedule, at(probe))
+            expect(fire).not.toBeNull()
+            expect({ schedule, probe, lastDue: iso(expectedLastDue(schedule, fire as number)) })
+              .toEqual({ schedule, probe, lastDue: iso(fire) })
+          }
+        }
+      }
+    }
+  })
+
+  it('holds in a zone that is NOT this machine’s', () => {
+    // Whatever the machine is set to, at least one of these is somewhere else.
+    const elsewhere = zones.find((zone) => zone !== machineTimezone())
+    expect(elsewhere).toBeDefined()
+    const schedule: RoutineSchedule = { kind: 'daily', at: '09:00', timezone: elsewhere as string }
+    const fire = nextRunAfter(schedule, at('2026-06-15T11:11:11Z'))
+    expect(fire).not.toBeNull()
+    expect(expectedLastDue(schedule, fire as number)).toBe(fire)
+  })
+
+  it('walks a whole year of daily fires without drifting or repeating', () => {
+    // Every consecutive pair is strictly increasing and each is its own last-due,
+    // which is rule 3 stated over the sequence rather than over one transition.
+    const schedule: RoutineSchedule = { kind: 'daily', at: '02:30', timezone: NY }
+    let cursor = at('2026-01-01T00:00:00Z')
+    for (let day = 0; day < 366; day += 1) {
+      const fire = nextRunAfter(schedule, cursor)
+      expect(fire).not.toBeNull()
+      expect(fire as number).toBeGreaterThan(cursor)
+      expect(expectedLastDue(schedule, fire as number)).toBe(fire)
+      cursor = fire as number
+    }
+    // 366 daily fires from New Year’s Day land inside the following year.
+    expect(new Date(cursor).getUTCFullYear()).toBe(2027)
+  })
+})

--- a/apps/desktop/src/shared/schedule.ts
+++ b/apps/desktop/src/shared/schedule.ts
@@ -1,0 +1,351 @@
+/**
+ * The **Routine** schedule value and the arithmetic over it (#467, ADR-0028
+ * part 2 + part 6) — a structured `when`, never a cron string, and the ONE pure
+ * module the firer and the missed-run detector both compute with.
+ *
+ * Two directions, and the second is the reason this file exists. ADR-0028 makes
+ * *missed / late / never* **derived** rather than stored, so the detector has to
+ * answer a question schedulers usually never ask — *when was this last due,
+ * before now?* — from the stored schedule alone, sharing no code with the thing
+ * that failed to fire. Forwards is `nextRunAfter`; backwards is
+ * `expectedLastDue`; they are each other's inverse over the fire instants, which
+ * is what makes the firer and the detector agree about time (see the round-trip
+ * property in `schedule.test.ts`).
+ *
+ * **No date or cron dependency, deliberately.** Electron ships full ICU, so IANA
+ * zones are `Intl`'s job; the PRD rejects adding a library to do arithmetic that
+ * is a few lines here.
+ *
+ * The three DST rules of ADR-0028 part 2, which both functions obey because they
+ * resolve every fire instant through the same `fireInstantOn`:
+ *
+ * 1. the scheduled hour happens TWICE (a fall-back) → fire at the **first**
+ *    occurrence;
+ * 2. the scheduled hour does NOT exist (a spring-forward) → fire at the **next
+ *    valid local time** that day;
+ * 3. a Routine fires **at most once per scheduled slot** — one instant per
+ *    matching local date, by construction.
+ *
+ * Node/DOM-free like everything under `shared/`, so main, preload and the
+ * renderer all compute the same answer.
+ */
+
+/** The schedule shapes a Routine can carry today. */
+export type RoutineScheduleKind = 'daily' | 'weekdays' | 'weekly'
+
+/** `0` = Sunday … `6` = Saturday — `Date.prototype.getDay`'s numbering. */
+export type RoutineWeekday = 0 | 1 | 2 | 3 | 4 | 5 | 6
+
+/**
+ * A Routine's `when`, as a value.
+ *
+ * A DISCRIMINATED UNION on `kind`, which is the whole point (ADR-0028 part 2): a
+ * `cron` variant can be added later as one more branch, with no migration and no
+ * rewrite of the branches here — the stored JSON of the existing kinds does not
+ * change shape. `weekly` requires its `weekday` at the type level, so a weekly
+ * schedule with nothing to key on cannot be constructed.
+ *
+ * `at` is local wall-clock `HH:MM` (24-hour) **in `timezone`**, an IANA name
+ * STORED with the Routine and defaulted to the machine's at creation. Following
+ * the machine instead would make the same stored data mean different instants in
+ * different places, which destroys the one property the detector needs.
+ */
+export type RoutineSchedule =
+  | { kind: 'daily'; at: string; timezone: string }
+  | { kind: 'weekdays'; at: string; timezone: string }
+  | { kind: 'weekly'; at: string; weekday: RoutineWeekday; timezone: string }
+
+/** `HH:MM`, 24-hour, zero-padded. Nothing else is a time of day here. */
+const TIME_OF_DAY = /^([01][0-9]|2[0-3]):([0-5][0-9])$/
+
+/**
+ * How many local days either function will scan before giving up. A weekly
+ * schedule needs 8; the headroom costs nothing (the scan stops at the first
+ * match) and bounds the loop for a schedule whose kind can never match.
+ */
+const SCAN_DAY_LIMIT = 366
+
+/** A civil date in some zone — no instant attached, no zone attached. */
+interface CivilDate {
+  year: number
+  /** 1-12, not `Date`'s 0-11. */
+  month: number
+  day: number
+}
+
+/** A wall-clock reading in some zone: a civil date plus hours and minutes. */
+interface LocalReading extends CivilDate {
+  hours: number
+  minutes: number
+}
+
+/** `HH:MM` → its parts, or null when it is not a time of day. */
+export function parseTimeOfDay(at: string): { hours: number; minutes: number } | null {
+  const match = typeof at === 'string' ? TIME_OF_DAY.exec(at) : null
+  if (!match) return null
+  return { hours: Number(match[1]), minutes: Number(match[2]) }
+}
+
+/**
+ * Does `Intl` know this IANA zone? The validator's timezone check and the guard
+ * both arithmetic functions open with — an unknown zone makes every instant
+ * unanswerable, so it is refused at the door rather than thrown mid-flow.
+ */
+export function isSupportedTimezone(timezone: string): boolean {
+  return zoneFormatter(timezone) !== null
+}
+
+/**
+ * Is this parsed JSON a schedule we can carry? The guard the store reads rows
+ * through, so a hand-edited or half-written row cannot enter the app as a
+ * `RoutineSchedule` that then fails somewhere with no clue where it came from.
+ *
+ * STRUCTURAL only: it checks the shape and that `at` is a time of day, and it
+ * deliberately does NOT ask `Intl` about the zone. Timezone acceptance is the
+ * validator's job at write time; a stored zone this ICU no longer knows leaves a
+ * readable, deletable, editable Routine that simply computes no next run —
+ * which is a far better failure than a row that cannot be listed.
+ */
+export function isRoutineSchedule(value: unknown): value is RoutineSchedule {
+  if (typeof value !== 'object' || value === null) return false
+  const candidate = value as { kind?: unknown; at?: unknown; timezone?: unknown; weekday?: unknown }
+  if (typeof candidate.at !== 'string' || parseTimeOfDay(candidate.at) === null) return false
+  if (typeof candidate.timezone !== 'string' || !candidate.timezone) return false
+  switch (candidate.kind) {
+    case 'daily':
+    case 'weekdays':
+      return true
+    case 'weekly':
+      return (
+        typeof candidate.weekday === 'number' &&
+        Number.isInteger(candidate.weekday) &&
+        candidate.weekday >= 0 &&
+        candidate.weekday <= 6
+      )
+    default:
+      return false
+  }
+}
+
+/**
+ * The machine's IANA zone, for defaulting a NEW Routine's `timezone`. Read once
+ * at creation and then stored — never consulted again for an existing Routine.
+ */
+export function machineTimezone(): string {
+  const resolved = Intl.DateTimeFormat().resolvedOptions().timeZone
+  return resolved && isSupportedTimezone(resolved) ? resolved : 'UTC'
+}
+
+/**
+ * The first instant this schedule is due STRICTLY AFTER `from` — what the firer
+ * asks, and what the UI shows as "next run".
+ *
+ * Null when the schedule cannot be computed with (a malformed `at`, a zone
+ * `Intl` does not know, or no matching day inside {@link SCAN_DAY_LIMIT}):
+ * best-effort per ADR-0019, so a corrupt row makes a Routine inert and loudly
+ * un-schedulable rather than throwing into the tick.
+ */
+export function nextRunAfter(schedule: RoutineSchedule, from: number): number | null {
+  return scan(schedule, from, 1)
+}
+
+/**
+ * The most recent instant this schedule was due, AT OR BEFORE `now` — the
+ * backwards computation ADR-0028 part 6 is built on. Compare it with the
+ * Routine's `lastRunAt` and a missed run is a comparison rather than a flag
+ * somebody had to remember to set.
+ *
+ * Inclusive of `now` on purpose: a fire instant is its own last-due, which is
+ * exactly the round-trip property that makes the detector and the firer agree.
+ *
+ * Null for the same reasons as {@link nextRunAfter}.
+ */
+export function expectedLastDue(schedule: RoutineSchedule, now: number): number | null {
+  return scan(schedule, now, -1)
+}
+
+/**
+ * Walk local days from `pivot`'s own local date in `direction`, resolving each
+ * matching day's fire instant, and answer with the first one on the right side
+ * of `pivot`. ONE traversal for both directions so the two functions can never
+ * disagree about a day, a kind or a DST rule.
+ */
+function scan(schedule: RoutineSchedule, pivot: number, direction: 1 | -1): number | null {
+  const time = parseTimeOfDay(schedule.at)
+  if (!time || !Number.isFinite(pivot)) return null
+  const formatter = zoneFormatter(schedule.timezone)
+  if (!formatter) return null
+
+  let date: CivilDate = readLocal(pivot, formatter)
+  for (let scanned = 0; scanned < SCAN_DAY_LIMIT; scanned += 1) {
+    if (matchesKind(schedule, date)) {
+      const instant = fireInstantOn(date, time.hours, time.minutes, formatter)
+      if (instant !== null && (direction === 1 ? instant > pivot : instant <= pivot)) return instant
+    }
+    date = addDays(date, direction)
+  }
+  return null
+}
+
+/** Is this local date one the schedule fires on? */
+function matchesKind(schedule: RoutineSchedule, date: CivilDate): boolean {
+  switch (schedule.kind) {
+    case 'daily':
+      return true
+    case 'weekdays':
+      // Monday-Friday in the schedule's OWN zone, which is why the weekday is
+      // read off the local civil date and never off the instant.
+      return weekdayOf(date) >= 1 && weekdayOf(date) <= 5
+    case 'weekly':
+      return weekdayOf(date) === schedule.weekday
+  }
+}
+
+/**
+ * The instant a routine scheduled at `hours:minutes` fires on this local date —
+ * where the three DST rules live.
+ *
+ * A wall-clock reading maps to **two** instants across a fall-back and to
+ * **none** across a spring-forward, so:
+ *
+ * - two candidates → the EARLIER (rule 1). The later occurrence is never
+ *   returned, which is also what gives rule 3: the second pass of a repeated
+ *   hour is not a second slot.
+ * - none → walk the local clock forward a minute at a time to the next reading
+ *   that exists (rule 2), stopping at the end of the local day. A whole
+ *   remaining day with no valid local time (a date-line shift, not a DST
+ *   transition) yields null and the day is skipped, which keeps one instant per
+ *   local date and keeps the day sequence strictly increasing.
+ */
+function fireInstantOn(
+  date: CivilDate,
+  hours: number,
+  minutes: number,
+  formatter: Intl.DateTimeFormat,
+): number | null {
+  for (let minuteOfDay = hours * 60 + minutes; minuteOfDay < 24 * 60; minuteOfDay += 1) {
+    const candidates = instantsForLocal(
+      { ...date, hours: Math.floor(minuteOfDay / 60), minutes: minuteOfDay % 60 },
+      formatter,
+    )
+    if (candidates.length > 0) return Math.min(...candidates)
+  }
+  return null
+}
+
+/**
+ * Every instant whose wall clock in this zone reads exactly `reading` — 1
+ * normally, 2 inside a repeated hour, 0 inside a skipped one.
+ *
+ * The offset at the sought instant is unknown before we have the instant, so
+ * every offset in force AROUND it is tried — a day either side, which brackets
+ * any transition, plus the naive instant's own — and each resulting candidate is
+ * VERIFIED by reading its wall clock back. Verification, not arithmetic, is what
+ * makes the gap and the overlap answer honestly: probing only one side finds
+ * just one of a repeated hour's two instants, and which one it finds depends on
+ * the direction the zone shifted.
+ */
+function instantsForLocal(reading: LocalReading, formatter: Intl.DateTimeFormat): number[] {
+  const naive = utcKey(reading)
+  const candidates = new Set<number>()
+  for (const probe of [naive - DAY_MS, naive, naive + DAY_MS]) {
+    candidates.add(naive - offsetAt(probe, formatter))
+  }
+  const found: number[] = []
+  for (const candidate of candidates) {
+    if (utcKey(readLocalReading(candidate, formatter)) === naive) found.push(candidate)
+  }
+  return found
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+/**
+ * The zone's offset from UTC at `instant`, in milliseconds: read the wall clock
+ * there and measure how far it is from the same reading in UTC.
+ */
+function offsetAt(instant: number, formatter: Intl.DateTimeFormat): number {
+  return utcKey(readLocalReading(instant, formatter)) - Math.floor(instant / 60_000) * 60_000
+}
+
+/**
+ * A wall-clock reading as a comparable number: the same civil fields read as if
+ * they were UTC. Only ever compared with another key from this function — it is
+ * an ordering, not an instant.
+ */
+function utcKey(reading: LocalReading): number {
+  return Date.UTC(reading.year, reading.month - 1, reading.day, reading.hours, reading.minutes)
+}
+
+/** The local civil date of an instant. */
+function readLocal(instant: number, formatter: Intl.DateTimeFormat): CivilDate {
+  const reading = readLocalReading(instant, formatter)
+  return { year: reading.year, month: reading.month, day: reading.day }
+}
+
+/** The local wall-clock reading of an instant. */
+function readLocalReading(instant: number, formatter: Intl.DateTimeFormat): LocalReading {
+  const parts = formatter.formatToParts(new Date(instant))
+  const field = (type: Intl.DateTimeFormatPartTypes): number => {
+    const part = parts.find((candidate) => candidate.type === type)
+    return part ? Number(part.value) : 0
+  }
+  const era = parts.find((part) => part.type === 'era')?.value
+  const year = field('year')
+  return {
+    // `formatToParts` renders a BC year unsigned; nothing schedules there, but a
+    // silently-positive year would make the ordering lie.
+    year: era === 'B' ? 1 - year : year,
+    month: field('month'),
+    day: field('day'),
+    // Some ICU builds render midnight as hour 24 of the previous day; h23 asks
+    // for 0-23 and this is the belt to that pair of braces.
+    hours: field('hour') % 24,
+    minutes: field('minute'),
+  }
+}
+
+/** The day after (or before) a civil date, carrying month and year properly. */
+function addDays(date: CivilDate, delta: number): CivilDate {
+  const shifted = new Date(Date.UTC(date.year, date.month - 1, date.day + delta))
+  return {
+    year: shifted.getUTCFullYear(),
+    month: shifted.getUTCMonth() + 1,
+    day: shifted.getUTCDate(),
+  }
+}
+
+/** A civil date's day of the week, 0 = Sunday — pure calendar, no zone involved. */
+function weekdayOf(date: CivilDate): number {
+  return new Date(Date.UTC(date.year, date.month - 1, date.day)).getUTCDay()
+}
+
+/**
+ * One `Intl.DateTimeFormat` per zone, cached — the scan reads a wall clock
+ * several times per day it considers, and constructing a formatter is the
+ * expensive half. Null (and cached as such) for a zone `Intl` rejects.
+ */
+const FORMATTERS = new Map<string, Intl.DateTimeFormat | null>()
+
+function zoneFormatter(timezone: string): Intl.DateTimeFormat | null {
+  if (typeof timezone !== 'string' || !timezone) return null
+  const cached = FORMATTERS.get(timezone)
+  if (cached !== undefined) return cached
+  let formatter: Intl.DateTimeFormat | null
+  try {
+    formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      hourCycle: 'h23',
+      era: 'narrow',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  } catch {
+    formatter = null // not a zone this ICU knows
+  }
+  FORMATTERS.set(timezone, formatter)
+  return formatter
+}


### PR DESCRIPTION
Closes #467. Parent PRD #466, decisions in ADR-0028 (parts 2 and 6).

The value a schedule is, the two computations over it, and the store. **No firing, no scheduler, no UI** — those are #468–#472.

## What is here

**`src/shared/schedule.ts`** — `RoutineSchedule` and the arithmetic, pure and Node/DOM-free so main, preload and the renderer all get the same answer.

- A **discriminated union on `kind`** (`daily` | `weekdays` | `weekly`), which is what keeps ADR-0028's escape hatch free: a `cron` variant is one more branch, with no migration and no rewrite of the others. `weekly` requires its `weekday` at the type level, so a weekly schedule with nothing to key on cannot be constructed.
- `nextRunAfter(schedule, from)` — the first instant strictly after `from`.
- `expectedLastDue(schedule, now)` — the most recent instant at or before `now`. This is the backwards computation ADR-0028 part 6 is built on, and the reason a date/cron library would have been the wrong shape rather than merely an extra dependency.
- **No date or cron dependency.** IANA zones are `Intl`'s job; Electron ships full ICU.
- Both directions walk local days through one `fireInstantOn`, so the three DST rules are resolved in exactly one place and the two functions cannot disagree about a day, a kind or a transition.

**`routines` table (migration 6) + `SqliteRoutineStore` behind `RoutineStoreApi`**, following the `bots` store's shape, naming and test style, on the same `state.sqlite`.

**`routines:list | create | update | delete`** in `src/shared/ipc/routines.ts`, re-exported by the barrel, registered by `src/main/routines/register-ipc.ts` beside the store, thin over `routine-lifecycle.ts` and the pure `validate-routine.ts`. Preload exposes the four.

## The round-trip property, and why it matters

For any kind, zone, time of day and probe instant, `expectedLastDue(s, nextRunAfter(s, t))` returns that same fire instant. The suite runs it over 6 zones × 5 times × 4 schedules × 10 probe instants, plus a 366-day walk that also asserts the sequence is strictly increasing.

It matters because ADR-0028 deliberately gives the missed-run detector **no code in common with the firing path** — that is the correction of a mistake this codebase made three times, where the component that broke was also the one responsible for reporting that it broke. The detector may only share the pure arithmetic, and only because the firer and the detector must **agree**. If the round trip ever failed, the detector would either re-report a run that had already happened or miss one that never did, and everything downstream of this slice believes it.

DST is covered in both directions, in three zones that are not this machine's (New York, Berlin, and Sydney for the southern hemisphere), plus a test that picks a zone different from `machineTimezone()` whatever the machine is set to.

## No `nextRunAt` column

Deliberately, per ADR-0028 part 6, and asserted by a test that reads `PRAGMA table_info` and requires the column to be absent. A stored next-fire is a value somebody must remember to rewrite; the derivation exists to remove exactly that failure mode. Nothing here caches it.

## Decisions the ticket did not settle

1. **The `routines.thread_id` FK points at `bots(thread_id)`, not `threads(id)`.** The ticket says "cascade when its Bot or its Workspace goes", and a `threads` reference would not do that: `bots:delete` drops the Bot row and *archives* the Thread (the conversation survives, #447), so Routines would outlive the teammate they belong to. Referencing `bots` cascades on a Bot delete, and still reaches all the way out because `bots` itself cascades from `threads` and from `workspaces`. It also enforces ADR-0028 part 1 in the schema: a Routine cannot be attached to a plain Thread. All three cascades are tested.
2. **The 5-per-Bot cap is enforced twice, on purpose.** The lifecycle checks it so the refusal carries a message a person reads (`reason: 'capped'`); the store enforces it as a data invariant so no writer can get past it. Both read `MAX_ROUTINES_PER_BOT` from `shared/routine-limits`, so they cannot drift.
3. **A `RoutineOutcome` and a `recordRun` method are in this slice.** The ticket's field list names `lastRunAt` / `lastOutcome` / `lastError`, and columns with no writer are columns nobody can test. The firer that calls it is #468.
4. **`prompt` is required and non-empty.** Not in the ticket's validation list, but a Routine with a blank prompt fires a blank turn on a schedule, and ADR-0028 part 5 makes every routine turn write an entry — so it would report, daily, that it had nothing to ask.
5. **A skipped local time is resolved by walking the local clock forward a minute at a time, and never past the end of the local day.** Real DST gaps are an hour or two. A whole remaining day with no valid local time is a date-line shift rather than a DST transition; that day is skipped, which keeps exactly one instant per local date and keeps the day sequence strictly increasing — the invariant the round trip rests on.
6. **A row whose stored `schedule` JSON is unreadable is logged and left out of the listing** rather than carried with an invented schedule. A stored zone `Intl` does not know is treated differently on purpose: the row still lists and can be edited or deleted, and simply computes no next run.
7. **Allowed commands are validated for shape only here** (one bounded, single-line invocation per entry, trimmed and de-duplicated at the write). Matching a requested command against them — whole-string, refusing redirects, pipes and substitutions — belongs beside the thing that answers, in #469.

Nothing in the ticket, the PRD or the ADR turned out to be wrong or impossible.

## Gates

All four green from the repo root: `lint`, `typecheck`, `build`, and `test` — **2097 tests in 184 files**, of which 75 are new (29 schedule, 19 store, 27 lifecycle + validator).
