### PR TITLE
Routines slice 4 — the scheduler: fire, defer, catch up once, and make a run that never happened visible (#470)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -69,6 +69,16 @@ _Avoid_: allowlist (unqualified — Vibe's own profile config has one too, and t
 doing different jobs: that one makes Vibe ASK us, this one is our ANSWER), permissions, whitelist,
 safe commands (nothing here is judged safe — it is listed or it is not).
 
+**Deferred run** (a Routine outcome):
+A **Routine** whose slot came due while its Bot was mid-turn. A Bot is one continuing conversation, so
+the run waits and is re-checked on the next tick, bounded by that Routine's OWN next slot; past it the
+run is given up and recorded as `deferred` against the slot it abandoned. A deferred run writes NOTHING
+into the conversation — a defer is not a failure, and reporting it there would make a Bot chattier the
+more you use it — but it is never invisible either, because it lands on the Routine's record (ADR-0028).
+_Avoid_: retry (nothing is retried — the next slot is the next attempt), queued, skipped (a skip is
+what a PAUSED Routine gets, and that is recorded nowhere), missed (that is the detector's word for a
+run nothing even tried to start).
+
 **ACP session**:
 The protocol-level handle returned by `session/new` and addressed by `session/*` methods. Lives only
 at the main-process / protocol layer; never surfaced in the UI. One `vibe-acp` process hosts many.

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -77,7 +77,12 @@ import type { MetadataStoreApi } from './persistence/metadata-store-api'
 import { createMetadataStore } from './persistence/create-metadata-store'
 import { maybeBackupStateDb } from './persistence/state-backup'
 import type { StateDb } from './persistence/sqlite-db'
-import { resolvePermissionEntry, turnErrorEntry, userPromptEntry } from './persistence/transcript'
+import {
+  resolvePermissionEntry,
+  routineLateEntry,
+  turnErrorEntry,
+  userPromptEntry,
+} from './persistence/transcript'
 import type { TranscriptStoreApi } from './persistence/transcript-store-api'
 import { createTranscriptStore } from './persistence/create-transcript-store'
 import { TranscriptBridge } from './persistence/transcript-bridge'
@@ -105,6 +110,7 @@ import type { ModeDiscovery } from './acp/agent-controls'
 import { SqliteBotStore } from './persistence/sqlite-bot-store'
 import type { BotStoreApi } from './persistence/bot-store-api'
 import { registerRoutinesIpc } from './routines/register-ipc'
+import { createRoutineScheduler, type RoutineScheduler } from './routines/scheduler'
 import { ensureRoutineGate } from './routines/write-routine-profile'
 import { nodeRoutineProfileFs } from './routines/node-routine-profile-fs'
 import { vibeProfileDirs } from './bots/profile-dirs'
