### PR TITLE
Routines slice 3 — the permission gate: a routine-only profile that forces the ask, and the allowlist that answers it (#469)

### DIFF
--- a/apps/desktop/scripts/spike-routine-gate.ts
+++ b/apps/desktop/scripts/spike-routine-gate.ts
@@ -1,0 +1,269 @@
+/**
+ * Spike probe for GitHub issue #469 — the **Routine permission gate**.
+ *
+ * Two questions, both of which decide code in `src/main/routines/`:
+ *
+ *  1. Does a routine-only profile carrying `[tools.*]` blocks (file-writing tools
+ *     `never`, shell `ask` with an EMPTY allowlist) actually force `vibe-acp` to
+ *     ASK — over a user `config.toml` layer that otherwise auto-approves?
+ *  2. What EXACTLY does the `session/request_permission` for a shell command carry,
+ *     and what does the preceding `tool_call` update carry? The request itself is
+ *     only a `toolCallId` (acp-capture §6/§15F), so the answerer has to recover the
+ *     invocation from somewhere — this prints every candidate verbatim.
+ *
+ * HITL / LIVE: drives the user's REAL Mistral account with two short prompts. It
+ * answers EVERY `session/request_permission` with `reject_once` and REFUSES
+ * `fs/write_text_file`, so the agent cannot touch disk through us.
+ *
+ * ISOLATION — nothing of the user's is written:
+ *  - `VIBE_HOME` is a scratch dir under `$TMPDIR`; the real `~/.vibe/config.toml` is
+ *    only READ, and copied in so the gate is tested against a permissive user layer.
+ *  - the workspace `cwd` is a scratch dir under `$TMPDIR`.
+ *  - profiles are named `zz-probe-*` and live in the scratch home.
+ *
+ *     bun build scripts/spike-routine-gate.ts --target=node --outfile=/tmp/spike-gate.mjs \
+ *       && node /tmp/spike-gate.mjs
+ *
+ * (Built to a node target, NOT run under bun — Bun's child_process doesn't deliver
+ * stdin.write to a piped child, which the AcpClient transport relies on.)
+ *
+ * Flags: --keep --command=<bin> --help
+ */
+
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { homedir, tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { AcpClient } from '../src/main/acp/client'
+
+const PROTOCOL_VERSION = 1
+const CLIENT_INFO = { name: 'vibe-mistro', version: '0.0.1' } as const
+const T = { init: 30_000, small: 20_000, prompt: 180_000 } as const
+
+const log = (m: string): void => console.log(m)
+const banner = (t: string): void => log(`\n===== ${t} =====`)
+const dump = (l: string, v: unknown): void => log(`${l}:\n${JSON.stringify(v, null, 2)}`)
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
+function withTimeout<T2>(p: Promise<T2>, ms: number, label: string): Promise<T2> {
+  return Promise.race([
+    p,
+    new Promise<T2>((_, rej) => setTimeout(() => rej(new Error(`${label} timed out after ${ms}ms`)), ms)),
+  ])
+}
+
+const keep = process.argv.includes('--keep')
+const command = process.argv.find((a) => a.startsWith('--command='))?.slice(10) ?? 'vibe-acp'
+if (process.argv.includes('--help')) {
+  log('usage: node /tmp/spike-gate.mjs [--keep] [--command=vibe-acp]')
+  process.exit(0)
+}
+
+// --- scratch home + workspace -------------------------------------------------
+const scratchHome = mkdtempSync(join(tmpdir(), 'zz-probe-469-home-'))
+const scratchCwd = mkdtempSync(join(tmpdir(), 'zz-probe-469-cwd-'))
+const agentsDir = join(scratchHome, 'agents')
+const promptsDir = join(scratchHome, 'prompts')
+mkdirSync(agentsDir, { recursive: true })
+mkdirSync(promptsDir, { recursive: true })
+
+const realConfig = join(homedir(), '.vibe', 'config.toml')
+if (existsSync(realConfig)) {
+  copyFileSync(realConfig, join(scratchHome, 'config.toml'))
+  log(`  [scratch] copied the user's config.toml into ${scratchHome} (read-only on the original)`)
+} else {
+  log('  [scratch] no ~/.vibe/config.toml to copy — running against a pristine home')
+}
+
+const PROMPT_MD = `You are ZZ Probe Bot, a throwaway test persona for issue 469.\n`
+writeFileSync(join(promptsDir, 'zz-probe-prompt.md'), PROMPT_MD, 'utf8')
+
+/** The shipped Bot profile shape (slice 1) — no tools block at all. */
+const UNGATED = `display_name = "ZZ Probe Ungated"
+description = "The Bot profile as slice 1 writes it"
+agent_type = "agent"
+safety = "neutral"
+system_prompt_id = "zz-probe-prompt"
+`
+
+/** The candidate ROUTINE profile: the gate this slice writes. */
+const GATED = `display_name = "ZZ Probe Routine"
+description = "Routine gate candidate for issue 469"
+agent_type = "agent"
+safety = "neutral"
+system_prompt_id = "zz-probe-prompt"
+
+[tools.write_file]
+permission = "never"
+
+[tools.edit]
+permission = "never"
+
+[tools.bash]
+permission = "ask"
+allowlist = []
+`
+
+writeFileSync(join(agentsDir, 'zz-probe-ungated.toml'), UNGATED, 'utf8')
+writeFileSync(join(agentsDir, 'zz-probe-routine.toml'), GATED, 'utf8')
+
+function cleanup(): void {
+  banner('cleanup')
+  if (keep) {
+    log(`  --keep: leaving ${scratchHome} and ${scratchCwd}`)
+    return
+  }
+  rmSync(scratchHome, { recursive: true, force: true })
+  rmSync(scratchCwd, { recursive: true, force: true })
+  log('  scratch home + cwd removed')
+}
+
+// --- ACP plumbing -------------------------------------------------------------
+interface SessionShape {
+  sessionId?: string
+  modes?: { currentModeId?: string; availableModes?: { id: string }[] }
+}
+
+class Probe {
+  readonly client: AcpClient
+  readonly permissions: unknown[] = []
+  readonly toolCalls: unknown[] = []
+  cancelOnFirstDenial = false
+  constructor() {
+    this.client = new AcpClient({
+      command,
+      cwd: scratchCwd,
+      env: { ...process.env, VIBE_HOME: scratchHome },
+    })
+    this.client.on('notification', (msg: unknown) => {
+      const m = msg as { method?: string; params?: { update?: { sessionUpdate?: string } } }
+      const kind = m?.params?.update?.sessionUpdate
+      if (kind === 'tool_call' || kind === 'tool_call_update') {
+        this.toolCalls.push(m.params?.update)
+        dump(`  [${kind}]`, m.params?.update)
+      }
+    })
+    this.client.on('serverRequest', (msg: unknown) => this.serve(msg))
+    this.client.on('stderr', (t: string) => process.stderr.write(`  [stderr] ${t}`))
+    this.client.on('error', (e: Error) => log(`  [client error] ${e.message}`))
+    this.client.start()
+  }
+  private serve(msg: unknown): void {
+    const m = msg as { id: number | string; method: string; params?: { path?: string } }
+    if (m.method === 'fs/read_text_file') {
+      try {
+        this.client.respond(m.id, { content: readFileSync(m.params?.path ?? '', 'utf8') })
+      } catch (e) {
+        this.client.respondError(m.id, { code: -32603, message: (e as Error).message })
+      }
+      return
+    }
+    if (m.method === 'fs/write_text_file') {
+      log('  [serverRequest] fs/write_text_file — probe REFUSES')
+      this.client.respondError(m.id, { code: -32603, message: 'probe refuses to write' })
+      return
+    }
+    if (m.method === 'session/request_permission') {
+      this.permissions.push(m.params)
+      dump(`  >>> PERMISSION #${this.permissions.length} (VERBATIM)`, m.params)
+      this.client.respond(m.id, { outcome: { outcome: 'selected', optionId: 'reject_once' } })
+      // The behaviour this slice depends on: the FIRST denial cancels the turn.
+      if (this.cancelOnFirstDenial) {
+        const sessionId = (m.params as { sessionId?: string } | undefined)?.sessionId
+        if (sessionId) {
+          log('  >>> first denial — sending session/cancel')
+          this.client.notify('session/cancel', { sessionId })
+        }
+      }
+      return
+    }
+    this.client.respondError(m.id, { code: -32601, message: 'probe refuses this request' })
+  }
+  async init(): Promise<void> {
+    await withTimeout(
+      this.client.request('initialize', {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: { fs: { readTextFile: true, writeTextFile: true } },
+        clientInfo: CLIENT_INFO,
+      }),
+      T.init,
+      'initialize',
+    )
+  }
+  async newSession(): Promise<SessionShape> {
+    return (await withTimeout(
+      this.client.request('session/new', { cwd: scratchCwd, mcpServers: [] }),
+      T.small,
+      'session/new',
+    )) as SessionShape
+  }
+  async setMode(sessionId: string, modeId: string): Promise<unknown> {
+    return await withTimeout(
+      this.client.request('session/set_config_option', { sessionId, configId: 'mode', value: modeId }),
+      T.small,
+      'session/set_config_option',
+    )
+  }
+  async prompt(sessionId: string, text: string): Promise<unknown> {
+    return await withTimeout(
+      this.client.request('session/prompt', { sessionId, prompt: [{ type: 'text', text }] }),
+      T.prompt,
+      'session/prompt',
+    )
+  }
+  stop(): void {
+    this.client.stop()
+  }
+}
+
+const WRITE_TASK =
+  'Create a file called probe.txt in the current directory containing the word hello. ' +
+  'Use a single shell command. Do not explain, just do it.'
+const READ_TASK = 'Run the shell command `ls -la` in the current directory and tell me the first line.'
+
+async function run(profileId: string, task: string, label: string, cancelOnFirstDenial = false): Promise<void> {
+  banner(`${label} — profile ${profileId}`)
+  const p = new Probe()
+  p.cancelOnFirstDenial = cancelOnFirstDenial
+  try {
+    await p.init()
+    const s = await p.newSession()
+    const ids = (s.modes?.availableModes ?? []).map((m) => m.id)
+    log(`  mode ids: ${ids.join(', ')}`)
+    log(`  ${profileId} offered? ${ids.includes(profileId)}`)
+    if (!s.sessionId) throw new Error('no sessionId')
+    dump('  set_config_option(mode) result', await p.setMode(s.sessionId, profileId))
+    const result = await p.prompt(s.sessionId, task)
+    dump('  session/prompt result', result)
+    log(`  PERMISSION REQUESTS: ${p.permissions.length}`)
+    log(`  probe.txt on disk? ${existsSync(join(scratchCwd, 'probe.txt'))}`)
+    rmSync(join(scratchCwd, 'probe.txt'), { force: true })
+  } catch (e) {
+    log(`  FAILED: ${e instanceof Error ? e.message : String(e)}`)
+  } finally {
+    p.stop()
+    await sleep(500)
+  }
+}
+
+async function main(): Promise<void> {
+  log(`scratch home: ${scratchHome}`)
+  log(`scratch cwd:  ${scratchCwd}`)
+  try {
+    const phase = process.argv.find((a) => a.startsWith('--phase='))?.slice(8) ?? 'all'
+    if (phase === 'all' || phase === 'a') {
+      await run('zz-probe-ungated', WRITE_TASK, 'A — UNGATED (slice-1 Bot profile)')
+    }
+    if (phase === 'all' || phase === 'b') {
+      await run('zz-probe-routine', WRITE_TASK, 'B — GATED (routine profile candidate)')
+    }
+    if (phase === 'all' || phase === 'c') {
+      await run('zz-probe-routine', READ_TASK, 'C — GATED, a read-only shell command')
+    }
+    if (phase === 'all' || phase === 'd') {
+      await run('zz-probe-routine', WRITE_TASK, 'D — GATED, cancel on the first denial', true)
+    }
+  } finally {
+    cleanup()
+  }
+}
+
+void main()

--- a/apps/desktop/src/main/bots/write-bot-profile.test.ts
+++ b/apps/desktop/src/main/bots/write-bot-profile.test.ts
@@ -138,14 +138,20 @@ describe('writeBotProfile', () => {
 })
 
 describe('removeBotProfile', () => {
-  it('deletes both files, TOML first', async () => {
+  it('deletes every generated file, TOML first — including the routine gate (#469)', async () => {
     const fs = fakeFs()
     await writeBotProfile({ source: source(), dirs: DIRS, fs })
+    // The routine-only gate profile a scheduled turn wears. It is generated from
+    // this Bot and meaningless without it, so it comes down with it — otherwise it
+    // lingers in every Mode picker as a mode for a teammate that is gone.
+    const routineToml = `${DIRS.agentsDir}/mistro-routine-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.toml`
+    fs.files.set(routineToml, 'gate')
     const ok = await removeBotProfile({ profileId: PROFILE_ID, dirs: DIRS, fs })
 
     expect(ok).toBe(true)
     expect(fs.removed).toEqual([
       `${DIRS.agentsDir}/${PROFILE_ID}.toml`,
+      routineToml,
       `${DIRS.promptsDir}/${PROFILE_ID}.md`,
     ])
     expect(fs.files.size).toBe(0)
@@ -166,6 +172,7 @@ describe('removeBotProfile', () => {
     const fs = fakeFs({ failRm: '.toml' })
     const ok = await removeBotProfile({ profileId: PROFILE_ID, dirs: DIRS, fs })
     expect(ok).toBe(false)
+    // Both TOMLs failed; the prompt still came down.
     expect(fs.removed).toEqual([`${DIRS.promptsDir}/${PROFILE_ID}.md`])
   })
 })

--- a/apps/desktop/src/main/bots/write-bot-profile.ts
+++ b/apps/desktop/src/main/bots/write-bot-profile.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path'
 import { projectBotProfile, type BotProfileSource } from './bot-profile'
-import { isMistroBotProfileId } from '../../shared/bot-profile-id'
+import { isMistroBotProfileId, routineProfileIdFor } from '../../shared/bot-profile-id'
 import type { VibeProfileDirs } from './profile-dirs'
 import {
   collectProblems,
@@ -96,11 +96,18 @@ export interface RemoveBotProfileArgs {
 }
 
 /**
- * Destroy a Bot's two generated files. Refuses a foreign id outright — the whole
+ * Destroy a Bot's generated files. Refuses a foreign id outright — the whole
  * point of the `mistro-bot-` prefix is that this can never reach a profile the
  * user wrote. Best-effort otherwise: the TOML is removed FIRST so a half-failed
  * delete leaves an orphan prompt rather than a mode with no persona, and each
  * removal is attempted independently.
+ *
+ * Since #469 that is THREE files, not two: a Bot also owns a routine-only gate
+ * profile derived from the same id (`mistro-routine-<uuid>`). It comes down here
+ * because it is generated from the Bot and has no meaning without it — left
+ * behind it would keep appearing in every Mode picker as a mode for a teammate
+ * that no longer exists, which is the exact orphan `cleanRemovedBots` was written
+ * to prevent.
  */
 export async function removeBotProfile(args: RemoveBotProfileArgs): Promise<boolean> {
   const { profileId, dirs, fs } = args
@@ -108,9 +115,11 @@ export async function removeBotProfile(args: RemoveBotProfileArgs): Promise<bool
     console.error(`[vibe-mistro:bots] refusing to delete a profile we do not own: ${profileId}`)
     return false
   }
+  const routineProfileId = routineProfileIdFor(profileId)
   let ok = true
   for (const path of [
     join(dirs.agentsDir, `${profileId}.toml`),
+    ...(routineProfileId ? [join(dirs.agentsDir, `${routineProfileId}.toml`)] : []),
     join(dirs.promptsDir, `${profileId}.md`),
   ]) {
     try {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -10,6 +10,7 @@ import {
 } from 'electron'
 import electronUpdater, { type UpdateInfo } from 'electron-updater'
 import { mkdir } from 'node:fs/promises'
+import { homedir } from 'node:os'
 import { randomUUID } from 'node:crypto'
 import { basename, join } from 'node:path'
 import {
@@ -76,7 +77,7 @@ import type { MetadataStoreApi } from './persistence/metadata-store-api'
 import { createMetadataStore } from './persistence/create-metadata-store'
 import { maybeBackupStateDb } from './persistence/state-backup'
 import type { StateDb } from './persistence/sqlite-db'
-import { resolvePermissionEntry } from './persistence/transcript'
+import { resolvePermissionEntry, turnErrorEntry, userPromptEntry } from './persistence/transcript'
 import type { TranscriptStoreApi } from './persistence/transcript-store-api'
 import { createTranscriptStore } from './persistence/create-transcript-store'
 import { TranscriptBridge } from './persistence/transcript-bridge'
@@ -104,6 +105,9 @@ import type { ModeDiscovery } from './acp/agent-controls'
 import { SqliteBotStore } from './persistence/sqlite-bot-store'
 import type { BotStoreApi } from './persistence/bot-store-api'
 import { registerRoutinesIpc } from './routines/register-ipc'
+import { ensureRoutineGate } from './routines/write-routine-profile'
+import { nodeRoutineProfileFs } from './routines/node-routine-profile-fs'
+import { vibeProfileDirs } from './bots/profile-dirs'
 import { SqliteRoutineStore } from './persistence/sqlite-routine-store'
 import type { RoutineStoreApi } from './persistence/routine-store-api'
 import { registerEditorsIpc } from './editors/register-ipc'
@@ -829,7 +833,27 @@ function registerIpc(deps: MainDeps): void {
         activity.beginRoutine(agentId)
       },
       endProtection: (agentId) => activity.endRoutine(agentId),
-      runTurn: (agent, args) => runPromptTurn(deps, { kind: 'headless' }, agent, args),
+      // The permission gate (#469): written and CONFIRMED before every run, into
+      // the same `~/.vibe/agents/` the Bot's own profile lives in. Dirs resolved
+      // lazily, like the Bots registrar's, so `getShellEnv`'s login-shell probe
+      // stays off the launch path.
+      ensureGate: (source) =>
+        ensureRoutineGate({
+          source,
+          dirs: vibeProfileDirs(getShellEnv(), homedir()),
+          fs: nodeRoutineProfileFs,
+        }),
+      // A routine failure lands in the Bot's OWN conversation (ADR-0028 part 5 —
+      // always an entry, success or failure) through the same turn-error tee every
+      // other failed turn uses, and moves `lastActiveAt` so the unread dot appears.
+      reportFailure: ({ threadId, message, prompt }) => {
+        if (prompt !== undefined) deps.bridge.tee(threadId, userPromptEntry(randomUUID(), prompt))
+        deps.bridge.tee(threadId, turnErrorEntry(message))
+        void deps.store.touchThread(threadId).catch((err) => {
+          console.error(`[vibe-mistro:routines] touchThread failed (${threadId}): ${String(err)}`)
+        })
+      },
+      runTurn: (agent, args, gate) => runPromptTurn(deps, { kind: 'headless', gate }, agent, args),
       now: () => Date.now(),
     },
   })

--- a/apps/desktop/src/main/persistence/routine-store-api.ts
+++ b/apps/desktop/src/main/persistence/routine-store-api.ts
@@ -56,6 +56,13 @@ export interface RoutineRunResult {
   lastOutcome: RoutineOutcome
   /** The fixable message behind a `failed` / `blocked` run; omitted for `ok`. */
   lastError?: string | null
+  /**
+   * The exact invocation the allowed-commands gate refused (#469), or null. Unlike
+   * `lastError` this is NOT carried forward: a run that was not blocked clears it,
+   * so the offer to add a command can never be made about a command that is no
+   * longer the reason anything failed.
+   */
+  lastBlockedCommand?: string | null
 }
 
 export interface RoutineStoreApi {

--- a/apps/desktop/src/main/persistence/sqlite-routine-store.test.ts
+++ b/apps/desktop/src/main/persistence/sqlite-routine-store.test.ts
@@ -197,6 +197,33 @@ describe('SqliteRoutineStore CRUD', () => {
     expect(recovered).toMatchObject({ lastRunAt: 1800, lastOutcome: 'ok', lastError: null })
   })
 
+  it('keeps the blocked invocation as its own value, and clears it on the next run', async () => {
+    // #469: slice 5 offers to ADD this command to the routine's allowed commands,
+    // so what comes back has to be the bytes the agent asked to run — not a
+    // fragment parsed out of a sentence.
+    const f = openFixture()
+    const bot = await seedBot(f)
+    insertRoutine(f, bot.threadId)
+
+    const blocked = f.routines.recordRun('routine-1', {
+      lastRunAt: 1700,
+      lastOutcome: 'blocked',
+      lastError: 'It was stopped before running `echo hi > a.txt`.',
+      lastBlockedCommand: 'echo hi > a.txt',
+    })
+    expect(blocked?.lastBlockedCommand).toBe('echo hi > a.txt')
+    expect(f.routines.get('routine-1')?.lastBlockedCommand).toBe('echo hi > a.txt')
+
+    // A later failure for an unrelated reason must not still be offering to allow
+    // yesterday's command — unlike `lastError`, this is never carried forward.
+    const failed = f.routines.recordRun('routine-1', {
+      lastRunAt: 1800,
+      lastOutcome: 'failed',
+      lastError: 'Context too long.',
+    })
+    expect(failed?.lastBlockedCommand).toBeNull()
+  })
+
   it('reports an unknown Routine rather than throwing', async () => {
     const f = openFixture()
     expect(f.routines.get('nope')).toBeNull()

--- a/apps/desktop/src/main/persistence/sqlite-routine-store.ts
+++ b/apps/desktop/src/main/persistence/sqlite-routine-store.ts
@@ -37,6 +37,7 @@ interface RoutineRow {
   last_run_at: number | null
   last_outcome: string | null
   last_error: string | null
+  last_blocked_command: string | null
   created_at: number
   updated_at: number
 }
@@ -118,6 +119,7 @@ export class SqliteRoutineStore implements RoutineStoreApi {
       lastRunAt: null,
       lastOutcome: null,
       lastError: null,
+      lastBlockedCommand: null,
       createdAt: ts,
       updatedAt: ts,
     }
@@ -125,8 +127,9 @@ export class SqliteRoutineStore implements RoutineStoreApi {
       this.db
         .prepare(
           `INSERT INTO routines (id, thread_id, name, prompt, schedule, allowed_commands, active,
-                                 last_run_at, last_outcome, last_error, created_at, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, ?, ?)`,
+                                 last_run_at, last_outcome, last_error, last_blocked_command,
+                                 created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?)`,
         )
         .run(
           record.id,
@@ -197,15 +200,27 @@ export class SqliteRoutineStore implements RoutineStoreApi {
       lastRunAt: result.lastRunAt,
       lastOutcome: result.lastOutcome,
       lastError,
+      // Deliberately NOT carried forward the way `lastError` is: the blocked
+      // command belongs to the run that was blocked, and a later run that failed
+      // for some other reason must not still be offering to allow it (#469).
+      lastBlockedCommand: result.lastBlockedCommand ?? null,
       updatedAt: this.now(),
     }
     try {
       this.db
         .prepare(
-          `UPDATE routines SET last_run_at = ?, last_outcome = ?, last_error = ?, updated_at = ?
+          `UPDATE routines SET last_run_at = ?, last_outcome = ?, last_error = ?,
+                               last_blocked_command = ?, updated_at = ?
            WHERE id = ?`,
         )
-        .run(next.lastRunAt, next.lastOutcome, next.lastError, next.updatedAt, id)
+        .run(
+          next.lastRunAt,
+          next.lastOutcome,
+          next.lastError,
+          next.lastBlockedCommand,
+          next.updatedAt,
+          id,
+        )
       return next
     } catch (err) {
       console.error('[SqliteRoutineStore] recordRun failed:', err)
@@ -271,6 +286,7 @@ function routineFromRow(row: RoutineRow): RoutineRecord | null {
     lastRunAt: row.last_run_at,
     lastOutcome: isOutcome(row.last_outcome) ? row.last_outcome : null,
     lastError: row.last_error,
+    lastBlockedCommand: row.last_blocked_command,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }

--- a/apps/desktop/src/main/persistence/state-migrations.ts
+++ b/apps/desktop/src/main/persistence/state-migrations.ts
@@ -235,4 +235,32 @@ export const STATE_MIGRATIONS: readonly Migration[] = [
       `)
     },
   },
+  {
+    id: 7,
+    name: 'routine-blocked-command',
+    // Nothing in `sqlite_master` — this ADDS A COLUMN to a table migration 6
+    // made, and a column is not an object the ledger can check for (#475). Two
+    // consequences, both handled below rather than left implicit: the `up` is
+    // written to be safely re-runnable, and it asks the table what it already has
+    // instead of assuming, so a database that reaches it twice is repaired rather
+    // than locked.
+    creates: [],
+    up: (db) => {
+      // The exact invocation the **allowed commands** gate refused (#469,
+      // ADR-0028 part 4), kept as its own column rather than folded into
+      // `last_error`.
+      //
+      // It is a column and not a parse of the message because slice 5 offers to
+      // ADD this command to the routine's list: what goes back must be the bytes
+      // the agent asked to run, and a value that has been through a sentence — a
+      // backtick, an ellipsis, a truncation — is a value that can come back
+      // subtly different from the one that was blocked. Nullable and unread by
+      // anything older, so no existing row needs rewriting.
+      const columns = db.prepare(`PRAGMA table_info(routines)`).all() as unknown as {
+        name: string
+      }[]
+      if (columns.some((column) => column.name === 'last_blocked_command')) return
+      db.exec(`ALTER TABLE routines ADD COLUMN last_blocked_command TEXT;`)
+    },
+  },
 ]

--- a/apps/desktop/src/main/prompt-turn.test.ts
+++ b/apps/desktop/src/main/prompt-turn.test.ts
@@ -263,3 +263,86 @@ describe('runPromptTurn — the turn itself does not care who is watching', () =
     expect(withoutRenderer.teed.map((t) => t.entry.t)).toEqual(withRenderer.teed.map((t) => t.entry.t))
   })
 })
+
+/**
+ * The routine permission gate on a headless turn (#469, ADR-0028 part 4).
+ *
+ * Two properties, and both are about REFUSING rather than about running: a turn
+ * whose gate profile cannot be selected must not be sent at all, and the answerer
+ * must be listening before it is.
+ */
+describe('runPromptTurn — the routine gate (#469)', () => {
+  const GATE_PROFILE = 'mistro-routine-11111111-2222-3333-4444-555555555555'
+
+  function gated(over: Partial<{ onSessionBound: (sessionId: string) => void }> = {}): {
+    delivery: PromptTurnDelivery
+    bound: string[]
+  } {
+    const bound: string[] = []
+    return {
+      bound,
+      delivery: {
+        kind: 'headless',
+        gate: {
+          profileId: GATE_PROFILE,
+          onSessionBound: (sessionId) => {
+            bound.push(sessionId)
+            over.onSessionBound?.(sessionId)
+          },
+        },
+      },
+    }
+  }
+
+  it('selects the gate profile before prompting, and reports the bound session', async () => {
+    const h = harness()
+    const agent = fakeAgent()
+    const modes: string[] = []
+    agent.setMode = async (_sessionId: string, modeId: string) => void modes.push(modeId)
+    const { delivery, bound } = gated()
+
+    const result = await runPromptTurn(h.deps, delivery, agent, args())
+
+    expect(result.ok).toBe(true)
+    expect(modes).toEqual([GATE_PROFILE])
+    // Reported before the prompt — the only window in which the answerer can be
+    // armed, since permission requests only arrive during `session/prompt`.
+    expect(bound).toEqual(['s1'])
+  })
+
+  it('REFUSES the turn when the gate profile cannot be selected', async () => {
+    // `setMode` routes through the validating `session/set_config_option`, so a
+    // rejection means the session does not offer the profile — the gate is not on.
+    // A routine that cannot be gated must not be prompted at all.
+    const h = harness()
+    const agent = fakeAgent()
+    agent.setMode = async () => {
+      throw new Error('-32602 unknown mode')
+    }
+    const { delivery, bound } = gated()
+
+    const result = await runPromptTurn(h.deps, delivery, agent, args())
+
+    expect(result).toMatchObject({ ok: false, kind: 'error' })
+    expect((result as { error: string }).error).toContain('permission gate')
+    expect(agent.prompts).toBe(0) // nothing was ever sent to the agent
+    expect(bound).toEqual([]) // and nothing was armed
+    // It still WRITES: the attempted prompt and the reason land in the Bot's own
+    // conversation, like every other headless pre-bind failure.
+    expect(h.teed.map((t) => t.entry.t)).toEqual(['user-prompt', 'turn-error'])
+    expect(h.touched).toEqual(['bot-thread'])
+  })
+
+  it('leaves an UNGATED headless turn exactly as it was', async () => {
+    const h = harness()
+    const agent = fakeAgent()
+    const modes: string[] = []
+    agent.setMode = async (_sessionId: string, modeId: string) => void modes.push(modeId)
+
+    await runPromptTurn(h.deps, h.headless, agent, args())
+
+    // No Bot record in this harness, so no persona and no gate: nothing selected.
+    expect(modes).toEqual([])
+    expect(agent.prompts).toBe(1)
+  })
+})

--- a/apps/desktop/src/main/prompt-turn.ts
+++ b/apps/desktop/src/main/prompt-turn.ts
@@ -62,13 +62,40 @@ export interface ThreadBoundSender {
 }
 
 /**
+ * The permission gate a scheduled turn wears (#469, ADR-0028 part 4).
+ *
+ * A Bot's own profile is its persona and is shared with interactive use, so the
+ * gate lives in a SECOND profile selected for this turn alone. Two properties
+ * make it a gate rather than a preference:
+ *
+ *  - it is selected on EVERY gated turn, including one that merely reuses a
+ *    session bound earlier — a reuse reports no controls, which the ordinary
+ *    persona plan reads as "already selected", and for a routine that reading
+ *    would mean running ungated;
+ *  - a selection failure is FATAL. `setMode` routes through the validating
+ *    `session/set_config_option`, so a rejection means the session does not offer
+ *    the profile — the gate is not on, and a routine whose gate cannot be
+ *    confirmed must not run.
+ */
+export interface PromptTurnGate {
+  /** The routine-only profile id to select on the mode axis. */
+  profileId: string
+  /**
+   * The session this turn bound to, reported the instant it is known and always
+   * before `session/prompt` — which is the only time a permission request can
+   * arrive, and so the moment the answerer must be listening by.
+   */
+  onSessionBound(sessionId: string): void
+}
+
+/**
  * Who receives this turn's out-of-band signals. `headless` carries no sender
  * because a Routine has no window: `thread:bound` has no consumer, and the
  * conversation itself becomes the reporting surface.
  */
 export type PromptTurnDelivery =
   | { kind: 'renderer'; sender: ThreadBoundSender }
-  | { kind: 'headless' }
+  | { kind: 'headless'; gate?: PromptTurnGate }
 
 /** The agent surface one turn drives — structural, so tests never spawn `vibe-acp`. */
 export interface PromptTurnAgent extends SessionBinder, PendingThreadControlAgent {
@@ -111,6 +138,10 @@ export async function runPromptTurn(
   // never pointed at a Thread whose row doesn't exist yet.
   let sessionId: string
   let rebound: boolean
+  // The routine gate (#469), when this turn is a scheduled one. Present ONLY on
+  // the headless path — every user-initiated turn keeps the Bot's own persona and
+  // the renderer's own answering (ADR-0001).
+  const gate = delivery.kind === 'headless' ? delivery.gate : undefined
   try {
     // A Routine warms a Workspace nobody selected, so the child may not be running
     // yet — the renderer path always arrives here on an agent `startThread` already
@@ -136,8 +167,13 @@ export async function runPromptTurn(
     // can never wear its persona — silently, for the rest of the run (every later
     // turn reuses that session and re-selection is skipped). Minting a fresh
     // `session/new` re-scans and costs one extra session in that case alone.
+    //
+    // A GATED turn asks the same question about the GATE profile instead: the
+    // primary session must be able to wear the gate, not merely the persona, or
+    // the selection below fails and the routine refuses to run.
     const preopened =
-      args.sessionId === null && mayClaimPreopenedSession(botProfileId, agent.primarySessionControls)
+      args.sessionId === null &&
+      mayClaimPreopenedSession(gate?.profileId ?? botProfileId, agent.primarySessionControls)
         ? (agent.consumePrimarySession() ?? undefined)
         : undefined
     const bound = await ensureBoundSession({
@@ -183,11 +219,28 @@ export async function runPromptTurn(
     // 2.24.x binary, all of which advertise the `mode` config option. A failure is
     // reported, never swallowed: a Bot that quietly answers with no persona is the
     // one failure ADR-0027 forbids.
+    //
+    // For a GATED turn the plan is not a plan at all: select the routine profile,
+    // unconditionally, and treat a failure as the end of the turn. See
+    // {@link PromptTurnGate} for why "the session already has a mode selected" is
+    // not an acceptable answer here.
     const profileOutcome = await applyBotProfile(
       agent,
       sessionId,
-      planBotProfileSelection(botProfileId, reportedControls),
+      gate ? { kind: 'select', profileId: gate.profileId } : planBotProfileSelection(botProfileId, reportedControls),
     )
+    if (gate && !profileOutcome.ok) {
+      // Thrown, so it lands in the catch below with every other pre-prompt
+      // failure: the attempted prompt and the reason are teed into the Bot's own
+      // conversation and NOTHING is sent to the agent.
+      throw new Error(
+        `${profileOutcome.message} A routine will not run without its permission gate.`,
+      )
+    }
+    // The answerer must be listening before `session/prompt`, and this is the
+    // first moment the session id exists. Ordered after the gate selection so a
+    // turn that never runs never arms anything.
+    if (gate) gate.onSessionBound(sessionId)
     if (profileOutcome.ok) {
       if (profileOutcome.selected && actualControls) {
         actualControls = controlsWithCurrentValue(actualControls, 'mode', profileOutcome.selected)

--- a/apps/desktop/src/main/routines/allowed-commands.test.ts
+++ b/apps/desktop/src/main/routines/allowed-commands.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest'
+import { hasShellOperator, matchAllowedCommand, refusalMessage } from './allowed-commands'
+
+/**
+ * The **Allowed commands** matcher (#469, ADR-0028 part 4), tested adversarially —
+ * and the adversary is not imagined. Every case in the first block is a route the
+ * #458 probe actually observed an agent take, or a shape the probe found inside
+ * Vibe's own permission payloads. A matcher that passes an invented suite and
+ * fails these would be worse than useless, because it would look tested.
+ */
+
+const ALLOWED = ['gh issue list --state open', 'git status', 'ls']
+
+describe('matchAllowedCommand', () => {
+  it('allows an invocation listed verbatim', () => {
+    expect(matchAllowedCommand('gh issue list --state open', ALLOWED)).toEqual({
+      allowed: true,
+      entry: 'gh issue list --state open',
+    })
+  })
+
+  describe("the routes #458 watched an agent take when it was denied", () => {
+    it('refuses THE redirect that passed a command allowlist', () => {
+      // The finding the whole design turns on: with the file-writing tools set to
+      // `never`, the agent wrote the file with `echo … > file`, because the
+      // redirect tokenises as a separate part and the allowlist only ever saw
+      // `echo`. Whole-string matching is what closes it.
+      expect(matchAllowedCommand('echo "hello" > file.txt', ['echo'])).toEqual({
+        allowed: false,
+        reason: 'shell-operator',
+      })
+    })
+
+    it('refuses an appending redirect, and a redirect onto a listed command', () => {
+      expect(matchAllowedCommand('ls >> out.txt', ALLOWED)).toEqual({
+        allowed: false,
+        reason: 'shell-operator',
+      })
+      expect(matchAllowedCommand('ls > /etc/hosts', ALLOWED)).toEqual({
+        allowed: false,
+        reason: 'shell-operator',
+      })
+    })
+
+    it('refuses a pipe, even when both halves are listed', () => {
+      expect(matchAllowedCommand('git status | ls', ALLOWED)).toEqual({
+        allowed: false,
+        reason: 'shell-operator',
+      })
+    })
+
+    it('refuses command substitution in both spellings, and a variable', () => {
+      expect(matchAllowedCommand('ls $(whoami)', ALLOWED)).toEqual({
+        allowed: false,
+        reason: 'shell-operator',
+      })
+      expect(matchAllowedCommand('ls `whoami`', ALLOWED)).toEqual({
+        allowed: false,
+        reason: 'shell-operator',
+      })
+      expect(matchAllowedCommand('ls ${HOME}', ALLOWED)).toEqual({
+        allowed: false,
+        reason: 'shell-operator',
+      })
+    })
+
+    it('refuses separators and a subshell — the `cd && echo >` shape', () => {
+      expect(matchAllowedCommand('cd /tmp && echo hi > a.txt', ALLOWED)).toEqual({
+        allowed: false,
+        reason: 'shell-operator',
+      })
+      expect(matchAllowedCommand('ls; rm -rf .', ALLOWED)).toEqual({
+        allowed: false,
+        reason: 'shell-operator',
+      })
+      expect(matchAllowedCommand('(ls)', ALLOWED)).toEqual({
+        allowed: false,
+        reason: 'shell-operator',
+      })
+    })
+  })
+
+  describe('whole-string matching', () => {
+    it('refuses a longer command that a listed entry is a PREFIX of', () => {
+      // The property that stops a list from widening as arguments are added:
+      // `git status` on the list must never authorise `git status --porcelain`,
+      // and `ls` must never authorise `ls /etc`.
+      expect(matchAllowedCommand('git status --porcelain', ALLOWED)).toEqual({
+        allowed: false,
+        reason: 'not-listed',
+      })
+      expect(matchAllowedCommand('ls /etc', ALLOWED)).toEqual({
+        allowed: false,
+        reason: 'not-listed',
+      })
+    })
+
+    it('refuses a command that a listed entry is a SUFFIX or substring of', () => {
+      expect(matchAllowedCommand('sudo ls', ALLOWED)).toEqual({
+        allowed: false,
+        reason: 'not-listed',
+      })
+      expect(matchAllowedCommand('gh issue list --state open --limit 5', ALLOWED)).toEqual({
+        allowed: false,
+        reason: 'not-listed',
+      })
+    })
+
+    it('is case- and whitespace-significant inside the command', () => {
+      expect(matchAllowedCommand('LS', ALLOWED).allowed).toBe(false)
+      expect(matchAllowedCommand('git  status', ALLOWED).allowed).toBe(false)
+    })
+  })
+
+  describe('whitespace at the edges', () => {
+    it('allows an invocation that differs only by leading or trailing whitespace', () => {
+      expect(matchAllowedCommand('  git status  ', ALLOWED)).toEqual({
+        allowed: true,
+        entry: 'git status',
+      })
+      expect(matchAllowedCommand('\tls\n', ALLOWED)).toEqual({ allowed: true, entry: 'ls' })
+    })
+
+    it('trims the LIST too, so a hand-edited row cannot mean something else', () => {
+      expect(matchAllowedCommand('git status', ['  git status  '])).toEqual({
+        allowed: true,
+        entry: 'git status',
+      })
+    })
+
+    it('refuses a blank or whitespace-only invocation', () => {
+      expect(matchAllowedCommand('', ALLOWED)).toEqual({ allowed: false, reason: 'blank' })
+      expect(matchAllowedCommand('   ', ALLOWED)).toEqual({ allowed: false, reason: 'blank' })
+    })
+  })
+
+  describe('the list itself', () => {
+    it('refuses everything when the list is empty — the default a Routine is created with', () => {
+      expect(matchAllowedCommand('ls', [])).toEqual({ allowed: false, reason: 'not-listed' })
+    })
+
+    it('allows an operator-carrying command when it is listed VERBATIM', () => {
+      // The one intended way past the operator rule: the user typed the whole
+      // line, so the whole line is what is authorised — and nothing near it is.
+      const listed = ['gh issue list --json number | head -5']
+      expect(matchAllowedCommand('gh issue list --json number | head -5', listed)).toEqual({
+        allowed: true,
+        entry: 'gh issue list --json number | head -5',
+      })
+      expect(matchAllowedCommand('gh issue list --json number | head -6', listed).allowed).toBe(false)
+    })
+
+    it('ignores blank and non-string entries rather than matching on them', () => {
+      const ragged = ['', '   ', 42 as unknown as string, 'ls']
+      expect(matchAllowedCommand('ls', ragged)).toEqual({ allowed: true, entry: 'ls' })
+      expect(matchAllowedCommand('', ragged)).toEqual({ allowed: false, reason: 'blank' })
+    })
+  })
+})
+
+describe('hasShellOperator', () => {
+  it('names the operators the refusal is about', () => {
+    for (const command of ['a > b', 'a | b', 'a; b', 'a && b', 'a $(b)', 'a `b`', '(a)']) {
+      expect({ command, operator: hasShellOperator(command) }).toEqual({ command, operator: true })
+    }
+    expect(hasShellOperator('gh issue list --state open')).toBe(false)
+  })
+})
+
+describe('refusalMessage', () => {
+  it('names the exact command, so the report is fixable', () => {
+    const message = refusalMessage('Morning triage', 'gh pr merge 12', 'not-listed')
+    expect(message).toContain('Morning triage')
+    expect(message).toContain('`gh pr merge 12`')
+  })
+
+  it('says something true when there was no command to name', () => {
+    expect(refusalMessage('Morning triage', null, 'unidentified')).toContain('not a shell command')
+    expect(refusalMessage('Morning triage', null, 'blank')).toContain('could not read')
+  })
+})

--- a/apps/desktop/src/main/routines/allowed-commands.ts
+++ b/apps/desktop/src/main/routines/allowed-commands.ts
@@ -1,0 +1,144 @@
+/**
+ * The **Allowed commands** matcher (#469, ADR-0028 part 4) — pure, total, and
+ * deliberately the least clever module in the feature.
+ *
+ * It answers one question: *may an unattended Routine run this exact invocation?*
+ * The answer is yes only when the WHOLE invocation string appears, verbatim, in
+ * the list the user authored. There is no prefix matching, no argument matching,
+ * no globbing and no tokenising, and each of those absences is a decision:
+ *
+ *  - **Whole-string, because Vibe's own tokeniser is what leaked.** #458 found
+ *    `echo "hello" > file` passing a command allowlist that never mentioned a
+ *    redirect, because the shell parser treats the redirect as a separate part.
+ *    Re-verified on the wire at vibe-acp 2.24.3 (`docs/acp-capture.md` §17): the
+ *    permission request's own `invocation_pattern` for that command reads
+ *    `echo hello <redirect>` — **the redirect is erased from it**. Anything that
+ *    matches per-part inherits that hole, so we match the raw command text and
+ *    nothing else.
+ *  - **No prefix matching**, because `git log` on the list would otherwise
+ *    authorise `git log --format=$(curl …)`.
+ *  - **No globbing**, because the widened patterns Vibe offers alongside a request
+ *    (`session_pattern: "echo *"`) are exactly the grant an unattended run must
+ *    not take.
+ *
+ * The shell-operator rule below is therefore REDUNDANT to whole-string matching —
+ * an invocation containing an operator is refused by rule 2 anyway unless it was
+ * listed verbatim. It exists to give the refusal a name (so slice 5 can say *why*
+ * rather than only *what*), and as a tripwire: if anyone ever loosens rule 2 into
+ * something fuzzier, this rule is the line the loosening must not cross.
+ *
+ * Node/DOM-free, no dependencies, no clock — every rule here is a unit test.
+ */
+
+/**
+ * The shell metacharacters that make one "command" into several, or into
+ * something whose text does not say what it runs:
+ *
+ * | char | why |
+ * |---|---|
+ * | `>` `<` | redirects — the #458 hole; the file written is not in the command name |
+ * | `\|` | pipes into another program |
+ * | `;` `&` | command separators / background |
+ * | `` ` `` `$` | command and variable substitution: `$(…)`, `` `…` ``, `${…}` |
+ * | `(` `)` | subshells |
+ * | newline | two invocations wearing one entry's clothes (also refused at write) |
+ *
+ * Not a sanitiser and not a parser — a name for the refusal. The gate is the
+ * whole-string comparison above it.
+ */
+const SHELL_OPERATORS = /[<>|;&`$()\n\r]/
+
+/** Why an invocation was refused, in the vocabulary the failure message uses. */
+export type AllowedCommandRefusal =
+  /**
+   * The request was not about a shell command we could identify at all — an
+   * unknown tool call (a subagent's, say), a non-shell tool, or a permission
+   * about something other than a command. Never returned by
+   * {@link matchAllowedCommand}, which is only ever asked about commands; it is
+   * the answering path's word for *there was nothing here to match*.
+   */
+  | 'unidentified'
+  /** Nothing to match — no command text was recovered from the wire. */
+  | 'blank'
+  /**
+   * It carries a redirect, pipe, separator or substitution and is not listed
+   * VERBATIM. Named separately because it is the #458 finding, and because
+   * "add this to the list" is worse advice for this case than for the next.
+   */
+  | 'shell-operator'
+  /** An ordinary invocation this Routine simply has not been allowed to run. */
+  | 'not-listed'
+
+export type AllowedCommandMatch =
+  /** Listed verbatim. `entry` is the list entry that authorised it. */
+  | { allowed: true; entry: string }
+  | { allowed: false; reason: AllowedCommandRefusal }
+
+/**
+ * Match one invocation against a Routine's allowed commands.
+ *
+ * Both sides are trimmed and nothing else is normalised: internal spacing, quoting
+ * and case are all significant, because they are all significant to a shell.
+ * `normalizeAllowedCommands` (the write path) already trims the stored entries —
+ * trimming again here means a hand-edited database row cannot authorise something
+ * its author would not recognise, which is the leading/trailing-whitespace case
+ * #458 called out.
+ */
+export function matchAllowedCommand(
+  invocation: string,
+  allowedCommands: readonly string[],
+): AllowedCommandMatch {
+  const command = typeof invocation === 'string' ? invocation.trim() : ''
+  if (!command) return { allowed: false, reason: 'blank' }
+
+  for (const candidate of allowedCommands) {
+    if (typeof candidate !== 'string') continue
+    const entry = candidate.trim()
+    // Rule 2, and the whole gate: WHOLE-STRING equality. A listed entry that
+    // itself contains an operator is honoured — the user typed it, verbatim, in
+    // full knowledge of what it does. That is the one intended way past the rule
+    // below, and it is why the rule is stated as "unless that exact string is
+    // listed" rather than as a ban.
+    if (entry && entry === command) return { allowed: true, entry }
+  }
+
+  if (SHELL_OPERATORS.test(command)) return { allowed: false, reason: 'shell-operator' }
+  return { allowed: false, reason: 'not-listed' }
+}
+
+/** Whether an invocation contains shell operators — exported for the refusal copy. */
+export function hasShellOperator(invocation: string): boolean {
+  return SHELL_OPERATORS.test(invocation)
+}
+
+/**
+ * The sentence a blocked Routine reports, naming the exact command (ADR-0028
+ * part 4: "the cancellation is reported naming the exact command").
+ *
+ * One wording, here, because it is read in three places — the Routine's failure
+ * detail, the entry written into the Bot's conversation, and (slice 5) the offer
+ * to add the command to the list.
+ */
+export function refusalMessage(routineName: string, command: string | null, reason: AllowedCommandRefusal): string {
+  const named = command ? `\`${command}\`` : 'a command it did not describe'
+  switch (reason) {
+    case 'unidentified':
+      return (
+        `"${routineName}" was stopped: the agent asked to do something that is not a shell command ` +
+        'this app could name, and an unattended run only ever allows commands you listed.'
+      )
+    case 'blank':
+      return (
+        `"${routineName}" was stopped: the agent asked to run something this app could not read, ` +
+        'so it was refused and the run was cancelled.'
+      )
+    case 'shell-operator':
+      return (
+        `"${routineName}" was stopped before running ${named}. It combines commands ` +
+        '(a redirect, pipe, separator or substitution), so it is only ever run when that exact ' +
+        "line is on the routine's allowed commands."
+      )
+    case 'not-listed':
+      return `"${routineName}" was stopped before running ${named}, which is not on its allowed commands.`
+  }
+}

--- a/apps/desktop/src/main/routines/confirm-routine-gate.test.ts
+++ b/apps/desktop/src/main/routines/confirm-routine-gate.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import { confirmRoutineGate, describeGateProblems, gateProblems } from './confirm-routine-gate'
+import { renderRoutineProfileToml } from './routine-profile'
+
+/**
+ * **Verify the gate took** (#469) — the check that stands between a typo and a
+ * routine that runs unattended with no permission gate and looks correctly
+ * configured while it does it.
+ *
+ * Each case below is a file Vibe would happily load. That is the point: Vibe
+ * validates nothing inside a profile's `tools` table and ignores what it does not
+ * recognise (#424), so every one of these is INVISIBLE on the wire. If this
+ * function does not catch them, nothing does.
+ */
+
+const BOT = 'mistro-bot-11111111-2222-3333-4444-555555555555'
+const GATE = 'mistro-routine-11111111-2222-3333-4444-555555555555'
+const EXPECTED = { profileId: GATE, botProfileId: BOT }
+const GOOD = renderRoutineProfileToml({ botProfileId: BOT, botName: 'Triager' })
+
+const fields = (toml: string): string[] =>
+  gateProblems(confirmRoutineGate(toml, EXPECTED)).map((problem) => problem.field)
+
+describe('confirmRoutineGate', () => {
+  it('confirms the file we write', () => {
+    expect(confirmRoutineGate(GOOD, EXPECTED)).toEqual({ ok: true })
+  })
+
+  it('refuses a MISSPELLED key — the silent-ignore case, in full', () => {
+    // `permisson` is a key Vibe has never heard of. It is swept into the profile's
+    // overrides, validated by nothing, and dropped. The profile loads, appears as
+    // a mode, and gates NOTHING.
+    const typo = GOOD.replace('permission = "ask"', 'permisson = "ask"')
+    expect(fields(typo)).toContain('tools.bash.permisson')
+    expect(fields(typo)).toContain('tools.bash.permission')
+  })
+
+  it('refuses a misspelled TABLE, which would gate a tool that does not exist', () => {
+    const typo = GOOD.replace('[tools.write_file]', '[tools.writefile]')
+    expect(fields(typo)).toContain('tools.writefile.permission')
+    expect(fields(typo)).toContain('tools.write_file.permission')
+  })
+
+  it('refuses a gate with the wrong VALUE', () => {
+    expect(fields(GOOD.replace('permission = "never"', 'permission = "always"'))).toContain(
+      'tools.write_file.permission',
+    )
+    expect(fields(GOOD.replace('permission = "ask"', 'permission = "always"'))).toContain(
+      'tools.bash.permission',
+    )
+  })
+
+  it('refuses a NON-EMPTY bash allowlist — the half that removes the defaults', () => {
+    const widened = GOOD.replace('allowlist = []', 'allowlist = ["echo"]')
+    expect(fields(widened)).toEqual(['tools.bash.allowlist'])
+  })
+
+  it('refuses a gate with an entry missing entirely', () => {
+    const partial = GOOD.split('\n')
+      .filter((line) => line !== 'allowlist = []')
+      .join('\n')
+    expect(fields(partial)).toEqual(['tools.bash.allowlist'])
+  })
+
+  it('refuses an extra key, however harmless it looks', () => {
+    // A gate erodes one well-meaning addition at a time, and an addition Vibe does
+    // not read is worse than one it does: it changes nothing and looks like it did.
+    // (Appended after the last table header it belongs to that table — which is
+    // what TOML says and what makes the key-path check the right shape of check.)
+    const extra = fields(`${GOOD}\nbypass_tool_permissions = true\n`)
+    expect(extra).toHaveLength(1)
+    expect(extra[0]).toMatch(/bypass_tool_permissions$/)
+  })
+
+  it('refuses a profile pointing at somebody else’s system prompt', () => {
+    const other = GOOD.replace(BOT, 'mistro-bot-99999999-2222-3333-4444-555555555555')
+    expect(fields(other)).toContain('system_prompt_id')
+  })
+
+  it('refuses agent_type = "subagent" and an unknown safety value', () => {
+    expect(fields(GOOD.replace('agent_type = "agent"', 'agent_type = "subagent"'))).toContain(
+      'agent_type',
+    )
+    expect(fields(GOOD.replace('safety = "neutral"', 'safety = "harmless"'))).toContain('safety')
+  })
+
+  it('refuses a file that is not the flat TOML we write', () => {
+    // A line that is neither a comment, a table header nor `key = value` is a
+    // file we did not write, and the refusal is about the FILE rather than about
+    // any key in it.
+    expect(fields('this is not valid toml [[[')).toEqual(['file'])
+    expect(fields('[tools.bash')).toEqual(['file'])
+    expect(fields('')).not.toEqual([]) // an empty file has no gate at all
+  })
+
+  it('refuses ids that are not ours', () => {
+    const problems = gateProblems(
+      confirmRoutineGate(GOOD, { profileId: 'ask', botProfileId: 'plan' }),
+    )
+    expect(problems.map((p) => p.field)).toContain('profileId')
+    expect(problems.map((p) => p.field)).toContain('system_prompt_id')
+  })
+
+  it('describes problems as "field: message", the shape a failure carries', () => {
+    const described = describeGateProblems(
+      gateProblems(confirmRoutineGate(GOOD.replace('allowlist = []', 'allowlist = ["ls"]'), EXPECTED)),
+    )
+    expect(described).toHaveLength(1)
+    expect(described[0]).toMatch(/^tools\.bash\.allowlist: /)
+  })
+})

--- a/apps/desktop/src/main/routines/confirm-routine-gate.ts
+++ b/apps/desktop/src/main/routines/confirm-routine-gate.ts
@@ -1,0 +1,231 @@
+import { isMistroBotProfileId, isMistroRoutineProfileId } from '../../shared/bot-profile-id'
+import { ROUTINE_GATE, type RoutineProfileFile } from './routine-profile'
+
+/**
+ * **Verify the gate took** (#469, ADR-0028: "a routine whose gate cannot be
+ * confirmed must refuse to run, and say why").
+ *
+ * This is the most important module in the slice, and the reason it exists is a
+ * measured property of Vibe rather than caution: **a profile key Vibe does not
+ * recognise is ignored in silence** (#424) — no error, no warning, nothing on the
+ * wire. Misspell `permission` as `permisson` and you get a profile that loads,
+ * appears in every mode picker, "works", and gates nothing. The routine then runs
+ * unattended with a posture nobody has, and looks correctly configured while it
+ * does it.
+ *
+ * So the gate is never assumed from the fact that a write returned. It is read
+ * back off disk and CONFIRMED, key by key and value by value, against
+ * `ROUTINE_GATE`. Three things this catches that nothing else does:
+ *
+ *  1. a typo introduced by a future edit to the projection (the case #424 makes
+ *     invisible);
+ *  2. a file that is not the one we think we wrote — hand-edited, half-written, or
+ *     the write silently landing somewhere else;
+ *  3. an extra key that crept in and would be ignored, which is how a gate erodes
+ *     one well-meaning addition at a time.
+ *
+ * It is deliberately NOT a TOML parser. Our projection emits one flat
+ * `key = value` per line under at most one table header, so a line scan is exact
+ * over the input it is fed — and anything more exotic in that text is itself the
+ * defect, which is why an unparseable line is a refusal rather than a skip.
+ *
+ * Pure and total: text in, problems out.
+ */
+
+/** One reason a gate was refused, addressed to whoever has to fix it. */
+export interface RoutineGateProblem {
+  /** The dotted key path at fault (`tools.bash.allowlist`), or the file itself. */
+  field: string
+  message: string
+}
+
+export type RoutineGateValidation = { ok: true } | { ok: false; problems: RoutineGateProblem[] }
+
+/**
+ * The top-level keys a routine profile may set. `display_name` / `description` /
+ * `safety` / `agent_type` are the four Vibe consumes itself; `system_prompt_id`
+ * is the ONE `VibeConfigSchema` override the Bots slice already allows.
+ */
+const ALLOWED_TOP_LEVEL = new Set([
+  'display_name',
+  'description',
+  'safety',
+  'agent_type',
+  'system_prompt_id',
+])
+
+/**
+ * The widening this slice makes to that allow-list, stated as the exact dotted
+ * paths rather than as "the `tools` table" (#469: *by exactly the keys needed*).
+ * `tools` is `dict[str, dict[str, Any]]` on Vibe's side and validated by nothing,
+ * so an allow-list of four paths is the only thing standing between a future edit
+ * and a silently ignored setting.
+ */
+const ALLOWED_GATE_PATHS = new Set(ROUTINE_GATE.map((entry) => `${entry.table}.${entry.key}`))
+
+/** `AgentSafety`. Anything else raises on load and drops the profile whole. */
+const SAFETY_VALUES = new Set(['safe', 'neutral', 'destructive', 'yolo'])
+
+/**
+ * Read our own emitted TOML back into dotted paths. Returns null for a line it
+ * cannot account for — see the module note: unparseable means refuse, never skip.
+ */
+export function parseRoutineProfileToml(toml: string): Map<string, string> | null {
+  const keys = new Map<string, string>()
+  let table = ''
+  for (const raw of toml.split('\n')) {
+    const line = raw.trim()
+    if (!line || line.startsWith('#')) continue
+    if (line.startsWith('[')) {
+      if (!line.endsWith(']')) return null
+      table = line.slice(1, -1).trim()
+      if (!table) return null
+      continue
+    }
+    const eq = line.indexOf('=')
+    if (eq <= 0) return null
+    const key = line.slice(0, eq).trim()
+    if (!key) return null
+    keys.set(table ? `${table}.${key}` : key, line.slice(eq + 1).trim())
+  }
+  return keys
+}
+
+/**
+ * Confirm that this TOML text IS the gate for `expected`.
+ *
+ * Every check is stated as a refusal, because the caller's only correct response
+ * to any of them is to refuse the run:
+ *
+ * 1. the file parses as our own flat emission;
+ * 2. every key in it is one Vibe reads AND one we meant to write — an unknown key
+ *    is the silent-ignore case, and an unexpected known key means this is not the
+ *    file we think it is;
+ * 3. every `ROUTINE_GATE` entry is present with EXACTLY its value — a gate with
+ *    three of its four entries is not three-quarters of a gate;
+ * 4. `agent_type` is `agent` (a subagent profile is filtered out of the mode list
+ *    with no wire signal at all, so the routine could never select it);
+ * 5. `safety` is a real value (anything else fails the load and drops the file);
+ * 6. `system_prompt_id` names the BOT's prompt, so a routine turn wears the same
+ *    persona a person talks to — and so a routine can never be pointed at somebody
+ *    else's system prompt.
+ */
+export function confirmRoutineGate(
+  toml: string,
+  expected: { profileId: string; botProfileId: string },
+): RoutineGateValidation {
+  const problems: RoutineGateProblem[] = []
+
+  if (!isMistroRoutineProfileId(expected.profileId)) {
+    problems.push({
+      field: 'profileId',
+      message: `"${expected.profileId}" is not a routine profile id (mistro-routine-<uuid>).`,
+    })
+  }
+  if (!isMistroBotProfileId(expected.botProfileId)) {
+    problems.push({
+      field: 'system_prompt_id',
+      message: `"${expected.botProfileId}" is not a Bot profile id (mistro-bot-<uuid>).`,
+    })
+  }
+
+  const keys = parseRoutineProfileToml(toml)
+  if (!keys) {
+    return {
+      ok: false,
+      problems: [
+        ...problems,
+        {
+          field: 'file',
+          message: 'The routine profile on disk is not the flat TOML this app writes.',
+        },
+      ],
+    }
+  }
+
+  for (const key of keys.keys()) {
+    if (ALLOWED_TOP_LEVEL.has(key) || ALLOWED_GATE_PATHS.has(key)) continue
+    problems.push({
+      field: key,
+      message: `"${key}" is not a key this app writes — Vibe would ignore it in silence.`,
+    })
+  }
+
+  for (const entry of ROUTINE_GATE) {
+    const path = `${entry.table}.${entry.key}`
+    const actual = keys.get(path)
+    if (actual === undefined) {
+      problems.push({ field: path, message: `The permission gate is missing ${path}.` })
+    } else if (actual !== entry.value) {
+      problems.push({
+        field: path,
+        message: `${path} is ${actual}, not ${entry.value} — the permission gate would not hold.`,
+      })
+    }
+  }
+
+  const agentType = unquote(keys.get('agent_type') ?? '')
+  if (agentType !== 'agent') {
+    problems.push({
+      field: 'agent_type',
+      message: 'A routine profile must be agent_type = "agent"; a subagent is never offered as a mode.',
+    })
+  }
+
+  const safety = unquote(keys.get('safety') ?? '')
+  if (!SAFETY_VALUES.has(safety)) {
+    problems.push({ field: 'safety', message: `"${safety}" is not a Vibe safety value.` })
+  }
+
+  const promptId = keys.get('system_prompt_id')
+  if (promptId === undefined) {
+    problems.push({
+      field: 'system_prompt_id',
+      message: 'The routine profile names no system prompt, so the Bot would have no persona.',
+    })
+  } else if (unquote(promptId) !== expected.botProfileId) {
+    problems.push({
+      field: 'system_prompt_id',
+      message:
+        `system_prompt_id "${unquote(promptId)}" is not this Bot's prompt ` +
+        `(${expected.botProfileId}).`,
+    })
+  }
+
+  return problems.length ? { ok: false, problems } : { ok: true }
+}
+
+/** Confirm a projection before it is written — the same rules, one call earlier. */
+export function validateRoutineProfileFile(file: RoutineProfileFile): RoutineGateValidation {
+  const problems = gateProblems(
+    confirmRoutineGate(file.agentToml, {
+      profileId: file.profileId,
+      botProfileId: file.botProfileId,
+    }),
+  )
+  if (file.agentFileName !== `${file.profileId}.toml`) {
+    // The ACP mode id IS the file stem, so a mismatch means the routine would
+    // select a mode that does not exist.
+    problems.push({
+      field: 'agentFileName',
+      message: `${file.agentFileName} does not match the profile id ${file.profileId}.`,
+    })
+  }
+  return problems.length ? { ok: false, problems } : { ok: true }
+}
+
+/** The problems of a validation, or none. */
+export function gateProblems(result: RoutineGateValidation): RoutineGateProblem[] {
+  return result.ok ? [] : result.problems
+}
+
+/** Render problems as the `string[]` a failure message carries. */
+export function describeGateProblems(problems: RoutineGateProblem[]): string[] {
+  return problems.map((problem) => `${problem.field}: ${problem.message}`)
+}
+
+/** Strip the surrounding quotes of a TOML basic string (and unescape the pairs we emit). */
+function unquote(value: string): string {
+  const inner = value.startsWith('"') && value.endsWith('"') ? value.slice(1, -1) : value
+  return inner.replace(/\\(["\\])/g, '$1')
+}

--- a/apps/desktop/src/main/routines/node-routine-profile-fs.ts
+++ b/apps/desktop/src/main/routines/node-routine-profile-fs.ts
@@ -1,0 +1,20 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import type { RoutineProfileFs } from './write-routine-profile'
+
+/**
+ * The real `RoutineProfileFs` (#469) — the ONLY binding of the routine-gate
+ * writer to `node:fs`. It lives alone in this file, exactly like
+ * `bots/node-profile-fs.ts`, so `write-routine-profile.ts` stays seam-only and
+ * every test injects a fake instead of touching `~/.vibe/`.
+ *
+ * `readFile` deliberately has no `force`-style tolerance: an absent file must
+ * REJECT, because "there is nothing to read" is the one answer that must never be
+ * mistaken for a confirmed gate.
+ */
+export const nodeRoutineProfileFs: RoutineProfileFs = {
+  mkdir: async (dir) => {
+    await mkdir(dir, { recursive: true })
+  },
+  writeFile: (path, contents) => writeFile(path, contents, 'utf8'),
+  readFile: (path) => readFile(path, 'utf8'),
+}

--- a/apps/desktop/src/main/routines/routine-lifecycle.test.ts
+++ b/apps/desktop/src/main/routines/routine-lifecycle.test.ts
@@ -47,6 +47,7 @@ class FakeRoutineStore implements RoutineStoreApi {
       lastRunAt: null,
       lastOutcome: null,
       lastError: null,
+      lastBlockedCommand: null,
       createdAt: 1000,
       updatedAt: 1000,
     }

--- a/apps/desktop/src/main/routines/routine-permission-gate.test.ts
+++ b/apps/desktop/src/main/routines/routine-permission-gate.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createRoutinePermissionGate,
+  decideRoutinePermission,
+  type RoutinePermissionGate,
+} from './routine-permission-gate'
+
+/**
+ * The answerer (#469, ADR-0028 part 4 — the ADR-0001 amendment): main answers a
+ * scheduled turn's `session/request_permission` from the Routine's allowed
+ * commands, and the first refusal cancels the turn.
+ *
+ * The frames below are VERBATIM from `scripts/spike-routine-gate.ts` against
+ * vibe-acp 2.24.3 (`docs/acp-capture.md` §17) — including the one that decides the
+ * whole design: for `echo hello > probe.txt` the request's own
+ * `invocation_pattern` reads `echo hello <redirect>`, with the redirect erased.
+ * A gate that matched on that string would authorise a command that writes a file
+ * the string never mentions.
+ */
+
+const SESSION = '7f2a997d-b167-df48-29e8-0d5e578bfa87'
+const TOOL_CALL = 'sbjyDUwlc'
+
+/** The `tool_call` frame, exactly as captured: a title, no command yet. */
+const toolCall = (toolCallId = TOOL_CALL): unknown => ({
+  jsonrpc: '2.0',
+  method: 'session/update',
+  params: {
+    sessionId: SESSION,
+    update: {
+      toolCallId,
+      title: 'bash',
+      kind: 'execute',
+      status: 'in_progress',
+      _meta: { tool_name: 'bash', effect_kind: 'shell' },
+      sessionUpdate: 'tool_call',
+    },
+  },
+})
+
+/** The update that carries `rawInput.command` — the only trustworthy copy. */
+const toolCallCommand = (command: string, toolCallId = TOOL_CALL): unknown => ({
+  jsonrpc: '2.0',
+  method: 'session/update',
+  params: {
+    sessionId: SESSION,
+    update: {
+      toolCallId,
+      kind: 'execute',
+      status: 'in_progress',
+      title: `bash: ${command}`,
+      rawInput: { command },
+      _meta: { tool_name: 'bash', effect_kind: 'shell' },
+      sessionUpdate: 'tool_call_update',
+    },
+  },
+})
+
+/** The status-only update that immediately precedes the request — no rawInput. */
+const toolCallTick = (toolCallId = TOOL_CALL): unknown => ({
+  jsonrpc: '2.0',
+  method: 'session/update',
+  params: {
+    sessionId: SESSION,
+    update: {
+      toolCallId,
+      kind: 'execute',
+      status: 'in_progress',
+      _meta: { tool_name: 'bash', effect_kind: 'shell' },
+      sessionUpdate: 'tool_call_update',
+    },
+  },
+})
+
+/** The request itself: a tool-call id, four options, and a tokenised pattern. */
+const permissionRequest = (
+  invocationPattern: string,
+  { id = 0, toolCallId = TOOL_CALL, sessionId = SESSION, scope = 'command_pattern' } = {},
+): unknown => ({
+  jsonrpc: '2.0',
+  id,
+  method: 'session/request_permission',
+  params: {
+    sessionId,
+    toolCall: { toolCallId },
+    options: [
+      { optionId: 'allow_once', name: 'Allow once', kind: 'allow_once' },
+      {
+        optionId: 'allow_always',
+        name: 'Allow for remainder of this session',
+        kind: 'allow_always',
+        _meta: {
+          required_permissions: [
+            { scope, invocation_pattern: invocationPattern, session_pattern: 'echo *', label: 'echo *' },
+          ],
+        },
+      },
+      {
+        optionId: 'allow_always_permanent',
+        name: 'Always allow',
+        kind: 'allow_always',
+        _meta: {
+          required_permissions: [
+            { scope, invocation_pattern: invocationPattern, session_pattern: 'echo *', label: 'echo *' },
+          ],
+        },
+      },
+      { optionId: 'reject_once', name: 'Deny', kind: 'reject_once' },
+    ],
+  },
+})
+
+interface Harness {
+  gate: RoutinePermissionGate
+  answers: { requestId: number | string; optionId: string }[]
+  cancels: string[]
+}
+
+function harness(allowedCommands: string[] = []): Harness {
+  const answers: { requestId: number | string; optionId: string }[] = []
+  const cancels: string[] = []
+  const gate = createRoutinePermissionGate({
+    allowedCommands,
+    seams: {
+      respond: (requestId, optionId) => void answers.push({ requestId, optionId }),
+      cancel: (sessionId) => void cancels.push(sessionId),
+    },
+  })
+  gate.armSession(SESSION)
+  return { gate, answers, cancels }
+}
+
+describe('decideRoutinePermission', () => {
+  const options = (permissionRequest('x') as { params: { options: [] } }).params.options
+
+  it('allows a listed command with allow_once — never either allow-always option', () => {
+    const decision = decideRoutinePermission({
+      options,
+      facts: { toolName: 'bash', effectKind: 'shell', command: 'ls -la' },
+      allowedCommands: ['ls -la'],
+    })
+    // "Allow for remainder of this session" is a session grant and "Always allow"
+    // is a PERMANENT config write (#464). An unattended run widens nothing.
+    expect(decision).toEqual({ kind: 'allow', optionId: 'allow_once', command: 'ls -la' })
+  })
+
+  it('denies a tool call it has never seen — a subagent’s, for instance', () => {
+    // acp-capture §15F: a subagent's tool calls raise requests on the ROOT session
+    // with ids that never appear in any `tool_call` frame. Unattended, the only
+    // answer to something unidentifiable is no.
+    expect(decideRoutinePermission({ options, facts: null, allowedCommands: ['ls'] })).toEqual({
+      kind: 'deny',
+      optionId: 'reject_once',
+      blocked: { command: null, reason: 'unidentified' },
+    })
+  })
+
+  it('denies anything that is not a shell effect, whatever the list says', () => {
+    const decision = decideRoutinePermission({
+      options,
+      facts: { toolName: 'write_file', effectKind: 'file_write', command: 'ls' },
+      allowedCommands: ['ls'],
+    })
+    expect(decision).toMatchObject({ kind: 'deny', blocked: { reason: 'unidentified' } })
+  })
+
+  it('denies when the request is about a scope other than a command pattern', () => {
+    const other = permissionRequest('/tmp/scratch/*', { scope: 'outside_directory' }) as {
+      params: { options: [] }
+    }
+    const decision = decideRoutinePermission({
+      options: other.params.options,
+      facts: { toolName: 'bash', effectKind: 'shell', command: 'ls' },
+      allowedCommands: ['ls'],
+    })
+    expect(decision).toMatchObject({ kind: 'deny', blocked: { reason: 'unidentified' } })
+  })
+
+  it('denies a shell call whose command text was never readable', () => {
+    const decision = decideRoutinePermission({
+      options,
+      facts: { toolName: 'bash', effectKind: 'shell', command: null },
+      allowedCommands: ['ls'],
+    })
+    expect(decision).toMatchObject({ kind: 'deny', blocked: { command: null, reason: 'blank' } })
+  })
+
+  it('falls back to the standard option ids when the request offers no kinds', () => {
+    expect(
+      decideRoutinePermission({
+        options: [{ optionId: 'weird' }],
+        facts: { toolName: 'bash', effectKind: 'shell', command: 'ls' },
+        allowedCommands: ['ls'],
+      }),
+    ).toMatchObject({ kind: 'allow', optionId: 'allow_once' })
+  })
+})
+
+describe('createRoutinePermissionGate', () => {
+  it('recovers the command from an EARLIER frame than the one before the request', () => {
+    // The captured order: tool_call, then the update carrying rawInput, then a
+    // status-only tick, then the request. A gate that read the last frame would
+    // find no command and deny a command the user had allowed.
+    const { gate, answers, cancels } = harness(['ls -la'])
+    gate.observe(toolCall())
+    gate.observe(toolCallCommand('ls -la'))
+    gate.observe(toolCallTick())
+    gate.observe(permissionRequest('ls -la'))
+    expect(answers).toEqual([{ requestId: 0, optionId: 'allow_once' }])
+    expect(cancels).toEqual([])
+    expect(gate.blocked).toBeNull()
+  })
+
+  it('THE REDIRECT: denies and cancels, and reports the RAW command, not the pattern', () => {
+    const { gate, answers, cancels } = harness(['echo hello'])
+    gate.observe(toolCall())
+    gate.observe(toolCallCommand('echo hello > probe.txt'))
+    gate.observe(permissionRequest('echo hello <redirect>'))
+    expect(answers).toEqual([{ requestId: 0, optionId: 'reject_once' }])
+    expect(cancels).toEqual([SESSION])
+    // The reported command is what would have RUN — `echo hello > probe.txt` —
+    // not the tokenised `echo hello <redirect>` the request carried, and not the
+    // listed `echo hello` it would otherwise have been mistaken for.
+    expect(gate.blocked).toEqual({ command: 'echo hello > probe.txt', reason: 'shell-operator' })
+  })
+
+  it('cancels ONCE: a second refusal is still answered, but nothing is overwritten', () => {
+    const { gate, answers, cancels } = harness([])
+    gate.observe(toolCall('one'))
+    gate.observe(toolCallCommand('ls', 'one'))
+    gate.observe(permissionRequest('ls', { id: 0, toolCallId: 'one' }))
+    gate.observe(toolCall('two'))
+    gate.observe(toolCallCommand('pwd', 'two'))
+    gate.observe(permissionRequest('pwd', { id: 1, toolCallId: 'two' }))
+    expect(answers).toEqual([
+      { requestId: 0, optionId: 'reject_once' },
+      { requestId: 1, optionId: 'reject_once' },
+    ])
+    expect(cancels).toEqual([SESSION])
+    expect(gate.blocked).toEqual({ command: 'ls', reason: 'not-listed' })
+  })
+
+  it('ignores another session on the same agent, and everything before it is armed', () => {
+    // One `vibe-acp` child hosts many sessions, and a person may be talking to
+    // another Thread in the same Workspace while a routine runs. Answering their
+    // permission request would be answering for a user who is right there.
+    const { gate, answers, cancels } = harness(['ls'])
+    gate.observe(permissionRequest('ls', { sessionId: 'someone-elses-session' }))
+    expect(answers).toEqual([])
+    expect(cancels).toEqual([])
+
+    const cold = createRoutinePermissionGate({
+      allowedCommands: ['ls'],
+      seams: { respond: () => expect.unreachable(), cancel: () => expect.unreachable() },
+    })
+    cold.observe(permissionRequest('ls'))
+    expect(cold.blocked).toBeNull()
+  })
+
+  it('survives malformed payloads without throwing', () => {
+    const { gate, answers } = harness(['ls'])
+    for (const payload of [null, undefined, 42, 'text', {}, { method: 'session/update' }]) {
+      expect(() => gate.observe(payload)).not.toThrow()
+    }
+    // A permission with no id is a notification we cannot answer; it must not
+    // silently look answered either.
+    gate.observe({ method: 'session/request_permission', params: { sessionId: SESSION } })
+    expect(answers).toEqual([])
+  })
+})

--- a/apps/desktop/src/main/routines/routine-permission-gate.ts
+++ b/apps/desktop/src/main/routines/routine-permission-gate.ts
@@ -1,0 +1,252 @@
+import { matchAllowedCommand, type AllowedCommandRefusal } from './allowed-commands'
+
+/**
+ * **We answer the agent's permission requests for a scheduled turn** (#469,
+ * ADR-0028 part 4 — the amendment to ADR-0001).
+ *
+ * ADR-0001 says the renderer owns conversation state and answers permission
+ * requests. That stays true for every turn a person started. It cannot be true
+ * for a routine: an unanswered request hangs the turn forever (Vibe waits on the
+ * client with no timeout), and there is no client to ask. So for scheduler-raised
+ * turns, and only those, main answers — from the Routine's **allowed commands**.
+ *
+ * ## Recovering what is being asked about
+ *
+ * The request itself is almost empty. Captured verbatim at vibe-acp 2.24.3
+ * (`docs/acp-capture.md` §17, and §6/§15F before it), `params.toolCall` is
+ * `{toolCallId}` and NOTHING else — no tool name, no path, no command. So the
+ * gate keeps a ledger of the session's `tool_call` / `tool_call_update` frames and
+ * looks the id up in it:
+ *
+ *  - **tool identity** is `_meta.tool_name` / `_meta.effect_kind` (snake_case, on
+ *    the update object);
+ *  - **the command text** is `rawInput.command`, which arrives on an EARLIER
+ *    update than the one immediately before the request — hence a ledger that
+ *    merges frames by id rather than a look at the last frame.
+ *
+ * ### The trap, and why the ledger is the only source of the command
+ *
+ * The permission request *does* carry an `invocation_pattern` inside its
+ * allow-always options' `_meta`, and using it would be the obvious implementation.
+ * It is also wrong in the one way that matters. For `echo hello > probe.txt` the
+ * pattern reads **`echo hello <redirect>`** — Vibe's shell parser tokenises the
+ * redirect into a placeholder, which is precisely the mechanism that let a write
+ * through a command allowlist in #458. A matcher fed that string authorises a
+ * command that writes a file it never names. We therefore match `rawInput.command`
+ * and treat the option metadata only as a scope check.
+ *
+ * ## What it does with the answer
+ *
+ * Allowed → `allow_once`, never either allow-always option: those are a session
+ * grant and a PERMANENT config write (#464), and an unattended run must not widen
+ * anything for the human who was not there.
+ *
+ * Refused → `reject_once` **and cancel the turn**. Not deny-and-continue: #458
+ * measured what continuing produces — fourteen different routes attempted on a
+ * one-file task until one was allowed. Stopping on the first denial is what turns
+ * an evasion loop into a message a person can fix.
+ */
+
+/** How the gate reaches the agent. Both calls are fire-and-forget by nature. */
+export interface RoutinePermissionSeams {
+  /** Answer a `session/request_permission` by its JSON-RPC request id. */
+  respond(requestId: number | string, optionId: string): void
+  /** `session/cancel` — the in-flight prompt then resolves `stopReason:"cancelled"`. */
+  cancel(sessionId: string): void
+}
+
+/** What the ledger knows about one tool call, merged across its frames. */
+export interface ToolCallFacts {
+  /** `_meta.tool_name`, e.g. `bash`. */
+  toolName: string | null
+  /** `_meta.effect_kind`, e.g. `shell` — Vibe's own vocabulary for what it does. */
+  effectKind: string | null
+  /** `rawInput.command` — the WHOLE invocation, the only trustworthy copy of it. */
+  command: string | null
+}
+
+/** The blocked invocation, kept as structure so slice 5 can offer to add it. */
+export interface BlockedInvocation {
+  /** The exact command text, or null when none was ever readable. */
+  command: string | null
+  reason: AllowedCommandRefusal
+}
+
+export type RoutinePermissionDecision =
+  | { kind: 'allow'; optionId: string; command: string }
+  | { kind: 'deny'; optionId: string; blocked: BlockedInvocation }
+
+/** One `options[]` entry of a `session/request_permission`. */
+interface PermissionOption {
+  optionId?: unknown
+  kind?: unknown
+  _meta?: { required_permissions?: { scope?: unknown }[] }
+}
+
+/** The fallback option ids, used only when the request offers no matching `kind`. */
+const ALLOW_ONCE = 'allow_once'
+const REJECT_ONCE = 'reject_once'
+
+/**
+ * Decide one permission request. PURE — the whole policy in one function over
+ * (what was asked, what we know about the tool call, what the user allowed), so
+ * every rule below is a unit test rather than a wire behaviour.
+ *
+ * It denies on every uncertainty, and the uncertainties are not hypothetical:
+ * a subagent's tool calls raise permission requests on the ROOT session carrying
+ * a `toolCallId` that never appeared in any `tool_call` frame (acp-capture §15F),
+ * so "unknown tool call" is a case that happens in normal operation. Unattended,
+ * the only defensible answer to *something I cannot identify* is no.
+ */
+export function decideRoutinePermission(input: {
+  options: readonly PermissionOption[]
+  facts: ToolCallFacts | null
+  allowedCommands: readonly string[]
+}): RoutinePermissionDecision {
+  const allowOption = optionIdOfKind(input.options, 'allow_once') ?? ALLOW_ONCE
+  const denyOption = optionIdOfKind(input.options, 'reject_once') ?? REJECT_ONCE
+  const deny = (blocked: BlockedInvocation): RoutinePermissionDecision => ({
+    kind: 'deny',
+    optionId: denyOption,
+    blocked,
+  })
+
+  // (1) An id we have never seen a tool call for — a subagent's tool, or a frame
+  // we missed. Nothing to match, nothing to report but the refusal itself.
+  if (!input.facts) return deny({ command: null, reason: 'unidentified' })
+
+  // (2) Only shell invocations are expressible on an allowed-commands list. Vibe
+  // has no effect-level notion of read versus write, so `effect_kind` is as close
+  // as the protocol gets to "this runs a command" — and anything else (a file
+  // write that reached us despite the gate, a web fetch, an MCP tool) has no entry
+  // that could authorise it.
+  if (input.facts.effectKind !== 'shell') return deny({ command: null, reason: 'unidentified' })
+
+  // (3) A scope we do not understand is a permission about something other than a
+  // command pattern (a path outside the workdir, say). The command text cannot
+  // stand for it, so it is refused whatever the list says.
+  if (!everyScopeIsCommandPattern(input.options)) {
+    return deny({ command: input.facts.command, reason: 'unidentified' })
+  }
+
+  // (4) Shell, but no readable command. Refuse: answering "yes" to a command we
+  // cannot name is the one thing an unattended gate must never do.
+  const command = input.facts.command?.trim() ?? ''
+  if (!command) return deny({ command: null, reason: 'blank' })
+
+  const match = matchAllowedCommand(command, input.allowedCommands)
+  if (!match.allowed) return deny({ command, reason: match.reason })
+  return { kind: 'allow', optionId: allowOption, command }
+}
+
+/** The live half: a ledger, an armed session, and the first denial it took. */
+export interface RoutinePermissionGate {
+  /**
+   * Start answering for this session. Called the moment the turn binds, which is
+   * before any permission request can arrive (they only occur during
+   * `session/prompt`). Until then every payload is ignored — an agent hosts many
+   * sessions and a Routine answers for exactly one.
+   */
+  armSession(sessionId: string): void
+  /** Feed one raw ACP payload. Never throws. */
+  observe(payload: unknown): void
+  /** The first refusal, or null. Set once: a cancelled turn cannot be blocked twice. */
+  readonly blocked: BlockedInvocation | null
+}
+
+export function createRoutinePermissionGate(deps: {
+  allowedCommands: readonly string[]
+  seams: RoutinePermissionSeams
+}): RoutinePermissionGate {
+  const ledger = new Map<string, ToolCallFacts>()
+  let sessionId: string | null = null
+  let blocked: BlockedInvocation | null = null
+
+  const remember = (update: Record<string, unknown>): void => {
+    const toolCallId = typeof update.toolCallId === 'string' ? update.toolCallId : null
+    if (!toolCallId) return
+    const meta = asRecord(update._meta)
+    const rawInput = asRecord(update.rawInput)
+    const previous = ledger.get(toolCallId) ?? { toolName: null, effectKind: null, command: null }
+    // MERGE, never replace: `rawInput.command` arrives on one frame and the frame
+    // immediately before the permission request carries only a status.
+    ledger.set(toolCallId, {
+      toolName: stringOr(meta?.tool_name, previous.toolName),
+      effectKind: stringOr(meta?.effect_kind, previous.effectKind),
+      command: stringOr(rawInput?.command, previous.command),
+    })
+  }
+
+  const answer = (requestId: number | string, params: Record<string, unknown>): void => {
+    const toolCall = asRecord(params.toolCall)
+    const toolCallId = typeof toolCall?.toolCallId === 'string' ? toolCall.toolCallId : null
+    const options = Array.isArray(params.options) ? (params.options as PermissionOption[]) : []
+    const decision = decideRoutinePermission({
+      options,
+      facts: toolCallId ? (ledger.get(toolCallId) ?? null) : null,
+      allowedCommands: deps.allowedCommands,
+    })
+    deps.seams.respond(requestId, decision.optionId)
+    if (decision.kind === 'allow') return
+    // The FIRST denial cancels; a later one (the turn takes a moment to unwind)
+    // is still refused, but must not overwrite the invocation being reported or
+    // re-cancel a session that is already stopping.
+    if (blocked) return
+    blocked = decision.blocked
+    if (sessionId) deps.seams.cancel(sessionId)
+  }
+
+  return {
+    armSession(id: string) {
+      sessionId = id
+    },
+    observe(payload: unknown) {
+      if (!sessionId) return
+      const message = asRecord(payload)
+      const params = asRecord(message?.params)
+      if (!message || !params || params.sessionId !== sessionId) return
+      if (message.method === 'session/update') {
+        const update = asRecord(params.update)
+        const kind = update?.sessionUpdate
+        if (update && (kind === 'tool_call' || kind === 'tool_call_update')) remember(update)
+        return
+      }
+      if (message.method === 'session/request_permission' && message.id !== undefined) {
+        answer(message.id as number | string, params)
+      }
+    },
+    get blocked() {
+      return blocked
+    },
+  }
+}
+
+/** The `optionId` of the first option declaring this `kind`, or null. */
+function optionIdOfKind(options: readonly PermissionOption[], kind: string): string | null {
+  for (const option of options) {
+    if (option?.kind === kind && typeof option.optionId === 'string') return option.optionId
+  }
+  return null
+}
+
+/**
+ * Every `required_permissions` entry the request carries is about a command
+ * pattern. An option with no `_meta` contributes nothing (the plain `allow_once`
+ * and `reject_once` options never carry one).
+ */
+function everyScopeIsCommandPattern(options: readonly PermissionOption[]): boolean {
+  for (const option of options) {
+    for (const required of option?._meta?.required_permissions ?? []) {
+      if (required?.scope !== 'command_pattern') return false
+    }
+  }
+  return true
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : null
+}
+
+function stringOr(value: unknown, fallback: string | null): string | null {
+  return typeof value === 'string' ? value : fallback
+}

--- a/apps/desktop/src/main/routines/routine-profile.test.ts
+++ b/apps/desktop/src/main/routines/routine-profile.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { projectRoutineProfile, renderRoutineProfileToml, ROUTINE_GATE } from './routine-profile'
+import { confirmRoutineGate, parseRoutineProfileToml } from './confirm-routine-gate'
+
+/**
+ * The routine-only gate profile (#469, ADR-0028 part 4): what we write, and the
+ * read-back that is the only proof it is really a gate.
+ *
+ * The projection tests are about the FILE — a profile Vibe would drop, or load and
+ * silently not honour, is the failure this slice exists to make impossible, and
+ * neither has a wire signal.
+ */
+
+const BOT = 'mistro-bot-11111111-2222-3333-4444-555555555555'
+const GATE = 'mistro-routine-11111111-2222-3333-4444-555555555555'
+
+const SOURCE = { botProfileId: BOT, botName: 'Triager' }
+
+describe('projectRoutineProfile', () => {
+  it('derives the routine profile id from the Bot, and names the file after it', () => {
+    const file = projectRoutineProfile(SOURCE)
+    expect(file).toMatchObject({ profileId: GATE, agentFileName: `${GATE}.toml`, botProfileId: BOT })
+  })
+
+  it('refuses a profile id that is not a Bot of ours', () => {
+    expect(projectRoutineProfile({ botProfileId: 'ask', botName: 'x' })).toBeNull()
+    expect(projectRoutineProfile({ botProfileId: GATE, botName: 'x' })).toBeNull()
+    expect(projectRoutineProfile({ botProfileId: 'mistro-bot-nope', botName: 'x' })).toBeNull()
+  })
+
+  it("points at the BOT's system prompt, so a routine turn is the same teammate", () => {
+    const keys = parseRoutineProfileToml(renderRoutineProfileToml(SOURCE))
+    expect(keys?.get('system_prompt_id')).toBe(`"${BOT}"`)
+  })
+
+  it('writes every gate entry, and nothing else', () => {
+    const keys = parseRoutineProfileToml(renderRoutineProfileToml(SOURCE))
+    expect(keys?.get('tools.write_file.permission')).toBe('"never"')
+    expect(keys?.get('tools.edit.permission')).toBe('"never"')
+    expect(keys?.get('tools.bash.permission')).toBe('"ask"')
+    // The empty allowlist is the load-bearing half: it is what removes the schema
+    // defaults that let `echo … > file` through a command allowlist (#458).
+    expect(keys?.get('tools.bash.allowlist')).toBe('[]')
+    expect([...(keys?.keys() ?? [])].sort()).toEqual(
+      [
+        'display_name',
+        'description',
+        'agent_type',
+        'safety',
+        'system_prompt_id',
+        ...ROUTINE_GATE.map((entry) => `${entry.table}.${entry.key}`),
+      ].sort(),
+    )
+  })
+
+  it('stays agent_type = "agent" — a subagent profile is never offered as a mode', () => {
+    const keys = parseRoutineProfileToml(renderRoutineProfileToml(SOURCE))
+    expect(keys?.get('agent_type')).toBe('"agent"')
+  })
+
+  it('escapes a Bot name that would otherwise break the TOML', () => {
+    const toml = renderRoutineProfileToml({ botProfileId: BOT, botName: 'He said "hi"' })
+    expect(parseRoutineProfileToml(toml)?.get('display_name')).toBe('"He said \\"hi\\" (routine)"')
+  })
+
+  it('round-trips: what we render is what confirms', () => {
+    const file = projectRoutineProfile(SOURCE)
+    expect(
+      confirmRoutineGate(file?.agentToml ?? '', { profileId: GATE, botProfileId: BOT }),
+    ).toEqual({ ok: true })
+  })
+})

--- a/apps/desktop/src/main/routines/routine-profile.ts
+++ b/apps/desktop/src/main/routines/routine-profile.ts
@@ -1,0 +1,131 @@
+import { BOT_PROFILE_HEADER, BOT_PROFILE_SAFETY, tomlString } from '../bots/bot-profile'
+import { routineProfileIdFor } from '../../shared/bot-profile-id'
+
+/**
+ * The **routine-only profile** projection (#469, ADR-0028 part 4). PURE: a Bot's
+ * profile id and name in, the exact text of one file out.
+ *
+ * A Bot already owns a Vibe agent profile — its persona. This is its second one,
+ * worn only by a scheduled turn: the SAME system prompt, plus a `[tools.*]` block
+ * whose entire job is to make Vibe **ask**.
+ *
+ * Why the gate has to be in a profile at all, and why this exact shape (all of it
+ * measured, none of it preference — #458, re-verified at vibe-acp 2.24.3 in
+ * `docs/acp-capture.md` §17):
+ *
+ *  - **A profile's `safety` enforces nothing.** It is presentation in Vibe's own
+ *    TUI. A profile declaring itself safe ran shell commands and file writes with
+ *    zero approval requests.
+ *  - **The user's own config layer decides the baseline, and it only ever
+ *    loosens.** One click on "Always allow" for a write, ever, in any thread,
+ *    writes a permanent allow into `~/.vibe/config.toml` (#464). So a gate must be
+ *    ASSERTED, never inherited — and an agent-profile layer sits above the user
+ *    layer, which is what lets this repair an already-permissive machine.
+ *  - **Denying the write TOOLS does not deny writing.** Permissions are scoped to
+ *    tool names and Vibe has no effect-level notion of "writes", so with
+ *    `write_file`/`edit` set to `never` the agent simply shells out. Hence the
+ *    second half: shell set to `ask` with an **empty allowlist**, because emptying
+ *    the list is what removes the schema defaults that let `echo … > file`
+ *    through. Verified: under this profile `ls -la` — a schema-default allowlisted
+ *    command — raised a permission request.
+ *  - **The profile makes Vibe ask; `allowed-commands.ts` is the answer.** Neither
+ *    half is sufficient: we can only refuse what we are asked about, and a list of
+ *    allowed commands is worthless if nothing consults it.
+ *
+ * There is no second `.md`: `system_prompt_id` names the Bot's existing prompt
+ * file, so a routine turn keeps the persona exactly. That also gives the gate a
+ * free integrity check — if the Bot's `.md` is missing, Vibe drops this profile
+ * whole (acp-capture §14.2), the mode cannot be selected, and the run refuses.
+ */
+
+/** The `[tools.*]` entries the gate consists of — the posture, as data. */
+export interface RoutineGateEntry {
+  /** The TOML table, e.g. `tools.bash`. */
+  table: string
+  key: string
+  /** The exact TOML value text, so rendering and confirming compare identically. */
+  value: string
+}
+
+/**
+ * The gate, verbatim and in emission order.
+ *
+ * `never` on the two file-writing tools is the belt — those die inside Vibe with
+ * no round trip. `ask` + `allowlist = []` on the shell is the braces, and the
+ * empty list is the load-bearing half: a list from a higher config layer REPLACES
+ * the lower one rather than merging into it, so `[]` wipes both the user's
+ * allowlist and the class defaults.
+ *
+ * The tool names are Vibe's, read off the wire and off its own builtin profiles;
+ * a name Vibe does not know would be ignored in silence (#424), which is exactly
+ * what `confirmRoutineGate` refuses to let happen unnoticed. Re-verify them
+ * against each Vibe minor by running `scripts/spike-routine-gate.ts`.
+ */
+export const ROUTINE_GATE: readonly RoutineGateEntry[] = [
+  { table: 'tools.write_file', key: 'permission', value: '"never"' },
+  { table: 'tools.edit', key: 'permission', value: '"never"' },
+  { table: 'tools.bash', key: 'permission', value: '"ask"' },
+  { table: 'tools.bash', key: 'allowlist', value: '[]' },
+]
+
+/** What the projection reads. A subset of `BotRecord`, so tests need no row. */
+export interface RoutineProfileSource {
+  /** The Bot's OWN profile id (`mistro-bot-<uuid>`) — the persona this gate wears. */
+  botProfileId: string
+  /** The Bot's display name, for a mode label a human can recognise. */
+  botName: string
+}
+
+/** The rendered projection: one file name and its exact contents. */
+export interface RoutineProfileFile {
+  /** `mistro-routine-<uuid>` — the file stem AND the ACP mode id. */
+  profileId: string
+  /** The Bot profile id this gate belongs to. */
+  botProfileId: string
+  /** File name inside the user agents dir (`~/.vibe/agents/`). */
+  agentFileName: string
+  /** The complete profile TOML. */
+  agentToml: string
+}
+
+/**
+ * Render a Bot's routine profile, or null when the argument is not a Bot profile
+ * id of ours. Pure — confirm the result before trusting it.
+ */
+export function projectRoutineProfile(source: RoutineProfileSource): RoutineProfileFile | null {
+  const profileId = routineProfileIdFor(source.botProfileId)
+  if (!profileId) return null
+  return {
+    profileId,
+    botProfileId: source.botProfileId,
+    agentFileName: `${profileId}.toml`,
+    agentToml: renderRoutineProfileToml(source),
+  }
+}
+
+/**
+ * The profile TOML. Emitted one flat `key = value` per line under at most one
+ * table header, which is what lets `parseRoutineProfileToml` read it back
+ * exactly — the read-back is the only thing that can prove the gate is really on
+ * disk in the shape we believe.
+ */
+export function renderRoutineProfileToml(source: RoutineProfileSource): string {
+  const lines = [
+    `# ${BOT_PROFILE_HEADER}`,
+    `display_name = ${tomlString(`${source.botName.trim()} (routine)`)}`,
+    `description = ${tomlString('Scheduled runs of this Bot. Every command is asked about.')}`,
+    `agent_type = "agent"`,
+    `safety = "${BOT_PROFILE_SAFETY}"`,
+    // The Bot's OWN prompt stem: a routine turn is the same teammate, gated.
+    `system_prompt_id = ${tomlString(source.botProfileId)}`,
+  ]
+  let table = ''
+  for (const entry of ROUTINE_GATE) {
+    if (entry.table !== table) {
+      table = entry.table
+      lines.push('', `[${table}]`)
+    }
+    lines.push(`${entry.key} = ${entry.value}`)
+  }
+  return `${lines.join('\n')}\n`
+}

--- a/apps/desktop/src/main/routines/run-routine-turn.test.ts
+++ b/apps/desktop/src/main/routines/run-routine-turn.test.ts
@@ -1,7 +1,13 @@
-import { describe, expect, it } from 'vitest'
-import { runRoutineTurn, type RoutineTurnDeps, type RoutineTurnPrompt } from './run-routine-turn'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  runRoutineTurn,
+  type RoutineTurnAgent,
+  type RoutineTurnDeps,
+  type RoutineTurnPrompt,
+} from './run-routine-turn'
 import { ThreadStatusTracker } from '../thread-status'
-import type { PromptTurnAgent } from '../prompt-turn'
+import type { PromptTurnGate } from '../prompt-turn'
+import type { RoutineGateResult } from './write-routine-profile'
 import type {
   BotRecord,
   RoutineRecord,
@@ -32,6 +38,7 @@ const ROUTINE: RoutineRecord = {
   lastRunAt: null,
   lastOutcome: null,
   lastError: null,
+  lastBlockedCommand: null,
   createdAt: 0,
   updatedAt: 0,
 }
@@ -47,10 +54,32 @@ const THREAD: ThreadMeta = {
 
 const WORKSPACE: WorkspaceMeta = { id: 'w1', dir: '/proj/a', displayName: 'a', lastOpenedAt: 0 }
 
-const BOT = { threadId: 'bot-thread', name: 'Triager' } as BotRecord
+const BOT_PROFILE_ID = 'mistro-bot-11111111-2222-3333-4444-555555555555'
+const GATE_PROFILE_ID = 'mistro-routine-11111111-2222-3333-4444-555555555555'
 
-/** A stand-in agent: the turn itself is `runPromptTurn`'s business, tested there. */
-const AGENT = {} as PromptTurnAgent
+const BOT = { threadId: 'bot-thread', name: 'Triager', profileId: BOT_PROFILE_ID } as BotRecord
+
+/**
+ * A stand-in agent: the turn itself is `runPromptTurn`'s business, tested there.
+ * Since #469 it also carries the four calls the permission gate drives — the raw
+ * event stream, the answer, the cancel and the persona restore.
+ */
+function stubAgent(): RoutineTurnAgent & { modes: string[]; listeners: ((p: unknown) => void)[] } {
+  const listeners: ((p: unknown) => void)[] = []
+  const modes: string[] = []
+  return {
+    modes,
+    listeners,
+    on: (_event: string, listener: (p: unknown) => void) => listeners.push(listener),
+    off: (_event: string, listener: (p: unknown) => void) => {
+      const at = listeners.indexOf(listener)
+      if (at >= 0) listeners.splice(at, 1)
+    },
+    respondPermission: () => {},
+    cancel: () => {},
+    setMode: async (_sessionId: string, modeId: string) => void modes.push(modeId),
+  } as unknown as RoutineTurnAgent & { modes: string[]; listeners: ((p: unknown) => void)[] }
+}
 
 interface Harness {
   deps: RoutineTurnDeps
@@ -59,6 +88,9 @@ interface Harness {
   protectedNow: Set<string>
   protectionHistory: string[]
   status: ThreadStatusTracker
+  /** Every failure written into the Bot's conversation (#469). */
+  failures: { threadId: string; message: string; prompt?: string }[]
+  agent: ReturnType<typeof stubAgent>
 }
 
 function harness(
@@ -67,7 +99,8 @@ function harness(
     bot?: BotRecord | null
     threads?: ThreadMeta[]
     workspaces?: WorkspaceMeta[]
-    turn?: (args: RoutineTurnPrompt) => Promise<SendPromptResult>
+    turn?: (args: RoutineTurnPrompt, gate: PromptTurnGate, agent: RoutineTurnAgent) => Promise<SendPromptResult>
+    gate?: RoutineGateResult
   } = {},
 ): Harness {
   const runs: RoutineRunResult[] = []
@@ -75,6 +108,8 @@ function harness(
   const protectedNow = new Set<string>()
   const protectionHistory: string[] = []
   const status = new ThreadStatusTracker()
+  const failures: { threadId: string; message: string; prompt?: string }[] = []
+  const agent = stubAgent()
   const routine = over.routine === undefined ? ROUTINE : over.routine
   return {
     runs,
@@ -82,6 +117,8 @@ function harness(
     protectedNow,
     protectionHistory,
     status,
+    failures,
+    agent,
     deps: {
       routines: {
         get: (id) => (routine && routine.id === id ? routine : null),
@@ -97,7 +134,7 @@ function harness(
           workspaces: over.workspaces ?? [WORKSPACE],
         }),
       },
-      acquireAgent: () => ({ agentId: 'a1', agent: AGENT }),
+      acquireAgent: () => ({ agentId: 'a1', agent }),
       claimThread: (agentId, threadId) => status.tryBeginTurn(agentId, threadId).claimed,
       releaseThread: (agentId, threadId) => void status.endTurn(agentId, threadId),
       beginProtection: (agentId) => {
@@ -108,10 +145,12 @@ function harness(
         protectedNow.delete(agentId)
         protectionHistory.push(`end ${agentId}`)
       },
-      runTurn: async (_agent, args) => {
+      ensureGate: async () => over.gate ?? { ok: true, profileId: GATE_PROFILE_ID },
+      reportFailure: (args) => void failures.push(args),
+      runTurn: async (turnAgent, args, gate) => {
         prompts.push(args)
         return over.turn
-          ? await over.turn(args)
+          ? await over.turn(args, gate, turnAgent)
           : { ok: true, result: { stopReason: 'end_turn' }, sessionId: 'sess-1' }
       },
       now: () => 1_700_000_000_000,
@@ -140,7 +179,9 @@ describe('runRoutineTurn — the happy path', () => {
   it('records the run on the Routine, clearing the failure it recovered from', async () => {
     const h = harness()
     await runRoutineTurn(h.deps, 'r1')
-    expect(h.runs).toEqual([{ lastRunAt: 1_700_000_000_000, lastOutcome: 'ok', lastError: null }])
+    expect(h.runs).toEqual([
+      { lastRunAt: 1_700_000_000_000, lastOutcome: 'ok', lastError: null, lastBlockedCommand: null },
+    ])
   })
 
   it('protects the agent for the whole run and releases it afterwards', async () => {
@@ -169,14 +210,17 @@ describe('runRoutineTurn — the busy claim (#456, atomically)', () => {
   it('two concurrent attempts on one Bot produce ONE turn and ONE defer', async () => {
     // A turn held open until the test lets it finish, so the second attempt lands
     // while the first is genuinely mid-stream.
-    const gate: { finish: (result: SendPromptResult) => void } = { finish: () => {} }
+    const held: { finish: (result: SendPromptResult) => void } = { finish: () => {} }
     const h = harness({
-      turn: () => new Promise<SendPromptResult>((resolve) => void (gate.finish = resolve)),
+      turn: () => new Promise<SendPromptResult>((resolve) => void (held.finish = resolve)),
     })
 
     const first = runRoutineTurn(h.deps, 'r1')
     const second = runRoutineTurn(h.deps, 'r1') // arrives while the first still streams
-    gate.finish({ ok: true, result: { stopReason: 'end_turn' }, sessionId: 'sess-1' })
+    // Both confirm their gate first (#469, an await), so wait for the turn to be
+    // genuinely in flight rather than assuming it is by this line.
+    await vi.waitFor(() => expect(h.prompts).toHaveLength(1))
+    held.finish({ ok: true, result: { stopReason: 'end_turn' }, sessionId: 'sess-1' })
     const outcomes = (await Promise.all([first, second])).map((r) => r.outcome)
 
     expect(outcomes.filter((o) => o === 'ok')).toHaveLength(1)
@@ -194,7 +238,12 @@ describe('runRoutineTurn — the busy claim (#456, atomically)', () => {
     expect(h.prompts).toEqual([])
     // Recorded on the Routine — ADR-0028 keeps a defer OUT of the conversation.
     expect(h.runs).toEqual([
-      { lastRunAt: 1_700_000_000_000, lastOutcome: 'deferred', lastError: expect.any(String) },
+      {
+        lastRunAt: 1_700_000_000_000,
+        lastOutcome: 'deferred',
+        lastError: expect.any(String),
+        lastBlockedCommand: null,
+      },
     ])
     // The refusal did not disturb the user's own turn.
     expect(h.status.statusFor('bot-thread').streaming).toBe(true)
@@ -218,7 +267,12 @@ describe('runRoutineTurn — every failure is an outcome, never a rejection', ()
 
     expect(result).toEqual({ outcome: 'failed', error: 'Context too long.', code: -31004 })
     expect(h.runs).toEqual([
-      { lastRunAt: 1_700_000_000_000, lastOutcome: 'failed', lastError: 'Context too long.' },
+      {
+        lastRunAt: 1_700_000_000_000,
+        lastOutcome: 'failed',
+        lastError: 'Context too long.',
+        lastBlockedCommand: null,
+      },
     ])
   })
 
@@ -267,5 +321,171 @@ describe('runRoutineTurn — every failure is an outcome, never a rejection', ()
       error: 'No routine r1.',
     })
     expect(h.runs).toEqual([])
+  })
+})
+
+/**
+ * The permission gate (#469, ADR-0028 part 4) — the half of a headless turn that
+ * decides what a scheduled agent may do with nobody at the keyboard.
+ *
+ * The three properties the ticket names, and one the design implies: a routine
+ * whose gate cannot be confirmed REFUSES TO RUN; the first denial CANCELS the
+ * turn; the written error NAMES THE COMMAND; and the Bot gets its own persona back
+ * afterwards, so it is not left read-only for the person who talks to it next.
+ */
+describe('runRoutineTurn — the permission gate', () => {
+  /** Drive one permission request through the gate the runner armed. */
+  const askFor = (command: string, agent: ReturnType<typeof stubAgent>): void => {
+    const frame = (update: Record<string, unknown>): unknown => ({
+      method: 'session/update',
+      params: { sessionId: 'sess-1', update },
+    })
+    for (const listener of agent.listeners) {
+      listener(
+        frame({
+          toolCallId: 't1',
+          rawInput: { command },
+          _meta: { tool_name: 'bash', effect_kind: 'shell' },
+          sessionUpdate: 'tool_call_update',
+        }),
+      )
+      listener({
+        id: 7,
+        method: 'session/request_permission',
+        params: {
+          sessionId: 'sess-1',
+          toolCall: { toolCallId: 't1' },
+          options: [
+            { optionId: 'allow_once', kind: 'allow_once' },
+            { optionId: 'reject_once', kind: 'reject_once' },
+          ],
+        },
+      })
+    }
+  }
+
+  it('REFUSES TO RUN when the gate cannot be confirmed, and says why', async () => {
+    // The single most important behaviour in the slice. An unknown profile key is
+    // ignored in silence, so a typo yields a routine that looks configured and
+    // gates nothing — running and hoping is the one thing that must not happen.
+    const h = harness({
+      gate: { ok: false, reason: 'invalid', problems: ['tools.bash.allowlist: it is ["echo"].'] },
+    })
+
+    const result = await runRoutineTurn(h.deps, 'r1')
+
+    expect(result.outcome).toBe('failed')
+    expect(result.error).toContain('permission gate could not be confirmed')
+    expect(result.error).toContain('tools.bash.allowlist')
+    // Nothing was prompted, nothing was claimed, no agent was protected.
+    expect(h.prompts).toEqual([])
+    expect(h.protectionHistory).toEqual([])
+    expect(h.status.statusFor('bot-thread').streaming).toBe(false)
+    // And it still WROTE something: a routine turn always writes an entry, and a
+    // refusal that only lives in a database row is a routine that looks silent.
+    expect(h.failures).toEqual([
+      {
+        threadId: 'bot-thread',
+        message: expect.stringContaining('permission gate'),
+        prompt: 'Triage this repo and say what changed.',
+      },
+    ])
+  })
+
+  it('selects the routine-only profile for the turn, not the Bot’s own', async () => {
+    const h = harness({
+      turn: async (_args, gate) => {
+        expect(gate.profileId).toBe(GATE_PROFILE_ID)
+        return { ok: true, result: { stopReason: 'end_turn' }, sessionId: 'sess-1' }
+      },
+    })
+    expect((await runRoutineTurn(h.deps, 'r1')).outcome).toBe('ok')
+  })
+
+  it('puts the Bot’s OWN persona back when the turn ends', async () => {
+    // Otherwise the Bot stays gated on that live session: read-only, and asking
+    // about every command, the next time a PERSON talks to it.
+    const h = harness({
+      turn: async (_args, gate, agent) => {
+        gate.onSessionBound('sess-1')
+        expect((agent as ReturnType<typeof stubAgent>).modes).toEqual([])
+        return { ok: true, result: { stopReason: 'end_turn' }, sessionId: 'sess-1' }
+      },
+    })
+    await runRoutineTurn(h.deps, 'r1')
+    expect(h.agent.modes).toEqual([BOT_PROFILE_ID])
+    expect(h.agent.listeners).toEqual([]) // and it stopped listening
+  })
+
+  it('allows a listed command and lets the turn finish', async () => {
+    const routine = { ...ROUTINE, allowedCommands: ['gh issue list --state open'] }
+    const h = harness({
+      routine,
+      turn: async (_args, gate, agent) => {
+        gate.onSessionBound('sess-1')
+        askFor('gh issue list --state open', agent as ReturnType<typeof stubAgent>)
+        return { ok: true, result: { stopReason: 'end_turn' }, sessionId: 'sess-1' }
+      },
+    })
+
+    const result = await runRoutineTurn(h.deps, 'r1')
+
+    expect(result.outcome).toBe('ok')
+    expect(h.failures).toEqual([])
+  })
+
+  it('THE FIRST DENIAL cancels the turn, and the written error names the command', async () => {
+    // Continuing past a denial is what produced #458's fourteen-attempt evasion
+    // loop. Stopping is what produces a message a person can act on.
+    const cancelled: string[] = []
+    const h = harness({
+      turn: async (_args, gate, agent) => {
+        const stub = agent as ReturnType<typeof stubAgent>
+        stub.cancel = (sessionId: string) => void cancelled.push(sessionId)
+        gate.onSessionBound('sess-1')
+        askFor('echo hello > notes.txt', stub)
+        // The cancel resolves the in-flight prompt through the NORMAL
+        // turn-complete path, so the turn itself reports success.
+        return { ok: true, result: { stopReason: 'cancelled' }, sessionId: 'sess-1' }
+      },
+    })
+
+    const result = await runRoutineTurn(h.deps, 'r1')
+
+    expect(cancelled).toEqual(['sess-1'])
+    expect(result.outcome).toBe('blocked')
+    expect(result.error).toContain('`echo hello > notes.txt`')
+    expect(result.blockedCommand).toBe('echo hello > notes.txt')
+    // Written into the Bot's own conversation through the turn-error tee. The
+    // prompt is NOT re-teed: the turn already teed it before it ran.
+    expect(h.failures).toEqual([
+      { threadId: 'bot-thread', message: expect.stringContaining('echo hello > notes.txt') },
+    ])
+    // And recorded as STRUCTURE, so slice 5 can offer to add exactly that string.
+    expect(h.runs).toEqual([
+      {
+        lastRunAt: 1_700_000_000_000,
+        lastOutcome: 'blocked',
+        lastError: expect.stringContaining('echo hello > notes.txt'),
+        lastBlockedCommand: 'echo hello > notes.txt',
+      },
+    ])
+  })
+
+  it('blocks a command that is merely NOT LISTED, with the routine named', async () => {
+    const h = harness({
+      turn: async (_args, gate, agent) => {
+        gate.onSessionBound('sess-1')
+        askFor('gh pr merge 12', agent as ReturnType<typeof stubAgent>)
+        return { ok: true, result: { stopReason: 'cancelled' }, sessionId: 'sess-1' }
+      },
+    })
+
+    const result = await runRoutineTurn(h.deps, 'r1')
+
+    expect(result.outcome).toBe('blocked')
+    expect(result.error).toContain('Morning triage')
+    expect(result.error).toContain('`gh pr merge 12`')
+    expect(result.blockedCommand).toBe('gh pr merge 12')
   })
 })

--- a/apps/desktop/src/main/routines/run-routine-turn.ts
+++ b/apps/desktop/src/main/routines/run-routine-turn.ts
@@ -2,7 +2,11 @@ import type { RoutineOutcome, SendPromptResult } from '../../shared/ipc'
 import type { BotStoreApi } from '../persistence/bot-store-api'
 import type { MetadataStoreApi } from '../persistence/metadata-store-api'
 import type { RoutineStoreApi } from '../persistence/routine-store-api'
-import type { PromptTurnAgent } from '../prompt-turn'
+import type { PromptTurnAgent, PromptTurnGate } from '../prompt-turn'
+import { refusalMessage } from './allowed-commands'
+import { createRoutinePermissionGate } from './routine-permission-gate'
+import type { RoutineProfileSource } from './routine-profile'
+import type { RoutineGateResult } from './write-routine-profile'
 
 /**
  * **Run one Routine's turn with nobody watching** (#468, ADR-0028) — the single
@@ -43,12 +47,36 @@ export interface RoutineTurnResult {
   sessionId?: string
   /** The JSON-RPC / app error code, when the failure carried one (e.g. -31004). */
   code?: number
+  /**
+   * The exact invocation the **allowed commands** gate refused, when the outcome
+   * is `blocked` (#469). STRUCTURED rather than dug back out of `error`, because
+   * slice 5's "add this command" offer has to hand back the same bytes the agent
+   * asked for — a message is prose, and prose is where an extra backtick or a
+   * truncation gets in. Null when the request named no command at all.
+   */
+  blockedCommand?: string | null
+}
+
+/**
+ * The agent surface a GATED turn drives. `PromptTurnAgent` plus the four calls the
+ * permission gate needs (#469) — the raw event stream it reads tool calls from,
+ * the answer, the cancel, and the mode setter that puts the Bot's own persona back
+ * afterwards. Structural, like everything else here: `WorkspaceAgent` satisfies it
+ * already, and a test satisfies it with an object literal.
+ */
+export interface RoutineTurnAgent extends PromptTurnAgent {
+  on(event: 'event', listener: (payload: unknown) => void): unknown
+  off(event: 'event', listener: (payload: unknown) => void): unknown
+  /** Answer a `session/request_permission` by its JSON-RPC request id. */
+  respondPermission(requestId: number | string, optionId: string): void
+  /** `session/cancel` — the in-flight prompt resolves `stopReason:"cancelled"`. */
+  cancel(sessionId: string): void
 }
 
 /** The pool half: warm-or-reuse a Workspace's agent, wiring its events if fresh. */
 export interface AcquiredRoutineAgent {
   agentId: string
-  agent: PromptTurnAgent
+  agent: RoutineTurnAgent
 }
 
 export interface RoutineTurnDeps {
@@ -70,8 +98,23 @@ export interface RoutineTurnDeps {
   /** Shield the agent from idle/cap eviction for the whole run. */
   beginProtection(agentId: string): void
   endProtection(agentId: string): void
+  /**
+   * Put this Bot's routine-only permission gate on disk and CONFIRM it is there
+   * (#469). Called before every run, never trusted from a previous one: a profile
+   * key Vibe does not recognise is ignored in silence, so only a read-back can
+   * tell a gated routine from one that merely looks configured.
+   */
+  ensureGate(source: RoutineProfileSource): Promise<RoutineGateResult>
+  /**
+   * Write a failure into the Bot's OWN conversation through the turn-error tee,
+   * and touch the Thread so the unread dot appears. `prompt` is teed first when
+   * the turn never got far enough to tee it itself, so the entry pair still reads
+   * as "what was asked, then why it did not happen" (ADR-0028 part 5: a routine
+   * turn always writes an entry).
+   */
+  reportFailure(args: { threadId: string; message: string; prompt?: string }): void
   /** Run the turn itself — production passes `runPromptTurn` with headless delivery. */
-  runTurn(agent: PromptTurnAgent, args: RoutineTurnPrompt): Promise<SendPromptResult>
+  runTurn(agent: RoutineTurnAgent, args: RoutineTurnPrompt, gate: PromptTurnGate): Promise<SendPromptResult>
   /** Epoch-ms clock, injected so a run's recorded timestamp is deterministic in tests. */
   now(): number
 }
@@ -108,11 +151,15 @@ export async function runRoutineTurn(
       lastRunAt: deps.now(),
       lastOutcome: result.outcome,
       lastError: result.error,
+      // Additive and optional (#469): a run that was not blocked carries null,
+      // which clears whatever the previous block left behind.
+      lastBlockedCommand: result.blockedCommand ?? null,
     })
     return result
   }
 
-  if (!deps.bots.get(routine.threadId)) {
+  const bot = deps.bots.get(routine.threadId)
+  if (!bot) {
     return record({ outcome: 'failed', error: 'This routine is not attached to a Bot any more.' })
   }
 
@@ -128,6 +175,22 @@ export async function runRoutineTurn(
     return record({ outcome: 'failed', error: "This routine's project could not be found." })
   }
 
+  // THE GATE, before anything is claimed or spawned (#469, ADR-0028 part 4).
+  //
+  // A routine whose permission gate cannot be CONFIRMED refuses to run and says
+  // why. It is checked here, first, for two reasons: there is nothing to release
+  // if it refuses, and a run that cannot be gated must never reach the point of
+  // warming an agent — the failure is durable, so the cheapest possible refusal is
+  // also the most honest one.
+  const gate = await deps.ensureGate({ botProfileId: bot.profileId, botName: bot.name })
+  if (!gate.ok) {
+    const message =
+      `"${routine.name}" did not run: its permission gate could not be confirmed, so it was ` +
+      `refused rather than run unguarded. ${gate.problems.join(' ')}`
+    deps.reportFailure({ threadId: routine.threadId, message, prompt: routine.prompt })
+    return record({ outcome: 'failed', error: message })
+  }
+
   // The critical section: acquire and claim with no `await` between them, so two
   // ticks arriving in the same turn of the event loop cannot both take the Bot.
   const { agentId, agent } = deps.acquireAgent(workspace.dir)
@@ -137,16 +200,66 @@ export async function runRoutineTurn(
   }
   deps.beginProtection(agentId)
 
+  // We are the permission SERVER for this turn (the ADR-0001 amendment): main
+  // answers, from the Routine's allowed commands, with no renderer in the loop.
+  const permissions = createRoutinePermissionGate({
+    allowedCommands: routine.allowedCommands,
+    seams: {
+      respond: (requestId, optionId) => agent.respondPermission(requestId, optionId),
+      cancel: (sessionId) => agent.cancel(sessionId),
+    },
+  })
+  // A holder rather than a `let`, because the assignment happens inside a callback
+  // and the `finally` below has to see it.
+  const bound: { sessionId: string | null } = { sessionId: null }
+  const observe = (payload: unknown): void => permissions.observe(payload)
+  agent.on('event', observe)
+
   try {
-    const result = await deps.runTurn(agent, {
-      agentId,
-      threadId: routine.threadId,
-      workspaceId: thread.workspaceId,
-      sessionId: thread.sessionId,
-      text: routine.prompt,
-    })
+    const result = await deps.runTurn(
+      agent,
+      {
+        agentId,
+        threadId: routine.threadId,
+        workspaceId: thread.workspaceId,
+        sessionId: thread.sessionId,
+        text: routine.prompt,
+      },
+      {
+        profileId: gate.profileId,
+        onSessionBound: (sessionId) => {
+          bound.sessionId = sessionId
+          permissions.armSession(sessionId)
+        },
+      },
+    )
+    const blocked = permissions.blocked
+    if (blocked) {
+      // The cancel already resolved the turn through the normal turn-complete
+      // path, so `result` reads as an ordinary cancelled turn. The Routine's
+      // outcome is decided by the gate, not by the stop reason.
+      const message = refusalMessage(routine.name, blocked.command, blocked.reason)
+      deps.reportFailure({ threadId: routine.threadId, message })
+      return record({ outcome: 'blocked', error: message, blockedCommand: blocked.command })
+    }
     return record(outcomeOf(result))
   } finally {
+    agent.off('event', observe)
+    // Put the Bot's OWN persona back on the session. The gate profile is this
+    // turn's posture, not the Bot's: leaving it selected would make the Bot
+    // refuse to write files and ask about every command the next time a PERSON
+    // talked to it on this same live session — which is exactly what ADR-0028
+    // rejected when it chose a second profile over rewriting the first.
+    // Best-effort: the next bind re-selects the persona anyway.
+    if (bound.sessionId) {
+      try {
+        await agent.setMode(bound.sessionId, bot.profileId)
+      } catch (err) {
+        console.error(
+          `[vibe-mistro:routines] could not restore ${bot.profileId} after a routine turn: ${String(err)}`,
+        )
+      }
+    }
     deps.endProtection(agentId)
     deps.releaseThread(agentId, routine.threadId)
   }
@@ -155,10 +268,12 @@ export async function runRoutineTurn(
 /**
  * Map a turn's result onto the Routine vocabulary.
  *
- * `blocked` is absent on purpose: it belongs to the allowed-commands gate (#469),
- * which is the only thing that can block a turn rather than fail it. Every failure
- * reachable today is durable — sign-in expired, context exhausted, profile missing,
- * agent binary gone — which is why ADR-0028 part 5 has no retry.
+ * `blocked` is absent HERE on purpose, and still is: a denial cancels the turn, so
+ * the wire result of a blocked run is an ordinary cancelled one and only the gate
+ * knows better. The caller reads `permissions.blocked` and overrides — mapping a
+ * stop reason to `blocked` would put the decision in the one place that cannot see
+ * it. Every other failure is durable — sign-in expired, context exhausted, profile
+ * missing, agent binary gone — which is why ADR-0028 part 5 has no retry.
  */
 function outcomeOf(result: SendPromptResult): RoutineTurnResult {
   if (result.ok) return { outcome: 'ok', error: null, sessionId: result.sessionId }

--- a/apps/desktop/src/main/routines/write-routine-profile.test.ts
+++ b/apps/desktop/src/main/routines/write-routine-profile.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import { ensureRoutineGate, type RoutineProfileFs } from './write-routine-profile'
+import { confirmRoutineGate } from './confirm-routine-gate'
+
+/**
+ * Putting the gate on disk and PROVING it is there (#469).
+ *
+ * Every test injects a fake filesystem — the real `~/.vibe/` is never touched,
+ * which is the same rule the Bot profile writer's suite holds and matters more
+ * here, since this writes into the directory a user's own profiles live in.
+ */
+
+const BOT = 'mistro-bot-11111111-2222-3333-4444-555555555555'
+const GATE = 'mistro-routine-11111111-2222-3333-4444-555555555555'
+const DIRS = { agentsDir: '/home/u/.vibe/agents', promptsDir: '/home/u/.vibe/prompts' }
+const SOURCE = { botProfileId: BOT, botName: 'Triager' }
+
+/** An in-memory `RoutineProfileFs`, with hooks for the failures that matter. */
+function fakeFs(
+  over: {
+    onWrite?: (path: string, contents: string) => string | void
+    onRead?: (path: string) => string
+    failMkdir?: boolean
+  } = {},
+): RoutineProfileFs & { files: Map<string, string>; dirs: string[] } {
+  const files = new Map<string, string>()
+  const dirs: string[] = []
+  return {
+    files,
+    dirs,
+    mkdir: async (dir) => {
+      if (over.failMkdir) throw new Error('EACCES')
+      dirs.push(dir)
+    },
+    writeFile: async (path, contents) => {
+      files.set(path, over.onWrite?.(path, contents) ?? contents)
+    },
+    readFile: async (path) => {
+      if (over.onRead) return over.onRead(path)
+      const found = files.get(path)
+      if (found === undefined) throw new Error(`ENOENT: ${path}`)
+      return found
+    },
+  }
+}
+
+describe('ensureRoutineGate', () => {
+  it('writes the gate into the agents dir and confirms it', async () => {
+    const fs = fakeFs()
+    const result = await ensureRoutineGate({ source: SOURCE, dirs: DIRS, fs })
+    expect(result).toEqual({ ok: true, profileId: GATE })
+    // ONE file, and no prompt `.md`: `system_prompt_id` names the Bot's own
+    // prompt, so a scheduled turn is the same teammate with a gate on it rather
+    // than a second persona that could drift from the first.
+    expect(fs.dirs).toEqual([DIRS.agentsDir])
+    expect([...fs.files.keys()]).toEqual([`${DIRS.agentsDir}/${GATE}.toml`])
+    const written = fs.files.get(`${DIRS.agentsDir}/${GATE}.toml`)
+    expect(written).toBeDefined()
+    expect(confirmRoutineGate(written ?? '', { profileId: GATE, botProfileId: BOT })).toEqual({
+      ok: true,
+    })
+  })
+
+  it('refuses a Bot profile id that is not ours, and writes nothing', async () => {
+    const fs = fakeFs()
+    for (const botProfileId of ['ask', GATE, 'mistro-bot-nope', '../../etc/passwd']) {
+      const result = await ensureRoutineGate({
+        source: { botProfileId, botName: 'x' },
+        dirs: DIRS,
+        fs,
+      })
+      expect(result).toMatchObject({ ok: false, reason: 'refused' })
+    }
+    expect(fs.files.size).toBe(0)
+  })
+
+  it('REFUSES when the file on disk is not the gate we wrote', async () => {
+    // The case the read-back exists for. Nothing on the wire would ever tell us:
+    // Vibe loads this file, offers it as a mode, and gates nothing.
+    const fs = fakeFs({ onWrite: (_path, contents) => contents.replace('allowlist = []', 'allowlist = ["echo"]') })
+    const result = await ensureRoutineGate({ source: SOURCE, dirs: DIRS, fs })
+    expect(result).toMatchObject({ ok: false, reason: 'invalid' })
+    expect((result as { problems: string[] }).problems.join(' ')).toContain('tools.bash.allowlist')
+  })
+
+  it('REFUSES when the read-back comes back empty or absent', async () => {
+    const empty = await ensureRoutineGate({ source: SOURCE, dirs: DIRS, fs: fakeFs({ onRead: () => '' }) })
+    expect(empty).toMatchObject({ ok: false, reason: 'invalid' })
+
+    const missing = await ensureRoutineGate({
+      source: SOURCE,
+      dirs: DIRS,
+      fs: fakeFs({
+        onRead: () => {
+          throw new Error('ENOENT')
+        },
+      }),
+    })
+    expect(missing).toMatchObject({ ok: false, reason: 'io' })
+  })
+
+  it('reports an unwritable agents dir as io rather than pretending it is gated', async () => {
+    const result = await ensureRoutineGate({ source: SOURCE, dirs: DIRS, fs: fakeFs({ failMkdir: true }) })
+    expect(result).toMatchObject({ ok: false, reason: 'io' })
+  })
+
+  it('is idempotent — every run rewrites and re-confirms the same bytes', async () => {
+    const fs = fakeFs()
+    await ensureRoutineGate({ source: SOURCE, dirs: DIRS, fs })
+    const first = fs.files.get(`${DIRS.agentsDir}/${GATE}.toml`)
+    // Somebody hand-edits the gate open between runs...
+    fs.files.set(`${DIRS.agentsDir}/${GATE}.toml`, 'display_name = "mine now"\n')
+    const again = await ensureRoutineGate({ source: SOURCE, dirs: DIRS, fs })
+    // ...and the next run heals it rather than refusing forever.
+    expect(again).toEqual({ ok: true, profileId: GATE })
+    expect(fs.files.get(`${DIRS.agentsDir}/${GATE}.toml`)).toBe(first)
+  })
+})

--- a/apps/desktop/src/main/routines/write-routine-profile.ts
+++ b/apps/desktop/src/main/routines/write-routine-profile.ts
@@ -1,0 +1,109 @@
+import { join } from 'node:path'
+import { isMistroBotProfileId } from '../../shared/bot-profile-id'
+import type { VibeProfileDirs } from '../bots/profile-dirs'
+import {
+  confirmRoutineGate,
+  describeGateProblems,
+  gateProblems,
+  validateRoutineProfileFile,
+} from './confirm-routine-gate'
+import { projectRoutineProfile, type RoutineProfileSource } from './routine-profile'
+
+/**
+ * Put a Bot's routine gate on disk and PROVE it is there (#469, ADR-0028 part 4).
+ *
+ * The only thing in the Routines feature that touches the filesystem, and — like
+ * the Bot profile writer it is modelled on — it does so through an INJECTED seam,
+ * so no test ever writes into the real `~/.vibe/`.
+ *
+ * Four steps, and the fourth is the one the slice is about:
+ *
+ * 1. **Ours only.** A Bot profile id that is not `mistro-bot-<uuid>` is foreign;
+ *    nothing is derived from it and nothing is written.
+ * 2. **Validate the projection** — refuse our own typo before it reaches disk.
+ * 3. **Write it**, `mkdir -p` first (Vibe creates `agents/` for nobody).
+ * 4. **Read it back and confirm the gate.** Not a paranoid flourish: a profile key
+ *    Vibe does not recognise is ignored in silence, so "the write returned" is
+ *    evidence of nothing at all. This is the step that lets the caller refuse to
+ *    run rather than run and hope.
+ *
+ * Called before EVERY routine run rather than once at Bot-creation time. It costs
+ * one small write and one read, it heals a file deleted or edited by hand, and it
+ * means the confirmation is about the file that is there NOW instead of about a
+ * write that happened three weeks ago. Rewriting cannot disturb a live session:
+ * Vibe resolves a session's profile when the session opens (acp-capture §14.6).
+ */
+
+/** The fs operations this needs. Injected — `node-routine-profile-fs.ts` is the real one. */
+export interface RoutineProfileFs {
+  /** Recursive `mkdir -p`. */
+  mkdir(dir: string): Promise<void>
+  /** Write (or overwrite) a UTF-8 text file. */
+  writeFile(path: string, contents: string): Promise<void>
+  /** Read a UTF-8 text file. Must reject when it is absent. */
+  readFile(path: string): Promise<string>
+}
+
+export interface EnsureRoutineGateArgs {
+  source: RoutineProfileSource
+  dirs: VibeProfileDirs
+  fs: RoutineProfileFs
+}
+
+/**
+ * `refused` = a Bot profile id we do not own; `invalid` = the gate we rendered or
+ * read back is not the gate (the silent-ignore case); `io` = it could not be
+ * written or read. All three refuse the run, and all three carry the reason —
+ * ADR-0028 is explicit that a routine which cannot confirm its gate must say why.
+ */
+export type RoutineGateResult =
+  | { ok: true; profileId: string }
+  | { ok: false; reason: 'refused' | 'invalid' | 'io'; problems: string[] }
+
+export async function ensureRoutineGate(args: EnsureRoutineGateArgs): Promise<RoutineGateResult> {
+  const { source, dirs, fs } = args
+
+  if (!isMistroBotProfileId(source.botProfileId)) {
+    const message = `refusing to derive a routine profile from a Bot we do not own: ${source.botProfileId}`
+    console.error(`[vibe-mistro:routines] ${message}`)
+    return { ok: false, reason: 'refused', problems: [message] }
+  }
+
+  const file = projectRoutineProfile(source)
+  if (!file) {
+    // Unreachable while the ownership check above holds; kept because the
+    // projection's null is a real branch and silently `!`-ing it away is how a
+    // gate stops existing.
+    return { ok: false, reason: 'refused', problems: [`No routine profile for ${source.botProfileId}.`] }
+  }
+
+  const rendered = gateProblems(validateRoutineProfileFile(file))
+  if (rendered.length) {
+    const described = describeGateProblems(rendered)
+    console.error(`[vibe-mistro:routines] refusing to write ${file.agentFileName}: ${described.join('; ')}`)
+    return { ok: false, reason: 'invalid', problems: described }
+  }
+
+  const path = join(dirs.agentsDir, file.agentFileName)
+  let readBack: string
+  try {
+    await fs.mkdir(dirs.agentsDir)
+    await fs.writeFile(path, file.agentToml)
+    readBack = await fs.readFile(path)
+  } catch (err) {
+    const message = `Could not write the routine's permission gate: ${String(err)}`
+    console.error(`[vibe-mistro:routines] ${message}`)
+    return { ok: false, reason: 'io', problems: [message] }
+  }
+
+  const confirmed = gateProblems(
+    confirmRoutineGate(readBack, { profileId: file.profileId, botProfileId: file.botProfileId }),
+  )
+  if (confirmed.length) {
+    const described = describeGateProblems(confirmed)
+    console.error(`[vibe-mistro:routines] ${file.agentFileName} is not gated: ${described.join('; ')}`)
+    return { ok: false, reason: 'invalid', problems: described }
+  }
+
+  return { ok: true, profileId: file.profileId }
+}

--- a/apps/desktop/src/renderer/src/conversation/ordinary-modes.ts
+++ b/apps/desktop/src/renderer/src/conversation/ordinary-modes.ts
@@ -1,4 +1,4 @@
-import { isMistroBotProfileId } from '../../../shared/bot-profile-id'
+import { isMistroProfileId } from '../../../shared/bot-profile-id'
 import type { ThreadModes } from '../../../shared/ipc'
 
 /**
@@ -18,12 +18,18 @@ import type { ThreadModes } from '../../../shared/ipc'
  * minted ourselves — `mistro-bot-<uuid>` is a mechanical test, not a heuristic,
  * so a hand-written profile of the user's is never touched.
  *
+ * Since #469 a Bot has a SECOND generated profile — `mistro-routine-<uuid>`, the
+ * permission gate a scheduled turn wears — and it is published as a mode like any
+ * other, so the filter asks the wider question (`isMistroProfileId`). A picker
+ * offering "Triage Bot (routine)" beside `ask` and `plan` would be offering a
+ * posture that only makes sense with nobody watching.
+ *
  * A Bot's OWN conversation never reaches this: it is handed no modes at all
  * (`ConnectedWorkspace`), because a Bot's behaviour is its profile.
  */
 export function modesWithoutBotProfiles(modes: ThreadModes | null): ThreadModes | null {
   if (!modes) return null
-  const availableModes = modes.availableModes.filter((mode) => !isMistroBotProfileId(mode.id))
+  const availableModes = modes.availableModes.filter((mode) => !isMistroProfileId(mode.id))
   // Nothing was filtered — the overwhelmingly common case, a user with no Bots.
   // Hand back the SAME object rather than a copy: a cheap fast path, not a
   // memoization guarantee (a user WITH Bots does get a fresh object per call).

--- a/apps/desktop/src/shared/bot-profile-id.test.ts
+++ b/apps/desktop/src/shared/bot-profile-id.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from 'vitest'
 import { randomUUID } from 'node:crypto'
-import { MISTRO_BOT_PROFILE_PREFIX, isMistroBotProfileId, mintBotProfileId } from './bot-profile-id'
+import {
+  MISTRO_BOT_PROFILE_PREFIX,
+  isMistroBotProfileId,
+  isMistroProfileId,
+  isMistroRoutineProfileId,
+  mintBotProfileId,
+  routineProfileIdFor,
+} from './bot-profile-id'
 
 describe('mintBotProfileId', () => {
   it('prefixes a uuid and produces an id we recognise as ours', () => {
@@ -49,5 +56,35 @@ describe('isMistroBotProfileId — the foreign-profile gate', () => {
     expect(isMistroBotProfileId(`../mistro-bot-${uuid}`)).toBe(false)
     expect(isMistroBotProfileId(`mistro-bot-${uuid}/../../evil`)).toBe(false)
     expect(isMistroBotProfileId(`mistro-bot-${uuid}.toml`)).toBe(false)
+  })
+})
+
+describe('the routine gate profile id (#469)', () => {
+  const BOT = 'mistro-bot-6f9619ff-8b86-d011-b42d-00c04fc964ff'
+  const GATE = 'mistro-routine-6f9619ff-8b86-d011-b42d-00c04fc964ff'
+
+  it('is derived from the Bot, sharing its uuid — never stored, never minted twice', () => {
+    expect(routineProfileIdFor(BOT)).toBe(GATE)
+  })
+
+  it('is null for anything that is not a Bot profile of ours', () => {
+    // Including a routine id: the pair is derived one way only, so there is no
+    // path by which a gate could father a second gate.
+    for (const id of ['ask', GATE, 'mistro-bot-nope', 'MISTRO-BOT-6f9619ff-8b86-d011-b42d-00c04fc964ff']) {
+      expect({ id, derived: routineProfileIdFor(id) }).toEqual({ id, derived: null })
+    }
+  })
+
+  it('keeps the two ownership tests apart, so neither writer can touch the other’s file', () => {
+    expect(isMistroBotProfileId(GATE)).toBe(false)
+    expect(isMistroRoutineProfileId(BOT)).toBe(false)
+    expect(isMistroRoutineProfileId(GATE)).toBe(true)
+  })
+
+  it('answers the PRESENTATION question for both — a Mode picker must hide each', () => {
+    expect(isMistroProfileId(BOT)).toBe(true)
+    expect(isMistroProfileId(GATE)).toBe(true)
+    expect(isMistroProfileId('ask')).toBe(false)
+    expect(isMistroProfileId('my-own-profile')).toBe(false)
   })
 })

--- a/apps/desktop/src/shared/bot-profile-id.ts
+++ b/apps/desktop/src/shared/bot-profile-id.ts
@@ -28,12 +28,33 @@
 export const MISTRO_BOT_PROFILE_PREFIX = 'mistro-bot-'
 
 /**
+ * The prefix of a Bot's SECOND profile — the routine-only gate (#469, ADR-0028
+ * part 4).
+ *
+ * A Bot has two generated profiles that share one uuid: `mistro-bot-<uuid>` is
+ * its persona, worn whenever a person is talking to it, and
+ * `mistro-routine-<uuid>` is that same persona with the permission gate bolted
+ * on, worn ONLY by a scheduled turn. They are two files rather than one rewritten
+ * file on purpose: a Bot must not become read-only when you talk to it, and a
+ * rewrite would leave a window where a crash strands the wrong posture.
+ *
+ * Sharing the uuid means the routine profile is derivable from the Bot's id
+ * (`routineProfileIdFor`) and never has to be stored, and it keeps the pair
+ * adjacent in `~/.vibe/agents/` for anyone reading the directory by hand.
+ */
+export const MISTRO_ROUTINE_PROFILE_PREFIX = 'mistro-routine-'
+
+/**
  * Exactly `mistro-bot-` + a canonical lowercase uuid. Deliberately strict: a
  * near-miss (uppercase, a truncated uuid, a nested path) is treated as foreign
  * rather than as one of ours, so the failure direction is always "leave it alone".
  */
 const MISTRO_BOT_PROFILE_ID =
   /^mistro-bot-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+
+/** The same shape for the routine-only gate profile. Equally strict, same reason. */
+const MISTRO_ROUTINE_PROFILE_ID =
+  /^mistro-routine-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 
 /** Mint a profile id from a freshly generated uuid (`randomUUID()`). */
 export function mintBotProfileId(uuid: string): string {
@@ -47,4 +68,36 @@ export function mintBotProfileId(uuid: string): string {
  */
 export function isMistroBotProfileId(profileId: string): boolean {
   return MISTRO_BOT_PROFILE_ID.test(profileId)
+}
+
+/** Whether this id names a Bot's routine-only gate profile (#469). */
+export function isMistroRoutineProfileId(profileId: string): boolean {
+  return MISTRO_ROUTINE_PROFILE_ID.test(profileId)
+}
+
+/**
+ * Whether this id is one WE generated at all — a Bot's persona OR its routine
+ * gate. The question every consumer that asks "is this profile ours?" for
+ * PRESENTATION should ask: both are published over ACP as selectable modes, so a
+ * filter that knows only about personas would leak the gate profile into every
+ * ordinary Thread's Mode picker.
+ *
+ * The file-ownership gates deliberately do NOT use this: each writer refuses
+ * anything that is not the exact shape it owns, so a Bot writer can never touch a
+ * routine profile and vice versa.
+ */
+export function isMistroProfileId(profileId: string): boolean {
+  return isMistroBotProfileId(profileId) || isMistroRoutineProfileId(profileId)
+}
+
+/**
+ * The routine-gate profile id that belongs with this Bot profile id, or null when
+ * the argument is not one of ours.
+ *
+ * Derived, never stored: the pair shares a uuid, so there is no second id to keep
+ * in sync and no way for the record to name a gate that belongs to another Bot.
+ */
+export function routineProfileIdFor(botProfileId: string): string | null {
+  if (!isMistroBotProfileId(botProfileId)) return null
+  return `${MISTRO_ROUTINE_PROFILE_PREFIX}${botProfileId.slice(MISTRO_BOT_PROFILE_PREFIX.length)}`
 }

--- a/apps/desktop/src/shared/ipc/routines.ts
+++ b/apps/desktop/src/shared/ipc/routines.ts
@@ -84,6 +84,17 @@ export interface RoutineRecord {
   lastOutcome: RoutineOutcome | null
   /** The failure detail behind a `failed` / `blocked` outcome — the fixable message. */
   lastError: string | null
+  /**
+   * The exact invocation the **allowed commands** gate refused, when the last run
+   * was `blocked` (#469). Null otherwise, and cleared by any run that was not
+   * blocked.
+   *
+   * Structured rather than parsed back out of `lastError`, because the authoring
+   * surface (slice 5) offers to ADD this command to the list — and a value that
+   * has been through a sentence is a value that can come back subtly different
+   * from the one the agent asked to run.
+   */
+  lastBlockedCommand: string | null
   createdAt: number
   updatedAt: number
 }

--- a/docs/acp-capture.md
+++ b/docs/acp-capture.md
@@ -1013,3 +1013,107 @@ later session does not mistake the resulting UI for something half-finished:
 The child session directory (I) is the only place the subagent's real transcript exists. It stays
 off-limits: reading it would couple us to an unversioned internal format, which is exactly what
 ADR-0002 forbids.
+
+---
+
+## 17. A routine-gated profile, and where a shell command's text actually lives (captured 2026-08-21 via `scripts/spike-routine-gate.ts`, vibe-acp **2.24.3**)
+
+The permission half of Bot Routines (#469, ADR-0028 part 4). Two questions: does a profile carrying
+`[tools.*]` blocks force `vibe-acp` to ASK over a user `config.toml` that otherwise auto-approves, and
+what exactly does the resulting request carry?
+
+Hygiene, same as §14.7: an isolated `VIBE_HOME` under `$TMPDIR` with the user's real `config.toml`
+COPIED in (the original only read), a scratch `cwd`, `zz-probe-*` profile names, every
+`fs/write_text_file` refused and every permission answered `reject_once`.
+
+### 17.1 The gate profile, and that it holds
+
+```toml
+display_name = "ZZ Probe Routine"
+agent_type = "agent"
+safety = "neutral"
+system_prompt_id = "zz-probe-prompt"
+
+[tools.write_file]
+permission = "never"
+
+[tools.edit]
+permission = "never"
+
+[tools.bash]
+permission = "ask"
+allowlist = []
+```
+
+Under this profile, `ls -la` — a command on the **schema-default** bash allowlist, which does not
+prompt under the shipped Bot profile — **raised a permission request**, as did
+`echo hello > probe.txt`. Emptying `allowlist` is what removes the defaults; §14 and #458 established
+the same at 2.24.1, and it still holds at 2.24.3.
+
+### 17.2 🚨 The request's `invocation_pattern` is TOKENISED — the redirect is erased
+
+For the command `echo hello > probe.txt`, the request (verbatim, options trimmed for length):
+
+```json
+{"sessionId":"7f2a997d-…","toolCall":{"toolCallId":"sbjyDUwlc"},
+ "options":[
+   {"optionId":"allow_once","name":"Allow once","kind":"allow_once"},
+   {"optionId":"allow_always","name":"Allow for remainder of this session","kind":"allow_always",
+    "_meta":{"required_permissions":[{"scope":"command_pattern",
+      "invocation_pattern":"echo hello <redirect>",
+      "session_pattern":"echo *","label":"echo *"}]}},
+   {"optionId":"allow_always_permanent","name":"Always allow","kind":"allow_always","_meta":{…same…}},
+   {"optionId":"reject_once","name":"Deny","kind":"reject_once"}]}
+```
+
+Three things a client must not get wrong:
+
+1. **`invocation_pattern` is not the command.** `echo hello <redirect>` names no file. A client that
+   matched a user's allow-list against it would authorise a command that writes somewhere the string
+   it matched never mentions — the #458 hole, re-opened one layer up.
+2. **`session_pattern` / `label` are WIDER still** (`echo *`). They are what the allow-always options
+   would grant, not what is being asked.
+3. **`scope` distinguishes the kind of permission** — `command_pattern` here, `outside_directory` for
+   a path (§15F). A client answering automatically should refuse a scope it does not understand.
+
+For `ls -la` the same fields read `invocation_pattern: "ls -la"` and `session_pattern: "ls *"` — i.e.
+the pattern happens to equal the command whenever the command contains nothing to tokenise, which is
+exactly what makes matching on it look correct in testing.
+
+### 17.3 The command text is `rawInput.command` on an EARLIER `tool_call_update`
+
+The frames for one bash call, in order:
+
+```jsonc
+{"toolCallId":"sbjyDUwlc","title":"bash","kind":"execute","status":"in_progress",
+ "_meta":{"tool_name":"bash","effect_kind":"shell"},"sessionUpdate":"tool_call"}
+{"toolCallId":"sbjyDUwlc","kind":"execute","status":"in_progress",
+ "title":"bash: echo hello > probe.txt","rawInput":{"command":"echo hello > probe.txt"},
+ "_meta":{"tool_name":"bash","effect_kind":"shell"},"sessionUpdate":"tool_call_update"}
+{"toolCallId":"sbjyDUwlc","kind":"execute","status":"in_progress",
+ "_meta":{"tool_name":"bash","effect_kind":"shell"},"sessionUpdate":"tool_call_update"}   // ← no rawInput
+// then session/request_permission
+```
+
+⇒ **Merge frames by `toolCallId`.** The update immediately before the request carries only a status,
+so a client that reads "the last frame" finds no command at all. `_meta` is snake_case and sits on the
+update object (§15B).
+
+### 17.4 A denial does not end the turn — `session/cancel` does
+
+Answering `reject_once` produced `status:"failed"` on that tool call with
+`rawOutput: "User rejected the tool call; provide an alternative plan"`, and the turn **continued**
+(five requests for one one-file task before the probe stopped it). Sending `session/cancel` right
+after the denial resolved the in-flight `session/prompt` with:
+
+```json
+{"stopReason":"cancelled","usage":{…}}
+```
+
+⇒ the cancel resolves through the ordinary turn-complete path (§12), so a blocked routine looks like a
+cancelled turn on the wire and only the client's own gate knows it was a refusal.
+
+### Infra — same `node`-not-`bun` gotcha as §9–§12, §15
+
+`bun build scripts/spike-routine-gate.ts --target=node --outfile=/tmp/spike-gate.mjs && node /tmp/spike-gate.mjs`
+(`--phase=a|b|c|d`, `--keep`). LIVE — costs credits.

--- a/docs/adr/0001-conversation-state-and-acp-layering.md
+++ b/docs/adr/0001-conversation-state-and-acp-layering.md
@@ -21,3 +21,17 @@ session**, the protocol handle from `session/new`). Agent-initiated **permission
   now; revisit if/when we add multiple windows, durable thread history, or the remote-backend slice —
   any of those may require promoting main to the source of truth (supersede this ADR then).
 - "ACP session" stays out of the UI vocabulary; the UI speaks "Thread" (see CONTEXT.md).
+
+## Amendment — main answers permission requests for a scheduled turn (ADR-0028, #469)
+
+A **Routine** runs a turn with nobody at the keyboard, and an unanswered permission request hangs that
+turn forever — `vibe-acp` waits on the client with no timeout. There is no renderer to queue it in.
+
+So for turns raised by the scheduler, and only those, **main answers** `request_permission` itself,
+from the Routine's **allowed commands** (`src/main/routines/routine-permission-gate.ts`). The first
+refusal cancels the turn. The renderer remains the only answerer for every user-initiated turn, and
+nothing else about the layering changes: the answer is still by JSON-RPC request id, main still
+forwards the raw event, and the renderer still owns conversation state.
+
+The departure is narrow and deliberate. ADR-0028 part 4 carries the reasoning and the alternatives it
+rejected (auto-deny-everything, and leaving the request pending until somebody opens the Bot).


### PR DESCRIPTION
Closes #469. Slice 3 of the Bot Routines epic (#466), on ADR-0028 part 4. Branched off `adc484e` (rebased mid-slice — see the note at the end).

A scheduled turn runs with nobody at the keyboard, so **what it may do has to be decided before it runs**. This slice builds both halves of that decision and the proof that the first half is actually on.

## The gate: a second, routine-only profile per Bot

`mistro-routine-<uuid>`, derived from the Bot's own `mistro-bot-<uuid>` (shared uuid, so nothing extra is stored). It carries the Bot's **own** `system_prompt_id` — a routine turn is the same teammate — plus:

```toml
[tools.write_file]
permission = "never"
[tools.edit]
permission = "never"
[tools.bash]
permission = "ask"
allowlist = []
```

Its job is not to stop things; it is to **make Vibe ask**. Emptying `allowlist` is the load-bearing half — that is what removes the schema defaults that let `echo … > file` through a command allowlist in #458. It lives in a second profile rather than the Bot's, because putting it in the Bot's would make the Bot read-only when you talk to it too.

Slice 1's override allow-list is widened by **exactly four dotted paths** — `tools.write_file.permission`, `tools.edit.permission`, `tools.bash.permission`, `tools.bash.allowlist` — not by "the `tools` table".

## The verification step (the most important thing here)

Vibe ignores a profile key it does not recognise: no error, no warning, nothing on the wire. Misspell `permission` and you get a profile that loads, appears in every mode picker, "works", and gates nothing.

So the gate is never inferred from a write returning. `ensureRoutineGate` writes the file and **reads it back**, and `confirmRoutineGate` checks it key by key and value by value: every gate entry present with exactly its value, no unknown key, `agent_type = "agent"`, a legal `safety`, and `system_prompt_id` naming *this* Bot's prompt. Anything short of that and **the routine refuses to run** — before an agent is warmed, with the reason written into the Bot's own conversation and onto the record.

It runs before every run rather than once at Bot creation, so it also heals a file deleted or hand-edited between runs.

There is a second confirmation at the session level: a gated turn selects the routine profile on the mode axis **unconditionally**, including on a reused session (where the ordinary persona plan says "already selected" — which for a routine would mean running ungated). `setMode` routes through the validating `session/set_config_option`, so a rejection means the session does not offer the profile, and the turn is **not sent at all**.

## The matcher's refusal rules

`matchAllowedCommand` compares the **whole** invocation, literally:

1. blank → refused;
2. exactly equal (after trimming both sides) to a listed entry → allowed;
3. otherwise refused — named `shell-operator` when it contains `> < | ; & $ ` ( )` or a newline, `not-listed` otherwise.

No prefix matching (`git status` must never authorise `git status --porcelain`), no globbing, no per-part tokenising — because per-part tokenising is precisely what leaked. Rule 3 is redundant to rule 2 by construction; it exists to name the refusal for slice 5 and as a tripwire if anyone ever loosens rule 2.

The one intended way past it: list the whole line, operators and all. You typed it; it is what is authorised, and nothing near it is.

## The answerer, and a probe finding that changed the implementation

`scripts/spike-routine-gate.ts` (new, tracked) drove vibe-acp **2.24.3** with an isolated `VIBE_HOME`; the capture is `docs/acp-capture.md` §17.

The ticket says the shell command's text is in the allow-always option's metadata. **On the wire it is not, and using it would have been a security bug.** For `echo hello > probe.txt` the request carries:

```json
"invocation_pattern": "echo hello <redirect>", "session_pattern": "echo *"
```

The redirect is **tokenised away**. A matcher fed that string authorises a command that writes a file the string never mentions — the #458 hole, re-opened one layer up. It looks correct in testing, because for a command with nothing to tokenise (`ls -la`) the pattern equals the command.

The real command is `rawInput.command`, on a `tool_call_update` **earlier** than the one immediately before the request (that one carries only a status). So the gate keeps a ledger merged by `toolCallId`, and the option metadata is used only for a `scope` check (`command_pattern`; anything else is refused).

It answers `allow_once` and never either allow-always option — a session grant and a **permanent config write** (#464) — because an unattended run must widen nothing for the person who was not there.

It denies on every uncertainty: an unknown tool-call id (which happens in normal operation — a subagent's tool calls raise requests on the root session with ids that never appear in any `tool_call`, §15F), a non-`shell` effect kind, an unrecognised scope, or an unreadable command.

## The first denial cancels the turn

Verified on the wire: `session/cancel` after the denial resolves the in-flight prompt with `stopReason: "cancelled"`, i.e. through the ordinary turn-complete path. Continuing instead is what produced #458's fourteen-attempt evasion loop.

That means a blocked run looks like a cancelled turn on the wire and **only our own gate knows better** — so the outcome is decided by the gate, not by the stop reason. It records `blocked`, writes an error naming the exact command through the existing turn-error tee, and stores the invocation as a structured `lastBlockedCommand` (migration 7, additive, nullable) for slice 5's "add this command" offer. No `REDUCER_SCHEMA_VERSION` bump — every addition is optional.

## Decisions the ticket did not settle

1. **The gate profile is restored to the Bot's persona when the turn ends.** Not in the ticket, but without it a Bot that just ran a routine stays gated on that live session — read-only and asking about every command — for the next person who talks to it, which is the exact outcome ADR-0028 chose a second profile to avoid. Best-effort, in a `finally`.
2. **Gate-unconfirmed is `failed`, not `blocked`.** `blocked` is documented as "an allowed commands denial cancelled the turn"; a gate that will not confirm never got that far.
3. **The gate profile is written per run, not at Bot creation**, so nothing in the Bots lifecycle changes and the confirmation is about the file that is there now. `removeBotProfile` does take it down with the Bot, or it would linger in every mode picker.
4. **Only `write_file` and `edit` are set to `never`** — the two names #458 verified and the two Vibe's own `plan` builtin uses. A write tool under another name would not be covered by the belt; it is still covered by the braces (we deny anything that is not an allowed shell command). Re-verify the names against each Vibe minor with the spike.
5. **`isMistroProfileId`** (bot **or** routine) is now what the renderer's mode-picker filter asks, or the gate profile would appear in every ordinary Thread's Mode picker.

## Known residuals

- **The renderer can still see the request.** A routine's permission request is broadcast to windows like any other, so with the Bot's conversation open a human could in principle click a button in the microseconds before main answers. Harmless in practice (main answers in-process, first) and out of scope here; suppressing routine-turn permission rows in the renderer belongs with slice 5's authoring UI.
- **Migration 7 declares `creates: []`** because it adds a column, and a column is not an object the #476 ledger can check for. Its `up` is written to be safely re-runnable (it asks `PRAGMA table_info` first).
- Nothing calls `runRoutineNow` yet — the scheduler is #470.

## Gates

```
bun run lint       ✓  eslint . && node scripts/check-theme-tokens.mjs
bun run typecheck  ✓  tsc (node + web) — 0 errors; astro check — 0 errors
bun run build      ✓  electron-vite + astro, complete
bun run test       ✓  193 files, 2220 tests passed
```

## Rebase note

Started at `1344ea1`; rebased onto `adc484e` (#476, migrations recorded by name) mid-slice. It changed nothing of substance — `state-migrations.ts` merged cleanly, and the new migration gained a `creates` declaration (empty, see above) plus the idempotence guard that goes with it.
