### PR TITLE
fix: record applied migrations by name, not by user_version (#475)

### DIFF
--- a/apps/desktop/src/main/persistence/migration-plan.test.ts
+++ b/apps/desktop/src/main/persistence/migration-plan.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest'
+import { planMigrations } from './migration-plan'
+import type { Migration } from './sqlite-db'
+
+/**
+ * The migration planner (#475). Every case here is one the integer
+ * `user_version` could not tell apart, which is why the ledger exists.
+ */
+
+function migration(id: number, name: string, creates: string[]): Migration {
+  return { id, name, creates, up: () => {} }
+}
+
+const CORE = migration(1, 'core', ['workspaces'])
+const LOG = migration(2, 'log', ['entries', 'idx_entries'])
+const BOTS = migration(3, 'bots', ['bots', 'idx_bots'])
+
+const ALL = [CORE, LOG, BOTS]
+
+function plan(args: Partial<Parameters<typeof planMigrations>[0]> = {}) {
+  return planMigrations({
+    migrations: ALL,
+    applied: new Set<string>(),
+    ledgerEmpty: true,
+    userVersion: 0,
+    existingObjects: new Set<string>(),
+    ...args,
+  })
+}
+
+describe('a fresh database', () => {
+  it('runs every migration and backfills nothing', () => {
+    const result = plan()
+    expect(result.run.map((m) => m.name)).toEqual(['core', 'log', 'bots'])
+    expect(result.backfill).toEqual([])
+    expect(result.repaired).toEqual([])
+    expect(result.inconsistent).toEqual([])
+  })
+})
+
+describe('the first open after the ledger was introduced', () => {
+  it('backfills the names user_version vouches for and runs the rest', () => {
+    const result = plan({
+      userVersion: 2,
+      existingObjects: new Set(['workspaces', 'entries', 'idx_entries']),
+    })
+    expect(result.backfill).toEqual(['core', 'log'])
+    expect(result.run.map((m) => m.name)).toEqual(['bots'])
+    expect(result.repaired).toEqual([])
+  })
+
+  it('does not backfill a name it is also about to run — a claim precedes nothing', () => {
+    // `bots` is claimed by user_version but no bots object exists, so it must be
+    // RUN. Recording it as backfilled too would assert it ran before it did.
+    const result = plan({ userVersion: 3, existingObjects: new Set(['workspaces', 'entries', 'idx_entries']) })
+    expect(result.run.map((m) => m.name)).toEqual(['bots'])
+    expect(result.backfill).not.toContain('bots')
+  })
+})
+
+describe('the divergent-branch case — the bug #475 was filed for', () => {
+  it('re-applies a migration whose objects are entirely absent, and says so', () => {
+    // A database another branch took to user_version 3 with ITS OWN third
+    // migration: the integer says "bots ran", the schema says otherwise.
+    const result = plan({
+      userVersion: 3,
+      existingObjects: new Set(['workspaces', 'entries', 'idx_entries', 'cli_sessions']),
+    })
+    expect(result.run.map((m) => m.name)).toEqual(['bots'])
+    expect(result.repaired).toEqual([{ name: 'bots', missing: ['bots', 'idx_bots'] }])
+    expect(result.inconsistent).toEqual([])
+  })
+
+  it('repairs an EARLY migration before the later ones that depend on it', () => {
+    const result = plan({
+      applied: new Set(['core', 'log', 'bots']),
+      ledgerEmpty: false,
+      userVersion: 3,
+      existingObjects: new Set(['bots', 'idx_bots']),
+    })
+    expect(result.run.map((m) => m.name)).toEqual(['core', 'log'])
+    expect(result.repaired.map((d) => d.name)).toEqual(['core', 'log'])
+  })
+})
+
+describe('a damaged schema', () => {
+  it('refuses a migration whose objects are only PARTLY there', () => {
+    const result = plan({
+      applied: new Set(['core', 'log']),
+      ledgerEmpty: false,
+      existingObjects: new Set(['workspaces', 'entries']), // idx_entries gone
+    })
+    expect(result.inconsistent).toEqual([{ name: 'log', missing: ['idx_entries'] }])
+    expect(result.run.map((m) => m.name)).toEqual(['bots'])
+    expect(result.repaired).toEqual([])
+  })
+})
+
+describe('the steady state', () => {
+  it('does nothing when the ledger and the schema agree', () => {
+    const result = plan({
+      applied: new Set(['core', 'log', 'bots']),
+      ledgerEmpty: false,
+      userVersion: 3,
+      existingObjects: new Set(['workspaces', 'entries', 'idx_entries', 'bots', 'idx_bots']),
+    })
+    expect(result.run).toEqual([])
+    expect(result.backfill).toEqual([])
+    expect(result.repaired).toEqual([])
+    expect(result.inconsistent).toEqual([])
+  })
+
+  it('ignores user_version entirely once the ledger exists', () => {
+    // A divergent database sits at a HIGHER number than this build's list. The
+    // ledger, not the integer, decides — the newer-build refusal is a separate
+    // check in `openStateDb`.
+    const result = plan({
+      applied: new Set(['core']),
+      ledgerEmpty: false,
+      userVersion: 99,
+      existingObjects: new Set(['workspaces']),
+    })
+    expect(result.run.map((m) => m.name)).toEqual(['log', 'bots'])
+  })
+})

--- a/apps/desktop/src/main/persistence/migration-plan.ts
+++ b/apps/desktop/src/main/persistence/migration-plan.ts
@@ -1,0 +1,104 @@
+import type { Migration } from './sqlite-db'
+
+/**
+ * What to do with a database's schema at open (#475) — the PURE core of the
+ * migration runner, so the awkward cases are settled in a unit test rather than
+ * against a real file.
+ *
+ * WHY THIS EXISTS. Migrations used to be keyed by `PRAGMA user_version` alone —
+ * an integer POSITION, not an identity. Two branches that each append a
+ * migration therefore both claim the same number, and a database that ran one
+ * branch's version 5 looks, to the other branch, exactly like a database that
+ * ran ITS version 5. The runner skips it forever and the table is never created.
+ *
+ * That is not hypothetical: a profile migrated by a parked branch reached
+ * `user_version = 6` with neither `bots` nor `routines`, and the app logged
+ * `no such table: bots` on every launch for eight days without anyone noticing,
+ * because the stores are best-effort and swallow their failures. The fail-closed
+ * check did not catch it either: it refuses a NEWER version, and this one was
+ * not newer, it was DIVERGENT — same number, different meaning.
+ *
+ * So the ledger records migrations by NAME, and every migration declares the
+ * schema objects it creates, which lets the plan tell three states apart that
+ * the integer could not:
+ *
+ * - **never applied** — no ledger row. Run it.
+ * - **claimed but absent** — a ledger row (usually from the `user_version`
+ *   backfill) yet NOT ONE of its objects exists. The claim is false; run it and
+ *   say so out loud. This is the divergent-branch case, and it self-heals.
+ * - **claimed and partial** — some objects exist and some do not. That is not a
+ *   version mix-up, it is a damaged schema, and re-running `up` would fail on the
+ *   half that IS there. Refuse, and let the caller lock the database rather than
+ *   write into it.
+ */
+
+/** A migration whose ledger row is a lie, with what makes it one. */
+export interface MigrationDiscrepancy {
+  name: string
+  /** Objects the migration declares but that `sqlite_master` does not have. */
+  missing: readonly string[]
+}
+
+export interface MigrationPlan {
+  /**
+   * Everything to run, in `id` order — never-applied and falsely-claimed alike,
+   * so a repaired early migration still precedes a later one that references it.
+   */
+  run: readonly Migration[]
+  /** Names to record as applied WITHOUT running: the `user_version` backfill. */
+  backfill: readonly string[]
+  /** The falsely-claimed subset of {@link run} — worth logging, never silent. */
+  repaired: readonly MigrationDiscrepancy[]
+  /** Damaged schemas. Non-empty means: do not migrate, do not write. */
+  inconsistent: readonly MigrationDiscrepancy[]
+}
+
+export function planMigrations(args: {
+  migrations: readonly Migration[]
+  /** Names in the `schema_migrations` ledger. */
+  applied: ReadonlySet<string>
+  /** True when the ledger table is new/empty, so `user_version` is all we have. */
+  ledgerEmpty: boolean
+  userVersion: number
+  /** Every name in `sqlite_master` — tables, indexes, triggers alike. */
+  existingObjects: ReadonlySet<string>
+}): MigrationPlan {
+  // The ledger is authoritative once it exists. On the FIRST open after this
+  // change it does not, so read `user_version` the only way it can honestly be
+  // read — "the first N migrations of this list ran" — and record those names.
+  // For a divergent database that reading is wrong, which is exactly what the
+  // object check below is for: the backfill states the claim, the objects test it.
+  const backfill = args.ledgerEmpty
+    ? args.migrations.filter((m) => m.id <= args.userVersion).map((m) => m.name)
+    : []
+  const claimed = new Set([...args.applied, ...backfill])
+
+  const run: Migration[] = []
+  const repaired: MigrationDiscrepancy[] = []
+  const inconsistent: MigrationDiscrepancy[] = []
+
+  for (const migration of args.migrations) {
+    if (!claimed.has(migration.name)) {
+      run.push(migration)
+      continue
+    }
+    const missing = migration.creates.filter((object) => !args.existingObjects.has(object))
+    if (missing.length === 0) continue
+    if (missing.length === migration.creates.length) {
+      // Nothing it makes is there: it never ran, whatever the ledger says.
+      run.push(migration)
+      repaired.push({ name: migration.name, missing })
+      continue
+    }
+    inconsistent.push({ name: migration.name, missing })
+  }
+
+  return {
+    run,
+    // A name that is being RUN is recorded by the runner, not by the backfill —
+    // recording it twice would be harmless but claiming it before it ran is not.
+    backfill: backfill.filter((name) => !run.some((m) => m.name === name)),
+    repaired,
+    inconsistent,
+  }
+}

--- a/apps/desktop/src/main/persistence/sqlite-db.test.ts
+++ b/apps/desktop/src/main/persistence/sqlite-db.test.ts
@@ -20,6 +20,7 @@ function marker(id: number): Migration {
   return {
     id,
     name: `marker-${id}`,
+    creates: ['applied'],
     up: (db) => {
       db.exec(`CREATE TABLE IF NOT EXISTS applied (id INTEGER)`)
       db.exec(`INSERT INTO applied (id) VALUES (${id})`)
@@ -83,6 +84,7 @@ describe('openStateDb migration runner', () => {
     const broken: Migration = {
       id: 2,
       name: 'boom',
+      creates: ['half'],
       up: (db) => {
         db.exec('CREATE TABLE half (x)')
         throw new Error('boom')
@@ -123,6 +125,128 @@ describe('STATE_MIGRATIONS registry', () => {
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
       .all() as unknown as { name: string }[]
     expect(tables.map((t) => t.name)).toEqual(expect.arrayContaining(['threads', 'workspaces']))
+    state.close()
+  })
+})
+
+describe('the migration ledger (#475)', () => {
+  /** Two branches that each appended a migration, both claiming id 2. */
+  const branchA: Migration = {
+    id: 2,
+    name: 'cli-sessions',
+    creates: ['cli_sessions'],
+    up: (db) => db.exec('CREATE TABLE cli_sessions (x)'),
+  }
+  const branchB: Migration = {
+    id: 2,
+    name: 'bots',
+    creates: ['bots'],
+    up: (db) => db.exec('CREATE TABLE bots (x)'),
+  }
+
+  it('creates the branch-B table on a database branch A already took to the same version', () => {
+    // THE REGRESSION TEST. Before the ledger this database looked fully migrated
+    // and `bots` was never created — silently, for eight days, in a real profile.
+    const path = join(dir, 'divergent.sqlite')
+    openStateDb({ path, migrations: [marker(1), branchA] }).close()
+
+    const reopened = openStateDb({ path, migrations: [marker(1), branchB] })
+    expect(reopened.locked).toBe(false)
+    const tables = reopened.db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
+      .all() as unknown as { name: string }[]
+    expect(tables.map((t) => t.name)).toContain('bots')
+    expect(tables.map((t) => t.name)).toContain('cli_sessions') // the orphan is left alone
+    reopened.close()
+  })
+
+  it('records every applied migration by name, and does not re-run it on reopen', () => {
+    const path = join(dir, 'ledger.sqlite')
+    const first = openStateDb({ path, migrations: [marker(1), marker(2)] })
+    const names = first.db
+      .prepare('SELECT name FROM schema_migrations ORDER BY name')
+      .all() as unknown as { name: string }[]
+    expect(names.map((n) => n.name)).toEqual(['marker-1', 'marker-2'])
+    first.close()
+
+    // `marker` INSERTs a row each time it runs, so a re-run would show up here.
+    const again = openStateDb({ path, migrations: [marker(1), marker(2)] })
+    const applied = again.db.prepare('SELECT id FROM applied').all() as unknown as { id: number }[]
+    expect(applied).toHaveLength(2)
+    again.close()
+  })
+
+  it('backfills names from user_version for a database written before the ledger existed', () => {
+    const path = join(dir, 'backfill.sqlite')
+    // A pre-ledger database: migrated, versioned, but with no schema_migrations.
+    const raw = new DatabaseSync(path)
+    raw.exec('CREATE TABLE applied (id INTEGER)')
+    raw.exec('INSERT INTO applied (id) VALUES (1)')
+    raw.exec('PRAGMA user_version = 1')
+    raw.close()
+
+    const state = openStateDb({ path, migrations: [marker(1), marker(2)] })
+    const names = state.db
+      .prepare('SELECT name FROM schema_migrations ORDER BY name')
+      .all() as unknown as { name: string }[]
+    expect(names.map((n) => n.name)).toEqual(['marker-1', 'marker-2'])
+    // marker-1 was backfilled, not re-run, so still exactly one pre-existing row + marker-2's.
+    const applied = state.db.prepare('SELECT id FROM applied ORDER BY rowid').all() as unknown as {
+      id: number
+    }[]
+    expect(applied.map((r) => r.id)).toEqual([1, 2])
+    state.close()
+  })
+
+  it('never lowers user_version when repairing a database that is already past it', () => {
+    const path = join(dir, 'no-regress.sqlite')
+    openStateDb({ path, migrations: [marker(1), branchA, marker(3)] }).close()
+    expect(readUserVersion(new DatabaseSync(path))).toBe(3)
+
+    const reopened = openStateDb({ path, migrations: [marker(1), branchB] })
+    expect(readUserVersion(reopened.db)).toBe(3) // not 2 — going back would re-arm fail-closed
+    reopened.close()
+  })
+
+  it('locks a database whose migration is only PARTLY present, rather than writing into it', () => {
+    const path = join(dir, 'damaged.sqlite')
+    const pair: Migration = {
+      id: 2,
+      name: 'pair',
+      creates: ['left', 'right'],
+      up: (db) => {
+        db.exec('CREATE TABLE left_t (x)')
+        db.exec('CREATE TABLE right_t (x)')
+      },
+    }
+    // Declare objects that `up` does not actually make, so the check sees a half.
+    const declared: Migration = { ...pair, creates: ['left_t', 'never_made'] }
+    openStateDb({ path, migrations: [marker(1), declared] }).close()
+
+    const reopened = openStateDb({ path, migrations: [marker(1), declared] })
+    expect(reopened.locked).toBe(true)
+    expect(reopened.lockReason).toContain('never_made')
+    reopened.close()
+  })
+
+  it('the real migration list declares objects that match what it actually creates', () => {
+    // Guards the whole mechanism: a `creates` typo would make every launch either
+    // re-run a migration or lock the database.
+    const state = openStateDb({ path: ':memory:', migrations: STATE_MIGRATIONS })
+    const objects = new Set(
+      (state.db.prepare('SELECT name FROM sqlite_master').all() as unknown as { name: string }[]).map(
+        (r) => r.name,
+      ),
+    )
+    for (const migration of STATE_MIGRATIONS) {
+      for (const object of migration.creates) {
+        expect({ migration: migration.name, object, present: objects.has(object) }).toEqual({
+          migration: migration.name,
+          object,
+          present: true,
+        })
+      }
+    }
     state.close()
   })
 })

--- a/apps/desktop/src/main/persistence/sqlite-db.ts
+++ b/apps/desktop/src/main/persistence/sqlite-db.ts
@@ -1,4 +1,5 @@
 import { DatabaseSync } from 'node:sqlite'
+import { planMigrations } from './migration-plan'
 
 /**
  * The one SQLite database for everything we persist (ADR-0019): `state.sqlite`
@@ -9,18 +10,37 @@ import { DatabaseSync } from 'node:sqlite'
  * pass `:memory:` or a temp-dir path) and never derive the path themselves.
  *
  * SCHEMA VERSIONING (fail-closed, carried over from the JSON MetadataStore):
- * the version lives in `PRAGMA user_version`. Migrations are forward-only,
- * statically registered in a numbered array (no filesystem discovery — survives
- * bundling), and run automatically at open, each inside a transaction. A file
- * whose `user_version` is NEWER than this build's latest migration is refused:
- * the db opens LOCKED — no migrations run, stores present empty and write
- * nothing — so an older build can never clobber data written by a newer one.
+ * migrations are forward-only, statically registered in a numbered array (no
+ * filesystem discovery — survives bundling), and run automatically at open, each
+ * inside a transaction. A file whose `user_version` is NEWER than this build's
+ * latest migration is refused: the db opens LOCKED — no migrations run, stores
+ * present empty and write nothing — so an older build can never clobber data
+ * written by a newer one.
+ *
+ * WHICH migrations have run is recorded BY NAME in `schema_migrations`, not by
+ * `user_version` alone (#475). An integer is a position, so two branches that
+ * each append a migration both claim the same number and each skips the other's
+ * forever; a name cannot collide that way. `user_version` is still written and
+ * still drives the newer-build refusal above — it just no longer decides what to
+ * run. Every migration declares the schema objects it creates, so a ledger row
+ * that is not backed by real tables is caught instead of believed.
  */
 
 export interface Migration {
-  /** Strictly increasing, starting at 1. Becomes `user_version` once applied. */
+  /** Strictly increasing, starting at 1. Drives ORDER and `user_version`. */
   id: number
+  /** The identity a migration is recorded under. Never reuse or rename one. */
   name: string
+  /**
+   * Every schema object `up` creates — tables, indexes, triggers, virtual tables
+   * — exactly as `sqlite_master.name` spells them.
+   *
+   * REQUIRED, so that adding a migration forces the question, and so a ledger row
+   * can be checked against the schema it claims to have made (#475). Shadow
+   * tables an FTS5 virtual table creates for itself are NOT listed: the virtual
+   * table is the object we made.
+   */
+  creates: readonly string[]
   up: (db: DatabaseSync) => void
 }
 
@@ -32,10 +52,24 @@ export interface StateDbDeps {
 
 export interface StateDb {
   db: DatabaseSync
-  /** True when the file was written by a newer build — see module doc. */
+  /**
+   * True when this database must not be migrated or written: either a newer
+   * build wrote it, or its schema is damaged in a way re-running cannot fix.
+   * `lockReason` says which, in words a user could act on.
+   */
   locked: boolean
+  /** Why it is locked, or null when it is not. */
+  lockReason: string | null
   close(): void
 }
+
+/** The ledger of applied migrations, by name (#475). Meta, so not a migration. */
+const SCHEMA_LEDGER = `
+  CREATE TABLE IF NOT EXISTS schema_migrations (
+    name       TEXT PRIMARY KEY,
+    applied_at INTEGER NOT NULL
+  );
+`
 
 /** Read `PRAGMA user_version` (0 on a fresh database). */
 export function readUserVersion(db: DatabaseSync): number {
@@ -58,20 +92,59 @@ export function openStateDb(deps: StateDbDeps): StateDb {
   const latest = deps.migrations.length ? deps.migrations[deps.migrations.length - 1].id : 0
   const current = readUserVersion(db)
   if (current > latest) {
-    console.error(
-      `[SqliteDb] ${deps.path} is user_version ${current}; this build supports ${latest}. ` +
-        `Refusing to migrate or write so a newer build's data is preserved. ` +
-        `Upgrade vibe-mistro to open these Workspaces/Threads.`,
-    )
-    return { db, locked: true, close: () => closeQuietly(db) }
+    const reason =
+      `This database was written by a newer version of Vibe Mistro (schema ${current}; ` +
+      `this build understands ${latest}). It has been opened read-only so that nothing ` +
+      `is overwritten. Update Vibe Mistro to use these Projects and Threads.`
+    console.error(`[SqliteDb] ${deps.path}: ${reason}`)
+    return { db, locked: true, lockReason: reason, close: () => closeQuietly(db) }
   }
 
-  for (const migration of deps.migrations) {
-    if (migration.id <= current) continue
+  db.exec(SCHEMA_LEDGER)
+  const plan = planMigrations({
+    migrations: deps.migrations,
+    applied: readAppliedNames(db),
+    ledgerEmpty: countLedgerRows(db) === 0,
+    userVersion: current,
+    existingObjects: readSchemaObjects(db),
+  })
+
+  if (plan.inconsistent.length > 0) {
+    // Half a migration's objects exist and half do not. Re-running `up` would
+    // fail on the half that IS there, and writing into a schema we cannot
+    // describe risks the data we do have — so stop, loudly, with the detail
+    // needed to repair it by hand.
+    const detail = plan.inconsistent
+      .map((d) => `${d.name} (missing: ${d.missing.join(', ')})`)
+      .join('; ')
+    const reason =
+      `This database's schema is incomplete and cannot be repaired automatically: ${detail}. ` +
+      `It has been opened read-only so nothing is lost. Please report this with the details above.`
+    console.error(`[SqliteDb] ${deps.path}: ${reason}`)
+    return { db, locked: true, lockReason: reason, close: () => closeQuietly(db) }
+  }
+
+  for (const discrepancy of plan.repaired) {
+    // NOT swallowed: this is the failure #475 was filed for, and it went unseen
+    // for eight days precisely because nothing said it out loud.
+    console.warn(
+      `[SqliteDb] ${deps.path}: migration '${discrepancy.name}' was recorded as applied but ` +
+        `created nothing (missing: ${discrepancy.missing.join(', ')}). Re-applying it. This ` +
+        `database was probably migrated by a different build or branch.`,
+    )
+  }
+
+  const now = Date.now()
+  if (plan.backfill.length > 0) recordApplied(db, plan.backfill, now)
+
+  for (const migration of plan.run) {
     db.exec('BEGIN')
     try {
       migration.up(db)
-      db.exec(`PRAGMA user_version = ${migration.id}`)
+      recordApplied(db, [migration.name], now)
+      // NEVER lower it: a divergent database is already past this id, and going
+      // backwards would re-arm the fail-closed check against its own data.
+      db.exec(`PRAGMA user_version = ${Math.max(readUserVersion(db), migration.id)}`)
       db.exec('COMMIT')
     } catch (err) {
       db.exec('ROLLBACK')
@@ -80,7 +153,31 @@ export function openStateDb(deps: StateDbDeps): StateDb {
     }
   }
 
-  return { db, locked: false, close: () => closeQuietly(db) }
+  return { db, locked: false, lockReason: null, close: () => closeQuietly(db) }
+}
+
+/** The migration names the ledger holds. */
+function readAppliedNames(db: DatabaseSync): Set<string> {
+  const rows = db.prepare('SELECT name FROM schema_migrations').all() as { name?: unknown }[]
+  return new Set(rows.map((row) => String(row.name)))
+}
+
+function countLedgerRows(db: DatabaseSync): number {
+  const row = db.prepare('SELECT COUNT(*) AS c FROM schema_migrations').get() as { c?: number }
+  return typeof row?.c === 'number' ? row.c : 0
+}
+
+/** Every name in `sqlite_master` — tables, indexes and triggers alike. */
+function readSchemaObjects(db: DatabaseSync): Set<string> {
+  const rows = db.prepare('SELECT name FROM sqlite_master').all() as { name?: unknown }[]
+  return new Set(rows.map((row) => String(row.name)))
+}
+
+function recordApplied(db: DatabaseSync, names: readonly string[], atMs: number): void {
+  const insert = db.prepare(
+    'INSERT INTO schema_migrations (name, applied_at) VALUES (?, ?) ON CONFLICT(name) DO NOTHING',
+  )
+  for (const name of names) insert.run(name, atMs)
 }
 
 function closeQuietly(db: DatabaseSync): void {

--- a/apps/desktop/src/main/persistence/state-migrations.ts
+++ b/apps/desktop/src/main/persistence/state-migrations.ts
@@ -5,8 +5,15 @@ import { isTranscriptEntry } from './transcript'
 /**
  * The state database's forward-only migration history (ADR-0019). Statically
  * registered — append new migrations to the END with the next id; never edit or
- * reorder an applied one. `user_version` tracks the last applied id; a database
- * ahead of this list fails closed in `openStateDb`.
+ * reorder an applied one, and never reuse a `name`. A database ahead of this list
+ * fails closed in `openStateDb`.
+ *
+ * Applied migrations are recorded BY NAME in `schema_migrations` (#475), so a
+ * long-lived branch that appends its own migration no longer consumes an `id`
+ * that `main` needs — the two lists can disagree about numbers without either
+ * silently skipping the other's work. `creates` is REQUIRED on every entry and
+ * must list every object `up` makes, spelled as `sqlite_master.name` spells it:
+ * it is what lets a ledger row be tested against the schema it claims.
  *
  * Schema conventions (ADR-0019): timestamps are epoch-millisecond INTEGERs
  * (matching the `shared/ipc` wire types), booleans are 0/1 INTEGERs — except
@@ -17,6 +24,7 @@ export const STATE_MIGRATIONS: readonly Migration[] = [
   {
     id: 1,
     name: 'metadata-tables',
+    creates: ['workspaces', 'threads', 'idx_threads_workspace_active', 'idx_threads_session'],
     up: (db) => {
       db.exec(`
         CREATE TABLE workspaces (
@@ -45,6 +53,7 @@ export const STATE_MIGRATIONS: readonly Migration[] = [
   {
     id: 2,
     name: 'transcript-entries',
+    creates: ['transcript_entries', 'idx_transcript_entries_thread'],
     up: (db) => {
       // The transcript event log (ADR-0019): the source of truth the projections
       // derive from. `seq` is the global total order (replacing per-file append
@@ -66,6 +75,15 @@ export const STATE_MIGRATIONS: readonly Migration[] = [
   {
     id: 3,
     name: 'prose-fts',
+    creates: [
+      'prose_items',
+      'idx_prose_items_thread_item',
+      'idx_prose_items_thread',
+      'prose_fts',
+      'prose_items_ai',
+      'prose_items_ad',
+      'prose_items_au',
+    ],
     up: (db) => {
       // The search projection (ADR-0019, #296): one prose row per conversation
       // item (see prose-projection.ts) + an FTS5 external-content index kept in
@@ -123,6 +141,7 @@ export const STATE_MIGRATIONS: readonly Migration[] = [
   {
     id: 4,
     name: 'thread-snapshots',
+    creates: ['thread_snapshots'],
     up: (db) => {
       // The fold-snapshot projection (ADR-0019, #297): the renderer's folded
       // ConversationState as an OPAQUE blob (main never parses it — ADR-0001),
@@ -144,6 +163,7 @@ export const STATE_MIGRATIONS: readonly Migration[] = [
   {
     id: 5,
     name: 'bots',
+    creates: ['bots', 'idx_bots_workspace'],
     up: (db) => {
       // The Mistro Bot record (#445, ADR-0027): a Bot IS one continuing Thread,
       // so `thread_id` is BOTH the primary key and the identity — there is no
@@ -175,6 +195,7 @@ export const STATE_MIGRATIONS: readonly Migration[] = [
   {
     id: 6,
     name: 'routines',
+    creates: ['routines', 'idx_routines_thread'],
     up: (db) => {
       // A Routine (#467, ADR-0028): a named schedule attached to a Mistro Bot.
       //


### PR DESCRIPTION
Closes #475.

## The bug

`PRAGMA user_version` is an integer **position**, not an identity. Two branches that each append a
migration both claim the same number, so a database that ran one branch's version N looks — to the
other branch — exactly like a database that ran **its** version N. The runner skips it forever.

This is not hypothetical. A profile migrated by `feat/411-cli-session-discovery` reached
`user_version = 6` with neither `bots` nor `routines`, and the app logged `no such table: bots` on every
launch **from 13 to 21 August** without anyone noticing — the stores are best-effort by design
(ADR-0005/0019), so the failure was logged and swallowed and the Bots section was simply empty.

The existing fail-closed guard does not catch it: it refuses a **newer** `user_version`, and this one was
not newer. It was **divergent** — same number, different meaning.

## The fix

Applied migrations are recorded **by name** in a `schema_migrations` ledger, and every `Migration`
declares the schema objects its `up` creates. Those two together distinguish three states the integer
could not:

| state | what it means | what happens |
|---|---|---|
| no ledger row | never applied | run it |
| row, but **none** of its objects exist | the claim is false — the divergent-branch case | run it, and **warn loudly** |
| row, but **some** objects exist | a damaged schema; re-running `up` would fail on the half that is there | **lock** the database rather than write into it |

The decision is a pure function in `migration-plan.ts`, so all of that is settled in unit tests rather
than against real files — the established pattern here (`agent-protection.ts`, `thread-status.ts`).

`user_version` keeps its job: it still drives the newer-build refusal, it seeds a one-time backfill for
databases written before the ledger existed, and it is **never lowered** — a divergent database is
already past this build's numbers, and going backwards would re-arm the fail-closed check against its
own data.

`creates` is **required**, so adding a migration forces the question. A test asserts every declaration
in `STATE_MIGRATIONS` matches what the migrations actually create — a typo there would make every
launch either re-run a migration or lock the database.

## Verified against the database that produced the bug

Run against a pre-repair copy of the real profile:

```
[SqliteDb] …: migration 'bots' was recorded as applied but created nothing
           (missing: bots, idx_bots_workspace). Re-applying it.
[SqliteDb] …: migration 'routines' was recorded as applied but created nothing
           (missing: routines, idx_routines_thread). Re-applying it.
locked: false | bots present: true | routines present: true
threads: 85 | entries: 11992
```

It self-heals, says so, and touches nothing else.

## Gates

`lint` clean · `typecheck` 0 errors/warnings/hints · `build` Complete · `test` **2152 passed** (188 files,
+14 tests).

## What I deliberately did NOT do

#475 also asks that a missing table **surface to the user** rather than scroll past in a terminal. The
self-heal removes the case that actually bit us, and `StateDb` now carries a `lockReason` written for a
human to read — but **nothing renders it yet**. A locked database still presents as empty and silent,
exactly as it did before this PR for the newer-build case.

That is a pre-existing gap, not a new one, and closing it means touching main's wiring, the IPC contract
and the renderer — too much to bolt onto a persistence fix, and it would collide with the Routines slice
in flight. Filed separately so it is not forgotten.