@@ -413,6 +419,20 @@ const gitStatus = new GitStatusManager({
 
 /** The periodic idle-evict sweep timer (cleared on quit). */
 let sweepTimer: ReturnType<typeof setInterval> | null = null
+
+/**
+ * The Routine scheduler (#470, ADR-0028), built with the IPC seams and held here
+ * so launch can start it and quit can stop it — module-level for the same reason
+ * the sweep timer is: no timer may outlive the app.
+ */
+let routineScheduler: RoutineScheduler | null = null
+
+/**
+ * How long after launch the missed-run catch-up runs. Off the launch path, like
+ * the daily state backup: a catch-up warms an agent for a Workspace nobody
+ * selected, and that must not compete with the first window's paint.
+ */
+const ROUTINE_CATCH_UP_DELAY_MS = 8 * 1000
 
 /**
  * The Workspace terminal sessions (ADR-0014), created at app-ready (its env comes
@@ -804,11 +824,11 @@ function registerIpc(deps: MainDeps): void {
   // Bot store: a Routine can only ever be attached to a Bot.
   //
   // The returned `runRoutineNow` is the ONE entry point a Routine's turn goes
-  // through, and NOTHING calls it in this slice — deciding when a Routine is due is
-  // the scheduler's job (#470), which will hold this handle. Everything the run
+  // through, and the scheduler built just below is its only caller (#470) —
+  // deciding WHEN is the scheduler's job and nothing else's. Everything the run
   // needs that only main has (the pool, the busy claim, eviction protection, the
   // turn) is passed in here rather than reached for, so the run stays testable.
-  registerRoutinesIpc({
+  const routinesRegistration = registerRoutinesIpc({
     routines: deps.routines,
     bots: deps.bots,
     turn: {
@@ -846,16 +866,39 @@ function registerIpc(deps: MainDeps): void {
       // A routine failure lands in the Bot's OWN conversation (ADR-0028 part 5 —
       // always an entry, success or failure) through the same turn-error tee every
       // other failed turn uses, and moves `lastActiveAt` so the unread dot appears.
-      reportFailure: ({ threadId, message, prompt }) => {
-        if (prompt !== undefined) deps.bridge.tee(threadId, userPromptEntry(randomUUID(), prompt))
+      reportFailure: ({ threadId, message, prompt, routine }) => {
+        if (prompt !== undefined) {
+          deps.bridge.tee(threadId, userPromptEntry(randomUUID(), prompt, undefined, routine))
+        }
         deps.bridge.tee(threadId, turnErrorEntry(message))
         void deps.store.touchThread(threadId).catch((err) => {
           console.error(`[vibe-mistro:routines] touchThread failed (${threadId}): ${String(err)}`)
         })
       },
-      runTurn: (agent, args, gate) => runPromptTurn(deps, { kind: 'headless', gate }, agent, args),
+      // "Late" is stated TWICE (#470, ADR-0028 part 3). This is our half: a notice
+      // in the Bot's own conversation, carrying only the two timestamps — the copy
+      // is a renderer-side constant, exactly like the context-reset notice. The
+      // other half is inside the prompt, because only the agent can act on the
+      // period the report has to cover.
+      reportLate: ({ threadId, dueAt, lastRunAt }) => {
+        deps.bridge.tee(threadId, routineLateEntry(dueAt, lastRunAt))
+      },
+      // The Routine's name rides the DELIVERY, not the args: a prompt is a routine
+      // prompt because the scheduler sent it, so the renderer can never claim it.
+      runTurn: (agent, args, gate) =>
+        runPromptTurn(deps, { kind: 'headless', gate, routine: args.routine }, agent, args),
       now: () => Date.now(),
     },
+  })
+  // The scheduler (#470): the periodic tick that decides what is due, what waits
+  // for a busy Bot and what is owed after the app was shut. It holds the ONE entry
+  // point above and the per-THREAD streaming flag; every decision it makes is a
+  // pure function tested beside it. Started (and caught up) at launch below.
+  routineScheduler = createRoutineScheduler({
+    routines: deps.routines,
+    isStreaming: (threadId) => threadStatus.statusFor(threadId).streaming,
+    runRoutine: (routineId, options) => routinesRegistration.runRoutineNow(routineId, options),
+    now: () => Date.now(),
   })
   // The same profile-file seam the Bot CRUD uses, reused by the Thread- and
   // Workspace-removal cleanup below so both paths refuse a foreign profile id
@@ -1546,6 +1589,25 @@ app.whenReady().then(async () => {
   }, SWEEP_INTERVAL_MS)
   sweepTimer.unref?.()
 
+  // Routines (#470, ADR-0028). Two starts, on purpose:
+  //
+  //  - the TICK, which fires what comes due while the app runs;
+  //  - the LAUNCH CATCH-UP, which recomputes what was owed while it was not, from
+  //    each Routine's stored schedule, and shares no code with the thing that
+  //    failed to fire it. A missed run happens ONCE and says so — nobody wants
+  //    Tuesday's triage on Thursday, and nobody can act on silence.
+  //
+  // Deliberately not on the launch path itself: a catch-up warms an agent for a
+  // Workspace nobody selected. Timers `unref`'d like the sweep's, and the tick is
+  // stopped on quit.
+  routineScheduler?.start()
+  setTimeout(() => {
+    const started = routineScheduler?.catchUp() ?? []
+    if (started.length > 0) {
+      console.log(`[vibe-mistro:routines] catching up ${started.length} missed run(s)`)
+    }
+  }, ROUTINE_CATCH_UP_DELAY_MS).unref?.()
+
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow()
   })
@@ -1602,6 +1664,8 @@ app.on('will-quit', () => {
     clearInterval(sweepTimer)
     sweepTimer = null
   }
+  // And the Routine tick, for the same reason (#470).
+  routineScheduler?.stop()
   // Tear down every git-status subscription (#84) so no fs watcher or fetch timer
   // outlives the app — mirrors the sweep-timer cleanup above.
   gitStatus.disposeAll()

--- a/apps/desktop/src/main/persistence/transcript.test.ts
+++ b/apps/desktop/src/main/persistence/transcript.test.ts
@@ -4,6 +4,7 @@ import {
   agentReboundEntry,
   parseTranscript,
   resolvePermissionEntry,
+  routineLateEntry,
   sessionIdFromPayload,
   titleFromSessionInfoUpdate,
   TRANSCRIPT_SCHEMA_VERSION,
@@ -71,6 +72,22 @@ describe('entry constructors mirror the reducer inputs', () => {
     expect(turnCompleteEntry()).toEqual({ t: 'turn-complete' })
     expect(turnErrorEntry('boom')).toEqual({ t: 'turn-error', message: 'boom' })
     expect(agentReboundEntry()).toEqual({ t: 'agent-rebound' })
+    // A Routine's late run (#470): only the two timestamps, because the copy is a
+    // renderer-side constant — and `lastRunAt: null` means it has NEVER run, which
+    // must never read like a run that found nothing.
+    expect(routineLateEntry(1_000, 500)).toEqual({ t: 'routine-late', dueAt: 1_000, lastRunAt: 500 })
+    expect(routineLateEntry(1_000, null)).toEqual({
+      t: 'routine-late',
+      dueAt: 1_000,
+      lastRunAt: null,
+    })
+    // The Routine marker is additive: omitted for a prompt somebody typed.
+    expect(userPromptEntry('id-1', 'text', undefined, { name: 'Morning triage' })).toEqual({
+      t: 'user-prompt',
+      id: 'id-1',
+      text: 'text',
+      routine: { name: 'Morning triage' },
+    })
     expect(resolvePermissionEntry(7, 'allow')).toEqual({
       t: 'resolve-permission',
       requestId: 7,

--- a/apps/desktop/src/main/persistence/transcript.ts
+++ b/apps/desktop/src/main/persistence/transcript.ts
@@ -1,4 +1,4 @@
-import type { TranscriptEntry, TranscriptImageRef } from '../../shared/ipc'
+import type { TranscriptEntry, TranscriptImageRef, TranscriptRoutineRef } from '../../shared/ipc'
 
 /**
  * The transcript ENTRY VOCABULARY + legacy-JSONL parsing (ADR-0005/0019). The
@@ -58,8 +58,25 @@ export function userPromptEntry(
   id: string,
   text: string,
   images?: TranscriptImageRef[],
+  routine?: TranscriptRoutineRef,
 ): TranscriptEntry {
-  return images && images.length > 0 ? { t: 'user-prompt', id, text, images } : { t: 'user-prompt', id, text }
+  const entry: Extract<TranscriptEntry, { t: 'user-prompt' }> = { t: 'user-prompt', id, text }
+  // Both fields are omitted entirely when absent, so an ordinary prompt's entry
+  // stays byte-identical to the legacy shape.
+  if (images && images.length > 0) entry.images = images
+  if (routine) entry.routine = routine
+  return entry
+}
+
+/**
+ * A **Routine** run that started later than its slot (#470, ADR-0028 part 3),
+ * teed just before the prompt it explains — mirrors the `routine-late` reducer
+ * action. Like `agent-rebound`, the user-facing copy is a renderer-side constant,
+ * so the entry carries only the two timestamps: the slot it was due at, and when
+ * it last ran (null = never, which is the distinction the whole slice is for).
+ */
+export function routineLateEntry(dueAt: number, lastRunAt: number | null): TranscriptEntry {
+  return { t: 'routine-late', dueAt, lastRunAt }
 }
 
 /** A streamed payload, teed at the `acp:event` forward — mirrors `acp-event`. */
@@ -181,6 +198,7 @@ export function isTranscriptEntry(value: unknown): value is TranscriptEntry {
     t === 'turn-complete' ||
     t === 'turn-error' ||
     t === 'resolve-permission' ||
-    t === 'agent-rebound'
+    t === 'agent-rebound' ||
+    t === 'routine-late'
   )
 }

--- a/apps/desktop/src/main/prompt-turn.ts
+++ b/apps/desktop/src/main/prompt-turn.ts
@@ -10,6 +10,7 @@ import {
   type ThreadConfigAxis,
   type ThreadInfo,
   type TranscriptImageRef,
+  type TranscriptRoutineRef,
 } from '../shared/ipc'
 import { controlsWithCurrentValue } from '../shared/thread-control-intent'
 import type { AttachmentStore } from './persistence/attachment-store'
@@ -95,7 +96,17 @@ export interface PromptTurnGate {
  */
 export type PromptTurnDelivery =
   | { kind: 'renderer'; sender: ThreadBoundSender }
-  | { kind: 'headless'; gate?: PromptTurnGate }
+  | {
+      kind: 'headless'
+      gate?: PromptTurnGate
+      /**
+       * The Routine that raised this turn (#470), stamped onto the teed prompt so
+       * the bubble wears a chip naming it. It rides the DELIVERY rather than
+       * `SendPromptArgs` because no renderer can ever set it: a prompt is a routine
+       * prompt because the scheduler sent it, not because someone said so.
+       */
+      routine?: TranscriptRoutineRef
+    }
 
 /** The agent surface one turn drives — structural, so tests never spawn `vibe-acp`. */
 export interface PromptTurnAgent extends SessionBinder, PendingThreadControlAgent {
@@ -285,7 +296,7 @@ export async function runPromptTurn(
     // The pre-bind hole (#456, ADR-0028 part 5): with a renderer this returns and
     // the composer renders it; headless, the return value has no reader, so the
     // Bot's own conversation is where it has to land.
-    if (delivery.kind === 'headless') reportPreBindFailure(deps, args, message)
+    if (delivery.kind === 'headless') reportPreBindFailure(deps, args, message, delivery.routine)
     if (err instanceof WorkspaceAgentError && err.authState === 'not-signed-in') {
       return { ok: false, kind: 'not-signed-in', agentId: args.agentId, authMethods: agent.authMethods }
     }
@@ -316,7 +327,10 @@ export async function runPromptTurn(
     imageRefs = await deps.attachments.saveAll(args.threadId, args.images)
     if (imageRefs.length === 0) imageRefs = undefined
   }
-  deps.bridge.tee(args.threadId, userPromptEntry(randomUUID(), args.text, imageRefs))
+  deps.bridge.tee(
+    args.threadId,
+    userPromptEntry(randomUUID(), args.text, imageRefs, routineRefOf(delivery)),
+  )
   // On a re-bind (TB4 #33), persist the "context reset" notice right AFTER the
   // user's prompt and BEFORE the turn's events — so a later reopen replays it
   // in the same position the live view rendered it (`thread:bound` -> notice).
@@ -362,10 +376,20 @@ export async function runPromptTurn(
  * bridge, and the touch cannot reject. The turn already failed; reporting it must
  * not fail louder.
  */
-function reportPreBindFailure(deps: PromptTurnDeps, args: SendPromptArgs, message: string): void {
-  deps.bridge.tee(args.threadId, userPromptEntry(randomUUID(), args.text))
+function reportPreBindFailure(
+  deps: PromptTurnDeps,
+  args: SendPromptArgs,
+  message: string,
+  routine?: TranscriptRoutineRef,
+): void {
+  deps.bridge.tee(args.threadId, userPromptEntry(randomUUID(), args.text, undefined, routine))
   deps.bridge.tee(args.threadId, turnErrorEntry(message))
   touchThread(deps, args.threadId)
+}
+
+/** The Routine marker to stamp on the teed prompt — never set for a renderer turn. */
+function routineRefOf(delivery: PromptTurnDelivery): TranscriptRoutineRef | undefined {
+  return delivery.kind === 'headless' ? delivery.routine : undefined
 }
 
 /** Bump `lastActiveAt`, fire-and-forget: a persist failure logs and gates nothing. */

--- a/apps/desktop/src/main/routines/late-run.test.ts
+++ b/apps/desktop/src/main/routines/late-run.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { lateCoverageNote, promptWithCoverage } from './late-run'
+
+/**
+ * The half of "late" the AGENT is told (#470, ADR-0028 part 3): the coverage
+ * period, inside the prompt, because "issues opened since 20 Aug" is a different
+ * query from "issues opened since yesterday" and only the agent can act on it.
+ */
+
+const SLOT_21 = Date.UTC(2026, 7, 21, 7, 0) // 09:00 Europe/Berlin
+const SLOT_20 = Date.UTC(2026, 7, 20, 7, 0)
+const NOW = Date.UTC(2026, 7, 21, 10, 30) // 12:30 Europe/Berlin
+
+describe('lateCoverageNote', () => {
+  it('states the slot, the actual start and the period since the last run', () => {
+    const note = lateCoverageNote({ dueAt: SLOT_21, lastRunAt: SLOT_20 }, 'Europe/Berlin', NOW)
+    expect(note).toContain('due at 2026-08-21 09:00 (Europe/Berlin)')
+    expect(note).toContain('starting now, at 2026-08-21 12:30 (Europe/Berlin)')
+    expect(note).toContain('since its last run at 2026-08-20 09:00 (Europe/Berlin)')
+  })
+
+  it('says outright when the Routine has NEVER run, rather than implying a window', () => {
+    const note = lateCoverageNote({ dueAt: SLOT_21, lastRunAt: null }, 'Europe/Berlin', NOW)
+    expect(note).toContain('never run before')
+    expect(note).not.toContain('last run at')
+  })
+
+  it('reads the wall clock in the Routine\'s OWN zone, not the machine\'s', () => {
+    const note = lateCoverageNote({ dueAt: SLOT_21, lastRunAt: null }, 'Asia/Tokyo', NOW)
+    expect(note).toContain('due at 2026-08-21 16:00 (Asia/Tokyo)')
+  })
+
+  it('degrades to UTC for a zone this ICU does not know, rather than throwing', () => {
+    const note = lateCoverageNote({ dueAt: SLOT_21, lastRunAt: null }, 'Mars/Olympus', NOW)
+    expect(note).toContain('(UTC)')
+  })
+})
+
+describe('promptWithCoverage', () => {
+  it('leaves an on-time prompt exactly as the user wrote it', () => {
+    expect(promptWithCoverage('Triage the repo.', null, 'Europe/Berlin', NOW)).toBe('Triage the repo.')
+  })
+
+  it('appends the note, so the Routine\'s own instruction still leads', () => {
+    const text = promptWithCoverage(
+      'Triage the repo.',
+      { dueAt: SLOT_21, lastRunAt: SLOT_20 },
+      'Europe/Berlin',
+      NOW,
+    )
+    expect(text.startsWith('Triage the repo.\n\n[Scheduled run — late]')).toBe(true)
+  })
+})

--- a/apps/desktop/src/main/routines/late-run.ts
+++ b/apps/desktop/src/main/routines/late-run.ts
@@ -1,0 +1,91 @@
+/**
+ * **"Late" as the agent has to hear it** (#470, ADR-0028 part 3 / #459 decision 9)
+ * — the coverage period, written into the prompt the Routine sends.
+ *
+ * Late is stated TWICE, deliberately, and this is the second half. We write the
+ * fact ourselves as a system notice (a renderer-side constant over the two
+ * timestamps, following the `agent-rebound` precedent), because a marker that
+ * depends on the model complying is not a marker. But only the agent can ACT on
+ * it: "issues opened since 20 Aug" is a different query from "issues opened since
+ * yesterday", and a report that silently covers the wrong window is worse than a
+ * missing one.
+ *
+ * Pure, and formatted in the Routine's OWN timezone — the same stored zone the
+ * schedule is computed in, so the instants the agent reads are the wall-clock
+ * times the user chose rather than wherever the laptop currently is.
+ */
+
+/** A run that is starting later than its slot. */
+export interface LateRun {
+  /** The slot this run is FOR. */
+  dueAt: number
+  /** When it last ran, or null when it has NEVER run — a different sentence. */
+  lastRunAt: number | null
+}
+
+/**
+ * The Routine's prompt with the coverage period appended, or the prompt verbatim
+ * when the run is on time.
+ *
+ * Appended rather than prepended so the Routine's own instruction still leads —
+ * it is the request; this is a qualifier on it.
+ */
+export function promptWithCoverage(prompt: string, late: LateRun | null, timezone: string, now: number): string {
+  if (!late) return prompt
+  return `${prompt}\n\n${lateCoverageNote(late, timezone, now)}`
+}
+
+/**
+ * The coverage sentence itself.
+ *
+ * Two shapes, because the difference is the whole point of this slice: a Routine
+ * that has run before states the period since that run; one that never has says
+ * so outright, so the agent does not invent a window.
+ */
+export function lateCoverageNote(late: LateRun, timezone: string, now: number): string {
+  const scheduled = formatInZone(late.dueAt, timezone)
+  const starting = formatInZone(now, timezone)
+  const period =
+    late.lastRunAt === null
+      ? 'This routine has never run before, so cover everything relevant rather than assuming a recent window.'
+      : `Cover the period since its last run at ${formatInZone(late.lastRunAt, timezone)} — not just since yesterday.`
+  return (
+    `[Scheduled run — late] This run was due at ${scheduled} and is starting now, at ${starting}. ` +
+    `Routines only run while the app is open, so the delay is ours, not yours. ${period}`
+  )
+}
+
+/**
+ * `YYYY-MM-DD HH:MM (Zone)` in the given IANA zone.
+ *
+ * Built from `formatToParts` rather than a locale style so the string is the same
+ * everywhere the app runs — the agent is reading it, and a machine-set locale must
+ * not change what period a report covers. An unknown zone degrades to UTC rather
+ * than throwing into a turn that is already running late.
+ */
+function formatInZone(instant: number, timezone: string): string {
+  const zone = safeZone(timezone)
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: zone,
+    hourCycle: 'h23',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).formatToParts(new Date(instant))
+  const field = (type: Intl.DateTimeFormatPartTypes): string =>
+    parts.find((part) => part.type === type)?.value ?? '00'
+  const hours = field('hour') === '24' ? '00' : field('hour')
+  return `${field('year')}-${field('month')}-${field('day')} ${hours}:${field('minute')} (${zone})`
+}
+
+/** The zone if `Intl` knows it, else UTC. */
+function safeZone(timezone: string): string {
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: timezone })
+    return timezone
+  } catch {
+    return 'UTC'
+  }
+}

--- a/apps/desktop/src/main/routines/missed-runs.test.ts
+++ b/apps/desktop/src/main/routines/missed-runs.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest'
+import type { RoutineRecord } from '../../shared/ipc'
+import { LATE_AFTER_MS, detectMissedRuns, expectedRun, routineBaseline } from './missed-runs'
+
+/**
+ * The missed-run detector (#470, ADR-0028 part 6) — the comparison that answers
+ * *should this have run by now, and did it?* from the stored schedule alone.
+ *
+ * The last test in this file is the one the whole slice exists for: a Routine that
+ * NEVER ran must not look like one that ran and found nothing.
+ *
+ * Instants are written as UTC so they can be read at a glance; Berlin is UTC+2 in
+ * August, so 07:00 UTC is the 09:00 slot the Routine was given.
+ */
+
+/** The 09:00 Europe/Berlin slot on 21 August 2026. */
+const SLOT_21 = Date.UTC(2026, 7, 21, 7, 0)
+/** The same slot the day before. */
+const SLOT_20 = Date.UTC(2026, 7, 20, 7, 0)
+/** Well after the 21st's slot — the app was shut when it came due. */
+const NOON_21 = Date.UTC(2026, 7, 21, 10, 0)
+
+function routine(over: Partial<RoutineRecord> = {}): RoutineRecord {
+  return {
+    id: 'r1',
+    threadId: 'bot-1',
+    name: 'Morning triage',
+    prompt: 'Triage this repo and say what changed.',
+    schedule: { kind: 'daily', at: '09:00', timezone: 'Europe/Berlin' },
+    allowedCommands: [],
+    active: true,
+    lastRunAt: null,
+    lastOutcome: null,
+    lastError: null,
+    lastBlockedCommand: null,
+    createdAt: Date.UTC(2026, 7, 19, 12, 0),
+    updatedAt: Date.UTC(2026, 7, 19, 12, 0),
+    ...over,
+  }
+}
+
+describe('routineBaseline', () => {
+  it('is the last run when there was one', () => {
+    expect(routineBaseline(routine({ lastRunAt: SLOT_20 }))).toBe(SLOT_20)
+  })
+
+  it('falls back to creation, so a new Routine never fires before its first slot', () => {
+    // Created at 10:00 on the 21st, an hour AFTER that day's 09:00 slot. Without
+    // the floor the Routine would be "owed" a run the moment it was saved.
+    const created = Date.UTC(2026, 7, 21, 8, 0)
+    expect(routineBaseline(routine({ createdAt: created }))).toBe(created)
+    expect(expectedRun(routine({ createdAt: created }), NOON_21)).toBeNull()
+  })
+
+  it('takes the caller floor when it is later — a Routine resumed this session', () => {
+    expect(routineBaseline(routine({ lastRunAt: SLOT_20 }), NOON_21)).toBe(NOON_21)
+  })
+})
+
+describe('expectedRun', () => {
+  it('answers the slot a Routine that ran yesterday is owed today', () => {
+    expect(expectedRun(routine({ lastRunAt: SLOT_20 }), NOON_21)).toEqual({
+      dueAt: SLOT_21,
+      late: true,
+    })
+  })
+
+  it('is null once that slot has been run', () => {
+    expect(expectedRun(routine({ lastRunAt: SLOT_21 }), NOON_21)).toBeNull()
+  })
+
+  it('is not late while the run starts within the grace window', () => {
+    const justAfter = SLOT_21 + LATE_AFTER_MS - 1
+    expect(expectedRun(routine({ lastRunAt: SLOT_20 }), justAfter)?.late).toBe(false)
+    expect(expectedRun(routine({ lastRunAt: SLOT_20 }), SLOT_21 + LATE_AFTER_MS + 1)?.late).toBe(true)
+  })
+
+  it('skips a PAUSED Routine — pausing decides what the scheduler considers due', () => {
+    expect(expectedRun(routine({ lastRunAt: SLOT_20, active: false }), NOON_21)).toBeNull()
+  })
+
+  it('skips a Routine whose schedule cannot be computed, leaving it inert not thrown', () => {
+    const broken = routine({
+      lastRunAt: SLOT_20,
+      schedule: { kind: 'daily', at: '09:00', timezone: 'Mars/Olympus' },
+    })
+    expect(expectedRun(broken, NOON_21)).toBeNull()
+  })
+
+  it('honours a resume floor, so a paused fortnight accrues no catch-up', () => {
+    const resumed = routine({ lastRunAt: Date.UTC(2026, 7, 7, 7, 0) })
+    expect(expectedRun(resumed, NOON_21)).not.toBeNull()
+    expect(expectedRun(resumed, NOON_21, Date.UTC(2026, 7, 21, 9, 0))).toBeNull()
+  })
+})
+
+describe('detectMissedRuns — the launch catch-up', () => {
+  it('owes ONE run however many slots went by: nobody wants Tuesday triage on Thursday', () => {
+    // Last ran a fortnight ago. Fourteen slots have passed; exactly one run is owed.
+    const stale = routine({ lastRunAt: Date.UTC(2026, 7, 7, 7, 0) })
+    const missed = detectMissedRuns([stale], NOON_21)
+    expect(missed).toHaveLength(1)
+    expect(missed[0]).toEqual({
+      routineId: 'r1',
+      threadId: 'bot-1',
+      lastRunAt: Date.UTC(2026, 7, 7, 7, 0),
+      dueAt: SLOT_21,
+      late: true,
+    })
+  })
+
+  it('orders by slot, so a Bot owed two runs starts with the older one', () => {
+    const early = routine({
+      id: 'early',
+      threadId: 'bot-2',
+      schedule: { kind: 'daily', at: '07:00', timezone: 'Europe/Berlin' },
+      lastRunAt: SLOT_20,
+    })
+    const later = routine({ id: 'later', lastRunAt: SLOT_20 })
+    expect(detectMissedRuns([later, early], NOON_21).map((run) => run.routineId)).toEqual([
+      'early',
+      'later',
+    ])
+  })
+
+  it('distinguishes a Routine that NEVER ran from one that ran and found nothing', () => {
+    // The story this slice exists for. Both Bots show an empty report; only one of
+    // them actually reported. `never` has no `lastRunAt` at all, so the detector
+    // owes it a run and the notice it carries says so in its own sentence — while
+    // `ran` is owed nothing, because it ran, and "nothing to say" is what it said.
+    const never = routine({ id: 'never', threadId: 'bot-never', lastRunAt: null })
+    const ran = routine({
+      id: 'ran',
+      threadId: 'bot-ran',
+      lastRunAt: SLOT_21,
+      lastOutcome: 'ok',
+      lastError: null,
+    })
+
+    const missed = detectMissedRuns([never, ran], NOON_21)
+
+    expect(missed.map((run) => run.routineId)).toEqual(['never'])
+    expect(missed[0]?.lastRunAt).toBeNull()
+  })
+
+  it('needs nothing but the rows and a clock — no flag the firer was meant to set', () => {
+    // The point of ADR-0028 part 6, as a test: a Routine whose fire path threw
+    // before it reached the store looks EXACTLY like one nothing ever tried to run,
+    // and both are detected. Neither wrote an outcome; neither had to.
+    const threwBeforeRecording = routine({ id: 'threw', lastRunAt: SLOT_20, lastOutcome: null })
+    const nothingEverRan = routine({ id: 'never-tried', threadId: 'bot-2', lastRunAt: SLOT_20 })
+    expect(detectMissedRuns([threwBeforeRecording, nothingEverRan], NOON_21)).toHaveLength(2)
+  })
+})

--- a/apps/desktop/src/main/routines/missed-runs.ts
+++ b/apps/desktop/src/main/routines/missed-runs.ts
@@ -1,0 +1,131 @@
+import type { RoutineRecord } from '../../shared/ipc'
+import { expectedLastDue } from '../../shared/schedule'
+
+/**
+ * **The missed-run detector** (#470, ADR-0028 part 6) — the arithmetic that
+ * answers *should this Routine have run by now, and did it?* from the stored
+ * schedule alone.
+ *
+ * This module SHARES NO CODE WITH THE FIRING PATH, and that is its whole point.
+ * It reads no flag the firer was supposed to set, because the case worth catching
+ * is exactly the one where **no code ran at all**: the app was never open, a bug
+ * ate the timer, the fire path threw before it reached the store. A flag nobody
+ * set is indistinguishable from a flag nobody needed to set — the mistake this
+ * codebase has now made three times (#427, #433, the persona-loss case), where the
+ * component that broke was also the one responsible for reporting that it broke.
+ *
+ * What it DOES share with the firer is `shared/schedule`'s pure arithmetic, and it
+ * must: the two have to agree about which instants are fire instants, which slice
+ * 1 proved with a round-trip property test. Sharing arithmetic is required.
+ * Sharing responsibility for self-report is the anti-pattern.
+ *
+ * The comparison, in one line: `expectedLastDue(schedule, now) > baseline` means a
+ * run is owed. Everything below is what "baseline" means and how "late" is decided.
+ */
+
+/**
+ * How far past its slot a run may start before it counts as **late**.
+ *
+ * A run that starts a few seconds after its slot is simply the tick doing its
+ * job; one that starts hours later happened because the app was shut, or because
+ * the Bot was busy through the whole window. Only the second is worth telling
+ * anyone about, in the conversation or in the prompt — so the threshold is
+ * comfortably wider than the tick interval and far narrower than any schedule.
+ */
+export const LATE_AFTER_MS = 5 * 60 * 1000
+
+/** A run this Routine is owed: the slot it is for, and whether it is late. */
+export interface ExpectedRun {
+  /** The scheduled instant this run belongs to — never `now`. */
+  dueAt: number
+  /** True when `now` is more than {@link LATE_AFTER_MS} past `dueAt`. */
+  late: boolean
+}
+
+/** A Routine that is owed a run at launch, with the two timestamps the notice states. */
+export interface MissedRun extends ExpectedRun {
+  routineId: string
+  /** The Bot's Thread — a Bot IS one continuing Thread, so this is the whole address. */
+  threadId: string
+  /**
+   * When this Routine last ran, or **null when it has never run at all**.
+   *
+   * Carried, rather than derived later, because it is the difference the whole
+   * slice exists for: a Routine that never ran must never look like one that ran
+   * and found nothing. Null reaches the conversation notice as its own sentence.
+   */
+  lastRunAt: number | null
+}
+
+/**
+ * The instant a Routine is measured FROM — the far side of the comparison.
+ *
+ * `lastRunAt` when it has ever run, and `createdAt` when it has not. The
+ * `createdAt` floor is not a convenience: without it, a Routine created at 10:00
+ * with a 09:00 daily schedule would be "owed" 09:00 the moment it was saved, and
+ * would fire immediately instead of tomorrow — a Routine whose first run happens
+ * before its first slot.
+ *
+ * `floor` is the caller's in-memory baseline, used for exactly one thing: a
+ * Routine RESUMED in this session (ADR-0028 part 7 — resuming sets a fresh
+ * baseline, so a fortnight of pause does not accrue catch-up). It is deliberately
+ * not persisted and deliberately not `updatedAt`: reading a column that any write
+ * touches would let an unrelated edit SUPPRESS a missed-run report, which is the
+ * failure direction this module exists to make impossible. Erring the other way
+ * costs one extra late run.
+ */
+export function routineBaseline(routine: RoutineRecord, floor?: number): number {
+  const own = routine.lastRunAt ?? routine.createdAt
+  return floor === undefined ? own : Math.max(own, floor)
+}
+
+/**
+ * The run this Routine is owed at `now`, or null when it is owed none.
+ *
+ * Null for a **paused** Routine (pausing decides what the scheduler considers
+ * due — `runRoutineTurn` deliberately does not ask, so the skip belongs here),
+ * for a schedule the arithmetic cannot compute with (a zone this ICU no longer
+ * knows, a malformed time — the Routine stays listable, editable and inert), and
+ * for one whose last due instant is already covered by its baseline.
+ *
+ * Used by BOTH the launch catch-up and every tick, on purpose: the question is the
+ * same question, so asking it in one place is what keeps the two answers equal.
+ * Neither caller stores the answer.
+ */
+export function expectedRun(
+  routine: RoutineRecord,
+  now: number,
+  floor?: number,
+): ExpectedRun | null {
+  if (!routine.active) return null
+  const dueAt = expectedLastDue(routine.schedule, now)
+  if (dueAt === null) return null
+  if (dueAt <= routineBaseline(routine, floor)) return null
+  return { dueAt, late: now - dueAt > LATE_AFTER_MS }
+}
+
+/**
+ * Every Routine owed a run at `now` — **the launch catch-up** (ADR-0028 part 3).
+ *
+ * Each answer is ONE run, whatever the reason and however many slots went by:
+ * nobody wants Tuesday's triage on Thursday. Ordered by slot so a Bot owed two
+ * runs starts with the older one.
+ *
+ * Independent of the tick by construction — it needs nothing but the rows and a
+ * clock, so it answers at launch, before the first tick, and would still answer if
+ * the tick never ran at all.
+ */
+export function detectMissedRuns(routines: readonly RoutineRecord[], now: number): MissedRun[] {
+  const missed: MissedRun[] = []
+  for (const routine of routines) {
+    const run = expectedRun(routine, now)
+    if (!run) continue
+    missed.push({
+      routineId: routine.id,
+      threadId: routine.threadId,
+      lastRunAt: routine.lastRunAt,
+      ...run,
+    })
+  }
+  return missed.sort((a, b) => a.dueAt - b.dueAt)
+}

--- a/apps/desktop/src/main/routines/register-ipc.ts
+++ b/apps/desktop/src/main/routines/register-ipc.ts
@@ -23,6 +23,7 @@ import {
   runRoutineTurn,
   type RoutineTurnDeps,
   type RoutineTurnResult,
+  type RunRoutineOptions,
 } from './run-routine-turn'
 
 /**
@@ -55,10 +56,11 @@ export interface RoutinesRegistration {
    * Run this Routine's prompt into its Bot's conversation NOW, with nobody
    * watching, and record how it went. Resolves with the outcome; never rejects.
    *
-   * The scheduler (#470) is the intended caller — deciding WHEN a Routine is due
-   * is deliberately not this slice's business, so nothing calls this yet.
+   * The scheduler (#470) is the caller: it decides WHEN, this decides nothing
+   * about time. `options.late` carries a slot the run is starting after, which the
+   * turn states twice — as a notice we write, and inside the agent's own prompt.
    */
-  runRoutineNow(routineId: string): Promise<RoutineTurnResult>
+  runRoutineNow(routineId: string, options?: RunRoutineOptions): Promise<RoutineTurnResult>
 }
 
 export function registerRoutinesIpc(deps: RoutinesIpcDeps): RoutinesRegistration {
@@ -91,5 +93,5 @@ export function registerRoutinesIpc(deps: RoutinesIpcDeps): RoutinesRegistration
     (_event, args: RoutinesDeleteArgs): RoutinesDeleteResult => deleteRoutine(lifecycle, args),
   )
 
-  return { runRoutineNow: (routineId) => runRoutineTurn(turn, routineId) }
+  return { runRoutineNow: (routineId, options) => runRoutineTurn(turn, routineId, options) }
 }

--- a/apps/desktop/src/main/routines/run-routine-turn.test.ts
+++ b/apps/desktop/src/main/routines/run-routine-turn.test.ts
@@ -89,7 +89,9 @@ interface Harness {
   protectionHistory: string[]
   status: ThreadStatusTracker
   /** Every failure written into the Bot's conversation (#469). */
-  failures: { threadId: string; message: string; prompt?: string }[]
+  failures: { threadId: string; message: string; prompt?: string; routine?: { name: string } }[]
+  /** Every "this run is late" notice written into the conversation (#470). */
+  lates: { threadId: string; dueAt: number; lastRunAt: number | null }[]
   agent: ReturnType<typeof stubAgent>
 }
 
@@ -108,7 +110,13 @@ function harness(
   const protectedNow = new Set<string>()
   const protectionHistory: string[] = []
   const status = new ThreadStatusTracker()
-  const failures: { threadId: string; message: string; prompt?: string }[] = []
+  const failures: {
+    threadId: string
+    message: string
+    prompt?: string
+    routine?: { name: string }
+  }[] = []
+  const lates: { threadId: string; dueAt: number; lastRunAt: number | null }[] = []
   const agent = stubAgent()
   const routine = over.routine === undefined ? ROUTINE : over.routine
   return {
@@ -118,6 +126,7 @@ function harness(
     protectionHistory,
     status,
     failures,
+    lates,
     agent,
     deps: {
       routines: {
@@ -147,6 +156,7 @@ function harness(
       },
       ensureGate: async () => over.gate ?? { ok: true, profileId: GATE_PROFILE_ID },
       reportFailure: (args) => void failures.push(args),
+      reportLate: (args) => void lates.push(args),
       runTurn: async (turnAgent, args, gate) => {
         prompts.push(args)
         return over.turn
@@ -172,6 +182,8 @@ describe('runRoutineTurn — the happy path', () => {
         workspaceId: 'w1',
         sessionId: 'sess-1', // the Bot's continuing conversation, never a fresh Thread
         text: 'Triage this repo and say what changed.',
+        // The chip's name, stamped at send: this prompt was not typed by anyone.
+        routine: { name: 'Morning triage' },
       },
     ])
   })
@@ -388,6 +400,9 @@ describe('runRoutineTurn — the permission gate', () => {
         threadId: 'bot-thread',
         message: expect.stringContaining('permission gate'),
         prompt: 'Triage this repo and say what changed.',
+        // Even a refused run's bubble names the Routine that sent it (#470) — it
+        // was still not typed by anyone.
+        routine: { name: 'Morning triage' },
       },
     ])
   })
@@ -487,5 +502,54 @@ describe('runRoutineTurn — the permission gate', () => {
     expect(result.error).toContain('Morning triage')
     expect(result.error).toContain('`gh pr merge 12`')
     expect(result.blockedCommand).toBe('gh pr merge 12')
+  })
+})
+
+describe('runRoutineTurn — a run that is LATE (#470)', () => {
+  /** The 09:00 Europe/Berlin slot on 21 August 2026, and the run before it. */
+  const DUE_AT = Date.UTC(2026, 7, 21, 7, 0)
+  const LAST_RUN_AT = Date.UTC(2026, 7, 20, 7, 0)
+
+  it('states it TWICE: a notice we write, and the coverage period in the prompt', async () => {
+    const h = harness()
+
+    await runRoutineTurn(h.deps, 'r1', { late: { dueAt: DUE_AT, lastRunAt: LAST_RUN_AT } })
+
+    // Ours: only the two timestamps cross, because the copy is a renderer constant.
+    expect(h.lates).toEqual([
+      { threadId: 'bot-thread', dueAt: DUE_AT, lastRunAt: LAST_RUN_AT },
+    ])
+    // The agent's: inside the prompt, because only it can act on the period.
+    const text = h.prompts[0]?.text ?? ''
+    expect(text.startsWith('Triage this repo and say what changed.')).toBe(true)
+    expect(text).toContain('2026-08-21 09:00 (Europe/Berlin)')
+    expect(text).toContain('since its last run at 2026-08-20 09:00 (Europe/Berlin)')
+  })
+
+  it('tells the agent outright when the Routine has NEVER run', async () => {
+    const h = harness()
+    await runRoutineTurn(h.deps, 'r1', { late: { dueAt: DUE_AT, lastRunAt: null } })
+    expect(h.lates[0]?.lastRunAt).toBeNull()
+    expect(h.prompts[0]?.text).toContain('never run before')
+  })
+
+  it('sends the prompt VERBATIM and writes no notice when the run is on time', async () => {
+    const h = harness()
+    await runRoutineTurn(h.deps, 'r1')
+    expect(h.prompts[0]?.text).toBe('Triage this repo and say what changed.')
+    expect(h.lates).toEqual([])
+  })
+
+  it('writes nothing at all when the Bot is busy — a defer stays off the conversation', async () => {
+    const h = harness()
+    h.status.beginTurn('a1', 'bot-thread') // somebody is already talking to this Bot
+
+    const result = await runRoutineTurn(h.deps, 'r1', {
+      late: { dueAt: DUE_AT, lastRunAt: LAST_RUN_AT },
+    })
+
+    expect(result.outcome).toBe('deferred')
+    expect(h.lates).toEqual([])
+    expect(h.failures).toEqual([])
   })
 })

--- a/apps/desktop/src/main/routines/run-routine-turn.ts
+++ b/apps/desktop/src/main/routines/run-routine-turn.ts
@@ -1,9 +1,10 @@
-import type { RoutineOutcome, SendPromptResult } from '../../shared/ipc'
+import type { RoutineOutcome, SendPromptResult, TranscriptRoutineRef } from '../../shared/ipc'
 import type { BotStoreApi } from '../persistence/bot-store-api'
 import type { MetadataStoreApi } from '../persistence/metadata-store-api'
 import type { RoutineStoreApi } from '../persistence/routine-store-api'
 import type { PromptTurnAgent, PromptTurnGate } from '../prompt-turn'
 import { refusalMessage } from './allowed-commands'
+import { promptWithCoverage, type LateRun } from './late-run'
 import { createRoutinePermissionGate } from './routine-permission-gate'
 import type { RoutineProfileSource } from './routine-profile'
 import type { RoutineGateResult } from './write-routine-profile'
@@ -112,7 +113,23 @@ export interface RoutineTurnDeps {
    * as "what was asked, then why it did not happen" (ADR-0028 part 5: a routine
    * turn always writes an entry).
    */
-  reportFailure(args: { threadId: string; message: string; prompt?: string }): void
+  reportFailure(args: {
+    threadId: string
+    message: string
+    prompt?: string
+    /** Names the Routine on the teed prompt, so even a refused run's bubble says who sent it. */
+    routine?: TranscriptRoutineRef
+  }): void
+  /**
+   * Write the "this run is late" notice into the Bot's conversation (#470,
+   * ADR-0028 part 3), just before the prompt it explains. Copy is a renderer-side
+   * constant, so only the two timestamps cross — `lastRunAt: null` says the
+   * Routine has never run, which is the distinction this whole slice exists for.
+   *
+   * The agent is told the same fact a second time, inside its prompt, because only
+   * it can act on the period. Neither statement replaces the other.
+   */
+  reportLate(args: { threadId: string; dueAt: number; lastRunAt: number | null }): void
   /** Run the turn itself — production passes `runPromptTurn` with headless delivery. */
   runTurn(agent: RoutineTurnAgent, args: RoutineTurnPrompt, gate: PromptTurnGate): Promise<SendPromptResult>
   /** Epoch-ms clock, injected so a run's recorded timestamp is deterministic in tests. */
@@ -126,6 +143,17 @@ export interface RoutineTurnPrompt {
   workspaceId: string
   sessionId: string | null
   text: string
+  /** Stamped onto the teed prompt so the bubble wears a chip naming the Routine. */
+  routine: TranscriptRoutineRef
+}
+
+/** What a caller may say about the run it is asking for. */
+export interface RunRoutineOptions {
+  /**
+   * This run is starting later than the slot it is for — the scheduler's launch
+   * catch-up, or a deferral that finally got the Bot. Null/absent = on time.
+   */
+  late?: LateRun | null
 }
 
 /**
@@ -140,6 +168,7 @@ export interface RoutineTurnPrompt {
 export async function runRoutineTurn(
   deps: RoutineTurnDeps,
   routineId: string,
+  options: RunRoutineOptions = {},
 ): Promise<RoutineTurnResult> {
   const routine = deps.routines.get(routineId)
   // No row means nothing to record against either — the only failure this function
@@ -187,7 +216,12 @@ export async function runRoutineTurn(
     const message =
       `"${routine.name}" did not run: its permission gate could not be confirmed, so it was ` +
       `refused rather than run unguarded. ${gate.problems.join(' ')}`
-    deps.reportFailure({ threadId: routine.threadId, message, prompt: routine.prompt })
+    deps.reportFailure({
+      threadId: routine.threadId,
+      message,
+      prompt: routine.prompt,
+      routine: { name: routine.name },
+    })
     return record({ outcome: 'failed', error: message })
   }
 
@@ -199,6 +233,12 @@ export async function runRoutineTurn(
     return record({ outcome: 'deferred', error: 'The Bot was busy, so this run was skipped.' })
   }
   deps.beginProtection(agentId)
+
+  // Late is stated TWICE, and both statements happen here — after the claim, so a
+  // deferred run writes nothing at all, and before the turn, so the notice sits
+  // above the prompt it explains.
+  const late = options.late ?? null
+  if (late) deps.reportLate({ threadId: routine.threadId, dueAt: late.dueAt, lastRunAt: late.lastRunAt })
 
   // We are the permission SERVER for this turn (the ADR-0001 amendment): main
   // answers, from the Routine's allowed commands, with no renderer in the loop.
@@ -223,7 +263,9 @@ export async function runRoutineTurn(
         threadId: routine.threadId,
         workspaceId: thread.workspaceId,
         sessionId: thread.sessionId,
-        text: routine.prompt,
+        // The prompt, verbatim, plus the coverage period when the run is late.
+        text: promptWithCoverage(routine.prompt, late, routine.schedule.timezone, deps.now()),
+        routine: { name: routine.name },
       },
       {
         profileId: gate.profileId,

--- a/apps/desktop/src/main/routines/schedule-tick.test.ts
+++ b/apps/desktop/src/main/routines/schedule-tick.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest'
+import type { RoutineRecord } from '../../shared/ipc'
+import { decideRoutineTick, type PendingDeferral } from './schedule-tick'
+
+/**
+ * One tick of the scheduler, decided purely (#470, ADR-0028) — collisions, the
+ * deferral bound and catch-up as unit tests rather than timing tests.
+ *
+ * Berlin is UTC+2 in August, so the 09:00 slots below are written as 07:00 UTC.
+ */
+
+const SLOT_20 = Date.UTC(2026, 7, 20, 7, 0)
+const SLOT_21 = Date.UTC(2026, 7, 21, 7, 0)
+const SLOT_22 = Date.UTC(2026, 7, 22, 7, 0)
+/** A minute past the 21st's slot: due, and not yet late. */
+const JUST_AFTER_21 = SLOT_21 + 60_000
+
+function routine(over: Partial<RoutineRecord> = {}): RoutineRecord {
+  return {
+    id: 'r1',
+    threadId: 'bot-1',
+    name: 'Morning triage',
+    prompt: 'Triage this repo and say what changed.',
+    schedule: { kind: 'daily', at: '09:00', timezone: 'Europe/Berlin' },
+    allowedCommands: [],
+    active: true,
+    lastRunAt: SLOT_20,
+    lastOutcome: 'ok',
+    lastError: null,
+    lastBlockedCommand: null,
+    createdAt: Date.UTC(2026, 7, 1, 12, 0),
+    updatedAt: Date.UTC(2026, 7, 1, 12, 0),
+    ...over,
+  }
+}
+
+/** A tick with nothing busy, nothing running and nothing deferred. */
+function tick(
+  routines: RoutineRecord[],
+  now: number,
+  over: Partial<Parameters<typeof decideRoutineTick>[0]> = {},
+) {
+  return decideRoutineTick({
+    routines,
+    now,
+    busyThreads: new Set(),
+    runningRoutines: new Set(),
+    deferrals: [],
+    ...over,
+  })
+}
+
+describe('decideRoutineTick — firing', () => {
+  it('fires a Routine whose slot has come, for the SLOT rather than for now', () => {
+    const decision = tick([routine()], JUST_AFTER_21)
+    expect(decision.fire).toEqual([
+      { routineId: 'r1', threadId: 'bot-1', dueAt: SLOT_21, late: false, lastRunAt: SLOT_20 },
+    ])
+    expect(decision.defer).toEqual([])
+    expect(decision.report).toEqual([])
+  })
+
+  it('fires nothing before the slot', () => {
+    expect(tick([routine()], SLOT_21 - 60_000).fire).toEqual([])
+  })
+
+  it('skips a PAUSED Routine, however overdue it is', () => {
+    const paused = routine({ active: false, lastRunAt: SLOT_20 })
+    const decision = tick([paused], Date.UTC(2026, 7, 25, 12, 0))
+    expect(decision).toEqual({ fire: [], defer: [], report: [] })
+  })
+
+  it('fires into a Bot whose Workspace is NOT connected — a Routine warms it', () => {
+    // Nothing about the pool reaches this decision: an unconnected Workspace has
+    // no streaming Thread, so it is not busy, and the run itself lazily warms the
+    // agent. Refusing here would mean a Routine only ever ran for Workspaces you
+    // had already opened, which is the opposite of the point.
+    const decision = tick([routine({ threadId: 'bot-cold' })], JUST_AFTER_21)
+    expect(decision.fire.map((fire) => fire.threadId)).toEqual(['bot-cold'])
+  })
+
+  it('leaves a Routine whose run is still in flight alone', () => {
+    const decision = tick([routine()], JUST_AFTER_21, { runningRoutines: new Set(['r1']) })
+    expect(decision).toEqual({ fire: [], defer: [], report: [] })
+  })
+
+  it('honours a resume floor: a Routine resumed after its slot waits for the next one', () => {
+    const decision = tick([routine()], JUST_AFTER_21, {
+      floors: new Map([['r1', JUST_AFTER_21 - 1_000]]),
+    })
+    expect(decision.fire).toEqual([])
+  })
+})
+
+describe('decideRoutineTick — two Routines on one Bot', () => {
+  const early = routine({
+    id: 'early',
+    schedule: { kind: 'daily', at: '08:00', timezone: 'Europe/Berlin' },
+  })
+  const late = routine({ id: 'late' })
+
+  it('fires the older slot and defers the other — a Bot is one conversation', () => {
+    const decision = tick([late, early], JUST_AFTER_21)
+
+    expect(decision.fire.map((fire) => fire.routineId)).toEqual(['early'])
+    expect(decision.defer).toEqual([
+      {
+        routineId: 'late',
+        threadId: 'bot-1',
+        dueAt: SLOT_21,
+        // Bounded by this Routine's OWN next slot, never by the other's.
+        expiresAt: SLOT_22,
+        lastRunAt: SLOT_20,
+      },
+    ])
+    expect(decision.report).toEqual([])
+  })
+
+  it('defers a due Routine while its Bot is streaming, writing nothing anywhere', () => {
+    const decision = tick([late], JUST_AFTER_21, { busyThreads: new Set(['bot-1']) })
+    expect(decision.fire).toEqual([])
+    expect(decision.defer).toHaveLength(1)
+    expect(decision.report).toEqual([])
+  })
+})
+
+describe('decideRoutineTick — deferrals', () => {
+  const pending: PendingDeferral = {
+    routineId: 'r1',
+    threadId: 'bot-1',
+    dueAt: SLOT_21,
+    expiresAt: SLOT_22,
+    lastRunAt: SLOT_20,
+  }
+
+  it('re-checks on the next tick and fires once the Bot is free', () => {
+    const decision = tick([routine()], JUST_AFTER_21 + 60_000, { deferrals: [pending] })
+    expect(decision.fire).toEqual([
+      { routineId: 'r1', threadId: 'bot-1', dueAt: SLOT_21, late: false, lastRunAt: SLOT_20 },
+    ])
+    expect(decision.defer).toEqual([])
+  })
+
+  it('keeps waiting while the Bot is still busy', () => {
+    const decision = tick([routine()], JUST_AFTER_21 + 60_000, {
+      deferrals: [pending],
+      busyThreads: new Set(['bot-1']),
+    })
+    expect(decision.fire).toEqual([])
+    expect(decision.defer).toEqual([pending])
+  })
+
+  it('marks a run that finally got its turn hours later as LATE', () => {
+    const decision = tick([routine()], SLOT_21 + 4 * 60 * 60 * 1000, { deferrals: [pending] })
+    expect(decision.fire[0]?.late).toBe(true)
+  })
+
+  it('gives up at the next slot: records `deferred`, and the new slot competes fresh', () => {
+    // The bound expires at exactly SLOT_22, which is also when the next slot is
+    // due. The abandoned slot is reported and the new one is fired in the SAME
+    // tick — a Routine must not lose a slot to its own backlog.
+    const decision = tick([routine()], SLOT_22, { deferrals: [pending] })
+
+    expect(decision.report).toEqual([{ routineId: 'r1', dueAt: SLOT_21 }])
+    expect(decision.fire).toEqual([
+      { routineId: 'r1', threadId: 'bot-1', dueAt: SLOT_22, late: false, lastRunAt: SLOT_20 },
+    ])
+    expect(decision.defer).toEqual([])
+  })
+
+  it('drops a deferral whose Routine was paused or deleted, recording nothing', () => {
+    expect(tick([routine({ active: false })], SLOT_22, { deferrals: [pending] })).toEqual({
+      fire: [],
+      defer: [],
+      report: [],
+    })
+    expect(tick([], SLOT_22, { deferrals: [pending] })).toEqual({ fire: [], defer: [], report: [] })
+  })
+
+  it('lets a carried deferral win the Bot over a sibling that only just came due', () => {
+    const sibling = routine({ id: 'sibling' })
+    const decision = tick([sibling, routine()], SLOT_21 + 30 * 60_000, { deferrals: [pending] })
+    expect(decision.fire.map((fire) => fire.routineId)).toEqual(['r1'])
+    expect(decision.defer.map((entry) => entry.routineId)).toEqual(['sibling'])
+  })
+})

--- a/apps/desktop/src/main/routines/schedule-tick.ts
+++ b/apps/desktop/src/main/routines/schedule-tick.ts
@@ -1,0 +1,177 @@
+import type { RoutineRecord } from '../../shared/ipc'
+import { nextRunAfter } from '../../shared/schedule'
+import { LATE_AFTER_MS, expectedRun } from './missed-runs'
+
+/**
+ * **One tick of the Routine scheduler, as a pure decision** (#470, ADR-0028) —
+ * given the Routine rows, the clock, which Bots are busy and what was deferred
+ * last time, decide what to fire, what to keep waiting for, and what to record.
+ *
+ * The decision is separated from the timer for the usual reason and one extra:
+ * collisions, the deferral bound and catch-up become ORDINARY UNIT TESTS instead
+ * of timing tests. Nothing here touches a store, a pool or an agent — the caller
+ * (`scheduler.ts`) does all of that, and hands the answers back on the next tick.
+ *
+ * Three rules it holds:
+ *
+ *  - **One Bot, one turn.** A Bot is one continuing conversation, so two Routines
+ *    due at the same instant cannot both run: the older slot fires and the other
+ *    is deferred. The Bot's live streaming flag is the busy signal (per-THREAD,
+ *    never the per-agent in-flight count — one `vibe-acp` child legitimately hosts
+ *    concurrent turns across sessions, #456).
+ *  - **A deferral is bounded by the Routine's own next slot.** Re-checked every
+ *    tick until then; past it we give up and record `deferred`. A Bot you talk to
+ *    all day must not accrue an unbounded queue of yesterday's runs.
+ *  - **A defer writes NOTHING into the conversation** (ADR-0028 part 5). It is
+ *    recorded on the Routine, which is what keeps it from being invisible without
+ *    making a Bot chattier the more you use it.
+ *
+ * Deferrals live in the caller's memory and are never stored: a deferral is a
+ * statement about this minute, and a stored one would be a stale value somebody
+ * has to remember to clear — the failure family ADR-0028 part 6 exists to remove.
+ */
+
+/** A run the tick decided to start now. */
+export interface RoutineFire {
+  routineId: string
+  /** The Bot's Thread this run goes into. */
+  threadId: string
+  /** The scheduled instant this run is FOR — not the instant it starts. */
+  dueAt: number
+  /** True when the slot is materially older than now (see `LATE_AFTER_MS`). */
+  late: boolean
+  /** The Routine's `lastRunAt` at decision time — null when it has NEVER run. */
+  lastRunAt: number | null
+}
+
+/**
+ * A due run waiting for its Bot to be free. Carried from tick to tick in memory.
+ */
+export interface PendingDeferral {
+  routineId: string
+  threadId: string
+  /** The slot being waited on — preserved, so a run that resolves late says which slot. */
+  dueAt: number
+  /** The Routine's NEXT slot: the instant we stop waiting and give up. */
+  expiresAt: number
+  /** `lastRunAt` as it stood when the slot came due (null = never run). */
+  lastRunAt: number | null
+}
+
+/** A deferral that hit its bound: record `deferred` on the Routine, write nothing else. */
+export interface ExpiredDeferral {
+  routineId: string
+  /** The slot that was given up — what the record's `lastRunAt` is set to. */
+  dueAt: number
+}
+
+export interface RoutineTickInput {
+  /** Every Routine, as stored. Paused ones are skipped here, not by the firer. */
+  routines: readonly RoutineRecord[]
+  now: number
+  /** Bot Threads that cannot take a turn: streaming, or already running a Routine. */
+  busyThreads: ReadonlySet<string>
+  /** Routines whose run is still in flight — their `lastRunAt` has not moved yet. */
+  runningRoutines: ReadonlySet<string>
+  /** What the previous tick decided to keep waiting for. */
+  deferrals: readonly PendingDeferral[]
+  /**
+   * Per-Routine baseline floors held in memory — today, the instant a Routine was
+   * RESUMED in this session (ADR-0028 part 7: no catch-up for a paused period).
+   */
+  floors?: ReadonlyMap<string, number>
+}
+
+export interface RoutineTickDecision {
+  /** Start these now, in order. At most one per Bot Thread. */
+  fire: RoutineFire[]
+  /** The WHOLE deferral set for the next tick — replaces the previous one. */
+  defer: PendingDeferral[]
+  /** Record `deferred` on these; nothing reaches the conversation. */
+  report: ExpiredDeferral[]
+}
+
+/**
+ * Decide one tick.
+ *
+ * Deferrals are settled BEFORE new slots, so a Routine whose old slot expires at
+ * the very instant its next slot arrives records the give-up and then competes for
+ * the new slot in the same tick — rather than losing a slot to its own backlog.
+ */
+export function decideRoutineTick(input: RoutineTickInput): RoutineTickDecision {
+  const byId = new Map(input.routines.map((routine) => [routine.id, routine]))
+  const fire: RoutineFire[] = []
+  const defer: PendingDeferral[] = []
+  const report: ExpiredDeferral[] = []
+  // Every Thread already spoken for this tick: busy before we started, or claimed
+  // by a fire we just decided on. One Bot, one turn.
+  const claimed = new Set(input.busyThreads)
+  /** Routines already settled this tick — a carried deferral wins over a new slot. */
+  const settled = new Set<string>()
+
+  for (const pending of input.deferrals) {
+    const routine = byId.get(pending.routineId)
+    // Deleted, paused or already running since the deferral was made: drop it
+    // silently. There is nothing to record against a Routine that is gone, and a
+    // paused one has no missed runs by definition.
+    if (!routine || !routine.active || input.runningRoutines.has(routine.id)) continue
+    if (input.now >= pending.expiresAt) {
+      // Given up — and deliberately NOT settled, so the slot that has just come due
+      // (the very instant this bound expires) competes in the pass below. A Routine
+      // must not lose a slot to its own backlog.
+      report.push({ routineId: pending.routineId, dueAt: pending.dueAt })
+      continue
+    }
+    settled.add(routine.id)
+    if (claimed.has(pending.threadId)) {
+      defer.push(pending)
+      continue
+    }
+    claimed.add(pending.threadId)
+    fire.push({
+      routineId: pending.routineId,
+      threadId: pending.threadId,
+      dueAt: pending.dueAt,
+      // Measured at FIRE time, not when the slot came due: a run that waited out a
+      // long turn is late for the same reason one that waited out a closed app is.
+      late: input.now - pending.dueAt > LATE_AFTER_MS,
+      lastRunAt: pending.lastRunAt,
+    })
+  }
+
+  // New slots, oldest first so the Bot owed two runs starts with the older one;
+  // creation order breaks a tie, which is the order the authoring list shows.
+  const due: { routine: RoutineRecord; dueAt: number; late: boolean }[] = []
+  for (const routine of input.routines) {
+    if (settled.has(routine.id) || input.runningRoutines.has(routine.id)) continue
+    const run = expectedRun(routine, input.now, input.floors?.get(routine.id))
+    if (run) due.push({ routine, ...run })
+  }
+  due.sort((a, b) => a.dueAt - b.dueAt || a.routine.createdAt - b.routine.createdAt)
+
+  for (const { routine, dueAt, late } of due) {
+    if (claimed.has(routine.threadId)) {
+      defer.push({
+        routineId: routine.id,
+        threadId: routine.threadId,
+        dueAt,
+        // The bound: this Routine's own next slot. Null cannot follow a computable
+        // last-due, but if the arithmetic ever declines, an already-expired bound
+        // gives up on the next tick rather than waiting forever.
+        expiresAt: nextRunAfter(routine.schedule, dueAt) ?? dueAt,
+        lastRunAt: routine.lastRunAt,
+      })
+      continue
+    }
+    claimed.add(routine.threadId)
+    fire.push({
+      routineId: routine.id,
+      threadId: routine.threadId,
+      dueAt,
+      late,
+      lastRunAt: routine.lastRunAt,
+    })
+  }
+
+  return { fire, defer, report }
+}

--- a/apps/desktop/src/main/routines/scheduler.test.ts
+++ b/apps/desktop/src/main/routines/scheduler.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from 'vitest'
+import type { RoutineRecord } from '../../shared/ipc'
+import type { RoutineRunResult } from '../persistence/routine-store-api'
+import { createRoutineScheduler } from './scheduler'
+import type { RunRoutineOptions } from './run-routine-turn'
+
+/**
+ * The scheduler itself (#470, ADR-0028): the tick, the launch catch-up, and the
+ * two writes a deferral is allowed to make (one on the Routine, none in the
+ * conversation).
+ *
+ * Everything it decides is decided by the pure modules beside it, so this suite is
+ * about the wiring: what actually gets RUN, exactly once, and what gets RECORDED.
+ *
+ * Berlin is UTC+2 in August, so the 09:00 slots are written as 07:00 UTC.
+ */
+
+const SLOT_20 = Date.UTC(2026, 7, 20, 7, 0)
+const SLOT_21 = Date.UTC(2026, 7, 21, 7, 0)
+const SLOT_22 = Date.UTC(2026, 7, 22, 7, 0)
+/** Noon Berlin on the 21st: this morning's slot went by with the app shut. */
+const NOON_21 = Date.UTC(2026, 7, 21, 10, 0)
+
+function routine(over: Partial<RoutineRecord> = {}): RoutineRecord {
+  return {
+    id: 'r1',
+    threadId: 'bot-1',
+    name: 'Morning triage',
+    prompt: 'Triage this repo and say what changed.',
+    schedule: { kind: 'daily', at: '09:00', timezone: 'Europe/Berlin' },
+    allowedCommands: [],
+    active: true,
+    lastRunAt: SLOT_20,
+    lastOutcome: 'ok',
+    lastError: null,
+    lastBlockedCommand: null,
+    createdAt: Date.UTC(2026, 7, 1, 12, 0),
+    updatedAt: Date.UTC(2026, 7, 1, 12, 0),
+    ...over,
+  }
+}
+
+interface Harness {
+  scheduler: ReturnType<typeof createRoutineScheduler>
+  runs: { routineId: string; options: RunRoutineOptions }[]
+  recorded: { routineId: string; result: RoutineRunResult }[]
+  rows: RoutineRecord[]
+  streaming: Set<string>
+  setNow(instant: number): void
+  /** Let the in-flight run settle. */
+  settle(): Promise<void>
+}
+
+function harness(
+  rows: RoutineRecord[],
+  now: number,
+  options: { hold?: boolean; loseRace?: Set<number> } = {},
+): Harness {
+  const runs: { routineId: string; options: RunRoutineOptions }[] = []
+  const recorded: { routineId: string; result: RoutineRunResult }[] = []
+  const streaming = new Set<string>()
+  let clock = now
+  let release: (() => void) | null = null
+  const scheduler = createRoutineScheduler({
+    routines: {
+      list: () => rows,
+      recordRun: (routineId, result) => {
+        recorded.push({ routineId, result })
+        const row = rows.find((candidate) => candidate.id === routineId)
+        if (row) Object.assign(row, result)
+        return row ?? null
+      },
+    },
+    isStreaming: (threadId) => streaming.has(threadId),
+    runRoutine: async (routineId, runOptions) => {
+      runs.push({ routineId, options: runOptions })
+      // The user won the Bot between the decision and the claim (#468's atomic
+      // `tryBeginTurn`), so the run itself refuses.
+      if (options.loseRace?.has(runs.length)) return { outcome: 'deferred', error: 'busy' }
+      // `hold` keeps the turn in flight, which is what makes a Routine BUSY for the
+      // next tick — the state a real turn spends most of its life in.
+      if (options.hold) await new Promise<void>((resolve) => (release = resolve))
+      return { outcome: 'ok', error: null }
+    },
+    now: () => clock,
+  })
+  return {
+    scheduler,
+    runs,
+    recorded,
+    rows,
+    streaming,
+    setNow: (instant) => void (clock = instant),
+    settle: async () => {
+      release?.()
+      release = null
+      await Promise.resolve()
+      await Promise.resolve()
+    },
+  }
+}
+
+describe('the launch catch-up', () => {
+  it('runs a missed Routine EXACTLY ONCE and marks it late', async () => {
+    const h = harness([routine({ lastRunAt: SLOT_20 })], NOON_21)
+
+    const started = h.scheduler.catchUp()
+    // The tick runs 30 seconds later and must not run it a second time: the turn
+    // is still in flight, so no outcome has been written yet.
+    await h.scheduler.tick()
+
+    expect(started.map((run) => run.routineId)).toEqual(['r1'])
+    expect(h.runs).toEqual([
+      { routineId: 'r1', options: { late: { dueAt: SLOT_21, lastRunAt: SLOT_20 } } },
+    ])
+  })
+
+  it('does not run again once the run has recorded its outcome', async () => {
+    const h = harness([routine({ lastRunAt: SLOT_20 })], NOON_21)
+    h.scheduler.catchUp()
+    await h.settle()
+    // What the real turn writes at the end of its run.
+    h.rows[0]!.lastRunAt = NOON_21
+    h.setNow(NOON_21 + 60_000)
+
+    await h.scheduler.tick()
+
+    expect(h.runs).toHaveLength(1)
+  })
+
+  it('runs the Routine that never ran, and hands the agent a null last-run', () => {
+    // The story: a Bot with nothing in its conversation because the app was never
+    // open at 09:00, next to one that ran and had nothing to say. Only the first is
+    // owed a run, and the run it gets says outright that there was no previous one.
+    const never = routine({ id: 'never', threadId: 'bot-never', lastRunAt: null })
+    const ranAndFoundNothing = routine({ id: 'ran', threadId: 'bot-ran', lastRunAt: SLOT_21 })
+    const h = harness([never, ranAndFoundNothing], NOON_21)
+
+    h.scheduler.catchUp()
+
+    expect(h.runs).toEqual([
+      { routineId: 'never', options: { late: { dueAt: SLOT_21, lastRunAt: null } } },
+    ])
+  })
+
+  it('starts one run per Bot, leaving the collision for the tick to re-decide', () => {
+    const first = routine({ id: 'first' })
+    const second = routine({
+      id: 'second',
+      schedule: { kind: 'daily', at: '10:00', timezone: 'Europe/Berlin' },
+    })
+    const h = harness([first, second], NOON_21)
+
+    expect(h.scheduler.catchUp().map((run) => run.routineId)).toEqual(['first'])
+  })
+})
+
+describe('the tick', () => {
+  it('fires a Routine as its slot arrives, with no late marker', async () => {
+    const h = harness([routine()], SLOT_21 + 15_000)
+    await h.scheduler.tick()
+    expect(h.runs).toEqual([{ routineId: 'r1', options: { late: null } }])
+  })
+
+  it('defers while the Bot is streaming and writes NOTHING anywhere', async () => {
+    const h = harness([routine()], SLOT_21 + 15_000)
+    h.streaming.add('bot-1')
+
+    await h.scheduler.tick()
+
+    expect(h.runs).toEqual([])
+    expect(h.recorded).toEqual([])
+  })
+
+  it('runs the deferred slot on a later tick, once the Bot is free', async () => {
+    const h = harness([routine()], SLOT_21 + 15_000)
+    h.streaming.add('bot-1')
+    await h.scheduler.tick()
+
+    h.streaming.delete('bot-1')
+    h.setNow(SLOT_21 + 45_000)
+    await h.scheduler.tick()
+
+    expect(h.runs).toEqual([
+      { routineId: 'r1', options: { late: null } },
+    ])
+    expect(h.recorded).toEqual([])
+  })
+
+  it('gives up at the next slot, recording `deferred` against the ABANDONED slot', async () => {
+    const h = harness([routine()], SLOT_21 + 15_000)
+    h.streaming.add('bot-1')
+    await h.scheduler.tick()
+
+    // A full day of talking to this Bot later: the 21st's slot is given up, and the
+    // 22nd's is deferred in its place rather than being swallowed by the give-up.
+    h.setNow(SLOT_22)
+    await h.scheduler.tick()
+
+    expect(h.recorded).toEqual([
+      {
+        routineId: 'r1',
+        result: {
+          // The slot that was abandoned — NOT `now`, which is the next slot and
+          // would make the detector think the next run had already happened.
+          lastRunAt: SLOT_21,
+          lastOutcome: 'deferred',
+          lastError: 'The Bot was busy for this whole slot, so the run was given up.',
+        },
+      },
+    ])
+    expect(h.runs).toEqual([])
+  })
+
+  it('does not start a second run on a Bot whose Routine is still running', async () => {
+    const sibling = routine({
+      id: 'sibling',
+      schedule: { kind: 'daily', at: '09:05', timezone: 'Europe/Berlin' },
+      lastRunAt: SLOT_20 + 5 * 60_000, // it ran at its own slot yesterday
+    })
+    const h = harness([routine(), sibling], SLOT_21 + 15_000, { hold: true })
+
+    // Tick one fires the 09:00 Routine and the turn stays in flight.
+    const firstTick = h.scheduler.tick()
+    expect(h.runs.map((run) => run.routineId)).toEqual(['r1'])
+
+    // Tick two: the 09:05 sibling is now due, but its Bot is mid-turn — and the
+    // Bot's streaming flag has not been consulted at all, because the scheduler
+    // knows it started that run itself.
+    h.setNow(SLOT_21 + 6 * 60_000)
+    const secondTick = h.scheduler.tick()
+    expect(h.runs.map((run) => run.routineId)).toEqual(['r1'])
+    expect(h.recorded).toEqual([])
+
+    await h.settle()
+    await Promise.all([firstTick, secondTick])
+  })
+
+  it('gives a Routine resumed in this session a fresh baseline', async () => {
+    const paused = routine({ active: false })
+    const h = harness([paused], NOON_21)
+
+    await h.scheduler.tick() // seen paused: nothing is due, nothing is owed
+    paused.active = true
+    await h.scheduler.tick() // resumed: this morning's slot belongs to the paused period
+
+    expect(h.runs).toEqual([])
+  })
+
+  it('still owes a run to a Routine it has never seen paused', async () => {
+    const h = harness([routine({ lastRunAt: SLOT_20 })], NOON_21)
+    await h.scheduler.tick()
+    expect(h.runs.map((run) => run.routineId)).toEqual(['r1'])
+  })
+})
+
+describe('a run that loses the claim race', () => {
+  it('goes back in the queue and is retried on the next tick, not lost for the day', async () => {
+    // The scheduler decided the Bot was free; a person started typing before the
+    // run took its claim. Without the re-queue the slot would be gone, because the
+    // refused run has already stamped the record.
+    const h = harness([routine()], SLOT_21 + 15_000, { loseRace: new Set([1]) })
+
+    await h.scheduler.tick()
+    expect(h.runs).toHaveLength(1)
+
+    h.setNow(SLOT_21 + 45_000)
+    await h.scheduler.tick()
+
+    expect(h.runs.map((run) => run.routineId)).toEqual(['r1', 'r1'])
+    // Still the ORIGINAL slot, so the report covers the period it was meant to.
+    expect(h.runs[1]?.options).toEqual({ late: null })
+    expect(h.recorded).toEqual([])
+  })
+})
+
+describe('the timer', () => {
+  it('starts and stops idempotently, so no tick outlives the app', () => {
+    const h = harness([], NOON_21)
+    h.scheduler.start()
+    h.scheduler.start()
+    h.scheduler.stop()
+    h.scheduler.stop()
+    expect(h.runs).toEqual([])
+  })
+})

--- a/apps/desktop/src/main/routines/scheduler.ts
+++ b/apps/desktop/src/main/routines/scheduler.ts
@@ -1,0 +1,203 @@
+import type { RoutineStoreApi } from '../persistence/routine-store-api'
+import { nextRunAfter } from '../../shared/schedule'
+import { detectMissedRuns, type MissedRun } from './missed-runs'
+import { decideRoutineTick, type PendingDeferral, type RoutineFire } from './schedule-tick'
+import type { RoutineTurnResult, RunRoutineOptions } from './run-routine-turn'
+
+/**
+ * **The Routine scheduler** (#470, ADR-0028) — the periodic tick in main that
+ * fires what is due, waits out a busy Bot, and catches up ONCE at launch for
+ * whatever could not run while the app was shut.
+ *
+ * The timer is the only thing in this file that is not a straight application of
+ * two pure modules: `schedule-tick.ts` decides each tick, `missed-runs.ts`
+ * recomputes what is owed, and this holds the interval, the in-flight set and the
+ * deferrals between them. That split is deliberate — collisions, the deferral
+ * bound and catch-up are unit tests here rather than timing tests.
+ *
+ * **Routines fire only while the app is open.** Electron has no background daemon
+ * and we ship no server, so this is stated rather than disguised: it is exactly
+ * why the launch catch-up exists, and why a run that never happened has to be
+ * visible instead of looking like one that happened and found nothing.
+ */
+
+/** How often the tick asks whether anything is due. */
+export const ROUTINE_TICK_MS = 30 * 1000
+
+export interface RoutineSchedulerDeps {
+  /** The rows. Re-listed every tick: a Routine edited mid-session must be honoured. */
+  routines: Pick<RoutineStoreApi, 'list' | 'recordRun'>
+  /**
+   * Is this Bot's Thread streaming? The per-THREAD busy signal (#456): one
+   * `vibe-acp` child legitimately hosts concurrent turns across sessions, so the
+   * per-agent in-flight count would defer a Routine because an unrelated Thread in
+   * the same Workspace happens to be mid-turn.
+   */
+  isStreaming(threadId: string): boolean
+  /** Run one Routine's turn — `runRoutineNow`, the single entry point of slice 2. */
+  runRoutine(routineId: string, options: RunRoutineOptions): Promise<RoutineTurnResult>
+  now(): number
+}
+
+export interface RoutineScheduler {
+  /** Begin ticking. Idempotent. */
+  start(): void
+  /** Stop ticking, so no timer outlives the app. Idempotent. */
+  stop(): void
+  /**
+   * The launch catch-up: run whatever is owed, ONCE each. Independent of the tick
+   * — it needs nothing but the rows and a clock, and it would still answer if the
+   * tick never ran at all.
+   */
+  catchUp(): MissedRun[]
+  /** One tick. Resolves when the runs it started have settled (the tests' seam). */
+  tick(): Promise<void>
+}
+
+export function createRoutineScheduler(deps: RoutineSchedulerDeps): RoutineScheduler {
+  /** Due runs waiting for a busy Bot. In memory only — a deferral is about this minute. */
+  let deferrals: PendingDeferral[] = []
+  /** Routines whose turn is in flight: their `lastRunAt` has not moved yet. */
+  const running = new Set<string>()
+  /** The Threads those runs hold, so a sibling Routine defers instead of racing the claim. */
+  const runningThreads = new Set<string>()
+  /**
+   * Baseline floors for Routines RESUMED in this session (ADR-0028 part 7: no
+   * catch-up for a paused period). Held in memory rather than written to the row,
+   * because the alternative — reading a column that any write touches — would let
+   * an unrelated edit SUPPRESS a missed-run report, and silence is the one failure
+   * this design refuses. The cost of keeping it in memory is at most one extra
+   * late run after a resume that spans a restart.
+   */
+  const floors = new Map<string, number>()
+  /** Each Routine's `active` as of the previous tick, to spot the resume. */
+  const wasActive = new Map<string, boolean>()
+  let timer: ReturnType<typeof setInterval> | null = null
+
+  /**
+   * Put a slot back in the deferral queue after the RUN itself refused it.
+   *
+   * The scheduler decides busy-ness a moment before `runRoutineTurn` takes its
+   * atomic claim, so a user who starts typing inside that window wins the Bot and
+   * the run comes back `deferred`. Re-queuing is what keeps ADR-0028's "re-check on
+   * the next tick" true for that race: the slot keeps its own bound and is retried
+   * until its next slot arrives, instead of being lost because the losing run
+   * already stamped the record.
+   */
+  const requeue = (run: RoutineFire): void => {
+    const routine = deps.routines.list().find((candidate) => candidate.id === run.routineId)
+    if (!routine || !routine.active) return
+    if (deferrals.some((pending) => pending.routineId === run.routineId)) return
+    deferrals.push({
+      routineId: run.routineId,
+      threadId: run.threadId,
+      dueAt: run.dueAt,
+      expiresAt: nextRunAfter(routine.schedule, run.dueAt) ?? run.dueAt,
+      lastRunAt: run.lastRunAt,
+    })
+  }
+
+  const startRun = (run: RoutineFire): Promise<void> => {
+    running.add(run.routineId)
+    runningThreads.add(run.threadId)
+    return deps
+      .runRoutine(run.routineId, lateOf(run))
+      .then((result) => {
+        // The Bot was taken between the decision and the claim — see `requeue`.
+        if (result.outcome === 'deferred') requeue(run)
+      })
+      .catch((err: unknown) => {
+        // `runRoutineTurn` answers with an outcome rather than rejecting; this is
+        // the belt to that pair of braces, because a rejection here would leave the
+        // Routine marked in flight forever and silently stop scheduling it.
+        console.error(`[vibe-mistro:routines] run ${run.routineId} rejected: ${String(err)}`)
+      })
+      .then(() => {
+        running.delete(run.routineId)
+        runningThreads.delete(run.threadId)
+      })
+  }
+
+  const tick = async (): Promise<void> => {
+    const now = deps.now()
+    const routines = deps.routines.list()
+
+    // Spot a resume (paused -> active) and give that Routine a fresh baseline, so
+    // resuming after a fortnight does not accrue a fortnight of catch-up. A Routine
+    // seen for the first time gets no floor: we do not know when it was resumed,
+    // and guessing would suppress a real missed run.
+    for (const routine of routines) {
+      if (wasActive.get(routine.id) === false && routine.active) floors.set(routine.id, now)
+      wasActive.set(routine.id, routine.active)
+    }
+
+    const busyThreads = new Set(runningThreads)
+    for (const routine of routines) {
+      if (deps.isStreaming(routine.threadId)) busyThreads.add(routine.threadId)
+    }
+
+    const decision = decideRoutineTick({
+      routines,
+      now,
+      busyThreads,
+      runningRoutines: running,
+      deferrals,
+      floors,
+    })
+    deferrals = decision.defer
+
+    // A deferral that ran out of time is recorded on the Routine and NOWHERE else
+    // (ADR-0028 part 5): a defer is not a failure, and writing it into the
+    // conversation would make a Bot chattier the more you use it. The record's
+    // `lastRunAt` is the ABANDONED SLOT rather than now — the give-up settles that
+    // slot, and stamping `now` (which is the next slot's instant) would swallow the
+    // next slot as well.
+    for (const expired of decision.report) {
+      deps.routines.recordRun(expired.routineId, {
+        lastRunAt: expired.dueAt,
+        lastOutcome: 'deferred',
+        lastError: 'The Bot was busy for this whole slot, so the run was given up.',
+      })
+    }
+
+    await Promise.all(decision.fire.map(startRun))
+  }
+
+  return {
+    start(): void {
+      if (timer) return
+      timer = setInterval(() => {
+        void tick()
+      }, ROUTINE_TICK_MS)
+      // Never keep the process alive on its own — the idle sweep's precedent.
+      timer.unref?.()
+    },
+    stop(): void {
+      if (!timer) return
+      clearInterval(timer)
+      timer = null
+    },
+    catchUp(): MissedRun[] {
+      const now = deps.now()
+      const missed = detectMissedRuns(deps.routines.list(), now)
+      const started: MissedRun[] = []
+      const claimed = new Set<string>()
+      for (const run of missed) {
+        // One Bot, one turn — a Bot owed two runs starts the older one here and the
+        // tick picks the other up, deferral bound and all. Nothing is remembered
+        // about the one left behind: it is still owed, and still recomputed.
+        if (claimed.has(run.threadId) || running.has(run.routineId)) continue
+        claimed.add(run.threadId)
+        started.push(run)
+        void startRun(run)
+      }
+      return started
+    },
+    tick,
+  }
+}
+
+/** A fired slot, as the run options the turn needs. */
+function lateOf(fire: RoutineFire): RunRoutineOptions {
+  return { late: fire.late ? { dueAt: fire.dueAt, lastRunAt: fire.lastRunAt } : null }
+}

--- a/apps/desktop/src/renderer/src/conversation/items/message-rows.tsx
+++ b/apps/desktop/src/renderer/src/conversation/items/message-rows.tsx
@@ -1,5 +1,14 @@
 import { useEffect, useRef, useState, type JSX } from 'react'
-import { Check, Clipboard, Copy, File, MessageSquareText, MousePointerClick, Sparkles } from 'lucide-react'
+import {
+  Check,
+  Clipboard,
+  Copy,
+  File,
+  MessageSquareText,
+  MousePointerClick,
+  Sparkles,
+  Timer,
+} from 'lucide-react'
 import { IconButton } from '../../ui/icon-button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../../ui/tooltip'
 import { Response } from '../Response'
@@ -30,13 +39,30 @@ export function UserRow({ item, selectable }: { item: UserItem; selectable: bool
   // instead of spanning the pane. Echoed attachments (#100) re-home into the bubble.
   return (
     <div className="group flex flex-col items-end gap-1.5">
-      {(command ||
+      {(item.routine ||
+        command ||
         files.length > 0 ||
         elements.length > 0 ||
         reviews.length > 0 ||
         pasted.length > 0 ||
         selections.length > 0) && (
         <div className="flex max-w-[80%] flex-wrap justify-end gap-1.5">
+          {item.routine && (
+            // Routine chip (#470, ADR-0028 part 5): this prompt was sent by a
+            // schedule, not typed. Same treatment as the slash-command chip beside
+            // it, for the same reason — real input the agent received, which you
+            // did not write. Stamped at SEND time (unlike the command chip, which
+            // is matched at render), because the Routine that sent it is a fact
+            // about the turn rather than a guess from the text.
+            <span
+              data-routine-chip
+              title={`Sent by the "${item.routine.name}" routine`}
+              className="inline-flex max-w-full items-center gap-1 rounded-md border border-primary/30 bg-primary/10 px-1.5 py-0.5 font-mono text-xs leading-none text-primary"
+            >
+              <Timer className="size-3 shrink-0" aria-hidden />
+              <span className="truncate">{item.routine.name}</span>
+            </span>
+          )}
           {command && (
             <span
               data-command-chip

--- a/apps/desktop/src/renderer/src/conversation/reducer.test.ts
+++ b/apps/desktop/src/renderer/src/conversation/reducer.test.ts
@@ -3,6 +3,7 @@ import {
   conversationReducer,
   initialConversationState,
   REBOUND_NOTICE,
+  routineLateNotice,
   type AssistantItem,
   type ConversationState,
   type ErrorItem,
@@ -416,6 +417,55 @@ describe('agent-rebound (TB4 context reset notice)', () => {
     expect(next.items.map((i) => i.kind)).toEqual(['user', 'notice'])
     expect(next.isProcessing).toBe(false)
     expect(next.items.some((i) => i.kind === 'error')).toBe(false)
+  })
+})
+
+/**
+ * A Routine's turn (#470, ADR-0028 part 5): the prompt is real input the agent
+ * received which nobody typed, so it stays an ordinary user bubble and wears a
+ * chip naming the Routine — and a run that started late says so, twice.
+ */
+describe('a routine turn', () => {
+  it('keeps the prompt an ordinary user item, marked with the Routine that sent it', () => {
+    const next = conversationReducer(initialConversationState, {
+      type: 'send-prompt',
+      id: 'u1',
+      text: 'Triage this repo and say what changed.',
+      routine: { name: 'Morning triage' },
+    })
+    const user = next.items[0]
+    expect(user).toMatchObject({ kind: 'user', routine: { name: 'Morning triage' } })
+    // Still a normal turn in every other respect.
+    expect(next.isProcessing).toBe(true)
+  })
+
+  it('leaves a prompt somebody typed unmarked', () => {
+    const next = conversationReducer(initialConversationState, {
+      type: 'send-prompt',
+      id: 'u1',
+      text: 'hello',
+    })
+    expect(next.items[0]).toMatchObject({ kind: 'user', routine: undefined })
+  })
+
+  it('appends the late notice with BOTH timestamps, without ending the turn', () => {
+    const dueAt = Date.UTC(2026, 7, 21, 7, 0)
+    const lastRunAt = Date.UTC(2026, 7, 20, 7, 0)
+    const next = conversationReducer(initialConversationState, {
+      type: 'routine-late',
+      dueAt,
+      lastRunAt,
+    })
+    const notice = next.items.find((i): i is NoticeItem => i.kind === 'notice')
+    expect(notice?.message).toBe(routineLateNotice(dueAt, lastRunAt))
+    expect(notice?.message).toContain('covers the period since then')
+    expect(next.items.some((i) => i.kind === 'error')).toBe(false)
+  })
+
+  it('says a Routine that NEVER ran never ran — not that it found nothing', () => {
+    const message = routineLateNotice(Date.UTC(2026, 7, 21, 7, 0), null)
+    expect(message).toContain('never run before')
+    expect(message).not.toContain('covers the period since then')
   })
 })
 

--- a/apps/desktop/src/renderer/src/conversation/reducer.ts
+++ b/apps/desktop/src/renderer/src/conversation/reducer.ts
@@ -36,6 +36,16 @@ export interface UserItem {
   text: string
   /** Image attachments echoed with this turn (#100); absent on replay from JSONL. */
   images?: UserImage[]
+  /**
+   * The **Routine** that sent this prompt (#470, ADR-0028 part 5), when it was not
+   * typed by anyone. Renders as a chip on the bubble, exactly like an invoked
+   * slash command — the prompt is real input the agent received, so hiding it
+   * behind a system line would conceal what shaped the answer.
+   *
+   * Optional and additive: absent means "not a routine turn", which is what every
+   * older entry means, so no `REDUCER_SCHEMA_VERSION` bump.
+   */
+  routine?: { name: string }
 }
 
 export interface ReasoningItem {
@@ -195,6 +205,29 @@ export const REBOUND_NOTICE =
   "Agent context was reset — the agent couldn't resume this thread, so it starts fresh and won't recall earlier turns. Your conversation history above is preserved."
 
 /**
+ * The "this run is late" copy (#470, ADR-0028 part 3), stated by US.
+ *
+ * A renderer-side constant over the entry's two timestamps, following
+ * {@link REBOUND_NOTICE} — the stored entry carries facts, never prose. The agent
+ * is told the same thing inside its prompt, because only it can act on the period;
+ * this half exists so the marker does not depend on the model complying.
+ *
+ * `lastRunAt === null` gets its own sentence on purpose: a routine that has never
+ * run must never read like one that ran and found nothing.
+ */
+export function routineLateNotice(dueAt: number, lastRunAt: number | null): string {
+  const when = (instant: number): string => new Date(instant).toLocaleString()
+  const covered =
+    lastRunAt === null
+      ? 'It has never run before, so this report starts from scratch.'
+      : `It last ran on ${when(lastRunAt)}, and this report covers the period since then.`
+  return (
+    `Scheduled run was late — it was due on ${when(dueAt)} and ran now instead, ` +
+    `because routines only run while the app is open. ${covered}`
+  )
+}
+
+/**
  * The DURABLE FOLD-SNAPSHOT schema version (ADR-0019, #297). A folded
  * `ConversationState` is persisted as an opaque blob keyed by this constant and
  * re-hydrated by a LATER app run — so it must be bumped in ANY PR that changes
@@ -235,7 +268,7 @@ export const initialConversationState: ConversationState = {
 }
 
 export type ConversationAction =
-  | { type: 'send-prompt'; id: string; text: string; images?: UserImage[] }
+  | { type: 'send-prompt'; id: string; text: string; images?: UserImage[]; routine?: { name: string } }
   | { type: 'acp-event'; payload: unknown }
   | { type: 'turn-complete' }
   | { type: 'turn-error'; message: string }
@@ -244,6 +277,9 @@ export type ConversationAction =
   // The agent's context was reset after a failed `session/load` resume (TB4 #33):
   // append the honest "context reset" notice. Not a turn error — input stays usable.
   | { type: 'agent-rebound' }
+  // A Routine's run started later than its slot (#470): append the honest "this run
+  // was late" notice, built from the two timestamps by `routineLateNotice`.
+  | { type: 'routine-late'; dueAt: number; lastRunAt: number | null }
   // A recoverable system condition that should be visible in the transcript without
   // ending the active turn (for example, a rejected initial Agent-control setter).
   | { type: 'system-notice'; message: string }
@@ -265,7 +301,13 @@ export function conversationReducer(
         isProcessing: true,
         items: [
           ...state.items,
-          { kind: 'user', id: action.id, text: action.text, images: action.images },
+          {
+            kind: 'user',
+            id: action.id,
+            text: action.text,
+            images: action.images,
+            routine: action.routine,
+          },
         ],
       }
     case 'turn-complete':
@@ -280,6 +322,8 @@ export function conversationReducer(
       return resolvePermission(state, action.requestId, action.optionId, action.name)
     case 'agent-rebound':
       return appendNotice(state, REBOUND_NOTICE)
+    case 'routine-late':
+      return appendNotice(state, routineLateNotice(action.dueAt, action.lastRunAt))
     case 'system-notice':
       return appendNotice(state, action.message)
     case 'acp-event':

--- a/apps/desktop/src/renderer/src/conversation/replay.test.ts
+++ b/apps/desktop/src/renderer/src/conversation/replay.test.ts
@@ -4,6 +4,7 @@ import {
   conversationReducer,
   initialConversationState,
   REBOUND_NOTICE,
+  routineLateNotice,
   type AssistantItem,
   type ConversationState,
   type NoticeItem,
@@ -130,6 +131,25 @@ describe('replayTranscript (TB3 #32)', () => {
     const notice = replayed.items.find((i): i is NoticeItem => i.kind === 'notice')
     expect(notice?.message).toBe(REBOUND_NOTICE)
     expect(replayed.isProcessing).toBe(false)
+  })
+
+  it("replays a Routine's late run: the notice, then the prompt with its chip (#470)", () => {
+    // The app was shut at 09:00, so the run happened at noon. Reopening the Bot
+    // must show both halves again: our notice, and a user bubble that says plainly
+    // it was sent by a routine rather than typed.
+    const dueAt = Date.UTC(2026, 7, 21, 7, 0)
+    const transcript: TranscriptEntry[] = [
+      { t: 'routine-late', dueAt, lastRunAt: null },
+      { t: 'user-prompt', id: 'user:0', text: 'Triage this repo.', routine: { name: 'Morning triage' } },
+      { t: 'turn-complete' },
+    ]
+
+    const replayed = replayTranscript(transcript)
+
+    expect(replayed.items.map((i) => i.kind)).toEqual(['notice', 'user'])
+    const notice = replayed.items.find((i): i is NoticeItem => i.kind === 'notice')
+    expect(notice?.message).toBe(routineLateNotice(dueAt, null))
+    expect(replayed.items[1]).toMatchObject({ kind: 'user', routine: { name: 'Morning triage' } })
   })
 
   it('replays an empty transcript to the initial (empty) conversation, never throwing', () => {

--- a/apps/desktop/src/renderer/src/conversation/replay.ts
+++ b/apps/desktop/src/renderer/src/conversation/replay.ts
@@ -128,6 +128,9 @@ function toAction(
         id: entry.id,
         text: entry.text,
         images: images && images.length > 0 ? images : undefined,
+        // Present only on a Routine's turn (#470); absent reads as "typed by you",
+        // which is what every entry written before Routines existed means.
+        routine: entry.routine,
       }
     }
     case 'acp-event':
@@ -138,6 +141,8 @@ function toAction(
       return { type: 'turn-error', message: entry.message }
     case 'agent-rebound':
       return { type: 'agent-rebound' }
+    case 'routine-late':
+      return { type: 'routine-late', dueAt: entry.dueAt, lastRunAt: entry.lastRunAt }
     case 'resolve-permission':
       return {
         type: 'resolve-permission',

--- a/apps/desktop/src/shared/ipc/thread.ts
+++ b/apps/desktop/src/shared/ipc/thread.ts
@@ -404,7 +404,7 @@ export type ListMetadataResult = WorkspaceThreads[]
  * — the renderer cannot import the main process. `transcript.ts` re-exports it.
  */
 export type TranscriptEntry =
-  | { t: 'user-prompt'; id: string; text: string; images?: TranscriptImageRef[] }
+  | { t: 'user-prompt'; id: string; text: string; images?: TranscriptImageRef[]; routine?: TranscriptRoutineRef }
   | { t: 'acp-event'; payload: unknown }
   | { t: 'turn-complete' }
   | { t: 'turn-error'; message: string }
@@ -414,6 +414,29 @@ export type TranscriptEntry =
   // "context reset" notice persists in history across a later reopen. The copy is
   // a renderer-side constant, so the entry carries no payload.
   | { t: 'agent-rebound' }
+  // A **Routine** run started later than its slot (#470, ADR-0028 part 3): the app
+  // was shut when it came due, or the Bot was busy through the whole window. The
+  // copy is a renderer-side constant like `agent-rebound`'s, so the entry carries
+  // only the two timestamps the sentence is about — `lastRunAt: null` says the
+  // Routine has NEVER run, which must never read like one that ran and found
+  // nothing. Written by us; the agent is told the same fact inside its prompt,
+  // because only it can act on the period.
+  | { t: 'routine-late'; dueAt: number; lastRunAt: number | null }
+
+/**
+ * The **Routine** a prompt was sent by (#470, ADR-0028 part 5) — carried on the
+ * `user-prompt` entry so the bubble can wear a chip naming it, the treatment an
+ * invoked slash command already gets and for the same reason: real input the agent
+ * received, which you did not type.
+ *
+ * OPTIONAL and additive, so no `REDUCER_SCHEMA_VERSION` bump: an entry without it
+ * reads as "not a routine turn", which is true (same precedent as
+ * `TranscriptImageRef` and `ThreadMeta.pinned`). Only the NAME is stored — a
+ * Routine's id would let a renamed or deleted Routine leave the chip unlabelled.
+ */
+export interface TranscriptRoutineRef {
+  name: string
+}
 
 /** The `readTranscript` request (ADR-0019, #297): the renderer states which
  * reducer schema it can hydrate; `forceFull` bypasses a stored-but-unparseable


### PR DESCRIPTION
Closes #470. Parent: #466. Load-bearing decision: ADR-0028 (part 6 especially).

## What this adds

**A periodic tick in main** (`ROUTINE_TICK_MS` = 30s, `unref`'d and stopped on quit, following the
idle sweep and the update check). Every tick asks a **pure decision function** —
`decideRoutineTick({ routines, now, busyThreads, runningRoutines, deferrals, floors })` →
`{ fire[], defer[], report[] }` — so collisions, the deferral bound and catch-up are unit tests
rather than timing tests. `scheduler.ts` holds only the interval, the in-flight set and the
deferrals between ticks.

**Firing** goes through slice 2's `runRoutineTurn` under slice 3's gate. Nothing new runs a turn,
and nothing writes a next-run time.

**The detector is independent** (`missed-runs.ts`). It recomputes `expectedLastDue(schedule, now)`
from the stored schedule and compares it with the Routine's baseline. It reads **no flag the firer
was supposed to set** — the case worth catching is the one where no code ran at all, and a flag
nobody set is indistinguishable from a flag nobody needed to set. What it shares with the firing
path is `shared/schedule`'s arithmetic, and only that, because the two have to agree about which
instants are fire instants.

**Deferral**: when the Bot is busy the slot waits, is re-checked on the next tick, and is bounded by
**that Routine's own next slot**. Past the bound it is given up and recorded `deferred`. A defer
writes nothing into the conversation.

**The launch catch-up** runs 8s after ready, independent of the tick: everything owed runs **once**,
marked late, one run per Bot (the rest stay owed and the tick re-decides them).

**"Late" is stated twice** — a `routine-late` transcript entry carrying only the two timestamps
(copy is the renderer constant `routineLateNotice`, following `agent-rebound`), **and** the coverage
period appended to the agent's own prompt in the Routine's stored timezone, because only the agent
can act on it.

**The routine chip**: a Routine's prompt stays an ordinary user bubble and wears a chip naming the
Routine, beside the slash-command chip it copies. Optional field on `UserItem` and on the
`user-prompt` entry, so **no `REDUCER_SCHEMA_VERSION` bump** — an absent marker reads as "not a
routine turn", which is true. The marker rides the headless *delivery*, not `SendPromptArgs`: a
prompt is a routine prompt because the scheduler sent it, so a renderer can never claim it.

**Paused Routines are skipped** in the decision function (`runRoutineTurn` still deliberately ignores
`active`), and a resume seen by the scheduler sets a fresh in-memory baseline.

## Decisions the ticket did not settle

- **The baseline a run is measured from is `lastRunAt ?? createdAt`.** The `createdAt` floor is not a
  nicety: without it a Routine created at 10:00 with a 09:00 schedule would be "owed" 09:00 the
  moment it was saved and fire before its first slot.
- **`updatedAt` is deliberately NOT part of the baseline**, though it would have given pause/resume a
  persisted baseline for free. Every write touches it, including `recordRun` — so the detector would
  end up comparing against a value the firer writes, and an unrelated edit could *suppress* a
  missed-run report. That is the wrong failure direction; erring the other way costs one extra late
  run. The resume baseline is therefore in-memory (the scheduler watches for paused → active). The
  gap: pause → resume → quit before the next slot → relaunch yields **one** late catch-up run for
  the paused period. If that is not acceptable, the fix is a `baseline_at` column written by the
  pause/resume path (a user action, not a self-report), not by the firer.
- **A give-up records `lastRunAt` as the abandoned slot, not `now`.** Stamping `now` — which at the
  bound *is* the next slot's instant — would settle the next slot as well and swallow it.
- **The tick applies the same `expectedRun` the launch catch-up does.** The independence the ADR
  requires is between the detector and the firer, not between the tick and the launch pass; sharing
  the comparison is what makes the two agree, and it means a missed run is still caught even if the
  launch pass never ran.
- **Tick interval 30s / late threshold 5 min.** Slots have minute granularity, so 30s fires within
  half a minute of the slot; a run that starts seconds late is the tick doing its job, not news.
- **A run that loses the claim race is re-queued.** The scheduler decides busy-ness a moment before
  `runRoutineTurn` takes its atomic claim, so a user who starts typing in that window wins the Bot
  and the run comes back `deferred`. Without the re-queue the slot would be lost for the day,
  because the refused run has already stamped the record (see below).

## The two things slice 2 left to confirm

1. **`runRoutineTurn` records `lastRunAt` alongside `lastOutcome: 'deferred'`.** For the detector
   this is *mostly* harmless — a defer settles that slot, which matches "give up" — but it is a real
   sharp edge: `lastRunAt` there means *last attempt*, not *last run*, and it is the firer moving the
   value the detector compares against. Two things keep it safe here, and they are deliberate rather
   than incidental: the scheduler decides busy-ness itself, so a busy Bot never reaches that code
   path at all (the tick defers with no write anywhere), and the one case that does reach it — the
   lost claim race — is re-queued so the slot survives its own record. I did not change slice 2's
   behaviour; if the sharp edge is unwanted, the honest fix is for a defer not to write `lastRunAt`
   at all and for the row to carry the attempt separately.
2. **`runRoutineTurn` ignoring `active` is correct**, and the skip now lives in `expectedRun` /
   `decideRoutineTick`, so "run now" from the authoring surface (#471) will still work on a paused
   Routine.

## Known gap, not fixed here

A routine turn's user bubble and its late notice are **teed, not pushed**. If you happen to have the
Bot open while a routine fires, the reply streams in with no prompt above it; the bubble and its chip
appear on the next reopen/replay. Closing that needs a main→renderer push for teed entries (a new
channel or a synthetic `acp:event`), which is more than this slice should carry. Everything about the
turn is already durable and correct — this is live echo only.

## Tests

- `missed-runs.test.ts` — baseline (including the created-after-its-slot case), paused, unschedulable
  zone, the late grace window, one run however many slots went by, and **a Routine that never ran is
  distinguishable from one that ran and found nothing**, plus a fire path that threw before reaching
  the store being indistinguishable from one nothing tried to run — both detected.
- `schedule-tick.test.ts` — two Routines colliding on one Bot, a defer that resolves on a later tick,
  a defer that expires at its next slot (and the new slot competing in the same tick), a paused
  Routine, a Bot whose Workspace is not connected (it fires — a Routine warms it), a run already in
  flight, and the resume floor.
- `scheduler.test.ts` — the launch catch-up runs a missed Routine **exactly once** and marks it late;
  the never-ran story end to end; the give-up recording against the abandoned slot; the lost race
  re-queued.
- `late-run.test.ts` — both coverage shapes, the Routine's own timezone, an unknown zone.
- `run-routine-turn.test.ts` — late stated twice, the prompt verbatim when on time, and **nothing at
  all written when the Bot is busy**.
- Reducer/replay/transcript — the chip, the late notice, the entry builders and the guard.

## Gates

```
bun run lint      → eslint . && node scripts/check-theme-tokens.mjs  (clean)
bun run typecheck → tsc node + web, astro check: 0 errors, 0 warnings, 0 hints
bun run build     → electron-vite + astro, Complete!
bun run test      → Test Files 197 passed (197) · Tests 2275 passed (2275)
```